### PR TITLE
feat: #636 support Cloudflare Access JWT (CF_Authorization) for user identity in --auth mode

### DIFF
--- a/apps/server/src/lib/resolve-username.spec.ts
+++ b/apps/server/src/lib/resolve-username.spec.ts
@@ -1,0 +1,90 @@
+import { extractEmailFromCfJwt, resolveUsername } from './resolve-username'
+
+// Helper: build a minimal JWT-shaped token with the given payload
+function buildJwt(payload: object): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${header}.${body}.fakesignature`
+}
+
+describe('extractEmailFromCfJwt', () => {
+  it('returns the email claim from a valid JWT', () => {
+    const token = buildJwt({ sub: 'user-id', email: 'alice@example.com' })
+    expect(extractEmailFromCfJwt(token)).toBe('alice@example.com')
+  })
+
+  it('returns null when token is undefined', () => {
+    expect(extractEmailFromCfJwt(undefined)).toBeNull()
+  })
+
+  it('returns null when token is not a valid JWT (wrong segment count)', () => {
+    expect(extractEmailFromCfJwt('not.a.valid.jwt.here')).toBeNull()
+  })
+
+  it('returns null when payload is not valid JSON', () => {
+    const token = `header.!!!invalid_base64!!!.sig`
+    expect(extractEmailFromCfJwt(token)).toBeNull()
+  })
+
+  it('returns null when JWT payload has no email claim', () => {
+    const token = buildJwt({ sub: 'user-id', name: 'Alice' })
+    expect(extractEmailFromCfJwt(token)).toBeNull()
+  })
+
+  it('returns null when email claim is an empty string', () => {
+    const token = buildJwt({ email: '' })
+    expect(extractEmailFromCfJwt(token)).toBeNull()
+  })
+})
+
+describe('resolveUsername', () => {
+  describe('when auth is disabled', () => {
+    it('returns the OS username regardless of headers', () => {
+      const result = resolveUsername({}, false)
+      // Just verify it returns a non-empty string (the actual OS user)
+      expect(typeof result).toBe('string')
+      expect(result.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('when auth is enabled', () => {
+    it('uses CF_Authorization JWT email (path 1)', () => {
+      const token = buildJwt({ email: 'cf-user@example.com' })
+      const headers = { cf_authorization: token }
+      expect(resolveUsername(headers, true)).toBe('cf-user@example.com')
+    })
+
+    it('falls back to x-forwarded-email when CF header is absent (path 2)', () => {
+      const headers = { 'x-forwarded-email': 'proxy-user@example.com' }
+      expect(resolveUsername(headers, true)).toBe('proxy-user@example.com')
+    })
+
+    it('falls back to x-forwarded-email when CF JWT is malformed (path 2)', () => {
+      const headers = {
+        cf_authorization: 'not-a-jwt',
+        'x-forwarded-email': 'proxy-user@example.com',
+      }
+      expect(resolveUsername(headers, true)).toBe('proxy-user@example.com')
+    })
+
+    it('falls back to x-forwarded-email when CF JWT has no email claim (path 2)', () => {
+      const token = buildJwt({ sub: 'user-id' })
+      const headers = {
+        cf_authorization: token,
+        'x-forwarded-email': 'proxy-user@example.com',
+      }
+      expect(resolveUsername(headers, true)).toBe('proxy-user@example.com')
+    })
+
+    it('throws when neither header provides a valid identity (path 3)', () => {
+      expect(() => resolveUsername({}, true)).toThrow('Authentication required but no valid identity header found.')
+    })
+
+    it('throws when CF JWT is malformed and x-forwarded-email is absent (path 3)', () => {
+      const headers = { cf_authorization: 'bad.token' }
+      expect(() => resolveUsername(headers, true)).toThrow(
+        'Authentication required but no valid identity header found.'
+      )
+    })
+  })
+})

--- a/apps/server/src/lib/resolve-username.ts
+++ b/apps/server/src/lib/resolve-username.ts
@@ -1,0 +1,77 @@
+/**
+ * Resolves the authenticated username from an incoming HTTP request.
+ *
+ * Resolution order when `--auth` is enabled:
+ *  1. `CF_Authorization` header — Cloudflare Access JWT. The payload (middle
+ *     base64 segment) is decoded and the `email` claim is extracted. No
+ *     signature verification is performed here: Cloudflare already validated
+ *     the token at the edge before forwarding the request.
+ *  2. `x-forwarded-email` header — standard reverse-proxy header.
+ *  3. Throws an error if neither source yields a valid email.
+ *
+ * When `--auth` is NOT enabled (local / development mode), the OS username is
+ * returned directly.
+ */
+
+import * as os from 'node:os'
+
+const CF_JWT_HEADER = 'cf_authorization'
+const EMAIL_HEADER = 'x-forwarded-email'
+
+/**
+ * Attempt to extract the `email` claim from a Cloudflare Access JWT.
+ *
+ * The JWT payload is the second dot-separated segment, base64url-encoded.
+ * We only decode it — signature verification is intentionally skipped because
+ * Cloudflare validates the token before forwarding.
+ *
+ * @param token - Raw JWT string from the `CF_Authorization` header.
+ * @returns The email string, or `null` if the token is absent / malformed.
+ */
+export function extractEmailFromCfJwt(token: string | undefined): string | null {
+  if (!token) return null
+
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+
+  try {
+    // base64url -> base64 -> JSON
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const json = Buffer.from(payload, 'base64').toString('utf8')
+    const claims = JSON.parse(json)
+    const email = claims?.email
+    return typeof email === 'string' && email.length > 0 ? email : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the username for an incoming Express request.
+ *
+ * @param headers     - HTTP request headers (lowercased by Express).
+ * @param authEnabled - Whether `--auth` mode is active.
+ * @returns The resolved username.
+ * @throws Error if `authEnabled` is true and no valid identity can be found.
+ */
+export function resolveUsername(headers: Record<string, string | string[] | undefined>, authEnabled: boolean): string {
+  if (!authEnabled) {
+    return os.userInfo().username
+  }
+
+  // 1. Cloudflare Access JWT
+  const cfToken = headers[CF_JWT_HEADER] as string | undefined
+  const cfEmail = extractEmailFromCfJwt(cfToken)
+  if (cfEmail) return cfEmail
+
+  // 2. Standard reverse-proxy header
+  const fwdEmail = headers[EMAIL_HEADER] as string | undefined
+  if (fwdEmail && fwdEmail.length > 0) return fwdEmail
+
+  // 3. No valid identity found
+  throw new Error(
+    'Authentication required but no valid identity header found. ' +
+      'Expected either a CF_Authorization JWT (Cloudflare Access) or ' +
+      'an x-forwarded-email header from the upstream auth proxy.'
+  )
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import fs from 'fs'
 import { ThreadCodayManager } from './lib/thread-coday-manager'
 
-import * as os from 'node:os'
 import { debugLog } from './lib/log'
 import { CodayLoggerUtils } from '@coday/utils'
 import {
@@ -34,6 +33,7 @@ import { parseCodayOptions } from './lib/coday-options-utils'
 import { ProjectFileRepository } from '@coday/repository'
 import { McpInstancePool } from '@coday/mcp'
 import { createProxyMiddleware } from 'http-proxy-middleware'
+import { resolveUsername } from './lib/resolve-username'
 
 const app = express()
 const DEFAULT_PORT = process.env.PORT
@@ -44,7 +44,7 @@ const DEFAULT_PORT = process.env.PORT
 
 // Dynamically find an available port
 const PORT_PROMISE = findAvailablePort(DEFAULT_PORT)
-const EMAIL_HEADER = 'x-forwarded-email'
+// Note: header constants are now managed in ./lib/resolve-username.ts
 
 // Parse options once for all clients
 const codayOptions = parseCodayOptions()
@@ -253,18 +253,24 @@ const FORBIDDEN_USERNAMES = [
 ] as const
 
 /**
- * Extract username for authentication and logging purposes
+ * Extract username for authentication and logging purposes.
  *
- * In authenticated mode, extracts username from the x-forwarded-email header
- * (typically set by reverse proxy or authentication middleware).
- * In non-authenticated mode (default), uses the local system username for development/testing.
+ * Resolution order when `--auth` is enabled:
+ *  1. `CF_Authorization` header — Cloudflare Access JWT (email claim decoded
+ *     from the base64url payload; no signature verification needed as
+ *     Cloudflare validates the token at the edge).
+ *  2. `x-forwarded-email` header — standard reverse-proxy header.
+ *  3. Throws if neither source yields a valid email.
+ *
+ * When `--auth` is NOT enabled, uses the local OS username (development mode).
  *
  * @param req - Express request object containing headers
  * @returns Username string for logging and thread ownership
  * @throws Error if username is a system/service account (security protection)
+ * @throws Error if `--auth` is enabled but no valid identity header is found
  */
 function getUsername(req: express.Request): string {
-  const username = codayOptions.auth ? (req.headers[EMAIL_HEADER] as string) : os.userInfo().username
+  const username = resolveUsername(req.headers as Record<string, string | string[] | undefined>, !!codayOptions.auth)
 
   // Security check: prevent running as system/service accounts
   if (FORBIDDEN_USERNAMES.includes(username.toLowerCase() as any)) {

--- a/docs/02-getting-started/launching.md
+++ b/docs/02-getting-started/launching.md
@@ -34,7 +34,9 @@ Open your browser and navigate to the displayed URL (usually `http://localhost:3
 ### Server Options
 
 - `--port <number>` - Specify server port (default: 3000, auto-increments if occupied)
