### PR TITLE
fix: incorrect toolResponse creation 

### DIFF
--- a/libs/ai-thread/ai-thread.ts
+++ b/libs/ai-thread/ai-thread.ts
@@ -114,11 +114,11 @@ export class AiThread {
     const messageIds: Set<string> = new Set(messages.map((m) => m.timestamp))
     for (let i = 0; i < messages.length; i++) {
       const message = messages[i]
-      if (message instanceof ToolResponseEvent && messageIds.has(message.toolRequestId)) {
+      if (message instanceof ToolResponseEvent && !messageIds.has(message.parentKey ?? 'no_parent_key')) {
         messages.splice(i, 1)
         overflow.push(message)
       }
-      // ignore other weird cases like a tool request without a response, the thread is either broken or oblivious to that
+      //ignore other weird cases like a tool request without a response, the thread is either broken or oblivious to that
     }
 
     if (!compactor) {

--- a/libs/coday-events/src/lib/coday-events.ts
+++ b/libs/coday-events/src/lib/coday-events.ts
@@ -151,7 +151,7 @@ export class ToolRequestEvent extends CodayEvent {
   }
 
   buildResponse(output: string): ToolResponseEvent {
-    return new ToolResponseEvent({ output, toolRequestId: this.toolRequestId })
+    return new ToolResponseEvent({ output, toolRequestId: this.toolRequestId, parentKey: this.timestamp })
   }
 
   /**

--- a/libs/coday.ts
+++ b/libs/coday.ts
@@ -132,7 +132,7 @@ export class Coday {
       this.context?.addCommands(userCommand!)
 
       try {
-        this.context = await this.handlerLooper!.handle(this.context)
+        this.context = (await this.handlerLooper?.handle(this.context)) ?? null
       } finally {
         this.stop()
       }

--- a/libs/integration/tool-set.ts
+++ b/libs/integration/tool-set.ts
@@ -48,9 +48,6 @@ export class ToolSet {
       output = JSON.stringify(output)
     }
 
-    return new ToolResponseEvent({
-      toolRequestId: toolRequest.toolRequestId,
-      output,
-    })
+    return toolRequest.buildResponse(output)
   }
 }


### PR DESCRIPTION
It resulted in lost link to toolRequest, hence lonely toolResponse on compaction, and corrupted aiThread for the overly sensitive Anthropic API.