### PR TITLE
feat: self-healing CI release pipeline with Coday webhook notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,10 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+          CODAY_WEBHOOK_URL: ${{ secrets.CODAY_WEBHOOK_URL }}
+          CODAY_CI_HEALING_PROMPT_ID: ${{ secrets.CODAY_CI_HEALING_PROMPT_ID }}
         run: |
-          pnpm nx release --yes
+          pnpm nx run tools-release:release
           # Capture the new version for desktop build from client package.json
           NEW_VERSION=$(node -p "require('./apps/client/package.json').version")
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT

--- a/tools/release/project.json
+++ b/tools/release/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "tools-release",
+  "targets": {
+    "release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsx tools/release/release.ts",
+        "env": {
+          "HUSKY": "0"
+        }
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "jest tools/release/release.test.ts --config jest.config.ts"
+      },
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/release.ts",
+        "{projectRoot}/release.test.ts"
+      ]
+    }
+  }
+}

--- a/tools/release/release.test.ts
+++ b/tools/release/release.test.ts
@@ -1,0 +1,101 @@
+import { notifyCoday, type NotifyCodayEnv } from './release'
+
+const baseEnv: NotifyCodayEnv = {
+  baseUrl: 'https://coday.example.com',
+  promptId: 'test-prompt-id',
+  runUrl: 'https://github.com/whoz-oss/coday/actions/runs/123',
+  branch: 'master',
+  commitSha: 'abc123',
+}
+
+describe('notifyCoday', () => {
+  let fetchMock: jest.MockedFunction<typeof fetch>
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response)
+    global.fetch = fetchMock
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when env vars are missing', () => {
+    it('skips and warns when baseUrl is missing', async () => {
+      await notifyCoday('releaseVersion', new Error('boom'), {}, { ...baseEnv, baseUrl: undefined })
+
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Skipped'))
+    })
+
+    it('skips and warns when promptId is missing', async () => {
+      await notifyCoday('releaseVersion', new Error('boom'), {}, { ...baseEnv, promptId: undefined })
+
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Skipped'))
+    })
+  })
+
+  describe('when env vars are present', () => {
+    it('builds and calls the correct webhook URL from baseUrl and promptId', async () => {
+      await notifyCoday('releaseVersion', new Error('boom'), {}, baseEnv)
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://coday.example.com/api/webhooks/test-prompt-id/execute',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('sends correct headers', async () => {
+      await notifyCoday('releaseVersion', new Error('boom'), {}, baseEnv)
+
+      const [, options] = fetchMock.mock.calls[0]!
+      expect((options as RequestInit).headers).toEqual({
+        'Content-Type': 'application/json',
+        'x-forwarded-email': 'ci-bot@coday',
+      })
+    })
+
+    it('includes phase, error and env context in the payload', async () => {
+      await notifyCoday('releaseChangelog', new Error('changelog failed'), {}, baseEnv)
+
+      const [, options] = fetchMock.mock.calls[0]!
+      const body = JSON.parse((options as RequestInit).body as string)
+
+      expect(body.phase).toBe('releaseChangelog')
+      expect(body.error).toBe('Error: changelog failed')
+      expect(body.runUrl).toBe(baseEnv.runUrl)
+      expect(body.branch).toBe('master')
+      expect(body.commitSha).toBe('abc123')
+      expect(body.awaitFinalAnswer).toBe(false)
+    })
+
+    it('merges extra context into the payload', async () => {
+      await notifyCoday('releasePublish', 'publish failed', { failedProjects: ['server', 'client'] }, baseEnv)
+
+      const [, options] = fetchMock.mock.calls[0]!
+      const body = JSON.parse((options as RequestInit).body as string)
+
+      expect(body.failedProjects).toEqual(['server', 'client'])
+    })
+
+    it('sets the title from the phase name', async () => {
+      await notifyCoday('releaseVersion', 'error', {}, baseEnv)
+
+      const [, options] = fetchMock.mock.calls[0]!
+      const body = JSON.parse((options as RequestInit).body as string)
+
+      expect(body.title).toBe('Release failure: releaseVersion')
+    })
+
+    it('does not throw when fetch fails', async () => {
+      fetchMock.mockRejectedValue(new Error('network error'))
+
+      await expect(notifyCoday('releaseVersion', 'error', {}, baseEnv)).resolves.toBeUndefined()
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to notify Coday'), expect.any(Error))
+    })
+  })
+})

