### PR TITLE
feat: #322 add download all files button in exchange drawer

### DIFF
--- a/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.html
+++ b/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.html
@@ -5,9 +5,22 @@
       <h3 class="drawer-title">Exchange</h3>
       <span class="file-count">({{ files().length }})</span>
     </div>
-    <button mat-icon-button class="close-btn" (click)="close()" title="Close" type="button">
-      <mat-icon>chevron_right</mat-icon>
-    </button>
+    <div class="header-actions">
+      @if (files().length > 0) {
+        <button
+          mat-icon-button
+          class="download-all-btn"
+          (click)="downloadAll()"
+          title="Download all files"
+          type="button"
+        >
+          <mat-icon>download_for_offline</mat-icon>
+        </button>
+      }
+      <button mat-icon-button class="close-btn" (click)="close()" title="Close" type="button">
+        <mat-icon>chevron_right</mat-icon>
+      </button>
+    </div>
   </div>
 
   <!-- File list -->

--- a/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.scss
+++ b/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.scss
@@ -24,6 +24,12 @@
   gap: 0.5rem;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .drawer-title {
   margin: 0;
   font-size: 1.25rem;
@@ -34,6 +40,14 @@
 .file-count {
   font-size: 0.9rem;
   color: var(--color-text-secondary);
+}
+
+.download-all-btn {
+  color: var(--color-primary);
+
+  &:hover {
+    background: var(--color-bg-hover);
+  }
 }
 
 .close-btn {

--- a/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.ts
+++ b/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.ts
@@ -32,6 +32,11 @@ export class FileExchangeDrawerComponent {
     this.closeDrawer.emit()
   }
 
+  downloadAll(): void {
+    console.log('[FILE_DRAWER] Download all files')
+    this.fileExchangeState.downloadAllFiles()
+  }
+
   download(file: FileInfo): void {
     console.log('[FILE_DRAWER] Download file:', file.filename)
     this.fileExchangeState.downloadFile(file.filename)

--- a/apps/client/src/app/core/services/file-exchange-state.service.ts
+++ b/apps/client/src/app/core/services/file-exchange-state.service.ts
@@ -136,6 +136,27 @@ export class FileExchangeStateService {
   }
 
   /**
+   * Download all files from the exchange space
+   * Files are downloaded sequentially with a small delay to avoid overwhelming the browser
+   */
+  downloadAllFiles(): void {
+    const files = this.filesSignal()
+    if (files.length === 0) {
+      console.warn('[FILE_EXCHANGE_STATE] No files to download')
+      return
+    }
+
+    console.log('[FILE_EXCHANGE_STATE] Downloading all files:', files.length)
+
+    // Download files sequentially with small delay between each
+    files.forEach((file, index) => {
+      setTimeout(() => {
+        this.downloadFile(file.filename)
+      }, index * 300) // 300ms delay between downloads
+    })
+  }
+
+  /**
    * Download a file from the exchange space
    *
    * @param filename - Name of the file to download


### PR DESCRIPTION
## Description

This PR implements the "Download all files" button requested in issue #322.

## Changes

### FileExchangeStateService
- Added `downloadAllFiles()` method that downloads all files sequentially with a 300ms delay between each download to avoid overwhelming the browser

### FileExchangeDrawerComponent
- Added `downloadAll()` method that delegates to the state service
- Added a "Download all" button in the header (using Material icon `download_for_offline`)
- Button only appears when there are files to download

### UI/UX
- The button appears in the header next to the close button
- Uses primary color to indicate it's an action button
- Has proper hover state
- Shows tooltip "Download all files"

## Implementation Details

- Files are downloaded sequentially with 300ms delay to avoid browser limitations
- Simple and effective approach without additional dependencies
- Follows the existing architecture pattern (State Service → API Service)
- Consistent with existing download functionality

## Testing

- ✅ Compilation successful
- ✅ Follows project conventions
- ✅ UI integrates cleanly with existing design

## Future Enhancements

If needed in the future, we could:
- Add a ZIP creation endpoint on the backend
- Show download progress indicator
- Add client-side ZIP creation with JSZip

Closes #322