### PR TITLE
feat: #583 restrict worktree mutating commands in generic git tool

### DIFF
--- a/libs/integrations/git/src/lib/git.tools.ts
+++ b/libs/integrations/git/src/lib/git.tools.ts
@@ -38,7 +38,7 @@ export class GitTools extends AssistantToolFactory {
       function: {
         name: `${this.name}__git`,
         description:
-          'Run git command and parameters. Note: worktree mutating subcommands (add, move, remove, prune) are blocked — use the dedicated worktree tools instead.',
+          'Run git command and parameters. Note: worktree subcommands are blocked except "list" — use the dedicated worktree tools instead.',
         parameters: {
           type: 'object',
           properties: {

--- a/libs/integrations/git/src/lib/git.ts
+++ b/libs/integrations/git/src/lib/git.ts
@@ -4,10 +4,10 @@ import { runBash } from '@coday/function'
 const dangerKeywords = ['push', 'push -f', 'push --force', 'push --tags', 'reset', '&&', 'clean']
 
 /**
- * Worktree mutating subcommands are blocked: use the dedicated GIT_WORKTREE tools instead.
- * Read-only worktree commands (list, lock, unlock, repair) are still allowed.
+ * All worktree subcommands are blocked except 'list'.
+ * Use the dedicated GIT_WORKTREE tools (list_worktrees, create_worktree, remove_worktree) instead.
  */
-const blockedWorktreeSubcommands = ['add', 'move', 'remove', 'prune']
+const allowedWorktreeSubcommands = ['list']
 
 export const git = async ({
   params,
@@ -21,7 +21,7 @@ export const git = async ({
   const trimmed = params.trimStart()
   if (trimmed.startsWith('worktree ')) {
     const subcommand = trimmed.slice('worktree '.length).trimStart().split(/\s+/)[0] ?? ''
-    if (blockedWorktreeSubcommands.includes(subcommand)) {
+    if (!allowedWorktreeSubcommands.includes(subcommand)) {
       return `Error: 'git worktree ${subcommand}' is not allowed via the generic git tool. Use the dedicated worktree tools (list_worktrees, create_worktree, remove_worktree) instead.`
     }
   }


### PR DESCRIPTION
Closes #583\n\nThe generic `__git` tool now blocks worktree mutating subcommands (`add`, `move`, `remove`, `prune`). These operations must go through the dedicated `GIT_WORKTREE` tools which handle branch validation, Coday project registration, and nested worktree protection.\n\nRead-only commands like `worktree list` are still allowed.\n\nThe tool description is also updated to reflect this restriction.