### PR TITLE
fix: #324 uniform streaming message style with assistant message

### DIFF
--- a/apps/client/src/app/components/chat-history/chat-history.component.scss
+++ b/apps/client/src/app/components/chat-history/chat-history.component.scss
@@ -1,23 +1,22 @@
-// Streaming message style (matches ChatMessageComponent assistant style)
+// Streaming message style (matches ChatMessageComponent assistant style exactly)
 .streaming-message {
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-  max-width: 75%;
-  width: fit-content;
-  min-width: 100px;
-  word-wrap: break-word;
-
   &.assistant {
-    background-color: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
+    // Match exact style from chat-message.component.scss .message.assistant
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
     margin-left: 0;
     margin-right: auto;
-    border-bottom-left-radius: 4px;
+    padding: 0.5rem 0 0.5rem 0;
+    width: 100%;
+    max-width: none;
+    min-width: 0;
   }
 
   .content {
     color: var(--color-text);
-    line-height: 1.6;
+    line-height: 1.5; // Match line-height from ChatMessageComponent
     white-space: pre-wrap;
   }
 }


### PR DESCRIPTION
## Description

Fixes #324 - Uniformise le style des messages en streaming avec les messages assistant finaux pour éliminer le "saut" visuel.

## Problème résolu

Quand l'agent émet des `TextChunkEvent` (streaming), le texte était affiché avec un style différent du message assistant final, créant une discontinuité visuelle désagréable :

**Avant** :
- Message streaming : fond coloré, bordure, padding important, largeur limitée à 75%
- Message final : transparent, sans bordure, pleine largeur

**Résultat** : Le message "saute" visuellement lors de la transition streaming → message final.

## Solution implémentée

Modification du style CSS du message streaming pour qu'il corresponde **exactement** au style du message assistant final :

```scss
.streaming-message {
  &.assistant {
    // Style identique à .message.assistant de ChatMessageComponent
    background: transparent;
    border: none;
    box-shadow: none;
    border-radius: 0;
    padding: 0.5rem 0 0.5rem 0;
    width: 100%;
    max-width: none;
    // ...
  }
}
```

## Bénéfices

✅ **Transition fluide** : Plus de "saut" visuel lors du passage streaming → message final
✅ **Cohérence visuelle** : Le message garde la même apparence du début à la fin
✅ **Simple** : Modification CSS uniquement, aucun changement d'architecture
✅ **Performance** : Aucun impact sur les performances

## Fichiers modifiés

- `apps/client/src/app/components/chat-history/chat-history.component.scss` : Uniformisation des styles

## Tests

- ✅ Compilation réussie
- ✅ Le message streaming s'affiche maintenant avec le même style que le message final
- ✅ Aucun changement fonctionnel, uniquement visuel

## Type de changement

- [x] Bug fix (changement non-cassant qui corrige un problème)
- [ ] Nouvelle fonctionnalité
- [ ] Breaking change
- [ ] Documentation