### PR TITLE
fix: add GITHUB_TOKEN for pnpm install in macos host

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import Code Signing Certificate
         env:


### PR DESCRIPTION
(see https://github.com/microsoft/vscode-ripgrep/issues/9)