### PR TITLE
fix: prevent duplicate speech transcripts on Chrome mobile

### DIFF
--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -414,6 +414,7 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
     this.recognition.onend = () => {
       console.log('[SPEECH] Recognition ended. Was recording:', this.isRecording)
       this.isRecording = false
+      this.lastProcessedResultIndex = 0
       this.voiceRecordingToggled.emit(this.isRecording)
     }
 
@@ -425,6 +426,7 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
         timeStamp: event.timeStamp,
       })
       this.isRecording = false
+      this.lastProcessedResultIndex = 0
       this.clearPendingLineBreaks()
       this.voiceRecordingToggled.emit(this.isRecording)
     }


### PR DESCRIPTION
Chrome mobile resets event.resultIndex to 0 on subsequent onresult callbacks, causing all previous final results to be re-processed and appended incrementally. Track lastProcessedResultIndex to ensure each final result is consumed exactly once per session.