### PR TITLE
feat: #264 invert auth option from --no_auth to --auth

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -220,7 +220,7 @@ async function startCodayServer(): Promise<void> {
 
     log('INFO', 'Found npx at:', npxPath)
     const command = npxPath
-    const args = ['--yes', '@whoz-oss/coday-web', '--no_auth']
+    const args = ['--yes', '@whoz-oss/coday-web']
 
     log('INFO', 'Spawning:', command, args.join(' '))
 
@@ -232,8 +232,6 @@ async function startCodayServer(): Promise<void> {
     } catch {
       env['PATH'] = '/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin'
     }
-
-    env['NO_AUTH'] = 'true'
 
     // Start the server
     serverProcess = spawn(command, args, {

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -55,7 +55,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["server:build"],
       "options": {
-        "commands": ["node apps/server/dist/bin.js --no_auth"],
+        "commands": ["node apps/server/dist/bin.js"],
         "parallel": false
       }
     },
@@ -65,7 +65,7 @@
         "env": {
           "BUILD_ENV": "development"
         },
-        "commands": ["tsx watch apps/server/src/server.ts --no_auth"]
+        "commands": ["tsx watch apps/server/src/server.ts"]
       }
     },
     "nx-release-publish": {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -166,13 +166,13 @@ const configRegistry = new ConfigServiceRegistry(codayOptions.configDir, configI
  *
  * In authenticated mode, extracts username from the x-forwarded-email header
  * (typically set by reverse proxy or authentication middleware).
- * In no-auth mode, uses the local system username for development/testing.
+ * In non-authenticated mode (default), uses the local system username for development/testing.
  *
  * @param req - Express request object containing headers
  * @returns Username string for logging and thread ownership
  */
 function getUsername(req: express.Request): string {
-  return codayOptions.noAuth ? os.userInfo().username : (req.headers[EMAIL_HEADER] as string)
+  return codayOptions.auth ? (req.headers[EMAIL_HEADER] as string) : os.userInfo().username
 }
 
 // Register user information routes

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -9,7 +9,7 @@
     "serve": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["node index.js --no_auth"],
+        "commands": ["node index.js"],
         "parallel": false,
         "cwd": "{projectRoot}"
       }

--- a/libs/options.ts
+++ b/libs/options.ts
@@ -7,7 +7,7 @@ import { hideBin } from 'yargs/helpers'
 export interface Argv {
   coday_project?: string
   coday_config_dir?: string
-  no_auth?: boolean
+  auth?: boolean
   prompt?: string[]
   oneshot?: boolean
   debug?: boolean
@@ -30,7 +30,7 @@ export interface CodayOptions {
   prompts: string[]
   fileReadOnly: boolean
   configDir: string // Always defined with default value
-  noAuth: boolean
+  auth: boolean
   agentFolders: string[]
   noLog: boolean
   logFolder?: string
@@ -57,9 +57,9 @@ export function parseCodayOptions(): CodayOptions {
       type: 'boolean',
       description: 'Run in one-shot mode (non-interactive)',
     })
-    .option('no auth', {
+    .option('auth', {
       type: 'boolean',
-      description: 'Disables web auth check',
+      description: 'Enables web auth check (expects x-forwarded-email header from auth proxy)',
     })
     .option('local', {
       type: 'boolean',
@@ -107,7 +107,7 @@ export function parseCodayOptions(): CodayOptions {
   const defaultConfigDir = path.join(os.homedir(), '.coday')
   const configDir: string = argv.coday_config_dir || defaultConfigDir
 
-  const noAuth: boolean = !!argv.no_auth
+  const auth: boolean = !!argv.auth
   const debug: boolean = !!argv.debug
   const noLog: boolean = !argv.log // Inverted: log=false means noLog=true
   const logFolder: string | undefined = argv.log_folder
@@ -137,7 +137,7 @@ export function parseCodayOptions(): CodayOptions {
     prompts,
     fileReadOnly,
     configDir,
-    noAuth,
+    auth,
     agentFolders: (argv.agentFolders || []) as string[],
     noLog,
     logFolder,

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "type": "module",
   "scripts": {
     "client": "nx run client:serve",
-    "coday": "npx --yes @whoz-oss/coday-web --no_auth",
+    "coday": "npx --yes @whoz-oss/coday-web",
     "desktop": "nx run desktop:serve",
     "husky-setup": "husky",
     "lint": "nx run-many --target=lint",
     "postinstall": "pnpm husky-setup",
     "server": "nx run server:serve",
     "test": "nx run-many --target=test",
-    "web": "npx --yes @whoz-oss/coday-web --no_auth",
+    "web": "npx --yes @whoz-oss/coday-web",
     "web:dev": "nx run-many --target=serve --projects=client,server --parallel=2"
   },
   "lint-staged": {


### PR DESCRIPTION
## Description

This PR inverts the authentication option logic to make local development the default behavior.

## Breaking Change ⚠️

**Previous behavior:**
- Default: Authentication required (expected `x-forwarded-email` header from auth proxy)
- `--no_auth` flag: Disabled authentication for local development

**New behavior:**
- Default: No authentication required (uses local system username)
- `--auth` flag: Enables authentication via `x-forwarded-email` header from auth proxy

## Rationale

The previous behavior required developers to always add `--no_auth` for local development, which was:
1. Counter-intuitive (negative flag for the most common use case)
2. Error-prone (forgetting the flag would cause failures)
3. Inconsistent with other development tools

The new behavior makes local development work out-of-the-box while requiring explicit opt-in for authenticated deployments.

## Changes

### Code Changes
- `libs/options.ts`: Changed `Argv.no_auth` → `auth`, `CodayOptions.noAuth` → `auth`
- `apps/server/src/server.ts`: Inverted `getUsername()` logic to check `auth` flag
- `package.json`: Removed `--no_auth` from `web` and `coday` scripts
- `apps/web/project.json`: Removed `--no_auth` from serve command
- `apps/server/project.json`: Removed `--no_auth` from serve commands
- `apps/desktop/src/main.ts`: Removed `--no_auth` arg and `NO_AUTH` env var

### Migration Guide

**For Local Development:**
- Before: `pnpm web --no_auth`
- After: `pnpm web` (no flag needed)

**For Production with Auth Proxy:**
- Before: `pnpm web` (default)
- After: `pnpm web --auth` (explicit flag)

## Testing

- ✅ All projects compile successfully
- ✅ All occurrences of `no_auth`/`noAuth` have been updated
- ✅ Desktop app updated to remove authentication bypass

## Checklist

- [x] Code compiles without errors
- [x] Breaking change documented
- [x] Migration guide provided
- [x] All related files updated
- [x] Commit follows conventional commits format

Closes #264