### PR TITLE
fix: #648 stop microphone when sending a message

### DIFF
--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -329,6 +329,13 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
     const canSend = !this.isDisabled && (allowEmpty || messageToSend)
 
     if (canSend) {
+      // Stop microphone if active — sending ends the voice session.
+      // We stop directly without scheduling line breaks since the message is about to be cleared.
+      if (this.isRecording && this.recognition) {
+        this.clearPendingLineBreaks()
+        this.recognition.stop()
+      }
+
       // Send the trimmed message (can be empty string if allowEmpty=true)
       this.messageSubmitted.emit(messageToSend)
       this.message = ''


### PR DESCRIPTION
## Problem

When the user activates the microphone (speech-to-text) and then clicks the Send button (or uses the keyboard shortcut), the microphone remained active after the message was sent.

## Fix

In `sendMessage()`, before emitting the message, stop the microphone if it is currently active:

- Cancel any pending line-break timeout (`clearPendingLineBreaks()`) — we don't want `\n\n` appended to a message that is about to be cleared.
- Call `this.recognition.stop()` directly — this triggers the existing `onend` handler which sets `isRecording = false` and emits `voiceRecordingToggled`.

This covers all send paths: Send button click, Enter key, and Cmd/Ctrl+Enter.

## Scope

`apps/client/src/app/components/chat-textarea/chat-textarea.component.ts` — `sendMessage()` method only.

Closes #648