### PR TITLE
fix: #508 prevent event loss with fast AI models via ReplaySubject bridge

### DIFF
--- a/libs/model/src/lib/agent.ts
+++ b/libs/model/src/lib/agent.ts
@@ -1,6 +1,6 @@
 import { AiClient } from './ai.client'
 import { AiThread } from './ai-thread'
-import { Observable } from 'rxjs'
+import { Observable, ReplaySubject } from 'rxjs'
 import { AnswerEvent, CodayEvent } from './coday-events'
 import { AgentDefinition } from './agent-definition'
 import { ToolSet } from './integration-tool-set'
@@ -61,6 +61,12 @@ export class Agent {
     thread.addAnswerEvent(answerEvent)
 
     // Run with AI client
-    return await this.aiClient.run(this, thread)
+    const events = await this.aiClient.run(this, thread)
+
+    // Bridge through a ReplaySubject to prevent event loss when the AI client
+    // completes before subscribers attach (race condition with fast models - issue #508).
+    const replay = new ReplaySubject<CodayEvent>()
+    events.subscribe(replay)
+    return replay.asObservable()
   }
 }


### PR DESCRIPTION
## Problem

With fast AI models (e.g., Gemini), the `Subject<CodayEvent>` returned by AI clients can complete before downstream subscribers attach, causing RxJS `EmptyError` ("no elements in sequence"). The response is actually saved in the thread (visible on reconnection), but the live session shows an error.

**Root cause**: AI clients create a hot `Subject`, launch `processThread()` asynchronously (fire-and-forget), and return the Subject immediately. If the model responds before `AiHandler.runAgent()` calls `.subscribe()` and `lastValueFrom()`, events are lost.

## Solution

Add a `ReplaySubject` bridge in `Agent.run()` — the single gateway between all AI clients and all consumers. This buffers all emitted events and replays them to late subscribers.

```typescript
const events = await this.aiClient.run(this, thread)
const replay = new ReplaySubject<CodayEvent>()
events.subscribe(replay)
return replay.asObservable()
```

## Why this approach

- **Single point of change**: `Agent.run()` sits between all AI clients (OpenAI, Anthropic) and all consumers (`AiHandler`, delegation functions)
- **Preserves fire-and-forget semantics**: Processing starts immediately — no subscriber required (important for webhooks, async delegations, reconnection)
- **No duplicate events**: The existing double-subscribe pattern in `AiHandler` (`.subscribe()` + `lastValueFrom()`) works correctly since `lastValueFrom` has no `next` side-effect
- **Transparent**: No changes needed in AI clients or consumers

## Verification

- ✅ Lint passes (`pnpm nx lint model`)
- ✅ Build passes (`pnpm nx build model` + full TS build)

Closes #508