### PR TITLE
fix: #666 remove_worktree falls back to prune when path is missing

### DIFF
--- a/libs/integrations/git/src/lib/git-worktree.tools.ts
+++ b/libs/integrations/git/src/lib/git-worktree.tools.ts
@@ -211,11 +211,12 @@ export class GitWorktreeTools extends AssistantToolFactory {
             return `Error: cannot remove the main worktree`
           }
 
-          let pathExists = true
+          let pathExists = false
           try {
-            await fsp.access(worktreePath)
+            const stat = await fsp.stat(worktreePath)
+            pathExists = stat.isDirectory()
           } catch {
-            pathExists = false
+            /* path does not exist or is inaccessible */
           }
 
           if (pathExists) {


### PR DESCRIPTION
Problem

remove_worktree was returning a hard error when the worktree directory had already been deleted from disk, even when force=true was passed. The Coday project entry remained registered with no way to clean it up through the tool.

Fixes #666.

## Solution

Instead of failing when the path doesn't exist, the tool now:\n1. Checks whether the worktree path exists on disk\n2. If it does exist → proceeds with git worktree remove as before\n3. If it doesn't exist → logs a debug message and skips straight to the fallback\n4. Always runs git worktree prune to clean up stale git references\n5. Always calls unregisterWorktreeProject to remove the Coday project entry\n6. Returns success in both cases

This makes the tool idempotent: calling it when the directory is already gone is no longer an error.

## Changes

- libs/integrations/git/src/lib/git-worktree.tools.ts: replaced the hard-error guard on missing path with a conditional that falls back gracefully to prune + unregister. Also fixed two pre-existing ESLint warnings (unnecessary escape \\/ in regex character classes).