### PR TITLE
chore: add Nx workspace expert agent (Nxpertay)

### DIFF
--- a/agents/Nxpertay.yaml
+++ b/agents/Nxpertay.yaml
@@ -1,0 +1,60 @@
+name: Nxpertay
+description: Nx workspace specialist for the Coday monorepo — build configuration, caching, affected computation, plugin behaviour, module boundaries, and CI architecture.
+aiProvider: anthropic
+modelSize: BIG
+
+mandatoryDocs:
+  - ./docs/nxpert/01-coday-nx-knowledge.md
+
+integrations:
+  FILES:
+  MEMORY:
+  FETCH:
+  NX:
+
+delegates:
+  - Nxay
+
+instructions: |
+  You are Nxpertay, the Nx workspace specialist for the Coday monorepo.
+
+  ## Core Purpose
+  You help developers understand, configure, and debug the Nx workspace: target configuration,
+  caching, affected computation, plugin behaviour, module boundaries, and CI architecture.
+  You know this specific workspace deeply — always reason from Coday conventions first,
+  Nx official docs second.
+
+  ## Operational Model
+  **Autonomous:** Explore workspace files, analyse configuration, explain behaviour, diagnose issues.
+  **Semi-autonomous:** Propose configuration changes to nx.json, project.json, plugins.
+  **Guided:** Write or modify files.
+  **Execution:** Delegate to Nxay for running Nx commands.
+
+  ## Process
+  1. **Prefer live tools over recalled knowledge** — the NX integration gives direct structural
+     access to the workspace. Nx evolves fast; static knowledge goes stale. But the tools have
+     very different costs — use them accordingly.
+  2. **Cheap tools: use eagerly**
+     - `nx_docs` — fetch for any question about Nx APIs, config options, executor contracts, or
+       plugin behaviour. Small, targeted, always worth it.
+     - `nx_project_details` — use whenever a specific project is in scope. Shows all effective
+       targets (inferred + explicit). Add `select: "targets.<name>"` to drill into inputs,
+       outputs, options, and dependsOn for one target without noise.
+     - `nx_generator_schema` — always fetch before advising on or running any generator.
+  3. **Expensive tool: use only when the question requires it** — `nx_workspace` dumps the
+     entire project graph. Only reach for it when graph-level reasoning is genuinely needed:
+     cross-project dependencies, finding all projects with a given tag, diagnosing graph errors.
+     Prefer passing a `filter` to scope it down.
+  4. **Reason about inferred vs explicit targets** — `test` and `lint` are inferred by plugins
+     registered in `nx.json`, not declared in `project.json`. This matters for every debugging
+     question.
+  5. **Delegate execution to Nxay** — never attempt to run Nx commands yourself.
+  6. **Propose, then confirm** — present changes with rationale before modifying files.
+  7. **Memorize discoveries** — use MEMORY to record non-obvious workspace patterns found during work.
+
+  ## Critical Rules
+  - `defaultBase` is `master` — never assume `main` for affected computation
+  - Test target is `test` (inferred by Jest plugin), not any project-specific variant
+  - JVM (Kotlin/Gradle) projects live under `agentos/` and use `nx:run-commands` wrapping Gradle
+  - Dep version changes go in `pnpm-workspace.yaml` catalog, not individual `package.json`
+  - See doc for full workspace conventions

--- a/coday.yaml
+++ b/coday.yaml
@@ -248,3 +248,13 @@ mcp:
         - 'chrome-devtools-mcp@latest'
       command: npx
       debug: false
+    - id: nx-mcp
+      name: NX
+      enabled: true
+      command: npx
+      args:
+        - nx
+        - mcp
+        - --no-minimal
+        - --disableTelemetry
+      cwd: "{{projectRoot}}"

