### PR TITLE
feat: resolve {{projectRoot}} token in MCP server config fields

### DIFF
--- a/libs/service/src/lib/mcp-config.service.ts
+++ b/libs/service/src/lib/mcp-config.service.ts
@@ -5,6 +5,7 @@ import { McpServerConfig } from '@coday/model'
 import { ConfigLevel, ConfigLevelValidator } from '@coday/model'
 import { CommandContext } from '@coday/model'
 import { mergeMcpConfigs } from './mcp-config-merger'
+import { resolveServerTokens } from './mcp-token-resolver'
 
 /**
  * Represents the combined MCP configuration from all levels
@@ -25,6 +26,7 @@ export interface McpConfiguration {
 export class McpConfigService {
   private mcpCache: Map<ConfigLevel, McpServerConfig[]> = new Map()
   private mergedConfig: McpConfiguration | null = null
+  private projectRoot: string = ''
 
   constructor(
     private userService: UserService,
@@ -38,6 +40,7 @@ export class McpConfigService {
   initialize(context: CommandContext): void {
     this.mcpCache.clear()
     this.mergedConfig = null
+    this.projectRoot = context.project.root
 
     // Cache configurations at each level for faster access
     const codayServers = context.project.mcp?.servers || []
@@ -106,7 +109,10 @@ export class McpConfigService {
       )
     })
 
-    this.mergedConfig = { servers: validatedServers }
+    const resolvedServers = validatedServers.map((server) => resolveServerTokens(server, this.projectRoot))
+
+    this.mergedConfig = { servers: resolvedServers }
+
     return this.mergedConfig
   }
 

--- a/libs/service/src/lib/mcp-token-resolver.test.ts
+++ b/libs/service/src/lib/mcp-token-resolver.test.ts
@@ -1,0 +1,142 @@
+import { McpServerConfig } from '@coday/model'
+import { resolveTokensInString, resolveServerTokens } from './mcp-token-resolver'
+
+describe('resolveTokensInString', () => {
+  it('replaces {{projectRoot}} with the given path', () => {
+    expect(resolveTokensInString('--workspacePath={{projectRoot}}', { projectRoot: '/home/user/my-project' })).toBe(
+      '--workspacePath=/home/user/my-project'
+    )
+  })
+
+  it('replaces multiple occurrences of {{projectRoot}}', () => {
+    expect(resolveTokensInString('{{projectRoot}}/a:{{projectRoot}}/b', { projectRoot: '/root' })).toBe(
+      '/root/a:/root/b'
+    )
+  })
+
+  it('leaves strings without tokens unchanged', () => {
+    expect(resolveTokensInString('--no-minimal', { projectRoot: '/root' })).toBe('--no-minimal')
+  })
+
+  it('leaves unknown tokens unchanged', () => {
+    expect(resolveTokensInString('{{unknownToken}}', { projectRoot: '/root' })).toBe('{{unknownToken}}')
+  })
+
+  it('handles empty string', () => {
+    expect(resolveTokensInString('', { projectRoot: '/root' })).toBe('')
+  })
+})
+
+describe('resolveServerTokens', () => {
+  const projectRoot = '/home/user/whoz'
+
+  it('resolves {{projectRoot}} in args', () => {
+    const server: McpServerConfig = {
+      id: 'nx-mcp',
+      name: 'NX',
+      command: 'npx',
+      args: ['nx', 'mcp', '--workspacePath={{projectRoot}}'],
+      enabled: true,
+    }
+    const result = resolveServerTokens(server, projectRoot)
+    expect(result.args).toEqual(['nx', 'mcp', `--workspacePath=${projectRoot}`])
+  })
+
+  it('resolves {{projectRoot}} in command', () => {
+    const server: McpServerConfig = {
+      id: 'test',
+      name: 'Test',
+      command: '{{projectRoot}}/bin/my-mcp',
+      enabled: true,
+    }
+    const result = resolveServerTokens(server, projectRoot)
+    expect(result.command).toBe(`${projectRoot}/bin/my-mcp`)
+  })
+
+  it('resolves {{projectRoot}} in cwd', () => {
+    const server: McpServerConfig = {
+      id: 'test',
+      name: 'Test',
+      command: 'some-mcp',
+      cwd: '{{projectRoot}}',
+      enabled: true,
+    }
+    const result = resolveServerTokens(server, projectRoot)
+    expect(result.cwd).toBe(projectRoot)
+  })
+
+  it('resolves {{projectRoot}} in env values', () => {
+    const server: McpServerConfig = {
+      id: 'test',
+      name: 'Test',
+      command: 'some-mcp',
+      env: { MY_PATH: '{{projectRoot}}/config', STATIC: 'no-token' },
+      enabled: true,
+    }
+    const result = resolveServerTokens(server, projectRoot)
+    expect(result.env).toEqual({
+      MY_PATH: `${projectRoot}/config`,
+      STATIC: 'no-token',
+    })
+  })
+
+  it('does not mutate the original server config', () => {
+    const server: McpServerConfig = {
+      id: 'nx-mcp',
+      name: 'NX',
+      command: 'npx',
+      args: ['nx', 'mcp', '--workspacePath={{projectRoot}}'],
+      enabled: true,
+    }
+    const originalArgs = [...server.args!]
+    resolveServerTokens(server, projectRoot)
+    expect(server.args).toEqual(originalArgs)
+  })
+
+  it('handles server with no args, cwd, or env', () => {
+    const server: McpServerConfig = {
+      id: 'minimal',
+      name: 'Minimal',
+      command: 'minimal-mcp',
+      enabled: true,
+    }
+    const result = resolveServerTokens(server, projectRoot)
+    expect(result.args).toBeUndefined()
+    expect(result.cwd).toBeUndefined()
+    expect(result.env).toBeUndefined()
+    expect(result.command).toBe('minimal-mcp')
+  })
+
+  it('handles undefined command', () => {
+    const server: McpServerConfig = {
+      id: 'url-based',
+      name: 'URL Based',
+      url: 'http://localhost:3000',
+      enabled: true,
+    }
+    const result = resolveServerTokens(server, projectRoot)
+    expect(result.command).toBeUndefined()
+  })
+
+  it('preserves all other server fields unchanged', () => {
+    const server: McpServerConfig = {
+      id: 'nx-mcp',
+      name: 'NX',
+      command: 'npx',
+      args: ['nx', 'mcp'],
+      enabled: true,
+      debug: true,
+      noShare: false,
+      allowedTools: ['nx_docs'],
+      authToken: 'secret',
+    }
+    const result = resolveServerTokens(server, projectRoot)
+    expect(result.id).toBe('nx-mcp')
+    expect(result.name).toBe('NX')
+    expect(result.enabled).toBe(true)
+    expect(result.debug).toBe(true)
+    expect(result.noShare).toBe(false)
+    expect(result.allowedTools).toEqual(['nx_docs'])
+    expect(result.authToken).toBe('secret')
+  })
+})

--- a/libs/service/src/lib/mcp-token-resolver.ts
+++ b/libs/service/src/lib/mcp-token-resolver.ts
@@ -1,0 +1,42 @@
+import { McpServerConfig } from '@coday/model'
+
+/**
+ * Tokens available for substitution in MCP server config fields.
+ *
+ * Usage in coday.yaml:
+ *   args:
+ *     - --workspacePath={{projectRoot}}
+ *
+ * Available tokens:
+ *   {{projectRoot}}  — absolute path to the project root (where coday.yaml lives)
+ */
+export type TokenContext = {
+  projectRoot: string
+}
+
+/**
+ * Replace all known {{token}} placeholders in a string value.
+ */
+export function resolveTokensInString(value: string, ctx: TokenContext): string {
+  return value.replace(/\{\{projectRoot\}\}/g, ctx.projectRoot)
+}
+
+/**
+ * Resolve tokens in all string fields of an MCP server config that
+ * may contain user-defined paths or values: command, args, cwd, env values.
+ *
+ * Returns a new McpServerConfig object — the original is not mutated.
+ */
+export function resolveServerTokens(server: McpServerConfig, projectRoot: string): McpServerConfig {
+  const ctx: TokenContext = { projectRoot }
+
+  return {
+    ...server,
+    command: server.command ? resolveTokensInString(server.command, ctx) : server.command,
+    args: server.args?.map((arg) => resolveTokensInString(arg, ctx)),
+    cwd: server.cwd ? resolveTokensInString(server.cwd, ctx) : server.cwd,
+    env: server.env
+      ? Object.fromEntries(Object.entries(server.env).map(([k, v]) => [k, resolveTokensInString(v, ctx)]))
+      : server.env,
+  }
+}


### PR DESCRIPTION
Adds `{{projectRoot}}` token support in MCP server configurations.

## Problem
MCP server configs in `coday.yaml` required hardcoded absolute paths (e.g. `--workspacePath=/Users/name/...`), making them non-portable across machines and contributors.

## Solution
Introduces a token resolver that substitutes `{{projectRoot}}` with the project's root path at runtime, applied to `command`, `args`, `cwd`, and `env` values before the MCP server is spawned.

## Usage
```yaml
- id: nx-mcp
  name: NX
  command: npx
  args:
    - nx
    - mcp
    - --no-minimal
  cwd: "{{projectRoot}}"
```

## Changes
- `mcp-token-resolver.ts` — new pure utility (`resolveTokensInString`, `resolveServerTokens`)
- `mcp-token-resolver.test.ts` — 12 unit tests
- `mcp-config.service.ts` — applies token resolution in `getMergedConfiguration()` after merge and validation