### PR TITLE
fix: hide "Share thread" button when not in auth/multi-user mode

### DIFF
--- a/apps/client/src/app/components/thread/thread.component.html
+++ b/apps/client/src/app/components/thread/thread.component.html
@@ -27,8 +27,8 @@
           </button>
         }
 
-        <!-- Share Button - hidden when share drawer open -->
-        @if (drawerMode !== 'share') {
+        <!-- Share Button - hidden when share drawer open or auth is disabled -->
+        @if (authEnabled && drawerMode !== 'share') {
           <button
             matFab
             class="share-toggle-btn"

--- a/apps/client/src/app/components/thread/thread.component.ts
+++ b/apps/client/src/app/components/thread/thread.component.ts
@@ -127,6 +127,7 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
   }
 
   currentUsername: string = ''
+  authEnabled: boolean = false
 
   // First message from implicit thread creation
   private pendingFirstMessage: string | null = null
@@ -160,6 +161,11 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
 
     // Setup print event listeners
     this.setupPrintHandlers()
+
+    // Track authEnabled reactively
+    this.userService.authEnabled$.pipe(takeUntil(this.destroy$)).subscribe((authEnabled) => {
+      this.authEnabled = authEnabled
+    })
 
     // Track username reactively — when it loads, force a new messages array reference
     // so Angular re-evaluates the isOtherUser binding for all rendered messages.

--- a/apps/client/src/app/core/services/user.service.ts
+++ b/apps/client/src/app/core/services/user.service.ts
@@ -8,6 +8,7 @@ import { tap } from 'rxjs/operators'
  */
 export interface UserInfo {
   username: string
+  authEnabled: boolean
 }
 
 /**
@@ -19,11 +20,17 @@ export interface UserInfo {
 export class UserService {
   private readonly http = inject(HttpClient)
   private readonly usernameSubject = new BehaviorSubject<string | null>(null)
+  private readonly authEnabledSubject = new BehaviorSubject<boolean>(false)
 
   /**
    * Observable of current username
    */
   username$ = this.usernameSubject.asObservable()
+
+  /**
+   * Observable of whether auth/multi-user mode is enabled
+   */
+  authEnabled$ = this.authEnabledSubject.asObservable()
 
   /**
    * Fetch current user information from the server
@@ -32,6 +39,7 @@ export class UserService {
     return this.http.get<UserInfo>('/api/user/me').pipe(
       tap((userInfo) => {
         this.usernameSubject.next(userInfo.username)
+        this.authEnabledSubject.next(userInfo.authEnabled)
       })
     )
   }

--- a/apps/server/src/lib/user.routes.ts
+++ b/apps/server/src/lib/user.routes.ts
@@ -23,11 +23,13 @@ import { readYamlFile } from '@coday/utils'
  * @param app - Express application instance
  * @param getUsernameFn - Function to extract username from request
  * @param configDir - Path to the Coday config directory (e.g. ~/.coday)
+ * @param authEnabled - Whether the server is running in auth/multi-user mode
  */
 export function registerUserRoutes(
   app: express.Application,
   getUsernameFn: (req: express.Request) => string,
-  configDir: string
+  configDir: string,
+  authEnabled: boolean = false
 ): void {
   /**
    * GET /api/user/me
@@ -45,6 +47,7 @@ export function registerUserRoutes(
 
       res.status(200).json({
         username,
+        authEnabled,
       })
     } catch (error) {
       console.error('Error retrieving user info:', error)

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -286,7 +286,7 @@ function getUsername(req: express.Request): string {
 }
 
 // Register user information routes
-registerUserRoutes(app, getUsername, codayOptions.configDir)
+registerUserRoutes(app, getUsername, codayOptions.configDir, !!codayOptions.auth)
 
 // Register configuration management routes
 registerConfigRoutes(app, configRegistry, getUsername)


### PR DESCRIPTION
## Summary

Closes #640

Hides the "Share thread" button when Coday is not running in auth/multi-user mode, as originally required by #622 and deferred in #628.

## Changes

- **`apps/server/src/lib/user.routes.ts`** — Added `authEnabled` parameter to `registerUserRoutes`, included in the `/api/user/me` response
- **`apps/server/src/server.ts`** — Passes `!!codayOptions.auth` as the `authEnabled` flag
- **`apps/client/src/app/core/services/user.service.ts`** — Added `authEnabled` to `UserInfo` interface and exposed `authEnabled$` as a reactive `BehaviorSubject` observable
- **`apps/client/src/app/components/thread/thread.component.ts`** — Subscribes to `authEnabled$` and tracks it as a component property
- **`apps/client/src/app/components/thread/thread.component.html`** — Conditionally renders the share button only when `authEnabled` is `true`