### PR TITLE
feat: #485 multi agent role and tool tagging

### DIFF
--- a/libs/handler/src/lib/anthropic.client.ts
+++ b/libs/handler/src/lib/anthropic.client.ts
@@ -576,7 +576,8 @@ export class AnthropicClient extends AiClient {
     subscriber: Subject<CodayEvent>,
     forceUpdateCache: boolean = false
   ): Promise<{ data: Anthropic.Messages.Message; response: Response | undefined }> {
-    const data = await this.getMessages(thread, charBudget, model.name)
+    const allowedToolNames = new Set(agent.tools.getTools().map((t) => t.function.name))
+    const data = await this.getMessages(thread, charBudget, model.name, agent.name, allowedToolNames)
     const messages = this.toClaudeMessage(data.messages, thread, forceUpdateCache)
 
     // Use the streaming helper from the SDK

--- a/libs/handler/src/lib/openai.client.ts
+++ b/libs/handler/src/lib/openai.client.ts
@@ -145,7 +145,8 @@ export class OpenaiClient extends AiClient {
 
     const charBudget =
       model.contextWindow * this.charsPerToken - agent.systemInstructions.length - agent.tools.charLength
-    const data = await this.getMessages(thread, charBudget, model.name)
+    const allowedToolNames = new Set(agent.tools.getTools().map((t) => t.function.name))
+    const data = await this.getMessages(thread, charBudget, model.name, agent.name, allowedToolNames)
     if (data.compacted) {
       // then need to reset the assistant thread as all the beginning is compacted
       thread.data.openai.assistantThreadData = {}
@@ -211,7 +212,8 @@ export class OpenaiClient extends AiClient {
       const initialContextCharLength = agent.systemInstructions.length + agent.tools.charLength + 20
       const charBudget = model.contextWindow * this.charsPerToken - initialContextCharLength
 
-      const data = await this.getMessages(thread, charBudget, model.name)
+      const allowedToolNames = new Set(agent.tools.getTools().map((t) => t.function.name))
+      const data = await this.getMessages(thread, charBudget, model.name, agent.name, allowedToolNames)
 
       // Try streaming first, with fallback to non-streaming
       let response: OpenAI.Chat.Completions.ChatCompletion


### PR DESCRIPTION
Move to better consistency when switching agents in same conversation with:
- automatic other agent message conversion into user message with `<agent=name>` tags
- filtering of tools the agent has no access to (to avoid "believing" it can use them)