### PR TITLE
fix: server build TS2532 on resolve-username parts[1] access

### DIFF
--- a/apps/server/src/lib/resolve-username.ts
+++ b/apps/server/src/lib/resolve-username.ts
@@ -36,7 +36,7 @@ export function extractEmailFromCfJwt(token: string | undefined): string | null 
 
   try {
     // base64url -> base64 -> JSON
-    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const payload = parts[1]!.replace(/-/g, '+').replace(/_/g, '/')
     const json = Buffer.from(payload, 'base64').toString('utf8')
     const claims = JSON.parse(json)
     const email = claims?.email


### PR DESCRIPTION
## Problem

`nx run server:build-server` was failing with TS2532 ("Object is possibly 'undefined'") on `parts[1]` in `resolve-username.ts`.

## Root cause

TypeScript strict mode couldn't infer that `parts[1]` is defined after the `parts.length !== 3` guard. The guard is correct and sufficient at runtime.

## Fix

Added a non-null assertion (`!`) on `parts[1]` to satisfy the TypeScript compiler without changing any runtime behaviour.