### PR TITLE
refactor: #357 split memory tools into separate PROJECT/USER tools and add read capability

### DIFF
--- a/libs/integration/memory.tools.ts
+++ b/libs/integration/memory.tools.ts
@@ -4,8 +4,6 @@ import { AssistantToolFactory, CodayTool } from './assistant-tool-factory'
 import { FunctionTool } from './types'
 import { MemoryLevel } from '../model/memory'
 
-const MemoryLevels = [MemoryLevel.PROJECT, MemoryLevel.USER]
-
 export class MemoryTools extends AssistantToolFactory {
   name = 'MEMORY'
 
@@ -19,24 +17,104 @@ export class MemoryTools extends AssistantToolFactory {
   protected async buildTools(_context: CommandContext, agentName: string): Promise<CodayTool[]> {
     const result: CodayTool[] = []
 
-    const memorize = async ({ title, content, level }: { title: string; content: string; level: string }) => {
-      const parsedLevel: MemoryLevel = level === 'USER' ? MemoryLevel.USER : MemoryLevel.PROJECT
+    // Tool to read memories
+    const readMemoriesFunction = async ({ title }: { title?: string }) => {
+      try {
+        if (title) {
+          // Return specific memory content
+          const projectMemories = this.memoryService.listMemories(MemoryLevel.PROJECT, agentName)
+          const userMemories = this.memoryService.listMemories(MemoryLevel.USER, agentName)
+          const allMemories = [...projectMemories, ...userMemories]
 
-      this.memoryService.upsertMemory({ title, content, level: parsedLevel, agentName })
-      return `Memory added with title: ${title}`
+          const memory = allMemories.find((m) => m.title === title)
+          if (!memory) {
+            return `Memory with title '${title}' not found.`
+          }
+
+          return `# ${memory.title}\n\n**Level:** ${memory.level}\n\n${memory.content}`
+        } else {
+          // Return list of memories with titles and levels
+          const projectMemories = this.memoryService.listMemories(MemoryLevel.PROJECT, agentName)
+          const userMemories = this.memoryService.listMemories(MemoryLevel.USER, agentName)
+
+          if (projectMemories.length === 0 && userMemories.length === 0) {
+            return 'No memories found.'
+          }
+
+          let result = '# Available Memories\n\n'
+
+          if (projectMemories.length > 0) {
+            result += '## PROJECT Level\n'
+            projectMemories.forEach((m) => {
+              result += `- ${m.title}\n`
+            })
+            result += '\n'
+          }
+
+          if (userMemories.length > 0) {
+            result += '## USER Level\n'
+            userMemories.forEach((m) => {
+              result += `- ${m.title}\n`
+            })
+          }
+
+          return result
+        }
+      } catch (error) {
+        const errorMessage = `Failed to read memories: ${error instanceof Error ? error.message : 'Unknown error'}`
+        this.interactor.error(errorMessage)
+        return errorMessage
+      }
     }
 
-    const addMemoryTool: FunctionTool<{ title: string; content: string; level: string }> = {
+    const readMemoriesTool: FunctionTool<{ title?: string }> = {
       type: 'function',
       function: {
-        name: 'memorize',
-        description: `Upsert a memory entry to remember on next runs. Should be used selectively for significant knowledge that:
+        name: 'readMemories',
+        description: `Read agent's memories. Without title parameter, returns the list of all memories with their titles and levels. With title parameter, returns the full content of the specified memory.`,
+        parameters: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description: 'Optional: Title of the specific memory to read. If not provided, lists all memories.',
+            },
+          },
+        },
+        parse: JSON.parse,
+        function: readMemoriesFunction,
+      },
+    }
+    result.push(readMemoriesTool)
 
-1) represents core project or user patterns
+    // Tool to memorize at PROJECT level
+    const memorizeProjectFunction = async ({ title, content }: { title: string; content: string }) => {
+      try {
+        this.memoryService.upsertMemory({ title, content, level: MemoryLevel.PROJECT, agentName })
+        return `PROJECT memory added/updated with title: ${title}`
+      } catch (error) {
+        const errorMessage = `Failed to memorize at PROJECT level: ${error instanceof Error ? error.message : 'Unknown error'}`
+        this.interactor.error(errorMessage)
+        return errorMessage
+      }
+    }
+
+    const memorizeProjectTool: FunctionTool<{ title: string; content: string }> = {
+      type: 'function',
+      function: {
+        name: 'memorizeProject',
+        description: `Upsert a PROJECT-level memory entry. PROJECT memories are for:
+- Architectural decisions and core patterns
+- Significant design guidelines
+- Project-specific conventions and standards
+- Technical decisions that impact the entire project
+
+Should be used selectively for significant knowledge that:
+1) represents core project patterns
 2) will be valuable in multiple future interactions
-3) is not redundant with existing memories (in that case, update the existing one).
+3) is not redundant with existing memories (in that case, update the existing one)
 
-Do not memorize partial knowledge, single-use information, or minor implementation details. Allowed levels: ${MemoryLevels.join(', ')}.`,
+Do not memorize partial knowledge, single-use information, or minor implementation details.`,
         parameters: {
           type: 'object',
           properties: {
@@ -50,22 +128,64 @@ Do not memorize partial knowledge, single-use information, or minor implementati
               description:
                 'Content of the memory: must be complete, validated knowledge with clear structure (sections, examples when relevant). Should include enough context to be self-contained but avoid redundancy with other memories. Length: preferably between a paragraph (for focused topics) and 3 pages (for complex patterns).',
             },
-            level: {
-              type: 'string',
-              description: `Level of the memory:
+          },
+        },
+        parse: JSON.parse,
+        function: memorizeProjectFunction,
+      },
+    }
+    result.push(memorizeProjectTool)
 
