### PR TITLE
#450 feat: add clipboard paste support for all file types

### DIFF
--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -44,6 +44,7 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
   isStopping: boolean = false
   // Local flag to immediately disable textarea when message is sent
   isLocallyDisabled: boolean = false
+  @Output() filesPasted = new EventEmitter<File[]>()
   @Output() messageSubmitted = new EventEmitter<string>()
   @Output() voiceRecordingToggled = new EventEmitter<boolean>()
   @Output() heightChanged = new EventEmitter<number>()
@@ -253,6 +254,30 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
 
     // Check for autocomplete triggers
     this.checkForAutocomplete()
+  }
+
+  @HostListener('paste', ['$event'])
+  onPaste(event: ClipboardEvent): void {
+    const items = event.clipboardData?.items
+    if (!items) {
+      return
+    }
+
+    const fileItems = Array.from(items).filter((item) => item.kind === 'file')
+    if (!fileItems.length) {
+      return
+    }
+
+    event.preventDefault()
+
+    const files = fileItems.reduce<File[]>((acc, item) => {
+      const file = item.getAsFile()
+      return file ? [...acc, file] : acc
+    }, [])
+
+    if (files.length) {
+      this.filesPasted.emit(files)
+    }
   }
 
   /**

--- a/apps/client/src/app/components/thread/thread.component.html
+++ b/apps/client/src/app/components/thread/thread.component.html
@@ -71,7 +71,8 @@
                   (voiceRecordingToggled)="onVoiceToggled($event)"
                   (heightChanged)="onInputHeightChanged($event)"
                   (stopRequested)="onStopRequested()"
-                ></app-chat-textarea>
+                  (filesPasted)="onFilesPasted($event)"
+                />
               }
 
               <!-- Choice Select - Overlay on top of input-section -->

--- a/apps/client/src/app/components/thread/thread.component.ts
+++ b/apps/client/src/app/components/thread/thread.component.ts
@@ -305,6 +305,23 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
     this.inputSectionHeight = height
   }
 
+  onFilesPasted(files: File[]): void {
+    console.log('[THREAD] File(s) pasted:', files.length)
+
+    const imageFiles = this.imageUploadService.filterImageFiles(files)
+    const otherFiles = files.filter((f) => !f.type.startsWith('image/'))
+
+    if (imageFiles.length) {
+      this.uploadFilesSequentially(imageFiles, 0)
+    }
+    if (otherFiles.length) {
+      void this.uploadFilesToExchangeSpace(otherFiles)
+    }
+    if (!imageFiles.length && !otherFiles.length) {
+      this.showUploadError('No supported files found')
+    }
+  }
+
   // File drawer methods
   toggleFileDrawer(): void {
     console.log('[THREAD] Toggling file drawer')


### PR DESCRIPTION
## Implementation
- Added paste handler in ChatTextareaComponent (~15 lines)
- Added file routing in ThreadComponent (~10 lines)
- Reuses 100% existing upload infrastructure
- Zero backend changes

## Testing
✅ Images, PDFs, multiple files
✅ Coexists with drag-and-drop
✅ Chrome, Firefox, Safari

## Files Changed
- `apps/client/src/app/components/chat-textarea/chat-textarea.component.ts`
- `apps/client/src/app/components/thread/thread.component.ts`
- `apps/client/src/app/components/thread/thread.component.html`