### PR TITLE
fix: #281 convert Windows paths to file:// URLs for ESM imports

### DIFF
--- a/apps/web/index.js
+++ b/apps/web/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname, resolve } from 'path';
 import { existsSync } from 'fs';
 import { createRequire } from 'module';
@@ -77,7 +77,9 @@ try {
   const serverMainPath = resolve(serverDir, 'server.js');
   
   // Import the server module
-  import(serverMainPath).catch((error) => {
+  // Convert Windows absolute path to file:// URL for ESM import
+  const serverModuleURL = pathToFileURL(serverMainPath).href;
+  import(serverModuleURL).catch((error) => {
     console.error('Failed to start server:', error);
     process.exit(1);
   });


### PR DESCRIPTION
## Problem

Issue #281 reported `ERR_UNSUPPORTED_ESM_URL_SCHEME` error on Windows when launching Coday Web with `npx @whoz-oss/coday-web`.

The error occurred because Node.js ESM `import()` received a Windows absolute path (e.g., `C:\Users\...\server.js`) instead of a proper `file://` URL.

## Root Cause

In `apps/web/index.js`, line 76:
```javascript
import(serverMainPath).catch((error) => {
```

The `serverMainPath` variable contained a Windows absolute path like `C:\Users\...\server.js`, which is not a valid URL scheme for ESM imports.

## Solution

Convert the Windows absolute path to a proper `file://` URL using Node.js built-in `pathToFileURL()`:

```javascript
import { pathToFileURL } from 'url';

// Convert Windows absolute path to file:// URL for ESM import
const serverModuleURL = pathToFileURL(serverMainPath).href;
import(serverModuleURL).catch((error) => {
```

## Testing

- ✅ Compilation successful
- ✅ Works on macOS/Linux (no regression)
- ⏳ Needs testing on Windows by reporter

## Related

Closes #281