### PR TITLE
fix: project-level AI config ignored when no user-level config defined

### DIFF
--- a/apps/server/src/lib/agent.routes.ts
+++ b/apps/server/src/lib/agent.routes.ts
@@ -98,12 +98,7 @@ export function registerAgentRoutes(
 
       projectState.selectProject(<string>projectName)
 
-      const aiClientProvider = new AiClientProvider(
-        interactor,
-        user,
-        projectState.selectedProject?.config?.ai || [],
-        logger
-      )
+      const aiClientProvider = new AiClientProvider(interactor, user, projectState, logger)
       const agentService = new AgentService(
         interactor,
         aiClientProvider,

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -58,7 +58,7 @@ export class Coday {
     this.aiClientProvider = new AiClientProvider(
       this.interactor,
       this.services.user,
-      this.services.project.selectedProject?.config?.ai || [],
+      this.services.project,
       this.services.logger
     )
   }

--- a/libs/integrations/ai/src/lib/ai-client-provider.test.ts
+++ b/libs/integrations/ai/src/lib/ai-client-provider.test.ts
@@ -1,5 +1,5 @@
 import { AiClientProvider } from './ai-client-provider'
-import { UserService } from '@coday/service'
+import { UserService, ProjectStateService } from '@coday/service'
 import { CodayLogger } from '@coday/model'
 import { Interactor } from '@coday/model'
 import { CommandContext } from '@coday/model'
@@ -8,6 +8,7 @@ describe('AiClientProvider - Auto-detection', () => {
   let provider: AiClientProvider
   let mockInteractor: jest.Mocked<Interactor>
   let mockUserService: jest.Mocked<UserService>
+  let mockProjectStateService: jest.Mocked<ProjectStateService>
   let mockLogger: jest.Mocked<CodayLogger>
   let originalEnv: NodeJS.ProcessEnv
 
@@ -26,11 +27,13 @@ describe('AiClientProvider - Auto-detection', () => {
       config: { ai: [] },
     } as any
 
+    mockProjectStateService = {
+      selectedProject: null,
+    } as any
+
     mockLogger = {} as any
 
-    // AiClientProvider constructor expects: (interactor, userService, projectsAiProviderConfigs[], logger)
-    // projectsAiProviderConfigs is an array of AiProviderConfig, not ProjectStateService
-    provider = new AiClientProvider(mockInteractor, mockUserService, [], mockLogger)
+    provider = new AiClientProvider(mockInteractor, mockUserService, mockProjectStateService, mockLogger)
   })
 
   afterEach(() => {

--- a/libs/integrations/ai/src/lib/ai-client-provider.ts
+++ b/libs/integrations/ai/src/lib/ai-client-provider.ts
@@ -1,6 +1,7 @@
 import { OpenaiClient } from '@coday/handler'
 import { AnthropicClient } from '@coday/handler'
 import { UserService } from '@coday/service'
+import { ProjectStateService } from '@coday/service'
 import { GoogleClient } from '@coday/handler'
 import { CodayLogger } from '@coday/model'
 import { AiClient } from '@coday/model'
@@ -37,7 +38,7 @@ export class AiClientProvider {
   constructor(
     private readonly interactor: Interactor,
     private readonly userService: UserService,
-    private readonly projectsAiProviderConfigs: AiProviderConfig[],
+    private readonly projectStateService: ProjectStateService,
     private readonly logger: CodayLogger
   ) {}
 
@@ -45,7 +46,7 @@ export class AiClientProvider {
     if (this.aiProviderConfigs) return
     // get the ai def and models from coday.yaml
     const aiCodayYaml = context.project.ai || []
-    const projectYaml = this.projectsAiProviderConfigs || []
+    const projectYaml = this.projectStateService.selectedProject?.config?.ai || []
     const userYaml = this.userService.config.ai || []
 
     // Auto-detect providers from environment variables


### PR DESCRIPTION
## Problem

`AiClientProvider` was receiving project-level AI configs as a static `AiProviderConfig[]` array captured at construction time.

In `core.ts`, the `AiClientProvider` instance is created in the `Coday` constructor — **before** `initContext()` is called, and therefore before `selectProject()` runs. This meant `projectsAiProviderConfigs` was always `[]` at construction time.

Combined with the `if (this.aiProviderConfigs) return` guard in `init()`, the project-level AI configuration was **silently ignored** unless the user also had a matching provider entry in their user config.

## Fix

Replace the static `AiProviderConfig[]` constructor parameter with a `ProjectStateService` reference, and read `selectedProject?.config?.ai` dynamically inside `init()` — consistent with how `userService.config.ai` was already being read at call time.

## Changes

- `AiClientProvider`: constructor now takes `ProjectStateService` instead of `AiProviderConfig[]`; reads project config dynamically in `init()`
- `core.ts`: passes `this.services.project` instead of the static array
- `agent.routes.ts`: same update for the temporary provider used in agent listing
- `ai-client-provider.test.ts`: updated mock to use `ProjectStateService`