### PR TITLE
feat: #361 add clean context mode for delegate tool

### DIFF
--- a/docs/features/DELEGATE_CLEAN_CONTEXT.md
+++ b/docs/features/DELEGATE_CLEAN_CONTEXT.md
@@ -1,0 +1,186 @@
+# Delegate Clean Context Mode
+
+## Overview
+
+The delegate tool can now operate in two modes:
+1. **Default mode** (fork with history): The delegated agent sees all previous conversation history
+2. **Clean context mode**: The delegated agent starts with a completely empty thread
+
+This feature is controlled by the `CODAY_DELEGATE_CLEAN_CONTEXT` environment variable.
+
+## Motivation
+
+When delegating tasks to specialized agents, sometimes the full conversation history is not needed and can:
+- Pollute the context with irrelevant information
+- Increase token usage unnecessarily
+- Confuse the delegated agent with unrelated context
+
+Clean context mode allows for more focused, isolated task execution.
+
+## Configuration
+
+### Environment Variable
+
+Set the environment variable to enable clean context mode:
+
+```bash
+export CODAY_DELEGATE_CLEAN_CONTEXT=true
+```
+
+Or inline when starting Coday:
+
+```bash
+CODAY_DELEGATE_CLEAN_CONTEXT=true pnpm start
+```
+
+### Default Behavior
+
+If the environment variable is not set or set to any value other than `"true"`, the delegate tool will use the default behavior (fork with full history).
+
+## How It Works
+
+### Default Mode (fork with history)
+
+```
+Parent Thread: [Msg1, Msg2, Msg3, Msg4]
+                      ↓ fork()
+Delegated Thread: [Msg1, Msg2, Msg3, Msg4] + new messages
+                      ↓ merge()
+Parent Thread: [Msg1, Msg2, Msg3, Msg4] + price from delegation
+```
+
+### Clean Context Mode
+
+```
+Parent Thread: [Msg1, Msg2, Msg3, Msg4]
+                      ↓ fork(cleanContext: true)
+Delegated Thread: [] + new messages (completely isolated)
+                      ↓ merge()
+Parent Thread: [Msg1, Msg2, Msg3, Msg4] + price from delegation
+```
+
+## Implementation Details
+
+### Modified Components
+
+1. **AiThread.fork()** (`libs/ai-thread/ai-thread.ts`)
+   - Added optional `cleanContext` parameter (default: `false`)
+   - When `true`, creates thread with empty `messages` array and empty `summary`
+   - When `false`, copies all messages and summary (existing behavior)
+
+2. **delegateFunction()** (`libs/integration/ai/delegate.function.ts`)
+   - Reads `CODAY_DELEGATE_CLEAN_CONTEXT` environment variable
+   - Passes `cleanContextMode` flag to `fork()` method
+   - Logs the mode for debugging
+
+3. **DelegateTools** (`libs/integration/ai/delegate.tools.ts`)
+   - Detects clean context mode from environment variable
+   - Provides different tool descriptions based on mode
+   - In clean mode, emphasizes the need for exhaustive, self-contained task descriptions
+
+### Tool Description Changes
+
+**Default Mode:**
+```
+THREAD ISOLATION: The delegated agent works in an isolated thread with limited context. 
+It will only see previous interactions with itself, not recent messages between you and the user.
+```
+
+**Clean Context Mode:**
+```
+⚠️ CLEAN CONTEXT MODE ACTIVE: The delegated agent will start with a COMPLETELY EMPTY thread.
+It will NOT see ANY previous messages, context, or history from this conversation.
+
+YOU MUST provide an EXHAUSTIVE and SELF-CONTAINED task description including:
+- Complete background and context of the situation
+- All relevant information discussed so far in this conversation
+- Precise requirements and constraints
+- Expected deliverables and definition of done
+- Any code, data, file paths, or references needed
+- ALL actions the agent should perform
+```
+
+## Merge Behavior
+
+The `merge()` method behavior is **identical** in both modes:
+- Only the **price** from the delegated thread is transferred to the parent
+- Messages from the delegated thread are **not** added to the parent thread
+- The result is returned as the tool response and added to the parent thread via `ToolResponseEvent`
+
+This ensures that:
+- The parent thread remains clean
+- Only the final result is visible in the parent conversation
+- Token costs are properly tracked
+
+## Use Cases
+
+### When to Use Default Mode (fork with history)
+
+- The delegated task requires understanding of the full conversation context
+- The agent needs to reference previous decisions or discussions
+- Continuity with the parent conversation is important
+
+### When to Use Clean Context Mode
+
+- The task is completely independent and self-contained
+- The parent conversation history would add noise or confusion
+- You want to minimize token usage for the delegation
+- The delegated agent is a specialized tool that doesn't need broader context
+
+## Example
+
+### Scenario: Code Review Task
+
+**With Default Mode:**
+```
+User: "I've been working on authentication. Can you review the login code?"
+Agent: [delegates to code-reviewer]
+Code Reviewer: [sees full conversation, including auth discussion]
+```
+
+**With Clean Context Mode:**
+```
+User: "I've been working on authentication. Can you review the login code?"
+Agent: [delegates with explicit task]
+Task: "Review the authentication code in src/auth/login.ts. 
+       Context: This is a new OAuth2 implementation for user login.
+       Requirements: Check security best practices, error handling, and token management.
+       Files: src/auth/login.ts, src/auth/oauth.ts"
+Code Reviewer: [starts fresh with only this task description]
+```
+
+## Testing
+
+To verify the feature is working:
+
+1. Enable clean context mode:
+   ```bash
+   export CODAY_DELEGATE_CLEAN_CONTEXT=true
+   ```
+
+2. Start Coday with debug mode:
+   ```bash
+   pnpm start --debug
+   ```
+
+3. Trigger a delegation and look for debug messages:
+   ```
+   Delegate clean context mode: true
+   ```
+
+4. The delegated agent should not have access to any previous conversation messages.
+
+## Backward Compatibility
+
+- The feature is **fully backward compatible**
+- Default behavior (fork with history) is unchanged
+- Existing configurations and workflows continue to work
+- The environment variable is optional
+
+## Future Enhancements
+
+Potential improvements to consider:
+- Per-agent configuration (some agents always use clean context)
+- Dynamic mode selection based on task complexity analysis
+- Metrics on context size reduction and token savings
+- User-facing configuration option in project settings