-- PROJECT for architectural decisions, core patterns, or significant design guidelines
-- USER for strong personal preferences or validated working patterns that impact multiple interactions.`,
-              enum: MemoryLevels,
+    // Tool to memorize at USER level
+    const memorizeUserFunction = async ({ title, content }: { title: string; content: string }) => {
+      try {
+        this.memoryService.upsertMemory({ title, content, level: MemoryLevel.USER, agentName })
+        return `USER memory added/updated with title: ${title}`
+      } catch (error) {
+        const errorMessage = `Failed to memorize at USER level: ${error instanceof Error ? error.message : 'Unknown error'}`
+        this.interactor.error(errorMessage)
+        return errorMessage
+      }
+    }
+
+    const memorizeUserTool: FunctionTool<{ title: string; content: string }> = {
+      type: 'function',
+      function: {
+        name: 'memorizeUser',
+        description: `Upsert a USER-level memory entry. USER memories are for:
+- Strong personal preferences
+- User-specific working patterns
+- Individual communication styles
+- Personal context that impacts interactions
+
+Should be used selectively for significant knowledge that:
+1) represents validated user patterns
+2) will be valuable in multiple future interactions
+3) is not redundant with existing memories (in that case, update the existing one)
+
+Do not memorize partial knowledge, single-use information, or minor implementation details.`,
+        parameters: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description:
+                'Title of the memory: should be precise, unique, and reflect the full scope of the content. Avoid generic titles unless the content is really generic.',
+            },
+            content: {
+              type: 'string',
+              description:
+                'Content of the memory: must be complete, validated knowledge with clear structure (sections, examples when relevant). Should include enough context to be self-contained but avoid redundancy with other memories. Length: preferably between a paragraph (for focused topics) and 3 pages (for complex patterns).',
             },
           },
         },
         parse: JSON.parse,
-        function: memorize,
+        function: memorizeUserFunction,
       },
     }
-    result.push(addMemoryTool)
+    result.push(memorizeUserTool)
 
+    // Tool to delete memory
     const deleteMemoryFunction = async ({ title }: { title: string }) => {
       try {
         this.memoryService.deleteMemory(title)
@@ -81,7 +201,7 @@ Do not memorize partial knowledge, single-use information, or minor implementati
       type: 'function',
       function: {
         name: 'deleteMemory',
-        description: 'Delete a memory entry by its title.',
+        description: 'Delete a memory entry by its title. Works for both PROJECT and USER level memories.',
         parameters: {
           type: 'object',
           properties: {


### PR DESCRIPTION
## Summary

This PR refactors the memory tools to improve separation of responsibilities and add read capabilities.

## Changes

### 1. Split memorization tools
- **Before**: Single `memorize` tool with `level` parameter
- **After**: Two separate tools:
  - `memorizeProject` - For PROJECT-level memories (architectural decisions, core patterns, conventions)
  - `memorizeUser` - For USER-level memories (personal preferences, working patterns, communication styles)

### 2. Add read capability
- **New tool**: `readMemories(title?)`
  - Without `title`: Lists all memories with titles and levels
  - With `title`: Returns full content of specific memory
  - Output formatted in markdown

### 3. Improved descriptions
- Each tool now has specific use cases clearly documented
- Better error handling with try-catch blocks
- Clearer success/failure messages

## Available Tools

1. `readMemories(title?)` - Read memories (list or detail)
2. `memorizeProject(title, content)` - Create/update PROJECT memory
3. `memorizeUser(title, content)` - Create/update USER memory
4. `deleteMemory(title)` - Delete memory (any level)

## Benefits

- ✅ Clear separation of PROJECT vs USER responsibilities
- ✅ Better permission model (can be controlled separately)
- ✅ Read capability enables agents to check existing memories
- ✅ Improved error handling and user feedback
- ✅ More explicit tool naming

## Testing

- ✅ Compilation successful
- ✅ All existing functionality preserved
- ✅ No breaking changes to memory service