### PR TITLE
docs: #684 Jira on PM, AgentOS vision, multi-user & delegation doc

### DIFF
--- a/agentos/docs/multi-user-and-delegation.md
+++ b/agentos/docs/multi-user-and-delegation.md
@@ -1,0 +1,85 @@
+# Multi-User & Delegation
+
+## Runtime Scope: CaseRuntime
+
+Each active case owns a `CaseRuntime` instance held in memory by `CaseServiceImpl`. The runtime is the unit of execution: it owns the event list, the SSE flow, the kill flag, and the main coroutine loop. It is callback-driven — all persistence and agent execution are delegated back to `CaseServiceImpl`, keeping the runtime itself free of Spring dependencies.
+
+A `CaseRuntime` lives from the first `addMessage()` call until the case reaches a terminal status (`KILLED` or `ERROR`), at which point it is evicted from the in-memory map. A case in `IDLE` status still has a live runtime and open SSE connections; it resumes on the next user message without rehydration.
+
+### Status lifecycle
+
+```
+PENDING → RUNNING → IDLE → RUNNING → IDLE ...   (normal turns)
+                  → KILLED                        (explicit kill)
+                  → ERROR                         (max iterations or exception)
+```
+
+Terminal statuses are permanent. `isTerminal()` returns true for `KILLED` and `ERROR`. The runtime is evicted *after* the terminal `CaseStatusEvent` is emitted so SSE clients always receive the final status.
+
+## Multi-User: Current State
+
+The `Actor` model (`id`, `displayName`, `role: ActorRole`) is already embedded in the event hierarchy. Every `MessageEvent` and `AnswerEvent` carries the originating actor. `ActorRole` has two values: `USER` and `AGENT`.
+
+`CaseRuntime.addUserMessage()` takes an explicit `Actor` parameter — the service layer is responsible for resolving who is sending a message. `processNextStep()` identifies the most recent user message by scanning backward for `actor.role == USER`, which means the runtime is already multi-actor-aware at the event level.
+
+What is **not yet implemented**:
+- Per-request user identity propagation through the HTTP layer into the runtime
+- SSE streams scoped to a specific user (currently one SSE flow per case, not per user-session)
+- User-to-user interaction routing (the `ActorSelectedEvent` concept described below)
+
+## ActorSelectedEvent — Product Target
+
+The sprint forge discussions identified a need to route a turn not just to an agent but to a specific actor — human or AI. The concept: an `ActorSelectedEvent` would carry a target actor that could be:
+
+- A **user** — triggers a push notification on their preferred channel
+- A **group** — fan-out notification
+- An **agent** — triggers a new agent run (current behaviour of `AgentSelectedEvent`)
+
+This generalises the current agent-selection pattern into a unified actor-selection pattern. `AgentSelectedEvent` becomes a specialisation for the `AGENT` role case.
+
+The SSE implication is significant: today the SSE flow is case-scoped. To support per-user notification, each browser session needs its own SSE connection scoped to the user (not the case), with a subscription model that fans events from cases to interested user sessions. This is a planned architectural evolution, not yet implemented.
+
+## Delegation Patterns
+
+AgentOS does not yet have a native delegation mechanism equivalent to Coday's `DELEGATE__delegate` tool. The notes below describe the Coday patterns that AgentOS will eventually need to support or replicate.
+
+### Sync vs async
+
+- **Sync delegation**: the parent waits for the sub-agent to finish before continuing. Result is returned inline. Safe for short-lived tasks.
+- **Async / fire-and-forget**: the parent receives a `threadId` immediately and continues. The sub-thread runs independently. Used for long-running tasks or when the result is not needed inline.
+
+The choice between sync and async has deep architectural implications: async delegation means the parent's SSE flow and the sub-thread's SSE flow are independent. Reconnecting to a case does not automatically surface sub-thread events — this is an open UX problem.
+
+### ThreadId routing
+
+A sub-thread is identified by its `threadId`. To resume a delegation (add new work to an existing sub-thread), pass the `threadId` to the delegate tool instead of creating a new thread. The agent in the resumed thread has full access to its prior history.
+
+### Known limitations (Coday, as of 2025)
+
+These bugs affect delegation in the current Coday runtime and are relevant context for designing AgentOS delegation:
+
+- **#623** — `AI__redirect` inside a delegation lands on the parent thread, not the sub-thread
+- **#619** — delegation blocks when a sub-agent asks an interactive question (no user is listening on the sub-thread SSE)
+- **#582** — delegation is blocked in `prompt` context
+
+The root cause of #619 is the mismatch between the interactive-question model (which assumes a user is present) and the delegation model (which runs headless). AgentOS should treat interactive questions in delegated/headless contexts as errors or timeouts, not blocking waits.
+
+### Design constraints for AgentOS
+
+When implementing delegation in AgentOS:
+
+1. A delegated `CaseRuntime` must know whether it is running interactively (user present on SSE) or headlessly (spawned by another agent). Interactive questions should be refused or time-out in headless mode.
+2. Sub-case events need a parent-case link if the UI is to surface them inline.
+3. Async delegation requires the parent to store the sub-case `id` as part of its event history so it can reconnect later.
+4. The `stackDepth` concept (max nesting of delegations) must be enforced to prevent infinite delegation chains.
+
+## Agent-Centric vs Project-Centric Scoping
+
+The current AgentOS model is namespace-scoped: a `Case` belongs to a `Namespace`, and agents are discovered within that namespace. This is essentially project-centric.
+
+The target is flexible agent scoping across multiple levels:
+- **User scope** — an agent that knows a specific user across all their projects (twin concept)
+- **Namespace/project scope** — current model, agents siloed per project
+- **Case/thread scope** — agents that only exist for the duration of a single case
+
+Cross-project agent access (a user-scoped agent that can reach into multiple namespaces) and namespace hierarchies (worktrees as sub-namespaces inheriting from a parent) are open design questions. No architectural decision has been taken yet; both models should remain possible as AgentOS evolves.