-- `--auth` - Enable authentication (requires auth proxy with x-forwarded-email header)
+- `--auth` - Enable authentication. Supports two identity sources (tried in order):
+  1. **Cloudflare Access** — decodes the `CF_Authorization` JWT and uses its `email` claim.
+  2. **Reverse-proxy header** — falls back to the `x-forwarded-email` header set by an upstream auth proxy.
 - `--debug` - Enable debug logging for troubleshooting
 
 ### Execution Options


### PR DESCRIPTION
## Summary

Adds Cloudflare Access JWT support for user identity resolution when `--auth` is enabled.

## Changes

### `apps/server/src/lib/resolve-username.ts` (new)
Extracts the username resolution logic into a dedicated, testable utility with the ordered resolution:
1. **`CF_Authorization` header** — decodes the JWT payload (base64url) and extracts the `email` claim. No signature verification needed (Cloudflare validates at the edge).
2. **`x-forwarded-email` header** — existing reverse-proxy fallback.
3. **Throws** if neither yields a valid email.

### `apps/server/src/lib/resolve-username.spec.ts` (new)
Unit tests covering all three resolution paths for both `extractEmailFromCfJwt` and `resolveUsername`.

### `apps/server/src/server.ts`
- `getUsername()` now delegates to `resolveUsername()` — behaviour unchanged for non-auth mode and `x-forwarded-email` users.
- JSDoc updated to reflect the new resolution order.
- Removed now-unused `os` import and `EMAIL_HEADER` constant (moved to the utility).

### `docs/02-getting-started/launching.md`
Documents the two supported identity sources under `--auth`.

## Acceptance criteria

- [x] When `CF_Authorization` contains a valid JWT with an `email` claim, that email is used as the username.
- [x] When `CF_Authorization` is absent or malformed, the server falls back to `x-forwarded-email`.
- [x] When neither header provides a valid email and `--auth` is enabled, the request fails with an appropriate error.
- [x] Existing behaviour (no `--auth` → system username) is unchanged.
- [x] Unit tests cover the three resolution paths.
- [x] Documentation updated.
