### PR TITLE
fix: #657 UI visual regressions post PR #644

### DIFF
--- a/apps/client/src/app/components/content-viewer/content-viewer.component.scss
+++ b/apps/client/src/app/components/content-viewer/content-viewer.component.scss
@@ -1,6 +1,16 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
+
 .viewer-container {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   height: 100%;
   background: var(--color-bg);
 }

--- a/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.scss
+++ b/apps/client/src/app/components/file-exchange-drawer/file-exchange-drawer.component.scss
@@ -1,6 +1,16 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
+
 .file-drawer-container {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   height: 100%;
   background: var(--glass-bg);
   backdrop-filter: var(--glass-backdrop-blur);

--- a/apps/client/src/app/components/main-app/main-app.component.html
+++ b/apps/client/src/app/components/main-app/main-app.component.html
@@ -1,5 +1,5 @@
 <app-sidenav [drawerOpen]="isDrawerOpen">
-  <div class="app">
+  <div class="app" (mousedown)="onChatFocusedOnMobile()" (touchstart)="onChatFocusedOnMobile()">
     @if (threadId) {
       <!-- Thread view - Full conversation management -->
       <app-thread

--- a/apps/client/src/app/components/thread/thread.component.html
+++ b/apps/client/src/app/components/thread/thread.component.html
@@ -51,7 +51,7 @@
         }
 
         <!-- Chat History - Scrollable area -->
-        <div class="chat-wrapper">
+        <div class="chat-wrapper" (mousedown)="chatFocused.emit()" (touchstart)="chatFocused.emit()">
           <div class="chat-center">
             <app-chat-history
               [messages]="messages"
@@ -87,7 +87,6 @@
                   (heightChanged)="onInputHeightChanged($event)"
                   (stopRequested)="onStopRequested()"
                   (filesPasted)="onFilesPasted($event)"
-                  (textareaFocused)="chatFocused.emit()"
                 />
               }
 

--- a/apps/client/src/app/components/thread/thread.component.scss
+++ b/apps/client/src/app/components/thread/thread.component.scss
@@ -72,6 +72,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  flex: 1; // Fill the flex column created by mat-drawer-inner-container
+  min-height: 0;
   background: var(--glass-bg);
   backdrop-filter: var(--glass-backdrop-blur);
   -webkit-backdrop-filter: var(--glass-backdrop-blur);

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -55,6 +55,10 @@ body {
     color 0.3s ease;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  // Ensure body padding is always 0 - guards against any inline styles or
+  // external CSS that could add padding and create an unwanted document-level scrollbar.
+  padding: 0 !important;
 }
 
 /* Global Markdown Styles */

--- a/libs/design-system/src/lib/components/autocomplete-input/autocomplete-input.component.scss
+++ b/libs/design-system/src/lib/components/autocomplete-input/autocomplete-input.component.scss
@@ -7,10 +7,13 @@
  * Token contract:
  *   --color-border          border color for the input
  *   --color-primary         focus ring and active highlight color
- *   --color-bg-surface      dropdown background
+ *   --glass-bg              input and dropdown background (theme-aware glass surface)
  *   --color-bg-hover        option hover / keyboard-selected background
  *   --color-text            primary text color
  *   --color-text-secondary  secondary / description text color
+ *
+ * Note: --color-bg-surface is NOT used — it is not defined in the host theme.
+ * Use --glass-bg instead, which resolves correctly in both light and dark modes.
  */
 
 .autocomplete-container {
@@ -27,7 +30,7 @@
     font-size: 14px;
     line-height: 1.5;
     color: var(--color-text, #1d1d1f);
-    background: var(--color-bg-surface, #ffffff);
+    background: var(--glass-bg);
     outline: none;
     transition:
       border-color 0.15s ease,
@@ -55,7 +58,7 @@
   left: 0;
   right: 0;
   z-index: 1000;
-  background: var(--color-bg-surface, #ffffff);
+  background: var(--glass-bg);
   border: 1px solid var(--color-border, #e0e0e0);
   border-radius: 8px;
   box-shadow:


### PR DESCRIPTION
Closes #657

Fixes four UI visual regressions introduced by PR #644:

1. **Unwanted document scrollbar** — Added `padding: 0 !important` on `body` in global styles to prevent an extra scrollbar at the document level.

2. **White background in dark mode (Share Thread panel)** — Replaced the missing `--color-bg-surface` token with `--glass-bg` in the autocomplete-input component, so the input and dropdown backgrounds respect the current theme.

3. **Panels not filling full drawer height** — Fixed the flex chain in file-exchange-drawer, share-drawer, and content-viewer components (`:host` display flex, `flex: 1`, `min-height: 0`) so panels properly stretch to fill their drawer and remain scrollable.

4. **Sidenav not closing on first tap (mobile)** — Replaced the `(textareaFocused)` event with `(mousedown)` / `(touchstart)` on the chat wrapper (and the welcome/new-thread view), so the sidenav closes immediately on the first tap of the chat area on mobile devices.