### PR TITLE
#441 fix: deep link navigation to project URLs

### DIFF
--- a/apps/client/src/app/core/guards/project-state.guard.ts
+++ b/apps/client/src/app/core/guards/project-state.guard.ts
@@ -1,6 +1,6 @@
 import { inject } from '@angular/core'
 import { ActivatedRouteSnapshot, CanActivateFn } from '@angular/router'
-import { lastValueFrom, take } from 'rxjs'
+import { first, firstValueFrom } from 'rxjs'
 import { ProjectStateService } from '../services/project-state.service'
 
 /**
@@ -35,11 +35,6 @@ export const projectStateGuard: CanActivateFn = async (route: ActivatedRouteSnap
   }
 
   projectState.selectProject(projectName)
-  const currentProject = await lastValueFrom(projectState.selectedProject$.pipe(take(1)))
-  const validity = currentProject?.name === projectName
-
-  if (!validity) {
-    console.log('[PROJECT GUARD] current project not matching the route')
-  }
-  return validity
+  const currentProject = await firstValueFrom(projectState.selectedProject$.pipe(first((p) => p?.name === projectName)))
+  return currentProject?.name === projectName
 }


### PR DESCRIPTION
Fixes #441

## Problem
Direct navigation to project URLs like \`/project/sprint\` resulted in a blank page because the route guard was taking the first cached value from \`selectedProject$\` instead of waiting for the correct project to load.

## Solution
Changed \`projectStateGuard\` to use RxJS \`first()\` operator with a predicate that waits for the specific project matching the route parameter.

### Changed
\`apps/client/src/app/core/guards/project-state.guard.ts\`

\`\`\`typescript
// Before:
const currentProject = await lastValueFrom(projectState.selectedProject$.pipe(take(1)))

// After:
const currentProject = await firstValueFrom(projectState.selectedProject$.pipe(first((p) => p?.name === projectName)))
\`\`\`

This ensures the guard waits until \`selectedProject$\` emits the project that matches the route parameter, rather than accepting whatever is currently cached.

## Testing
- Direct navigation to \`/project/:projectName\` now works correctly
- All existing tests pass
- Navigation from root still works as expected" \
  --base master