### PR TITLE
fix: #225 and #224 select agent in oneshot context

### DIFF
--- a/apps/web-ng/src/app/core/services/coday.service.ts
+++ b/apps/web-ng/src/app/core/services/coday.service.ts
@@ -142,16 +142,19 @@ export class CodayService implements OnDestroy {
       // Use the original ChoiceEvent to build proper answer with parentKey
       const answerEvent = this.currentChoiceEvent.buildAnswer(choice)
       
+      console.log('[CODAY-CHOICE] Choice sent successfully, clearing UI')
+      // Hide choice interface immediately
+      this.currentChoiceSubject.next(null)
+      // Clear the current choice event to prevent reuse
+      this.currentChoiceEvent = null
       this.codayApi.sendEvent(answerEvent).subscribe({
-        next: () => {
-          // Hide choice interface immediately
-          this.currentChoiceSubject.next(null)
-          // But keep currentChoiceEvent until next event
-        },
-        error: (error) => console.error('[CODAY] Choice error:', error)
+        next: () => {},
+        error: (error) => {
+          console.error('[CODAY-CHOICE] Choice error:', error)
+        }
       })
     } else {
-      console.error('[CODAY] No choice event available')
+      console.error('[CODAY-CHOICE] No choice event available for choice:', choice)
     }
   }
 

--- a/libs/agent/agent.service.ts
+++ b/libs/agent/agent.service.ts
@@ -141,7 +141,7 @@ export class AgentService implements Killable {
   }
 
   async findAgentByNameStart(nameStart: string | undefined, context: CommandContext): Promise<Agent | undefined> {
-    if (!nameStart || context.oneshot) {
+    if (!nameStart) {
       return
     }
 
@@ -160,6 +160,9 @@ export class AgentService implements Killable {
 
     const options = matchingAgents.map((agent) => agent.name)
     try {
+      if (context.oneshot) {
+        throw new Error('Agent ambiguous names not allowed in oneshot context')
+      }
       const selection = await this.interactor.chooseOption(
         options,
         `Multiple agents match '${nameStart}', please select one:`

--- a/libs/coday.ts
+++ b/libs/coday.ts
@@ -143,7 +143,7 @@ export class Coday {
         this.interactor.error('Could not initialize context 😭')
         break
       }
-
+      
       let userCommand = await this.initCommand()
       if ((!userCommand && this.options.oneshot) || userCommand === keywords.exit) {
         // default case: no initial prompt (or empty) and not interactive = get out
@@ -157,7 +157,9 @@ export class Coday {
       }
 
       const thread = this.context?.aiThread
-      if (thread) thread.runStatus = RunStatus.RUNNING
+      if (thread) {
+        thread.runStatus = RunStatus.RUNNING
+      }
 
       // add the user command to the queue and let handlers decompose it in many and resolve them ultimately
       this.context?.addCommands(userCommand!)


### PR DESCRIPTION
Agent selection by name start was not allowed in oneshot context (used by webhook execution), leading to:
- no agent instruction handled
- empty thread

fix #227 
fix #224 
fix #225 