### PR TITLE
fix: #372 MCP process cleanup with manual kill fallback

### DIFF
--- a/apps/server/src/thread-coday-manager.ts
+++ b/apps/server/src/thread-coday-manager.ts
@@ -322,9 +322,13 @@ class ThreadCodayInstance {
     }
     this.connections.clear()
 
-    // Kill Coday instance
+    // Kill Coday instance (this will trigger cleanup of agents and MCP servers)
     if (this.coday) {
-      await this.coday.kill()
+      try {
+        await this.coday.kill()
+      } catch (error) {
+        debugLog('THREAD_CODAY', `Error during Coday kill:`, error)
+      }
       this.coday = undefined
     }
   }


### PR DESCRIPTION
## Problem

Node processes accumulating overnight when MCP servers (especially Playwright) are used. Root cause: MCP SDK's `StdioClientTransport.close()` only calls `abortController.abort()` which doesn't reliably kill spawned child processes.

## Solution

Added manual process kill fallback in `McpToolsFactory`:

1. **Store references**: Transport and process PID for manual cleanup
2. **Cleanup on error**: New `cleanupOnError()` method for connection failures  
3. **Enhanced kill()**: 
   - Kill inspector process (SIGTERM → SIGKILL)
   - Close transport explicitly
   - Manual fallback: Kill process by PID with SIGTERM → SIGKILL
   - Proper ESRCH error handling (process doesn't exist = OK)

## Changes

- `libs/integration/mcp/mcp-tools-factory.ts` - Main fixes
- `apps/server/src/thread-coday-manager.ts` - Error handling

## Testing

✅ Compilation successful

**Next step**: Overnight test to verify no process accumulation

## Closes

#372