### PR TITLE
chore: rename github mcp integration

### DIFF
--- a/agents/Archay.yaml
+++ b/agents/Archay.yaml
@@ -7,7 +7,7 @@ integrations:
   AI:
   MEMORY:
   FETCH:
-  GIT-PLATFORM:
+  GITHUB:
   GIT:
   PROJECT_SCRIPTS:
   DELEGATE:

--- a/agents/Octopuss.yaml
+++ b/agents/Octopuss.yaml
@@ -7,7 +7,7 @@ integrations:
   FILES:
   AI:
   MEMORY:
-  GIT-PLATFORM:
+  GITHUB:
 instructions: |
   You are Octopuss, a specialized GitHub integration agent who serves as the project's connection to the GitHub ecosystem. Your purpose is to handle the complexity of GitHub operations so other agents can focus on their domains without being overwhelmed by GitHub's extensive toolset. You combine technical proficiency with collaborative sensibility, understanding that GitHub is both a technical platform and a social environment for software development.
 

--- a/agents/Sway.yaml
+++ b/agents/Sway.yaml
@@ -8,7 +8,7 @@ integrations:
   FETCH:
   AI:
   MEMORY:
-  GIT-PLATFORM:
+  GITHUB:
   GIT:
   PROJECT_SCRIPTS:
   PLAYWRIGHT:

--- a/coday.yaml
+++ b/coday.yaml
@@ -284,7 +284,7 @@ agents:
       - ./product/04-guidelines.md
       - ./docs/to-rework/INTEGRATIONS.md
     integrations:
-      GIT-PLATFORM:
+      GITHUB:
       FETCH:
       FILES:
       AI:
@@ -301,7 +301,7 @@ mcp:
       command: uvx
       debug: false
     - id: github
-      name: GIT-PLATFORM
+      name: GITHUB
       enabled: true
       command: docker
       whiteListedHostEnvVarNames:
@@ -313,7 +313,7 @@ mcp:
         - -e
         - GITHUB_PERSONAL_ACCESS_TOKEN
         - ghcr.io/github/github-mcp-server
-    # IMPORTANT, add through mcp config of GIT-PLATFORM at user level the env variable holding your access token, and the command
+    # IMPORTANT, add through mcp config of GITHUB at user level the env variable holding your access token, and the command
     #    env:
     #      GITHUB_PERSONAL_ACCESS_TOKEN: your_github_access_token
     #    command: /path/to/docker

--- a/docs/04-configuration/mcp-integrations.md
+++ b/docs/04-configuration/mcp-integrations.md
@@ -116,7 +116,7 @@ Allows agents to fetch web content for research.
 
 ```yaml
 - id: github
-  name: GIT-PLATFORM
+  name: GITHUB
   command: docker
   args:
     - run

--- a/docs/05-working-effectively/agent-tooling.md
+++ b/docs/05-working-effectively/agent-tooling.md
@@ -83,7 +83,7 @@ mcp:
       args: [mcp-server-fetch, --ignore-robots-txt]
       
     - id: github
-      name: GIT-PLATFORM
+      name: GITHUB
       command: docker
       args:
         - run
@@ -164,7 +164,7 @@ agents:
       FETCH:           # Web content retrieval
       AI:              # Delegate to other agents
       MEMORY:          # Memory management
-      GIT-PLATFORM:    # GitHub integration (~15 tools)
+      GITHUB:    # GitHub integration (~15 tools)
       GIT:             # Git operations
       PROJECT_SCRIPTS: # All project scripts
       PLAYWRIGHT:      # Browser automation (~30 tools)

--- a/libs/service/mcp-config-merger.spec.ts
+++ b/libs/service/mcp-config-merger.spec.ts
@@ -30,7 +30,7 @@ describe('McpConfigMerger', () => {
       const codayServers: McpServerConfig[] = [
         {
           id: 'github',
-          name: 'GIT-PLATFORM',
+          name: 'GITHUB',
           enabled: true,
           args: ['run', '-i', '--rm', '-e', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'ghcr.io/github/github-mcp-server'],
           debug: false,
@@ -40,7 +40,7 @@ describe('McpConfigMerger', () => {
       const projectServers: McpServerConfig[] = [
         {
           id: 'github',
-          name: 'GIT-PLATFORM',
+          name: 'GITHUB',
           command: '/usr/local/bin/docker',
           args: ['--network=host'],
           env: { GITHUB_PERSONAL_ACCESS_TOKEN: 'project-token' },
@@ -52,7 +52,7 @@ describe('McpConfigMerger', () => {
       const userServers: McpServerConfig[] = [
         {
           id: 'github',
-          name: 'GIT-PLATFORM',
+          name: 'GITHUB',
           command: '/path/to/user/docker',
           env: { GITHUB_PERSONAL_ACCESS_TOKEN: 'user-secret-token' },
           enabled: false,
@@ -67,7 +67,7 @@ describe('McpConfigMerger', () => {
 
       // Basic properties: later levels win
       expect(mergedServer.id).toBe('github')
-      expect(mergedServer.name).toBe('GIT-PLATFORM')
+      expect(mergedServer.name).toBe('GITHUB')
       expect(mergedServer.command).toBe('/path/to/user/docker') // USER level wins
 
       // Args: aggregated from all levels in order
@@ -378,7 +378,7 @@ describe('McpConfigMerger', () => {
       const codayServers: McpServerConfig[] = [
         {
           id: 'github',
-          name: 'GIT-PLATFORM',
+          name: 'GITHUB',
           command: 'docker',
           enabled: true,
           whiteListedHostEnvVarNames: ['GITHUB_PERSONAL_ACCESS_TOKEN'],
@@ -409,7 +409,7 @@ describe('McpConfigMerger', () => {
       const codayServers: McpServerConfig[] = [
         {
           id: 'github',
-          name: 'GIT-PLATFORM',
+          name: 'GITHUB',
           command: 'docker',
           enabled: true,
           whiteListedHostEnvVarNames: ['GITHUB_PERSONAL_ACCESS_TOKEN'],
@@ -442,7 +442,7 @@ describe('McpConfigMerger', () => {
       const codayServers: McpServerConfig[] = [
         {
           id: 'github',
-          name: 'GIT-PLATFORM',
+          name: 'GITHUB',
           command: 'docker',
           enabled: true,
           args: ['-e', 'GITHUB_PERSONAL_ACCESS_TOKEN'],
@@ -453,7 +453,7 @@ describe('McpConfigMerger', () => {
       const projectServers: McpServerConfig[] = [
         {
           id: 'github',
-          name: 'GIT-PLATFORM',
+          name: 'GITHUB',
           env: {
             OTHER_VAR: 'other-value',
           },


### PR DESCRIPTION
Target directly GITHUB instead of trying an indirection models do not always understand.