--- a/agents/PM.yaml
+++ b/agents/PM.yaml
@@ -43,6 +43,7 @@ integrations:
 #    - update_pull_request
 #    - update_pull_request_branch
   FILES:
+  JIRA:
   DELEGATE:
     - Sway
     - Archay
@@ -141,7 +142,10 @@ instructions: |
   5. Tool recommendations
   - use multiples searches or delegate to agents to find information
   - do not create entities (issues, projects) unless obviously needed for the user
-  - leverage the existing github issues and PRs to get an understanding of the project's state
+  - the roadmap lives in GitHub issues and milestones — there is no static roadmap file; use list_issues, search_issues, and milestone filters to get a current snapshot before making prioritisation decisions
+  - use Jira tools for sprint-level tracking (sprint status, velocity, ticket creation, story points); use GitHub tools for feature-level detail (PR review, code issues, CI status)
+  - Jira and GitHub are complementary: a feature typically has both a Jira ticket (sprint tracking) and a GitHub issue (technical detail + PR link); keep them in sync when working on a feature
+  - when assessing the strategic direction, refer to product/01-vision.md — it describes the AgentOS-first target and explains that all new server-side work belongs in AgentOS, not the Express prototype
 
   ## Git Worktree Workflow
 
@@ -187,3 +191,4 @@ mandatoryDocs:
   - ./product/04-guidelines.md
   - ./docs/to-rework/INTEGRATIONS.md
   - ./docs/to-rework/DEV_WORKFLOW.md
+  - ./agentos/docs/multi-user-and-delegation.md

--- a/product/01-vision.md
+++ b/product/01-vision.md
@@ -43,8 +43,29 @@ agents and internal technical agents to provide sophisticated capabilities while
 
 ## AgentOS Evolution
 
-**AgentOS** is the production-ready backend (Spring Boot + Kotlin + Spring AI) that will replace Coday's Node.js backend for enterprise deployment.
+**AgentOS** is the strategic backend (Spring Boot + Kotlin + Spring AI) that will replace Coday's current Node.js server entirely. It is already used in production at Whoz and is the target platform for all future server-side development. The Node.js Express server (`apps/server`) is a prototype that will be retired once AgentOS reaches feature parity.
 
