### PR TITLE
fix: #670 improve modal/background contrast with border, shadow and blurred backdrop

### DIFF
--- a/apps/client/src/app/styles/colors.scss
+++ b/apps/client/src/app/styles/colors.scss
@@ -45,14 +45,14 @@
   --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.15);
   --glass-backdrop-blur: blur(20px);
 
-  /* Utility Colors */
-  --color-shadow: rgba(0, 0, 0, 0.08);
-  --color-overlay: rgba(0, 0, 0, 0.4);
-
   /* Modal / Dialog */
   --color-modal-bg: #ffffff;
   --color-modal-border: rgba(0, 0, 0, 0.12);
   --color-modal-shadow: 0 8px 40px rgba(0, 0, 0, 0.18), 0 2px 8px rgba(0, 0, 0, 0.1);
+
+  /* Utility Colors */
+  --color-shadow: rgba(0, 0, 0, 0.08);
+  --color-overlay: rgba(0, 0, 0, 0.4);
 }
 
 /* Dark Theme - Apple Glass Aesthetic */
@@ -94,12 +94,12 @@
   --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
   --glass-backdrop-blur: blur(20px);
 
-  /* Utility Colors */
-  --color-shadow: rgba(0, 0, 0, 0.5);
-  --color-overlay: rgba(0, 0, 0, 0.8);
-
   /* Modal / Dialog */
   --color-modal-bg: #2c2c2e;
   --color-modal-border: rgba(255, 255, 255, 0.12);
   --color-modal-shadow: 0 8px 48px rgba(0, 0, 0, 0.55), 0 2px 12px rgba(0, 0, 0, 0.35);
+
+  /* Utility Colors */
+  --color-shadow: rgba(0, 0, 0, 0.5);
+  --color-overlay: rgba(0, 0, 0, 0.8);
 }

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -271,18 +271,19 @@ app-main {
   --mdc-dialog-container-color: var(--color-modal-bg);
   --mdc-dialog-supporting-text-color: var(--color-text);
 
+  // Elevate the dialog surface with a visible border and strong shadow
   .mdc-dialog__surface {
-    border-radius: 16px !important;
     border: 1px solid var(--color-modal-border) !important;
+    border-radius: 16px !important;
     box-shadow: var(--color-modal-shadow) !important;
   }
 }
 
-/* Blurred backdrop overlay behind modals */
+/* Semi-transparent backdrop overlay behind modals */
 .cdk-overlay-backdrop.cdk-overlay-backdrop-showing {
   background: var(--color-overlay);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 /* Default dialog size */


### PR DESCRIPTION

<img width="1743" height="906" alt="image" src="https://github.com/user-attachments/assets/c9f74447-c3f0-47db-9c6f-d0065629eaa0" />

<img width="1795" height="884" alt="image" src="https://github.com/user-attachments/assets/845aad62-d508-42f2-9f96-a1b765b39b3d" />


## Summary

Fixes #670 — modals were visually indistinguishable from the page background because `--mdc-dialog-container-color` was set to `var(--color-bg)` (the same gradient used for the page), with no border, no meaningful shadow, and no backdrop overlay.

---

## Root Cause

```scss
/* Before */
.mat-mdc-dialog-container {
  --mdc-dialog-container-color: var(--color-bg); /* same as page background → no contrast */
}
```

The dialog surface used the page's gradient background, had no border or shadow beyond Material defaults, and the CDK backdrop received no custom styling, leaving modals visually merged with the surrounding content.

---

## Changes

### `apps/client/src/app/styles/colors.scss`
Added a dedicated **Modal / Dialog** token group to both `:root` (light) and `[data-theme='dark']`:

| Token | Light | Dark |
|---|---|---|
| `--color-modal-bg` | `#ffffff` — pure white, clearly elevated above the light-grey page gradient | `#2c2c2e` — a distinctly lighter surface than the `#1c1c1e` dark page background |
| `--color-modal-border` | `rgba(0, 0, 0, 0.12)` | `rgba(255, 255, 255, 0.12)` |
| `--color-modal-shadow` | `0 8px 40px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.1)` | `0 8px 48px rgba(0,0,0,0.55), 0 2px 12px rgba(0,0,0,0.35)` |

### `apps/client/src/styles.scss`
Three targeted improvements to the Material Dialog global styles:

1. **Contrasting background** — `--mdc-dialog-container-color` now uses `var(--color-modal-bg)` instead of the page gradient
2. **Visible border + drop shadow** — `.mdc-dialog__surface` gets a subtle border and a strong multi-layer shadow, giving the modal clear visual depth and separation
3. **Rounded corners** — `border-radius: 16px` applied consistently on the surface element (matching the app's design language)
4. **Blurred backdrop overlay** — `.cdk-overlay-backdrop.cdk-overlay-backdrop-showing` now renders `var(--color-overlay)` (semi-transparent black) with `backdrop-filter: blur(2px)`, visually pushing the background away from the modal

---

## What was NOT changed
- No new dependencies introduced
- No component-level styles touched — all changes are in global stylesheets
- All values use existing design system tokens or extend them consistently
- Snackbar, slide-toggle, and all other global styles are untouched
