### PR TITLE
fix: #645 increase default cost limit from $2 to $10

### DIFF
--- a/libs/model/src/lib/ai-thread.types.ts
+++ b/libs/model/src/lib/ai-thread.types.ts
@@ -120,6 +120,6 @@ export const EmptyUsage: Usage = {
   cache_write: 0,
   price: 0,
   iterations: 0,
-  priceThreshold: 2.0, // Default $2 threshold
+  priceThreshold: 10.0, // Default $10 threshold
   iterationsThreshold: 100, // Default 100 iterations threshold
 }


### PR DESCRIPTION
## Summary

Increases the default `priceThreshold` in `EmptyUsage` from **$2** to **$10**.

## Change

Single-line change in `libs/model/src/lib/ai-thread.types.ts`.

## Why

$2 was too low for real-world agentic workflows — users hit the limit within minutes on complex tasks (e.g. BMAD workflows with adversarial reviews), triggering repeated confirmation prompts that break the flow.

$10 provides meaningful runway for multi-step agentic work while still catching runaway loops early. The doubling-on-confirm mechanism remains intact as a safety net.

Closes #645