-- **Coday**: Developer-focused, local workflows, rapid prototyping
-- **AgentOS**: Production orchestration, Docker deployment, plugin system (PF4J)
-- **Transition**: Both coexist during development, shared UI via `/agentos/` route
+- **Coday** (`libs/`, `apps/client`): the core runtime, tool implementations, and Angular frontend — these remain and are not replaced
+- **AgentOS** (`agentos/`): replaces `apps/server`; provides production-grade orchestration, multi-tenancy, plugin system (PF4J), and REST+SSE API
+- **Transition**: both coexist during development; the Angular client already proxies `/api/agentos/*` to AgentOS; new server-side features should be built in AgentOS, not in the Express server
+
+All tool integrations and agent capabilities currently implemented in the Node.js layer are to be progressively migrated or re-implemented in AgentOS plugins.
+
+### How the roadmap works
+
+There is no static roadmap file — the backlog lives in GitHub issues and milestones. When evaluating priorities or planning a sprint, PM should:
+- Browse open issues filtered by milestone or label on GitHub
+- Use the `list_issues` and `search_issues` tools to get a current snapshot
+- Use Jira for sprint-level tracking and velocity; GitHub for feature-level detail and PR linkage
+
+This keeps the roadmap as the single source of truth and avoids drift between a doc and the actual state of work.
+
+### Key design targets for AgentOS
+
+**Multi-user from the start.** A case (conversation thread) can involve multiple human actors. The `Actor` model is already in the event hierarchy; the HTTP layer and SSE routing need to follow. Each browser session should eventually have its own user-scoped SSE channel, with a subscription model that fans case events to the right sessions. This is a hard architectural concern — retrofitting multi-user later is expensive.
+
+**Flexible agent scoping.** Agents should not be locked to a single project namespace. The target model allows agent scope at multiple levels: user (a personal twin that spans projects), namespace/project (current model), and case (ephemeral). This enables cross-project agent access and a user having a personal agent space that can reach into their project namespaces.
+
+**Delegation as a first-class pattern.** Agent-to-agent delegation (spawning sub-cases, sync or async, with result routing) is central to multi-agent orchestration. The design must handle headless sub-cases (no user on SSE), result propagation back to the parent, and stack depth limits. Interactive questions in headless contexts must fail fast rather than block indefinitely.
+
+**Namespace hierarchies.** Worktrees and sub-projects suggest a natural parent/child namespace relationship. The data model should leave room for namespace trees and cross-namespace agent visibility without committing to a specific topology prematurely.

--- a/product/02-domain-model.md
+++ b/product/02-domain-model.md
@@ -37,9 +37,9 @@ Key aspects:
 - Configures integration points
 - Sets up development environment context
 
-### AiThread
+### AiThread / Case
 
-An AiThread represents an ongoing interaction context between User and Agents. It:
+An AiThread (Coday) or Case (AgentOS) represents an ongoing interaction context between User and Agents. It:
 
 - Maintains its own event history
 - Manages token limits for AI context
@@ -47,7 +47,7 @@ An AiThread represents an ongoing interaction context between User and Agents. I
 - Provides optimized views of its history
 - Ensures continuity of conversation
 - Maintains agent-specific state in thread scope
-- Supports multi-agent interaction patterns
+- Supports multi-actor interaction patterns
 
 Key characteristics:
 
@@ -56,6 +56,8 @@ Key characteristics:
 - History optimization
 - Context window management
 - Tool state tracking
+
+In AgentOS, a `Case` is backed by a `CaseRuntime` that owns the execution loop for the duration of the case. The runtime is scoped to the case (not the user): multiple users can send messages to the same case, each identified by their `Actor`. The runtime is alive from first message until the case reaches a terminal status (`KILLED` or `ERROR`); a case in `IDLE` state keeps its runtime alive and ready to resume.
 
 AiThreads are to be forked, cloned, and re-worked for use by technical agents and project agents. Yet, only the main
 AiThread holds only project agents contributions.
