### PR TITLE
fix: too frequent compaction

### DIFF
--- a/libs/ai-thread/ai-thread.helpers.test.ts
+++ b/libs/ai-thread/ai-thread.helpers.test.ts
@@ -9,52 +9,59 @@ const allMessages = [message1, message2, message3, message4]
 
 describe('partition', () => {
   it('should handle empty message list', () => {
-    const result = partition([], undefined)
+    const result = partition([], undefined, 1)
     expect(result.messages.length).toBe(0)
     expect(result.overflow.length).toBe(0)
   })
   it('should handle single message list', () => {
-    const result = partition([message1], undefined)
+    const result = partition([message1], undefined, 1)
     expect(result.messages.length).toBe(1)
     expect(result.overflow.length).toBe(0)
   })
   it('should handle single message list and overflow', () => {
-    const result = partition([message1], 1)
+    const result = partition([message1], 1, 1)
     expect(result.messages.length).toBe(0)
     expect(result.overflow.length).toBe(1)
   })
   it('should not overflow without max', () => {
-    const result = partition(allMessages, undefined)
+    const result = partition(allMessages, undefined, 1)
     expect(result.messages.length).toBe(4)
     expect(result.overflow.length).toBe(0)
   })
   it('should fully overflow with max at 1', () => {
-    const result = partition(allMessages, 1)
+    const result = partition(allMessages, 1, 1)
     expect(result.messages.length).toBe(0)
     expect(result.overflow.length).toBe(4)
   })
   it('should partially overflow with max after msg1', () => {
     const length = message1.length + 1
-    const result = partition(allMessages, length)
+    const result = partition(allMessages, length, 1)
     expect(result.messages.length).toBe(1)
     expect(result.overflow.length).toBe(3)
   })
   it('should partially overflow with max after msg2', () => {
     const length = message1.length + message2.length + 1
-    const result = partition(allMessages, length)
+    const result = partition(allMessages, length, 1)
     expect(result.messages.length).toBe(2)
     expect(result.overflow.length).toBe(2)
   })
   it('should partially overflow with max after msg3', () => {
     const length = message1.length + message2.length + message3.length + 1
-    const result = partition(allMessages, length)
+    const result = partition(allMessages, length, 1)
     expect(result.messages.length).toBe(3)
     expect(result.overflow.length).toBe(1)
   })
   it('should not overflow with max after msg4', () => {
     const length = message1.length + message2.length + message3.length + message4.length + 1
-    const result = partition(allMessages, length)
+    const result = partition(allMessages, length, 1)
     expect(result.messages.length).toBe(4)
     expect(result.overflow.length).toBe(0)
+  })
+  it('should overflow with ratio after msg2', () => {
+    const length = message1.length + message2.length + message3.length + message4.length - 1
+    const ratio = (message1.length + message2.length + 1) / length
+    const result = partition(allMessages, length, ratio)
+    expect(result.messages.length).toBe(2)
+    expect(result.overflow.length).toBe(2)
   })
 })

--- a/libs/ai-thread/ai-thread.helpers.ts
+++ b/libs/ai-thread/ai-thread.helpers.ts
@@ -2,7 +2,8 @@ import { ThreadMessage } from './ai-thread.types'
 
 export function partition(
   messages: ThreadMessage[],
-  charBudget: number | undefined
+  charBudget: number | undefined,
+  ratio: number = 0.7
 ): {
   messages: ThreadMessage[]
   overflow: ThreadMessage[]
@@ -10,9 +11,13 @@ export function partition(
   if (!charBudget || !messages.length) return { messages, overflow: [] }
   let overflowIndex = 0
   let count = 0
-  while (count < charBudget && overflowIndex < messages.length) {
-    count += messages[overflowIndex].length
-    overflowIndex += count < charBudget ? 1 : 0
+  const threshold = charBudget * ratio
+  for (const message of messages) {
+    count += message.length
+    overflowIndex += count < threshold ? 1 : 0
+  }
+  if (count < charBudget) {
+    return { messages, overflow: [] }
   }
 
   const underflow = messages.slice(0, overflowIndex)


### PR DESCRIPTION
Too frequent compactions when reaching the limit lead to too many messages, and forced truncations.

Fix the compaction with an effective threshold lower than the detection threshold.
Fix (partially) the forced truncations by ... truncating the content to summarize.