--- a/libs/ai-thread/ai-thread.ts
+++ b/libs/ai-thread/ai-thread.ts
@@ -420,9 +420,10 @@ export class AiThread {
   /**
    * Fork a thread, optionally for a specific agent
    * @param agentName Optional name of the agent to delegate to
+   * @param cleanContext If true, create an empty thread without parent messages (default: false)
    * @returns Forked AiThread instance
    */
-  fork(agentName?: string | null): AiThread {
+  fork(agentName?: string | null, cleanContext: boolean = false): AiThread {
     // Check if a forked thread for this agent already exists
     const existingForkedThread = this.forkedThreads.get(agentName ?? null)
     if (existingForkedThread) {
@@ -436,11 +437,11 @@ export class AiThread {
       username: this.username,
       projectId: this.projectId,
       name: agentName ? `${this.name} - Delegated to ${agentName}` : `${this.name} - Forked`,
-      summary: this.summary,
+      summary: cleanContext ? '' : this.summary, // Empty summary in clean context mode
       createdDate: this.createdDate,
       modifiedDate: new Date().toISOString(),
       price: 0,
-      messages: [...this.messages], // Create a new array reference
+      messages: cleanContext ? [] : [...this.messages], // Empty messages in clean context mode
     })
 
     // Increment delegation depth (non-serializable)

--- a/libs/integration/ai/delegate.function.ts
+++ b/libs/integration/ai/delegate.function.ts
@@ -25,7 +25,11 @@ export function delegateFunction(input: DelegateInput) {
         return `Agent ${agentName} not found.`
       }
 
-      const forkedThread: AiThread = context.aiThread!.fork(agentName ? agent.name : undefined)
+      // Check if clean context mode is enabled via environment variable
+      const cleanContextMode = process.env.CODAY_DELEGATE_CLEAN_CONTEXT === 'true'
+      interactor.debug(`Delegate clean context mode: ${cleanContextMode}`)
+
+      const forkedThread: AiThread = context.aiThread!.fork(agentName ? agent.name : undefined, cleanContextMode)
       const formattedTask: string = `You were delegated a task to try to complete the best you can.
 The parent conversation (all previous messages) is there for context, but your current focus should be on this precise task:
 

--- a/libs/integration/ai/delegate.tools.ts
+++ b/libs/integration/ai/delegate.tools.ts
@@ -45,6 +45,9 @@ export class DelegateTools extends AssistantToolFactory {
     // Build the tool description only with allowed agents
     const agentListText = agentSummaries.map((a) => `  - ${a.name} : ${a.description}`).join('\n')
 
+    // Check if clean context mode is enabled
+    const cleanContextMode = process.env.CODAY_DELEGATE_CLEAN_CONTEXT === 'true'
+
     // Wrap delegate function to enforce allow-list at call time
     const delegate = delegateFunction({
       context,
@@ -68,7 +71,26 @@ export class DelegateTools extends AssistantToolFactory {
       type: 'function',
       function: {
         name: 'delegate',
-        description: `Delegate the completion of a task to another available agent among:
+        description: cleanContextMode
+          ? `Delegate the completion of a task to another available agent among:
+${agentListText || '(No allowed agents for delegation)'}
+
+⚠️ CLEAN CONTEXT MODE ACTIVE: The delegated agent will start with a COMPLETELY EMPTY thread.
+It will NOT see ANY previous messages, context, or history from this conversation.
+
+YOU MUST provide an EXHAUSTIVE and SELF-CONTAINED task description including:
+- Complete background and context of the situation
+- All relevant information discussed so far in this conversation
+- Precise requirements and constraints
+- Expected deliverables and definition of done
+- Any code, data, file paths, or references needed
+- ALL actions the agent should perform (git operations, file management, etc.)
+
+IMPORTANT: This is a full delegation - the selected agent will have access to its own set of tools and capabilities to complete the entire task. The agent should perform ALL actions required.
+
+These agents are LLM-based, so you should assess in return if the task was correctly executed, and call again the agent if not sufficient or need to adapt. Agents can be called again and will maintain their own isolated context across calls.
+`
+          : `Delegate the completion of a task to another available agent among:
 ${agentListText || '(No allowed agents for delegation)'}
 
 IMPORTANT: This is a full delegation - the selected agent will have access to its own set of tools and capabilities to complete the entire task. Do not split the task between yourself and the delegated agent. The agent should perform ALL actions required, including using any tools it has access to (git operations, file management, etc.).


### PR DESCRIPTION
## Description

Implements issue #361 by adding a clean context mode for the delegate tool.

## Changes

### Core Implementation
- **AiThread.fork()**: Added optional `cleanContext` parameter (default: `false`)
  - When `true`: creates empty thread (no messages, no summary)
  - When `false`: existing behavior (copies all messages and summary)

- **delegateFunction()**: Reads `CODAY_DELEGATE_CLEAN_CONTEXT` environment variable
  - Passes flag to `fork()` method
  - Adds debug logging for mode detection

- **DelegateTools**: Adapts tool description based on mode
  - Clean mode: emphasizes need for exhaustive, self-contained task descriptions
  - Default mode: existing description about thread isolation

### Behavior

**Default Mode (env var not set or false):**
- Delegated agent sees full conversation history (fork behavior)
- Instructions mention thread isolation and limited context

**Clean Context Mode (env var = "true"):**
- Delegated agent starts with completely empty thread
- Instructions warn about empty context and require exhaustive descriptions
- Agent must include ALL context in task description

**Merge Behavior (unchanged):**
- Only price is transferred from delegated thread to parent
- Messages remain isolated (result returned via ToolResponseEvent)

## Environment Variable

```bash
# Enable clean context mode
export CODAY_DELEGATE_CLEAN_CONTEXT=true

# Or inline
CODAY_DELEGATE_CLEAN_CONTEXT=true pnpm start
```

## Documentation

Complete documentation added in `docs/features/DELEGATE_CLEAN_CONTEXT.md` including:
- Overview and motivation
- Configuration instructions
- Implementation details
- Use cases and examples
- Testing instructions

## Backward Compatibility

✅ Fully backward compatible
- Default behavior unchanged (fork with history)
- Environment variable is optional
- Existing workflows continue to work

## Testing

- ✅ Compilation successful
- ✅ Linter passed
- ✅ No breaking changes

## Related Issue

Closes #361