### PR TITLE
fix: #651 fix node process leaks in MCP and thread lifecycle

### DIFF
--- a/apps/server/src/lib/thread-coday-manager.ts
+++ b/apps/server/src/lib/thread-coday-manager.ts
@@ -577,10 +577,13 @@ export class ThreadCodayManager {
   async cleanup(threadId: string): Promise<void> {
     const instance = this.instances.get(threadId)
     if (instance) {
-      // Release MCP instances used by this thread
+      // First cleanup the Coday instance (stops agents, tools, etc.)
+      await instance.cleanup()
+
+      // Then release MCP instances from the pool
+      // (must be after instance cleanup to avoid race conditions with toolbox)
       await this.mcpPool.releaseThread(threadId)
 
-      await instance.cleanup()
       this.instances.delete(threadId)
       debugLog('THREAD_CODAY', `Removed instance for thread ${threadId}`)
     }
@@ -625,13 +628,20 @@ export class ThreadCodayManager {
     const cleanupPromises: Promise<void>[] = []
     for (const [threadId, instance] of this.instances.entries()) {
       debugLog('THREAD_CODAY_MANAGER', `Cleaning up thread ${threadId}`)
-      cleanupPromises.push(instance.cleanup())
+      cleanupPromises.push(
+        instance
+          .cleanup()
+          .then(() => this.mcpPool.releaseThread(threadId))
+          .catch((error) => {
+            debugLog('THREAD_CODAY_MANAGER', `Error cleaning up thread ${threadId}:`, error)
+          })
+      )
     }
 
     await Promise.all(cleanupPromises)
     this.instances.clear()
 
-    // Shutdown MCP instance pool
+    // Final safety net: shutdown any remaining MCP instances
     await this.mcpPool.shutdown()
 
     debugLog('THREAD_CODAY_MANAGER', 'All thread instances cleaned up')

--- a/libs/mcp/src/lib/mcp-tools-factory.ts
+++ b/libs/mcp/src/lib/mcp-tools-factory.ts
@@ -94,10 +94,35 @@ export class McpToolsFactory extends AssistantToolFactory {
       try {
         await this.transport.close()
         console.log(`Transport closed for ${this.serverConfig.name}`)
+        // Nullify PID synchronously after successful close
+        // (the async onclose handler also does this, but we need it before the fallback check below)
+        this.serverProcessPid = null
       } catch (error) {
         console.log(`Error closing transport for ${this.serverConfig.name}: ${error}`)
       }
       this.transport = undefined
+    }
+
+    // Fallback: manually kill the process if transport.close() failed silently
+    if (this.serverProcessPid) {
+      try {
+        process.kill(this.serverProcessPid, 0)
+        console.log(`Force killing MCP server process ${this.serverProcessPid} for ${this.serverConfig.name}`)
+        process.kill(this.serverProcessPid, 'SIGTERM')
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        try {
+          process.kill(this.serverProcessPid, 0)
+          process.kill(this.serverProcessPid, 'SIGKILL')
+          console.log(`Force killed with SIGKILL: ${this.serverProcessPid}`)
+        } catch {
+          // Process already dead, good
+        }
+      } catch (error: any) {
+        if (error.code !== 'ESRCH') {
+          console.log(`Error killing MCP server process ${this.serverProcessPid}: ${error}`)
+        }
+      }
+      this.serverProcessPid = null
     }
 
     console.log(`Closed mcp client ${this.serverConfig.name}`)
@@ -231,11 +256,19 @@ export class McpToolsFactory extends AssistantToolFactory {
     try {
       // Set a shorter timeout for MCP connections (default is 60s, we use MCP_CONNECT_TIMEOUT)
       const connectPromise = instance.connect(this.transport)
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`Connection timeout after ${MCP_CONNECT_TIMEOUT}ms`)), MCP_CONNECT_TIMEOUT)
-      )
+      let timeoutHandle: NodeJS.Timeout
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new Error(`Connection timeout after ${MCP_CONNECT_TIMEOUT}ms`)),
+          MCP_CONNECT_TIMEOUT
+        )
+      })
 
-      await Promise.race([connectPromise, timeoutPromise])
+      try {
+        await Promise.race([connectPromise, timeoutPromise])
+      } finally {
+        clearTimeout(timeoutHandle!)
+      }
 
       // Store the process PID for manual cleanup if needed
       if (this.transport && 'pid' in this.transport) {


### PR DESCRIPTION
## Problem

~85 zombie/orphan node processes accumulate over time on long-running Coday web server deployments. Several processes show 27–94% CPU usage with uptimes of 60–114 hours, indicating MCP server child processes are spawned but never properly terminated.

Closes #651

## Root Causes & Fixes

### 1. Missing PID fallback kill in `McpToolsFactory.kill()` (critical)

The `kill()` method closed the MCP client and transport but had **no fallback** if `transport.close()` failed silently to terminate the child process. The `cleanupOnError()` method in the same file already had this fallback — it was simply missing from the normal teardown path.

**Fix**: Added PID-based fallback kill after `transport.close()` — checks if the process is still alive via signal 0, sends SIGTERM, waits 100ms, escalates to SIGKILL if needed.

### 2. Wrong cleanup order in `ThreadCodayManager.cleanup()` (critical)

`mcpPool.releaseThread(threadId)` was called **before** `instance.cleanup()`. The pool could destroy a shared MCP factory (if it was the last thread using it) while Coday's toolbox was still mid-teardown, causing a race condition.

**Fix**: Swapped order — `instance.cleanup()` first (triggers full Coday → AgentService → Toolbox teardown chain), then `mcpPool.releaseThread()`. Also updated `shutdown()` to chain `releaseThread()` per instance after cleanup, keeping `mcpPool.shutdown()` as a final safety net.

### 3. Stale timeout timer in MCP connection (`buildClient()`)

The `setTimeout` used in the `Promise.race` for MCP connection was never cleared on success, allowing it to fire on a stale promise after cleanup had already run.

**Fix**: Captured the timeout handle and clear it in a `finally` block wrapping the `Promise.race`.

## Files Changed

- `libs/mcp/src/lib/mcp-tools-factory.ts` — PID fallback kill + timeout cleanup
- `apps/server/src/lib/thread-coday-manager.ts` — cleanup ordering fix

## Testing

- Lint ✅
- Build ✅
- Changes are surgical and follow existing patterns already proven in `cleanupOnError()`