### PR TITLE
feat: display send timestamp on user messages in chat

### DIFF
--- a/apps/client/src/app/components/chat-message/chat-message.component.html
+++ b/apps/client/src/app/components/chat-message/chat-message.component.html
@@ -14,6 +14,11 @@
       <!-- Content -->
       <div class="content markdown-content" [innerHTML]="renderedContent"></div>
 
+      <!-- Timestamp for user messages (inside bubble, bottom-right) -->
+      @if (formattedTimestamp) {
+        <time class="message-timestamp">{{ formattedTimestamp }}</time>
+      }
+
       <!-- Context menu for assistant messages (inside bubble) when long message -->
       @if (isLongMessage && shouldShowActions && message.role === 'assistant') {
         <div class="actions bottom-actions">

--- a/apps/client/src/app/components/chat-message/chat-message.component.scss
+++ b/apps/client/src/app/components/chat-message/chat-message.component.scss
@@ -15,7 +15,18 @@
   position: relative;
 
   &.user {
-    padding: 1rem 1.25rem;
+    padding: 1rem 1.25rem 0.5rem 1.25rem;
+
+    .message-timestamp {
+      display: block;
+      text-align: right;
+      font-size: 0.7rem;
+      color: var(--color-text-secondary, #6272a4);
+      white-space: nowrap;
+      margin-top: 0.4rem;
+      opacity: 0.7;
+    }
+
     background: var(--color-message-user);
     border-radius: 18px;
     border-bottom-right-radius: 6px;

--- a/apps/client/src/app/components/chat-message/chat-message.component.ts
+++ b/apps/client/src/app/components/chat-message/chat-message.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, inject } fro
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
 import { MessageContent } from '@coday/model'
 import { MessageContextMenuComponent, MenuAction } from '../message-context-menu/message-context-menu.component'
-import { NgClass } from '@angular/common'
+import { DatePipe, NgClass } from '@angular/common'
 import { NotificationService } from '../../services/notification.service'
 import { PreferencesService } from '../../services/preferences.service'
 import { ProjectStateService } from '../../core/services/project-state.service'
@@ -27,6 +27,7 @@ export interface ChatMessage {
   selector: 'app-chat-message',
   standalone: true,
   imports: [MessageContextMenuComponent, NgClass],
+  providers: [DatePipe],
   templateUrl: './chat-message.component.html',
   styleUrl: './chat-message.component.scss',
 })
@@ -99,6 +100,14 @@ export class ChatMessageComponent implements OnInit, OnDestroy {
   get isSimplified(): boolean {
     // Simplified messages for everything except user/assistant
     return this.message.role !== 'user' && this.message.role !== 'assistant'
+  }
+
+  private readonly datePipe = inject(DatePipe)
+
+  get formattedTimestamp(): string | null {
+    if (this.message.role !== 'user' || !this.message.timestamp) return null
+    const isToday = new Date().toDateString() === this.message.timestamp.toDateString()
+    return this.datePipe.transform(this.message.timestamp, isToday ? 'HH:mm' : 'dd/MM HH:mm')
   }
 
   get isLongMessage(): boolean {

--- a/apps/client/src/app/core/services/coday.service.ts
+++ b/apps/client/src/app/core/services/coday.service.ts
@@ -330,7 +330,7 @@ export class CodayService implements OnDestroy {
       role: event.role,
       speaker: event.name,
       content: event.content,
-      timestamp: new Date(),
+      timestamp: event.date,
       type: 'text',
     }
 
@@ -349,7 +349,7 @@ export class CodayService implements OnDestroy {
       role: event.speaker ? 'assistant' : 'system',
       speaker: event.speaker ?? 'System',
       content: [{ type: 'text', content: event.text }], // Convertir en contenu riche
-      timestamp: new Date(),
+      timestamp: event.date,
       type: event.speaker ? 'text' : 'technical',
     }
 
@@ -363,7 +363,7 @@ export class CodayService implements OnDestroy {
       role: 'user',
       speaker: 'User',
       content: [{ type: 'text', content: event.answer }],
-      timestamp: new Date(),
+      timestamp: event.date,
       type: 'text',
       parentKey: event.parentKey, // Link to the InviteEvent/ChoiceEvent
       invite: event.invite, // Original question for context
@@ -378,7 +378,7 @@ export class CodayService implements OnDestroy {
       role: 'system',
       speaker: 'System',
       content: [{ type: 'text', content: `Error: ${JSON.stringify(event.error)}` }], // Convertir en contenu riche
-      timestamp: new Date(),
+      timestamp: event.date,
       type: 'error',
     }
 
@@ -391,7 +391,7 @@ export class CodayService implements OnDestroy {
       role: 'system',
       speaker: 'System',
       content: [{ type: 'text', content: `Warning: ${JSON.stringify(event.warning)}` }], // Convertir en contenu riche
-      timestamp: new Date(),
+      timestamp: event.date,
       type: 'warning',
     }
 
@@ -430,7 +430,7 @@ export class CodayService implements OnDestroy {
       role: 'system',
       speaker: 'System',
       content: [{ type: 'text', content: event.toSingleLineString() }], // Convertir en contenu riche
-      timestamp: new Date(),
+      timestamp: event.date,
       type: 'technical',
       eventId: event.timestamp,
     }
@@ -444,7 +444,7 @@ export class CodayService implements OnDestroy {
       role: 'system',
       speaker: 'System',
       content: [{ type: 'text', content: event.toSingleLineString() }], // Convertir en contenu riche
-      timestamp: new Date(),
+      timestamp: event.date,
       type: 'technical',
       eventId: event.timestamp,
     }
@@ -497,7 +497,7 @@ export class CodayService implements OnDestroy {
         role: 'assistant',
         speaker: 'Assistant',
         content: [{ type: 'text', content: event.invite }],
-        timestamp: new Date(),
+        timestamp: event.date,
         type: 'text',
       }
 

--- a/libs/model/src/lib/coday-events.ts
+++ b/libs/model/src/lib/coday-events.ts
@@ -62,6 +62,22 @@ export abstract class CodayEvent {
     this.parentKey = event.parentKey
     this.length = 0
   }
+
+  /**
+   * Parse the timestamp string to a Date.
+   * Timestamps may carry a random 5-char alphanumeric suffix to avoid collisions
+   * (e.g. "2026-02-09T16:57:20.839Z-x81ku"). The suffix is stripped before parsing.
+   */
+  get date(): Date {
+    const lastDash = this.timestamp.lastIndexOf('-')
+    if (lastDash > 0) {
+      const suffix = this.timestamp.substring(lastDash + 1)
+      if (suffix.length === 5 && /^[a-z0-9]+$/.test(suffix)) {
+        return new Date(this.timestamp.substring(0, lastDash))
+      }
+    }
+    return new Date(this.timestamp)
+  }
 }
 
 export abstract class QuestionEvent extends CodayEvent {


### PR DESCRIPTION
## What

Display the send timestamp on user messages in the chat interface.

## Changes

### `libs/model/src/lib/coday-events.ts`
- Added `date` getter on `CodayEvent` base class that correctly parses the timestamp string, stripping the random 5-char suffix (e.g. `2026-02-09T16:57:20.839Z-x81ku`) before constructing the `Date` object. Single source of truth for timestamp parsing.

### `apps/client/src/app/core/services/coday.service.ts`
- Replaced all `new Date()` (reception time) and `new Date(event.timestamp)` (invalid due to suffix) with `event.date` across all event handlers. Messages now carry the actual event timestamp rather than the client reception time.

### `apps/client/src/app/components/chat-message/`
- Added `DatePipe` in component `providers`
- Added `formattedTimestamp` getter: returns `null` for non-user messages, `HH:mm` for today's messages, `dd/MM HH:mm` for older ones
- Rendered as a `<time>` element inside the user bubble, right-aligned below the message content
