### PR TITLE
fix: #222 thread corrupted tool response request

### DIFF
--- a/libs/ai-thread/ai-thread.test.ts
+++ b/libs/ai-thread/ai-thread.test.ts
@@ -1,4 +1,4 @@
-import { MessageEvent, ToolRequestEvent, ToolResponseEvent } from '../coday-events/src/lib/coday-events'
+import { MessageEvent, ToolRequestEvent, ToolResponseEvent } from '@coday/coday-events'
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { ToolCall, ToolResponse } from '../integration/tool-call'
 import { AiThread } from './ai-thread'


### PR DESCRIPTION
Clean thread messages to ensure at various points the tool request-response consistency is maintained.

Relates to #222 