### PR TITLE
fix: #652 inconsistent sub-thread content display on expand

### DIFF
--- a/apps/client/src/app/components/delegation-inline/delegation-inline.component.html
+++ b/apps/client/src/app/components/delegation-inline/delegation-inline.component.html
@@ -16,7 +16,7 @@
 
   @if (isExpanded) {
     <div class="delegation-body">
-      @if (isLoading) {
+      @if (isLoading && subMessages.length === 0) {
         <div class="loading">
           <mat-spinner [diameter]="16"></mat-spinner>
           <span>Loading...</span>

--- a/apps/client/src/app/components/delegation-inline/delegation-inline.component.ts
+++ b/apps/client/src/app/components/delegation-inline/delegation-inline.component.ts
@@ -35,6 +35,9 @@ export class DelegationInlineComponent implements OnInit, OnDestroy {
   subMessages: ChatMessage[] = []
   streamingText = ''
 
+  private restLoaded = false
+  private messageIds = new Set<string>()
+
   private eventSubscription?: Subscription
   private readonly codayService = inject(CodayService)
   private readonly threadApi = inject(ThreadApiService)
@@ -70,8 +73,8 @@ export class DelegationInlineComponent implements OnInit, OnDestroy {
   toggle(): void {
     this.isExpanded = !this.isExpanded
 
-    // On every expand, reload from REST — source of truth for persisted messages
-    if (this.isExpanded) {
+    // Only load from REST on first expand — subsequent expands retain accumulated state
+    if (this.isExpanded && !this.restLoaded) {
       this.loadSubThreadMessages()
     }
   }
@@ -82,20 +85,22 @@ export class DelegationInlineComponent implements OnInit, OnDestroy {
     this.threadApi.getThreadMessages(this.subThreadId).subscribe({
       next: (response) => {
         if (response.messages) {
-          // Rebuild from REST — source of truth for persisted messages
-          // SSE live streaming (streamingText) is unaffected
-          this.subMessages = []
+          // Merge REST messages into existing state — deduplication via addMessage()
           for (const rawMsg of response.messages) {
             const event = buildCodayEvent(rawMsg)
             if (event) {
               this.handleSubThreadEvent(event)
             }
           }
+          // Sort by timestamp to ensure chronological order after merge
+          this.subMessages = [...this.subMessages].sort((a, b) => a.id.localeCompare(b.id))
         }
+        this.restLoaded = true
         this.isLoading = false
       },
       error: (err) => {
         console.error('[DELEGATION-INLINE] Failed to load sub-thread messages:', err)
+        this.restLoaded = true // Don't retry on error — SSE data is still available
         this.isLoading = false
       },
     })
@@ -169,6 +174,10 @@ export class DelegationInlineComponent implements OnInit, OnDestroy {
   }
 
   private addMessage(message: ChatMessage): void {
+    if (this.messageIds.has(message.id)) {
+      return // Already have this message, skip
+    }
+    this.messageIds.add(message.id)
     this.subMessages = [...this.subMessages, message]
   }
 }


### PR DESCRIPTION
## Summary
Fixes #652

Replaces the destructive dual-source pattern in `DelegationInlineComponent` with a merge-based strategy:

- **`restLoaded` flag**: REST is fetched only once (first expand), not on every toggle
- **`messageIds` Set**: timestamp-based deduplication prevents duplicate messages from SSE + REST merge
- **`addMessage()` guard**: skips messages already present before appending
- **Merge not replace**: `loadSubThreadMessages()` no longer resets `subMessages = []`; it merges and sorts chronologically
- **Loading spinner**: only shown when `subMessages` is truly empty (SSE-populated content stays visible)

## Files Changed
- `apps/client/src/app/components/delegation-inline/delegation-inline.component.ts`
- `apps/client/src/app/components/delegation-inline/delegation-inline.component.html`