--- a/tools/release/release.ts
+++ b/tools/release/release.ts
@@ -1,0 +1,116 @@
+import { releaseChangelog, releasePublish, releaseVersion } from 'nx/release'
+
+export interface NotifyCodayEnv {
+  baseUrl: string | undefined
+  promptId: string | undefined
+  runUrl: string
+  branch: string
+  commitSha: string
+}
+
+export function buildNotifyEnv(): NotifyCodayEnv {
+  return {
+    baseUrl: process.env['CODAY_WEBHOOK_URL'],
+    promptId: process.env['CODAY_CI_HEALING_PROMPT_ID'],
+    runUrl: process.env['GITHUB_SERVER_URL']
+      ? `${process.env['GITHUB_SERVER_URL']}/${process.env['GITHUB_REPOSITORY']}/actions/runs/${process.env['GITHUB_RUN_ID']}`
+      : 'local',
+    branch: process.env['GITHUB_REF_NAME'] ?? 'unknown',
+    commitSha: process.env['GITHUB_SHA'] ?? 'unknown',
+  }
+}
+
+export async function notifyCoday(
+  phase: string,
+  error: unknown,
+  context: Record<string, unknown>,
+  env: NotifyCodayEnv = buildNotifyEnv()
+): Promise<void> {
+  if (!env.baseUrl || !env.promptId) {
+    console.warn('[self-healing] Skipped: CODAY_WEBHOOK_URL or CODAY_CI_HEALING_PROMPT_ID not set')
+    return
+  }
+  const webhookUrl = `${env.baseUrl}/api/webhooks/${env.promptId}/execute`
+  console.log(`[self-healing] Notifying Coday of failure at phase: ${phase}`)
+  try {
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-forwarded-email': 'ci-bot@coday',
+      },
+      body: JSON.stringify({
+        title: `Release failure: ${phase}`,
+        awaitFinalAnswer: false,
+        phase,
+        error: String(error),
+        runUrl: env.runUrl,
+        branch: env.branch,
+        commitSha: env.commitSha,
+        ...context,
+      }),
+    })
+    console.log('[self-healing] Coday notified successfully')
+  } catch (fetchError) {
+    console.error('[self-healing] Failed to notify Coday:', fetchError)
+  }
+}
+
+export async function main(): Promise<void> {
+  // Phase 1: Version bumping
+  console.log('\n--- Phase 1: releaseVersion ---')
+  let projectsVersionData: Awaited<ReturnType<typeof releaseVersion>>['projectsVersionData']
+  let releaseGraph: Awaited<ReturnType<typeof releaseVersion>>['releaseGraph']
+
+  const env = buildNotifyEnv()
+
+  try {
+    const result = await releaseVersion({ verbose: true })
+    projectsVersionData = result.projectsVersionData
+    releaseGraph = result.releaseGraph
+  } catch (e) {
+    await notifyCoday('releaseVersion', e, { projects: ['server', 'client', 'web', 'desktop', 'desktop-twin'] }, env)
+    process.exit(1)
+  }
+
+  // Phase 2: Changelog + GitHub release
+  console.log('\n--- Phase 2: releaseChangelog ---')
+  try {
+    await releaseChangelog({ versionData: projectsVersionData, releaseGraph, verbose: true })
+  } catch (e) {
+    await notifyCoday('releaseChangelog', e, { projectsVersionData }, env)
+    process.exit(1)
+  }
+
+  // Phase 3: npm publish
+  console.log('\n--- Phase 3: releasePublish ---')
+  let publishResults: Awaited<ReturnType<typeof releasePublish>>
+  try {
+    publishResults = await releasePublish({ releaseGraph, versionData: projectsVersionData, verbose: true })
+  } catch (e) {
+    await notifyCoday('releasePublish', e, { projectsVersionData }, env)
+    process.exit(1)
+  }
+
+  const failures = Object.entries(publishResults).filter(([, result]) => result.code !== 0)
+  if (failures.length > 0) {
+    await notifyCoday(
+      'releasePublish',
+      `${failures.length} project(s) failed to publish`,
+      {
+        failedProjects: failures.map(([name]) => name),
+        allResults: Object.fromEntries(Object.entries(publishResults).map(([name, r]) => [name, r.code])),
+      },
+      env
+    )
+    process.exit(1)
+  }
+
+  console.log('\nRelease completed successfully.')
+  process.exit(0)
+}
+
+// Only run when executed directly, not when imported (e.g. by Jest)
+if (process.env['NODE_ENV'] !== 'test') {
+  void main()
+}


### PR DESCRIPTION
## What this does

Replaces the bare `pnpm nx release --yes` step in the release workflow with a Node.js script that uses the `nx/release` programmatic API. The script runs the same three release phases (`releaseVersion` → `releaseChangelog` → `releasePublish`) and — on any failure — fires a Coday webhook so an AI agent can autonomously diagnose and fix the issue.

## Why a script and not a custom Nx executor

A custom executor is the right tool for reusable, cacheable, project-scoped tasks. The release pipeline is none of those things: it is workspace-level (not project-level), must never be cached, and its only novel behaviour is a side-effectful webhook call on failure. Wrapping the `nx/release` programmatic API in a plain script registered as an `nx:run-commands` target keeps things simple and maintainable without the overhead of executor registration, `executors.json`, and `schema.json`.

## Changes

- **`tools/release/release.ts`** — uses `nx/release` programmatic API; calls Coday webhook on failure at each phase with structured context (phase name, error, GitHub run URL, branch, commit SHA)
- **`tools/release/release.test.ts`** — 7 unit tests covering the `notifyCoday` function: skips gracefully when env vars are missing, correct URL/headers/payload, merges extra context, does not throw when `fetch` itself fails
- **`tools/release/project.json`** — registers `tools-release` Nx project with `release` and `test` targets
- **`.github/workflows/release.yml`** — replaces `pnpm nx release --yes` with `pnpm nx run tools-release:release`; adds `CODAY_WEBHOOK_URL` and `CODAY_CI_HEALING_PROMPT_ID ` env vars

## Setup required

A GitHub repo secret need to be added:
- `CODAY_WEBHOOK_URL` — URL of the running Coday instance
- `CODAY_CI_HEALING_PROMPT_ID` — UUID of the ci-release-failure prompt (webhook-enabled)