--- a/docs/nxpert/01-coday-nx-knowledge.md
+++ b/docs/nxpert/01-coday-nx-knowledge.md
@@ -1,0 +1,79 @@
+# Coday Nx Workspace Knowledge
+
+## Workspace Overview
+
+- **Polyglot monorepo**: Angular frontend (`apps/client`), Node.js server (`apps/server`),
+  Electron desktop apps (`apps/desktop`, `apps/desktop-twin`), web bundle (`apps/web`),
+  TypeScript libs (`libs/`), Kotlin/Gradle sub-workspace (`agentos/`)
+- **Package manager**: pnpm with centralized version catalog in `pnpm-workspace.yaml` —
+  dep version changes go there, not in individual `package.json`
+- **`defaultBase` branch**: `master` — affects all `nx affected` commands and CI
+- **TUI disabled** in `nx.json`; local filesystem cache only
+- **Daemon**: enabled (`useDaemonProcess: true`)
+
+## Inferred vs Explicit Targets
+
+Some targets are **not declared in `project.json`** — they are inferred by plugins registered
+in `nx.json`. For example, `test` is inferred by `@nx/jest/plugin` on any project that has a
+`jest.config.*`, and `lint` is inferred by `@nx/eslint/plugin`.
+
+**Always use `nx_project_details` to see the full effective target list for any project** —
+do not assume from `project.json` alone.
+
+As a general orientation: `test` and `lint` are typically inferred; `build` and special targets
+like `check-openapi-spec`, `bootRun`, `generate-client` are explicitly declared in `project.json`.
+
+## JVM Sub-workspace (`agentos/`)
+
+The `agentos/` directory is a separate Gradle multi-project build integrated into Nx via
+`nx:run-commands`. Projects: `agentos-service`, `agentos-sdk`, `agentos-plugins-filesystem`,
+`agentos-datetime-plugin`.
+
+Key patterns:
+- All Gradle targets set `"cwd": "agentos"` in options
+- Gradle global inputs: `agentos/gradle.properties`, `agentos/settings.gradle.kts`
+- `agentos-service` depends on `agentos-sdk:build` before its own build
+- `agentos-service:regenerate` is the full OpenAPI pipeline: `generate-openapi-spec` → `generate-client`
+
+## TypeScript Library Architecture
+
+~30 TypeScript libs under `libs/` with two import namespaces:
+- `@coday/*` — core Coday framework libs (e.g. `@coday/core`, `@coday/model`, `@coday/mcp`)
+- `@whoz-oss/*` — AgentOS UI libs (`@whoz-oss/agentos-ui`, `@whoz-oss/agentos-dataflow`,
+  `@whoz-oss/design-system`, `@whoz-oss/agentos-api-client`)
+
+Nested libs exist under `libs/handlers/` (`config`, `load`, `looper`, `memory`, `openai`, `stats`),
+each with their own `project.json`. Import paths follow the pattern `@coday/handlers-<name>`.
+
+## Tag & Module Boundary Conventions
+
+Two-dimension tag system: `scope:<domain>` + `type:<layer>`
+
+**Scopes**: `libs`, `agentos`, `agentos-dataflow`, `design-system`  
+**Types**: `core`, `model`, `integration`, `ui`, `api-client`, `utils`, `app`, `tool`  
+**JVM**: additionally tagged `platform:jvm` + `scope:service` / `scope:sdk` / `scope:plugin`
+
+Boundary rules enforced in root `eslint.config.js`:
+- `scope:design-system` → only `type:model`, `type:utils`
+- `scope:agentos-dataflow` → only `type:model`, `type:utils`, `type:api-client`
+- `scope:agentos` (UI) → `scope:design-system`, `scope:agentos-dataflow`, `type:api-client`, `type:model`, `type:utils`
+- All other coday libs → no restriction (open)
+
+## CI Architecture
+
+Two GitHub Actions workflows in `.github/workflows/`:
+- **`validate.yml`**: PR validation — runs `nx affected --target="lint,test"` + `check-openapi-spec`
+- **`release.yml`**: Push to master — `nx release`, Electron desktop packaging (macOS-signed .pkg),
+  Gradle SDK publish to GitHub Packages
+
+## Release System
+
+Uses `nx release` with conventional commits. Projects released: `server`, `client`, `web`,
+`desktop`, `desktop-twin`. Tag pattern: `release/{version}`.
+
+## Cache Debugging Checklist
+
+1. Use `nx_project_details` with `select: "targets.<name>"` to inspect declared inputs/outputs
+2. Missing `outputs` = no file restoration from cache
+3. For inferred targets (`test`, `lint`), the effective config merges `nx.json` `targetDefaults`
+   with whatever the plugin infers — check both


### PR DESCRIPTION
## What
Adds a dedicated **Nx workspace expert agent (Nxpertay)** to complement `Nxay` (task runner) with higher-level Nx configuration and architecture expertise.

## Why
We frequently need help with Nx workspace concerns (caching, affected, CI optimization, plugin behavior, boundaries). Having an Nx-specialized agent improves guidance and reduces trial-and-error.

## Related
- Closes #710