### PR TITLE
feat: #31353 add description field to IntegrationConfig and inject into agent prompt

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.agent
 
 import io.whozoss.agentos.aiModel.AiModelRegistry
 import io.whozoss.agentos.chat.ChatClientProvider
+import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.aiProvider.AiModel
@@ -24,6 +25,10 @@ import java.util.UUID
  *   the conversation grows (system prompt is never compacted by the provider).
  * - Scope tool resolution to the namespace via [ToolRegistryService.resolveToolsForNamespace],
  *   producing fresh tool instances for each agent run.
+ * - Append an integration-descriptions block to the system prompt listing any
+ *   [IntegrationConfig][io.whozoss.agentos.integrationConfig.IntegrationConfig]s in the
+ *   namespace that carry a non-null description, so the agent understands what each
+ *   named integration is for.
  *
  * Every agent-instantiating method requires a non-null [AgentExecutionContext].
  * Name-resolution methods ([getDefaultAgentName], [resolveAgentName]) are context-free.
@@ -34,6 +39,7 @@ class AgentServiceImpl(
     private val toolRegistryService: ToolRegistryService,
     private val aiModelRegistry: AiModelRegistry,
     private val namespaceService: NamespaceService,
+    private val integrationConfigService: IntegrationConfigService,
     private val userService: UserService,
 ) : AgentService {
     override fun findAgentByName(
@@ -100,9 +106,11 @@ class AgentServiceImpl(
      *
      * Starts from the model's own instructions (may be null) and appends:
      * 1. A namespace context block (always, when [context] is provided).
-     * 2. A user context block (when [context.userId] resolves to a known [User]).
+     * 2. An integrations block listing each [IntegrationConfig] in the namespace that
+     *    carries a non-null description (omitted entirely when none have a description).
+     * 3. A user context block (when [context.userId] resolves to a known [User]).
      *
-     * Both blocks are injected in the privileged system-prompt channel so they are
+     * All blocks are injected in the privileged system-prompt channel so they are
      * never compacted away by the provider, regardless of conversation length.
      */
     private fun buildInstructions(
@@ -114,10 +122,22 @@ class AgentServiceImpl(
             buildString {
                 appendLine()
                 appendLine("""## Context: ${namespace?.name ?: context.namespaceId}""")
-                if (!namespace?.description.isNullOrBlank()) {
-                    appendLine(namespace!!.description!!)
+                namespace?.description?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
+            }.trimEnd()
+
+        val integrationsWithDescription = integrationConfigService
+            .findByParent(context.namespaceId)
+            .filter { !it.description.isNullOrBlank() }
+        val integrationsBlock = when {
+            integrationsWithDescription.isEmpty() -> null
+            else -> buildString {
+                appendLine()
+                appendLine("## Integrations")
+                integrationsWithDescription.forEach { config ->
+                    appendLine("- ${config.name}: ${config.description}")
                 }
             }.trimEnd()
+        }
 
         val userBlock =
             context.userId?.let { userId ->
@@ -135,7 +155,8 @@ class AgentServiceImpl(
                 }
 
         val base = if (model.instructions.isNullOrBlank()) namespaceBlock else "${model.instructions}\n$namespaceBlock"
-        return if (userBlock != null) "$base\n$userBlock" else base
+        val withIntegrations = if (integrationsBlock != null) "$base\n$integrationsBlock" else base
+        return if (userBlock != null) "$withIntegrations\n$userBlock" else withIntegrations
     }
 
     companion object : KLogging()

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfig.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfig.kt
@@ -33,5 +33,6 @@ data class IntegrationConfig(
     val namespaceId: UUID,
     val name: String,
     val integrationType: String,
+    val description: String? = null,
     val parameters: JsonNode? = null,
 ) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
@@ -36,6 +36,7 @@ class IntegrationConfigController(
             namespaceId = entity.namespaceId,
             name = entity.name,
             integrationType = entity.integrationType,
+            description = entity.description,
             parameters = entity.parameters,
         )
 
@@ -47,6 +48,7 @@ class IntegrationConfigController(
             namespaceId = resource.namespaceId!!,
             name = resource.name,
             integrationType = resource.integrationType,
+            description = resource.description,
             parameters = resource.parameters,
         )
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigResource.kt
@@ -27,5 +27,6 @@ data class IntegrationConfigResource(
     val name: String,
     @field:NotBlank
     val integrationType: String,
+    val description: String? = null,
     val parameters: JsonNode? = null,
 )

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplSpec.kt
@@ -10,6 +10,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.whozoss.agentos.aiModel.AiModelRegistry
 import io.whozoss.agentos.chat.ChatClientProvider
+import io.whozoss.agentos.integrationConfig.IntegrationConfig
+import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.namespace.Namespace
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.aiProvider.AiModel
@@ -25,8 +27,9 @@ class AgentServiceImplSpec : StringSpec() {
     private val toolRegistryService: ToolRegistryService = mockk()
     private val aiModelRegistry: AiModelRegistry = mockk()
     private val namespaceService: NamespaceService = mockk()
+    private val integrationConfigService: IntegrationConfigService = mockk()
     private val userService: UserService = mockk(relaxed = true)
-    private val agentService = AgentServiceImpl(chatClientProvider, toolRegistryService, aiModelRegistry, namespaceService, userService)
+    private val agentService = AgentServiceImpl(chatClientProvider, toolRegistryService, aiModelRegistry, namespaceService, integrationConfigService, userService)
 
     // A context and matching namespace used across most tests
     private val namespaceId: UUID = UUID.randomUUID()
@@ -42,6 +45,7 @@ class AgentServiceImplSpec : StringSpec() {
     init {
         every { toolRegistryService.resolveToolsForNamespace(any()) } returns emptyList()
         every { namespaceService.findById(namespaceId) } returns namespace
+        every { integrationConfigService.findByParent(namespaceId) } returns emptyList()
 
         // The key scenario: name and modelName are intentionally different.
         // "my-agent" is the logical name used to look up the ChatClient,
@@ -169,6 +173,136 @@ class AgentServiceImplSpec : StringSpec() {
             agent.instructions!! shouldNotContain "null"
             // Restore the default stub for subsequent tests
             every { namespaceService.findById(namespaceId) } returns namespace
+        }
+
+        // -------------------------------------------------------------------------
+        // Integration descriptions block injection into instructions
+        // -------------------------------------------------------------------------
+
+        "findAgentByName appends integrations block when configs have descriptions" {
+            val configs = listOf(
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "JIRA_PROD",
+                    integrationType = "JIRA",
+                    description = "Production Jira workspace for the engineering team",
+                ),
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "SLACK_DEV",
+                    integrationType = "SLACK",
+                    description = "Dev Slack channel for notifications",
+                ),
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            val model = AiModel(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                name = "my-agent",
+                description = "desc",
+                modelName = "gpt-4o",
+                providerName = "openai",
+                instructions = "You are a helpful assistant.",
+            )
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { aiModelRegistry.findByName("my-agent") } returns model
+            every { chatClientProvider.getChatClient("my-agent") } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions!! shouldContain "## Integrations"
+            agent.instructions!! shouldContain "JIRA_PROD: Production Jira workspace for the engineering team"
+            agent.instructions!! shouldContain "SLACK_DEV: Dev Slack channel for notifications"
+            // Restore default stub
+            every { integrationConfigService.findByParent(namespaceId) } returns emptyList()
+        }
+
+        "findAgentByName omits integrations block when no config has a description" {
+            val configs = listOf(
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "JIRA_PROD",
+                    integrationType = "JIRA",
+                    description = null,
+                ),
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            val model = AiModel(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                name = "my-agent",
+                description = "desc",
+                modelName = "gpt-4o",
+                providerName = "openai",
+                instructions = "You are a helpful assistant.",
+            )
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { aiModelRegistry.findByName("my-agent") } returns model
+            every { chatClientProvider.getChatClient("my-agent") } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions!! shouldNotContain "## Integrations"
+            // Restore default stub
+            every { integrationConfigService.findByParent(namespaceId) } returns emptyList()
+        }
+
+        "findAgentByName only lists configs that have a description in the integrations block" {
+            val configs = listOf(
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "JIRA_PROD",
+                    integrationType = "JIRA",
+                    description = "Production Jira",
+                ),
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "GITHUB_MAIN",
+                    integrationType = "GITHUB",
+                    description = null,
+                ),
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            val model = AiModel(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                name = "my-agent",
+                description = "desc",
+                modelName = "gpt-4o",
+                providerName = "openai",
+                instructions = null,
+            )
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { aiModelRegistry.findByName("my-agent") } returns model
+            every { chatClientProvider.getChatClient("my-agent") } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions!! shouldContain "JIRA_PROD: Production Jira"
+            agent.instructions!! shouldNotContain "GITHUB_MAIN"
+            // Restore default stub
+            every { integrationConfigService.findByParent(namespaceId) } returns emptyList()
+        }
+
+        "findAgentByName omits integrations block when namespace has no configs" {
+            val model = AiModel(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                name = "my-agent",
+                description = "desc",
+                modelName = "gpt-4o",
+                providerName = "openai",
+                instructions = null,
+            )
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { aiModelRegistry.findByName("my-agent") } returns model
+            every { chatClientProvider.getChatClient("my-agent") } returns chatClient
+            // integrationConfigService returns emptyList() by default
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions!! shouldNotContain "## Integrations"
         }
 
         "findAgentByName resolves namespace by namespaceId from context" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigControllerSpec.kt
@@ -36,11 +36,13 @@ class IntegrationConfigControllerSpec : StringSpec({
         nsId: UUID = namespaceId,
         name: String = "JIRA_PROD",
         integrationType: String = "JIRA",
+        description: String? = null,
     ) = IntegrationConfig(
         metadata = EntityMetadata(id = id),
         namespaceId = nsId,
         name = name,
         integrationType = integrationType,
+        description = description,
         parameters = params,
     )
 
@@ -49,11 +51,13 @@ class IntegrationConfigControllerSpec : StringSpec({
         nsId: UUID = namespaceId,
         name: String = "JIRA_PROD",
         integrationType: String = "JIRA",
+        description: String? = null,
     ) = IntegrationConfigResource(
         id = id,
         namespaceId = nsId,
         name = name,
         integrationType = integrationType,
+        description = description,
         parameters = params,
     )
 
@@ -63,7 +67,7 @@ class IntegrationConfigControllerSpec : StringSpec({
 
     "toResource maps all fields from IntegrationConfig to IntegrationConfigResource" {
         val id = UUID.randomUUID()
-        val c = config(id = id, name = "SLACK_DEV", integrationType = "SLACK")
+        val c = config(id = id, name = "SLACK_DEV", integrationType = "SLACK", description = "Dev Slack workspace")
 
         val result = controller.toResource(c)
 
@@ -72,8 +76,17 @@ class IntegrationConfigControllerSpec : StringSpec({
             namespaceId = namespaceId,
             name = "SLACK_DEV",
             integrationType = "SLACK",
+            description = "Dev Slack workspace",
             parameters = params,
         )
+    }
+
+    "toResource preserves null description" {
+        val c = config(description = null)
+
+        val result = controller.toResource(c)
+
+        result.description shouldBe null
     }
 
     "toResource preserves null parameters" {
@@ -90,7 +103,7 @@ class IntegrationConfigControllerSpec : StringSpec({
 
     "toDomain maps all fields from IntegrationConfigResource to IntegrationConfig" {
         val id = UUID.randomUUID()
-        val r = resource(id = id, name = "GITHUB_MAIN", integrationType = "GITHUB")
+        val r = resource(id = id, name = "GITHUB_MAIN", integrationType = "GITHUB", description = "Main GitHub org")
 
         val result = controller.toDomain(r)
 
@@ -98,7 +111,16 @@ class IntegrationConfigControllerSpec : StringSpec({
         result.namespaceId shouldBe namespaceId
         result.name shouldBe "GITHUB_MAIN"
         result.integrationType shouldBe "GITHUB"
+        result.description shouldBe "Main GitHub org"
         result.parameters shouldBe params
+    }
+
+    "toDomain preserves null description" {
+        val r = resource(description = null)
+
+        val result = controller.toDomain(r)
+
+        result.description shouldBe null
     }
 
     "toDomain generates a random UUID when resource id is null" {

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -950,6 +950,8 @@ components:
         integrationType:
           type: string
           minLength: 1
+        description:
+          type: string
         parameters:
           $ref: "#/components/schemas/JsonNode"
       required:

--- a/libs/agentos-api-client/src/lib/model/integration-config.ts
+++ b/libs/agentos-api-client/src/lib/model/integration-config.ts
@@ -12,6 +12,7 @@ export interface IntegrationConfig {
   id?: string
   namespaceId: string
   name: string
+  description?: string | null
   integrationType: string
   parameters?: any | null
 }

--- a/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.html
+++ b/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.html
@@ -33,6 +33,17 @@
         />
       </div>
 
+      <div class="integration-form__field">
+        <label class="integration-form__label" for="integration-description">Description</label>
+        <textarea
+          id="integration-description"
+          class="integration-form__textarea"
+          placeholder="Optional description"
+          rows="3"
+          [formControl]="descriptionControl"
+        ></textarea>
+      </div>
+
       @if (schema(); as s) {
         <div class="integration-form__schema-form">
           <ds-json-schema-form [schema]="s" [value]="initialParams()" (valueChange)="onParamsChange($event)" />

--- a/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.scss
+++ b/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.scss
@@ -67,6 +67,7 @@
   }
 
   &__input,
+  &__textarea,
   &__select {
     width: 100%;
     padding: 0.625rem 0.875rem;
@@ -87,6 +88,12 @@
     &::placeholder {
       color: var(--color-text-secondary, #6e6e73);
     }
+  }
+
+  &__textarea {
+    resize: vertical;
+    min-height: 4.5rem;
+    line-height: 1.5;
   }
 
   &__select {

--- a/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.ts
@@ -41,6 +41,7 @@ export class IntegrationFormComponent implements OnInit {
       nonNullable: true,
       validators: [Validators.required, Validators.minLength(1)],
     }),
+    description: new FormControl<string | null>(null),
     type: new FormControl<string>('', {
       nonNullable: true,
       validators: [Validators.required],
@@ -49,6 +50,9 @@ export class IntegrationFormComponent implements OnInit {
 
   protected get nameControl() {
     return this.form.controls.name
+  }
+  protected get descriptionControl() {
+    return this.form.controls.description
   }
   protected get typeControl() {
     return this.form.controls.type
@@ -102,6 +106,7 @@ export class IntegrationFormComponent implements OnInit {
         next: (config) => {
           this.existingConfig = config
           this.nameControl.setValue(config.name)
+          this.descriptionControl.setValue(config.description ?? null)
           this.typeControl.setValue(config.integrationType)
           this.initialParams.set(config.parameters as Record<string, unknown> | null)
           this.paramsValue.set(config.parameters as Record<string, unknown> | null)
@@ -127,11 +132,13 @@ export class IntegrationFormComponent implements OnInit {
       ? this.integrationConfigController.updateIntegrationConfig(this.existingConfig!.id ?? '', {
           ...this.existingConfig!,
           name: this.nameControl.value.trim(),
+          description: this.descriptionControl.value?.trim() || null,
           integrationType: this.typeControl.value,
           parameters: this.paramsValue(),
         })
       : this.integrationConfigController.createIntegrationConfig({
           name: this.nameControl.value.trim(),
+          description: this.descriptionControl.value?.trim() || null,
           integrationType: this.typeControl.value,
           namespaceId: this.namespaceId,
           parameters: this.paramsValue(),


### PR DESCRIPTION
## Summary

Closes WZ-31353.

Adds an optional `description` field to `IntegrationConfig` so operators can document what each named integration instance is for (e.g. "JIRA_PROD: Production Jira for the engineering team"). When present, these descriptions are injected into the agent's system prompt as a dedicated `## Integrations` block, giving the LLM richer context about the available tools without duplicating the tool-level descriptions.

## Changes

**`IntegrationConfig` (domain entity)** — added `val description: String? = null`. Fully backward-compatible: Jackson's `@JsonIgnoreProperties` handles missing field on read, `@JsonInclude(NON_NULL)` omits it when absent on write.

**`IntegrationConfigResource` (HTTP DTO)** — added `val description: String? = null`. No validation annotation — the field is intentionally optional.

**`IntegrationConfigController`** — wired `description` through both `toResource()` and `toDomain()`.

**`AgentServiceImpl`** — injected `IntegrationConfigService` and extended `buildInstructions()` to append a `## Integrations` block listing only the configs that have a non-null, non-blank description. The block is omitted entirely when none qualify. Also cleaned up two unnecessary `!!` assertions in the namespace block.

**OpenAPI spec** — regenerated; `IntegrationConfig` schema now includes the optional `description` field.

## Tests

- `IntegrationConfigControllerSpec` — extended `toResource`/`toDomain` cases to cover description round-trip and null preservation.
- `AgentServiceImplSpec` — four new cases: block present when all configs have descriptions; block omitted when no config has a description; only described configs appear in the block; block omitted when namespace has no configs at all.