### PR TITLE
feat: #282 open external links in new tab with icon and aria-label

### DIFF
--- a/apps/client/src/app/components/chat-message/chat-message.component.ts
+++ b/apps/client/src/app/components/chat-message/chat-message.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, inject } from '@angular/core'
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
-import { marked } from 'marked'
 import { MessageContent } from '@coday/coday-events'
 import { MessageContextMenuComponent, MenuAction } from '../message-context-menu/message-context-menu.component'
 import { NgClass } from '@angular/common'
@@ -8,6 +7,7 @@ import { NotificationService } from '../../services/notification.service'
 import { PreferencesService } from '../../services/preferences.service'
 import { ProjectStateService } from '../../core/services/project-state.service'
 import { ThreadStateService } from '../../core/services/thread-state.service'
+import { MarkdownService } from '../../services/markdown.service'
 import { Subject } from 'rxjs'
 import { takeUntil } from 'rxjs/operators'
 
@@ -45,6 +45,7 @@ export class ChatMessageComponent implements OnInit, OnDestroy {
   private preferencesService = inject(PreferencesService)
   private projectState = inject(ProjectStateService)
   private threadState = inject(ThreadStateService)
+  private markdownService = inject(MarkdownService)
 
   get messageClasses() {
     return {
@@ -151,8 +152,8 @@ export class ChatMessageComponent implements OnInit, OnDestroy {
 
     for (const item of content) {
       if (item.type === 'text') {
-        // Parse markdown for text content
-        const html = await marked.parse(item.content)
+        // Parse markdown for text content using MarkdownService
+        const html = await this.markdownService.parse(item.content)
         htmlParts.push(`<div class="text-part">${html}</div>`)
       } else if (item.type === 'image') {
         // Create image element

--- a/apps/client/src/app/components/choice-select/choice-select.component.ts
+++ b/apps/client/src/app/components/choice-select/choice-select.component.ts
@@ -13,11 +13,11 @@ import {
 } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
-import { marked } from 'marked'
 import { BehaviorSubject, Observable } from 'rxjs'
 import { AsyncPipe } from '@angular/common'
 import { MatIconModule } from '@angular/material/icon'
 import { MatButtonModule } from '@angular/material/button'
+import { MarkdownService } from '../../services/markdown.service'
 
 export interface ChoiceOption {
   value: string
@@ -57,6 +57,7 @@ export class ChoiceSelectComponent implements AfterViewInit, OnChanges, OnDestro
 
   // Modern Angular dependency injection
   private sanitizer = inject(DomSanitizer)
+  private markdownService = inject(MarkdownService)
 
   ngOnDestroy(): void {
     this.renderedLabelSubject.complete()
@@ -116,7 +117,7 @@ export class ChoiceSelectComponent implements AfterViewInit, OnChanges, OnDestro
     }
 
     try {
-      const html = await marked.parse(label)
+      const html = await this.markdownService.parse(label)
       this.renderedLabelSubject.next(this.sanitizer.bypassSecurityTrustHtml(html))
     } catch (error) {
       console.error('[CHOICE-SELECT] Error parsing label markdown:', error)

--- a/apps/client/src/app/services/markdown.service.ts
+++ b/apps/client/src/app/services/markdown.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@angular/core'
+import { marked, Renderer } from 'marked'
+
+/**
+ * Service to configure and provide markdown rendering with custom link handling
+ *
+ * Features:
+ * - External links open in new tab with target="_blank"
+ * - External links have rel="noopener noreferrer" for security
+ * - External links display an icon to indicate they open in a new tab
+ * - Accessible aria-labels for screen readers
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class MarkdownService {
+  private renderer: Renderer
+
+  constructor() {
+    this.renderer = new Renderer()
+    this.configureRenderer()
+  }
+
+  /**
+   * Configure the marked renderer with custom link handling
+   */
+  private configureRenderer(): void {
+    // Store the original link renderer
+    const originalLinkRenderer = this.renderer.link.bind(this.renderer)
+
+    // Override the link renderer
+    // The parameter is a Tokens.Link object with properties: type, raw, href, title, text, tokens
+    this.renderer.link = (token): string => {
+      // Determine if link is external
+      const isExternal = this.isExternalLink(token.href)
+
+      // Get base HTML from original renderer
+      let html = originalLinkRenderer(token)
+
+      if (isExternal) {
+        // Add target="_blank" and security attributes
+        html = html.replace('<a ', '<a target="_blank" rel="noopener noreferrer" ')
+
+        // Create aria-label for accessibility
+        const ariaLabel = token.title
+          ? `${token.text} - ${token.title} (opens in new tab)`
+          : `${token.text} (opens in new tab)`
+        html = html.replace('<a ', `<a aria-label="${this.escapeHtml(ariaLabel)}" `)
+
+        // Add external link icon after the link text
+        // Using Unicode external link icon (U+2197 - North East Arrow)
+        // Wrapped in a span for styling control
+        const externalIcon = '<span class="external-link-icon" aria-hidden="true">↗</span>'
+        html = html.replace('</a>', `${externalIcon}</a>`)
+      }
+
+      return html
+    }
+  }
+
+  /**
+   * Determine if a URL is external
+   *
+   * A link is considered external if:
+   * - It starts with http:// or https:// and doesn't point to the current domain
+   * - It starts with // (protocol-relative URL)
+   *
+   * Internal links (starting with /, #, or relative paths) are not considered external
+   */
+  private isExternalLink(href: string): boolean {
+    if (!href) return false
+
+    // Relative links and anchors are not external
+    if (href.startsWith('/') || href.startsWith('#') || href.startsWith('?')) {
+      return false
+    }
+
+    // Protocol-relative URLs are considered external
+    if (href.startsWith('//')) {
+      return true
+    }
+
+    // Check if it's an absolute URL
+    try {
+      const url = new URL(href, window.location.href)
+      // If the hostname differs from current hostname, it's external
+      return url.hostname !== window.location.hostname
+    } catch {
+      // If URL parsing fails, treat as internal for safety
+      return false
+    }
+  }
+
+  /**
+   * Escape HTML special characters for use in attributes
+   */
+  private escapeHtml(text: string): string {
+    const map: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    }
+    return text.replace(/[&<>"']/g, (char) => map[char] || char)
+  }
+
+  /**
+   * Parse markdown to HTML with custom renderer
+   *
+   * @param markdown The markdown string to parse
+   * @returns Promise that resolves to HTML string
+   */
+  async parse(markdown: string): Promise<string> {
+    return marked.parse(markdown, { renderer: this.renderer })
+  }
+}

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -179,6 +179,21 @@ body {
     }
   }
 
+  /* External link icon styling */
+  .external-link-icon {
+    display: inline-block;
+    margin-left: 0.25rem;
+    font-size: 0.85em;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+    vertical-align: super;
+    line-height: 0;
+  }
+
+  a:hover .external-link-icon {
+    opacity: 1;
+  }
+
   hr {
     border: none;
     border-top: 1px solid var(--color-border, #e5e7eb);


### PR DESCRIPTION
## 🎯 Objectif

Résolution de l'issue #282 : Faire en sorte que les liens externes dans le contenu markdown ouvrent dans un nouvel onglet avec une icône visuelle et un aria-label pour l'accessibilité.

## 📝 Modifications

### Nouveau service centralisé : `MarkdownService`

Création d'un service Angular (`apps/client/src/app/services/markdown.service.ts`) qui configure `marked` avec un renderer personnalisé pour gérer les liens externes.

**Fonctionnalités :**
- ✅ Détection automatique des liens externes (comparaison de hostname)
- ✅ Ajout de `target="_blank"` pour ouvrir dans un nouvel onglet
- ✅ Ajout de `rel="noopener noreferrer"` pour la sécurité
- ✅ Icône "↗" après le texte du lien externe
- ✅ `aria-label` descriptif pour les lecteurs d'écran
- ✅ Les liens internes (/, #, relatifs) ne sont pas affectés

### Styles CSS pour l'icône

Ajout dans `apps/client/src/styles.scss` :
```scss
.external-link-icon {
  display: inline-block;
  margin-left: 0.25rem;
  font-size: 0.85em;
  opacity: 0.7;
  transition: opacity 0.2s ease;
  vertical-align: super;
  line-height: 0;
}

a:hover .external-link-icon {
  opacity: 1; // Icône plus visible au survol
}
```

### Migration des composants

Mise à jour de tous les composants utilisant `marked` pour utiliser le nouveau `MarkdownService` :
- `ChatMessageComponent`
- `ChoiceSelectComponent`

## 🔒 Sécurité

L'attribut `rel="noopener noreferrer"` empêche les attaques par `window.opener` où un site externe pourrait manipuler la page d'origine.

## ♿ Accessibilité

Chaque lien externe reçoit un `aria-label` du type :
- `"Texte du lien (opens in new tab)"`
- `"Texte du lien - Titre (opens in new tab)"` si un titre est présent

Cela informe les utilisateurs de lecteurs d'écran qu'un nouvel onglet va s'ouvrir.

## 🎨 Expérience utilisateur

- **Icône visuelle** : "↗" indique clairement qu'il s'agit d'un lien externe
- **Conservation du contexte** : La conversation reste ouverte dans l'onglet actuel
- **Cohérence** : Tous les liens externes ont le même comportement

## ✅ Tests

Pour tester cette fonctionnalité :

1. Lancer l'application : `pnpm client`
2. Envoyer un message avec un lien externe : `Regarde ce site : https://github.com`
3. Vérifier que :
   - Le lien a une icône "↗" après le texte
   - Un clic ouvre un nouvel onglet
   - L'onglet actuel reste sur la conversation
   - Le lien a un attribut `aria-label` (inspecter dans DevTools)

4. Tester aussi un lien interne : `[Accueil](/)`
   - Devrait ne PAS avoir d'icône
   - Devrait ne PAS ouvrir de nouvel onglet

## 📦 Compilation

✅ Tous les builds réussissent
✅ Aucune erreur TypeScript
⚠️ Warnings de budget (pré-existants, non bloquants)

## 🔗 Issue liée

Closes #282