### PR TITLE
fix: #604 thread sharing — shared user cannot see or interact with thread

### DIFF
--- a/apps/server/src/lib/message.routes.ts
+++ b/apps/server/src/lib/message.routes.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import { debugLog } from './log'
 import { ThreadCodayManager } from './thread-coday-manager'
-import { AnswerEvent, OAuthCallbackEvent, buildCodayEvent } from '@coday/model'
+import { AnswerEvent, OAuthCallbackEvent, buildCodayEvent, hasAccess } from '@coday/model'
 
 /**
  * Message Management REST API Routes
@@ -69,14 +69,14 @@ export function registerMessageRoutes(
           return
         }
 
-        // Verify thread ownership
-        if (instance.username !== username) {
+        // Verify thread access
+        const aiThread = instance.coday.context?.aiThread
+        if (!aiThread || !hasAccess(aiThread, username)) {
           res.status(403).json({ error: 'Access denied: thread belongs to another user' })
           return
         }
 
         // Get messages from AiThread
-        const aiThread = instance.coday.context?.aiThread
         if (!aiThread) {
           res.status(500).json({ error: 'Thread not properly initialized' })
           return
@@ -133,8 +133,9 @@ export function registerMessageRoutes(
           return
         }
 
-        // Verify thread ownership
-        if (instance.username !== username) {
+        // Verify thread access
+        const aiThread = instance.coday.context?.aiThread
+        if (!aiThread || !hasAccess(aiThread, username)) {
           res.status(403).send('Access denied: thread belongs to another user')
           return
         }
@@ -198,16 +199,10 @@ export function registerMessageRoutes(
           return
         }
 
-        // Verify thread ownership
-        if (instance.username !== username) {
-          res.status(403).json({ error: 'Access denied: thread belongs to another user' })
-          return
-        }
-
-        // Get AiThread
+        // Verify thread access
         const aiThread = instance.coday.context?.aiThread
-        if (!aiThread) {
-          res.status(500).json({ error: 'Thread not properly initialized' })
+        if (!aiThread || !hasAccess(aiThread, username)) {
+          res.status(403).json({ error: 'Access denied: thread belongs to another user' })
           return
         }
 
@@ -265,16 +260,10 @@ export function registerMessageRoutes(
           return
         }
 
-        // Verify thread ownership
-        if (instance.username !== username) {
-          res.status(403).send('Access denied: thread belongs to another user')
-          return
-        }
-
-        // Get AiThread
+        // Verify thread access
         const aiThread = instance.coday.context?.aiThread
-        if (!aiThread) {
-          res.status(500).send('Thread not properly initialized')
+        if (!aiThread || !hasAccess(aiThread, username)) {
+          res.status(403).send('Access denied: thread belongs to another user')
           return
         }
 
@@ -374,16 +363,10 @@ export function registerMessageRoutes(
           return
         }
 
-        // Verify thread ownership
-        if (instance.username !== username) {
-          res.status(403).json({ error: 'Access denied: thread belongs to another user' })
-          return
-        }
-
-        // Get AiThread
+        // Verify thread access
         const aiThread = instance.coday.context?.aiThread
-        if (!aiThread) {
-          res.status(500).json({ error: 'Thread not properly initialized' })
+        if (!aiThread || !hasAccess(aiThread, username)) {
+          res.status(403).json({ error: 'Access denied: thread belongs to another user' })
           return
         }
 

--- a/apps/server/src/lib/thread.routes.ts
+++ b/apps/server/src/lib/thread.routes.ts
@@ -240,6 +240,17 @@ export function registerThreadRoutes(
       debugLog('THREAD', `PUT update thread: ${threadId} in project: ${projectName}`)
       const updatedThread = await threadService.updateThread(projectName, threadId, { name, users: resolvedUsers })
 
+      // Sync users to the live in-memory AiThread instance if it's running,
+      // to prevent the running instance from overwriting the YAML with stale data on cleanup.
+      if (resolvedUsers !== undefined) {
+        const liveInstance = threadCodayManager.get(threadId)
+        const liveAiThread = liveInstance?.coday?.context?.aiThread
+        if (liveAiThread) {
+          liveAiThread.users = resolvedUsers
+          debugLog('THREAD', `Synced users to live AiThread for thread ${threadId}`)
+        }
+      }
+
       res.status(200).json({
         success: true,
         thread: {

--- a/apps/server/src/lib/user.routes.ts
+++ b/apps/server/src/lib/user.routes.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import fs from 'fs'
 import path from 'path'
 import { debugLog } from './log'
+import { readYamlFile } from '@coday/utils'
 
 /**
  * User Information REST API Routes
@@ -73,7 +74,18 @@ export function registerUserRoutes(
       }
 
       const entries = fs.readdirSync(usersDir, { withFileTypes: true })
-      const usernames = entries.filter((e) => e.isDirectory()).map((e) => ({ username: e.name }))
+      const usernames = entries
+        .filter((e) => e.isDirectory())
+        .flatMap((e) => {
+          const yamlPath = path.join(usersDir, e.name, 'user.yaml')
+          if (!fs.existsSync(yamlPath)) return []
+          const config = readYamlFile(yamlPath) as { username?: string } | null
+          // Use the stored raw username (email) if available, otherwise fall back to directory name
+          const rawUsername = config?.username ?? e.name
+          return [{ username: rawUsername }]
+        })
+        // Exclude the current user from the list
+        .filter((u) => u.username !== username)
 
       debugLog('USER', `GET all users: found ${usernames.length} user(s)`)
 

--- a/libs/model/src/lib/user-config.ts
+++ b/libs/model/src/lib/user-config.ts
@@ -42,6 +42,12 @@ export type UserProjectConfig = {
 export interface UserConfig {
   version: number
 
+  /**
+   * The raw username (email) of this user, stored on first login.
+   * Used by GET /api/users to return real emails for the share autocomplete.
+   */
+  username?: string
+
   groups?: string[]
 
   ai?: AiProviderConfig[]

--- a/libs/service/src/lib/user.service.ts
+++ b/libs/service/src/lib/user.service.ts
@@ -38,8 +38,8 @@ export class UserService {
     const filePath = path.join(this.userConfigPath, USER_FILENAME)
     if (!existsSync(filePath)) {
       console.log(`[USER_SERVICE] Creating default config for user '${this.sanitizedUsername}' at ${filePath}`)
-      // Add version to default config
-      const defaultConfig = { ...DEFAULT_USER_CONFIG, version: 1 }
+      // Store the raw username (email) so GET /api/users can return real emails
+      const defaultConfig = { ...DEFAULT_USER_CONFIG, version: 1, username }
       writeYamlFile(filePath, defaultConfig)
     }
 


### PR DESCRIPTION
Closes #604

Fixes multiple issues that together made thread sharing completely non-functional: the wrong user identifier was being stored when sharing, the participant list was being silently overwritten after the owner continued using the thread, and shared users were blocked from sending messages or viewing history even when they did have access.