### PR TITLE
fix: #404 ensure Coday agent is always available in fly projects

### DIFF
--- a/libs/agent/agent.service.ts
+++ b/libs/agent/agent.service.ts
@@ -99,17 +99,19 @@ export class AgentService implements Killable {
       const filesTime = performance.now() - filesStart
       this.interactor.debug(`📁 Loaded agent definitions from files: ${filesTime.toFixed(2)}ms`)
 
-      // Generate virtual agents from available models
-      const virtualStart = performance.now()
-      this.generateVirtualAgentsFromModels()
-      const virtualTime = performance.now() - virtualStart
-      this.interactor.debug(`🤖 Generated virtual agents from models: ${virtualTime.toFixed(2)}ms`)
-
       // If no agent definitions were loaded, use Coday as backup
+      // This must be done BEFORE generating virtual agents to ensure Coday is always available
       if (this.agentDefinitions.length === 0) {
         this.addDefinition(CodayAgentDefinition, this.projectPath)
         this.interactor.debug('🔄 No agent definitions found, using Coday as backup')
       }
+
+      // Generate virtual agents from available models
+      // This is done AFTER the backup check to ensure Coday is always present
+      const virtualStart = performance.now()
+      this.generateVirtualAgentsFromModels()
+      const virtualTime = performance.now() - virtualStart
+      this.interactor.debug(`🤖 Generated virtual agents from models: ${virtualTime.toFixed(2)}ms`)
     } catch (error: unknown) {
       this.interactor.error(`Failed to initialize agent definitions: ${error}`)
       throw error


### PR DESCRIPTION
## Problem

Issue #404: The default `Coday` agent was not available when initializing fly projects (projects without `coday.yaml`), blocking user onboarding.

**Root cause**: The backup check `if (agentDefinitions.length === 0)` was executed **after** virtual agents were generated from API keys, making it always false.

## Solution

Simple reordering fix: Execute the Coday backup check **before** generating virtual agents.

**Before** (buggy):
1. Load agents from coday.yml
2. Load agents from project config
3. Load agents from files
4. Generate virtual agents ← Creates definitions
5. Backup check: if empty, add Coday ← Never executes

**After** (fixed):
1. Load agents from coday.yml
2. Load agents from project config
3. Load agents from files
4. Backup check: if empty, add Coday ← Executes before virtuals
5. Generate virtual agents ← Adds virtuals after

## Changes

- **File**: `libs/agent/agent.service.ts`
- **Lines**: ~20 (reordering + explanatory comments)
- **Impact**: Minimal, respects original intent

## Testing

✅ Tested on fly project without coday.yaml
✅ Coday agent now available alongside virtual agents
✅ No regression on projects with explicit configuration

## Closes

Closes #404 
Relates to #408 