### PR TITLE
fix: #320 correct text color in dark mode when OS is in light mode

### DIFF
--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -14,8 +14,10 @@
 }
 
 html {
+  color-scheme: light;
+
   &[data-theme='dark'] {
-    color-scheme: light dark;
+    color-scheme: dark;
   }
 
   @include mat.theme(


### PR DESCRIPTION
## Problem
When the OS is in light mode and the user switches Coday to dark mode, the text color remained black instead of becoming white or light grey as expected.

## Root Cause
The CSS `color-scheme` property was incorrectly configured:
- Dark mode had `color-scheme: light dark;` which told the browser to prefer light mode colors
- Light mode had no explicit `color-scheme` declaration

## Solution
Fixed the `color-scheme` property in `apps/client/src/styles.scss`:
- Added explicit `color-scheme: light;` for the default light mode
- Changed dark mode to `color-scheme: dark;` (removed the incorrect `light dark` value)

## Changes
```scss
html {
  color-scheme: light;

  &[data-theme='dark'] {
    color-scheme: dark;
  }
}
```

This ensures:
- In **light mode**: `color-scheme: light` → black text on light background
- In **dark mode**: `color-scheme: dark` → light text on dark background

## Testing
- [x] Code compiles successfully
- [x] Prettier formatting applied

Fixes #320