### PR TITLE
fix: #297 prevent server from running with system/service usernames

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -181,6 +181,7 @@ const FORBIDDEN_USERNAMES = [
   'www-data', // Web server user (nginx, apache)
   'nginx', // Nginx user
   'apache', // Apache user
+  'ansible', // Ansible user
 ] as const
 
 /**


### PR DESCRIPTION
## Description

Prevents the server from running with system or service account usernames to avoid security issues where all users would share the same account.

## Problem

Following the recent change of auth parameter (from `--no_auth` to `--auth`), the deployed instance could run with no auth check, using the local username which could be `root`. This caused:
- All threads visible to everyone
- Same user config for everyone
- Security and privacy issues

## Solution

Added validation in `getUsername()` function to reject forbidden usernames:
- **System accounts**: `root`, `admin`, `administrator`, `system`, `daemon`, `nobody`
- **Container/service accounts**: `node`, `app`, `service`, `docker`
- **Web server accounts**: `www-data`, `nginx`, `apache`

The check is case-insensitive and throws a clear error message explaining:
- Why the username is forbidden
- What to do in local mode (run as regular user)
- What to do in production (configure `--auth` flag)

## Changes

- Added `FORBIDDEN_USERNAMES` constant with 13 system/service account names
- Modified `getUsername()` to validate username against forbidden list
- Throws explicit error with actionable guidance for users

## Testing

- [x] Code compiles successfully
- [x] Clear error message when running with forbidden username
- [x] Normal operation with regular usernames

Closes #297