### PR TITLE
fix: add close button to share thread panel

### DIFF
--- a/apps/client/src/app/components/thread-share/thread-share.component.html
+++ b/apps/client/src/app/components/thread-share/thread-share.component.html
@@ -1,6 +1,15 @@
 <div class="thread-share">
   <div class="share-header">
-    <mat-icon>group</mat-icon>
+    <div class="header-left">
+      <mat-icon>group</mat-icon>
+      <span>Share</span>
+    </div>
+    <button mat-icon-button class="close-btn" (click)="close()" title="Close" type="button">
+      <mat-icon>chevron_right</mat-icon>
+    </button>
+  </div>
+
+  <div class="share-subheader">
     <span>Participants</span>
   </div>
 

--- a/apps/client/src/app/components/thread-share/thread-share.component.scss
+++ b/apps/client/src/app/components/thread-share/thread-share.component.scss
@@ -1,29 +1,68 @@
-.thread-share {
-  padding: 1rem;
+:host {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  height: 100%;
+}
+
+.thread-share {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-backdrop-blur);
+  -webkit-backdrop-filter: var(--glass-backdrop-blur);
+  color: var(--color-text);
 }
 
 .share-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  font-size: 0.9rem;
-  color: var(--color-text);
+  justify-content: space-between;
+  padding: 1rem;
+  padding-top: calc(1rem + env(safe-area-inset-top, 0px));
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
 
-  mat-icon {
-    font-size: 18px;
-    width: 18px;
-    height: 18px;
-    color: var(--color-text-secondary);
+  .header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--color-text);
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+      color: var(--color-text-secondary);
+    }
   }
+
+  .close-btn {
+    color: var(--color-text-secondary);
+
+    &:hover {
+      color: var(--color-text);
+      background: var(--color-bg-hover);
+    }
+  }
+}
+
+.share-subheader {
+  padding: 0.75rem 1rem 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
 }
 
 .add-user-section {
   display: flex;
   align-items: center;
+  padding: 0 1rem 0.75rem;
   width: 50%;
 }
 
@@ -31,12 +70,14 @@
   color: var(--color-error);
   font-size: 0.75rem;
   margin-top: -0.5rem;
+  padding: 0 1rem;
 }
 
 .users-list {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  padding: 0.25rem;
 }
 
 .user-item {

--- a/apps/client/src/app/components/thread-share/thread-share.component.ts
+++ b/apps/client/src/app/components/thread-share/thread-share.component.ts
@@ -27,6 +27,7 @@ export class ThreadShareComponent {
 
   @Output() userAdded = new EventEmitter<string>()
   @Output() userRemoved = new EventEmitter<string>()
+  @Output() closed = new EventEmitter<void>()
 
   protected readonly isAdding = signal(false)
   protected readonly errorMessage = signal('')
@@ -54,5 +55,9 @@ export class ThreadShareComponent {
 
   removeUser(userId: string): void {
     this.userRemoved.emit(userId)
+  }
+
+  close(): void {
+    this.closed.emit()
   }
 }

--- a/apps/client/src/app/components/thread/thread.component.html
+++ b/apps/client/src/app/components/thread/thread.component.html
@@ -117,21 +117,14 @@
         <app-file-exchange-drawer [projectName]="projectName" [threadId]="threadId" (closeDrawer)="closeDrawer()" />
       }
       @if (drawerMode === 'share' && threadDetails) {
-        <div class="share-drawer-container">
-          <div class="drawer-header">
-            <h3 class="drawer-title">Share</h3>
-            <button mat-icon-button class="close-btn" (click)="closeDrawer()" title="Close" type="button">
-              <mat-icon>chevron_right</mat-icon>
-            </button>
-          </div>
-          <app-thread-share
-            [threadId]="threadId"
-            [users]="threadDetails.users || []"
-            [currentUsername]="currentUsername"
-            (userAdded)="onUserAdded($event)"
-            (userRemoved)="onUserRemoved($event)"
-          />
-        </div>
+        <app-thread-share
+          [threadId]="threadId"
+          [users]="threadDetails.users || []"
+          [currentUsername]="currentUsername"
+          (userAdded)="onUserAdded($event)"
+          (userRemoved)="onUserRemoved($event)"
+          (closed)="closeDrawer()"
+        />
       }
     </mat-drawer>
   </mat-drawer-container>

--- a/apps/client/src/app/components/thread/thread.component.scss
+++ b/apps/client/src/app/components/thread/thread.component.scss
@@ -67,44 +67,8 @@
   }
 }
 
-// Share drawer container (inside the shared right-side mat-drawer)
-.share-drawer-container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  flex: 1; // Fill the flex column created by mat-drawer-inner-container
-  min-height: 0;
-  background: var(--glass-bg);
-  backdrop-filter: var(--glass-backdrop-blur);
-  -webkit-backdrop-filter: var(--glass-backdrop-blur);
-  color: var(--color-text);
-
-  .drawer-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1rem;
-    // Push below iOS status bar / notch on mobile
-    padding-top: calc(1rem + env(safe-area-inset-top, 0px));
-    border-bottom: 1px solid var(--color-border);
-    flex-shrink: 0;
-  }
-
-  .drawer-title {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--color-text);
-  }
-
-  .close-btn {
-    color: var(--color-text-secondary);
-    &:hover {
-      color: var(--color-text);
-      background: var(--color-bg-hover);
-    }
-  }
-}
+// Share drawer — app-thread-share is now self-contained (header + close button)
+// No wrapper div needed; the component fills the drawer directly
 
 @keyframes pulse-subtle {
   0%,


### PR DESCRIPTION
## Summary

Fixes #682 — the Share thread panel had no functional close button.

## Changes

- **`ThreadShareComponent`**: added `@Output() closed` emitter and moved the close button (`chevron_right`) into the component's own header, consistent with the `FileExchangeDrawerComponent` pattern
- **`thread.component.html`**: removed the redundant outer `drawer-header` wrapper; wired `(closed)="closeDrawer()"` directly on `<app-thread-share>`
- **`thread-share.component.scss`**: added `:host` display rules so the panel fills the full `mat-drawer` height

## Before / After

**Before**: the share panel had no close button and was cut off vertically inside the drawer.

**After**: the panel has a proper header with title + close button, fills the drawer height, and is self-contained like the file exchange drawer.