@@ -73,10 +75,14 @@ Events are atomic units of interaction that flow through the system. Types inclu
 Key aspects:
 
 - Carry full context
-- AiThread-scoped
+- AiThread/Case-scoped
 - Immutable
 - Sequential
 - Traceable
+
+In AgentOS, every event carries `namespaceId`, `caseId`, `timestamp`, and an `Actor` where relevant. The `Actor` model (`id`, `displayName`, `role: USER|AGENT`) makes the event history inherently multi-actor: multiple human users can participate in the same case, each identified by their actor.
+
+**Target: ActorSelectedEvent.** Current agent selection produces an `AgentSelectedEvent`. The planned generalisation is an `ActorSelectedEvent` that can target a user (triggering a notification on their preferred channel), a group (fan-out), or an agent (triggering an agent run). This unifies human and agent routing under a single concept and is a prerequisite for true multi-user interactive cases.
 
 ### Tools
 
@@ -201,6 +207,24 @@ Key aspects:
 - Coday Project Agent → AgentOS Plugin Agent
 - Coday Technical Agent → AgentOS Orchestrator
 - Coday Tool → AgentOS Capability
+- Coday AiThread → AgentOS Case + CaseRuntime
+
+## Open Design Questions
+
+### Agent-centric vs project-centric scoping
+
+The current model is namespace/project-scoped: agents are discovered within a namespace, and a case belongs to a namespace. This is project-centric.
+
+The target is flexible scoping across multiple levels:
+- **User scope** — an agent that knows a specific user across all their projects (twin concept)
+- **Namespace/project scope** — current model
+- **Case/thread scope** — ephemeral agents for the duration of a single case
+
+Both models (and their coexistence) should remain possible. No architectural decision has been taken yet.
+
+### Namespace hierarchies and cross-project access
+
+Worktrees naturally create a parent/child relationship between a project and its branches. Whether this maps to a namespace hierarchy in AgentOS (sub-namespaces inheriting agents/tools from a parent) and whether agents can have cross-namespace reach are open questions. The data model should not close these doors prematurely.
 
 ## Domain Relationships
 


### PR DESCRIPTION
## Changes

Partial implementation of #684 — agent documentation update for Jira config, sprint forge learnings, and AgentOS vision alignment.

### `agents/PM.yaml`
- Added `JIRA` integration (mirrors `Dev.yaml`)
- Tool recommendations updated: roadmap lives in GitHub issues/milestones (no static file), Jira/GitHub split clarified (sprint vs feature), pointer to `01-vision.md` for AgentOS direction
- Added `agentos/docs/multi-user-and-delegation.md` to `mandatoryDocs`

### `product/01-vision.md`
- AgentOS section rewritten to be directional: replaces `apps/server`, already in prod at Whoz, all new server-side work belongs in AgentOS
- Clear distinction: Coday `libs/` + `apps/client` stay, `apps/server` is the prototype being retired
- Short \"How the roadmap works\" paragraph: GitHub issues + Jira, no static roadmap file
- Four AgentOS design targets added: multi-user, flexible agent scoping, delegation as first-class, namespace hierarchies

### `product/02-domain-model.md`
- `AiThread` section updated to `AiThread / Case` with `CaseRuntime` lifecycle description
- Events section enriched with `Actor` model and `ActorSelectedEvent` as product target
- New \"Open Design Questions\" section: agent-centric vs project-centric, namespace hierarchies

### `agentos/docs/multi-user-and-delegation.md` (new)
- `CaseRuntime` scope and lifecycle
- Multi-user current state vs target (`ActorSelectedEvent`)
- Delegation patterns: sync/async, threadId routing, known Coday bugs (#619, #623, #582) as design context for AgentOS
- Agent-centric vs project-centric as open question

## Not in scope
- `agents/Archay.yaml` — deferred, its `mandatoryDocs` point to `to-rework/` docs that need their own update first
- Personas, KPIs, transition timeline — require product decisions before documenting"