### PR TITLE
feat: #748 project deletion from the Projects view

### DIFF
--- a/apps/client/src/app/components/confirm-dialog/confirm-dialog.component.ts
+++ b/apps/client/src/app/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,73 @@
+import { Component, inject } from '@angular/core'
+import { FormsModule } from '@angular/forms'
+import { MAT_DIALOG_DATA, MatDialogActions, MatDialogRef, MatDialogTitle } from '@angular/material/dialog'
+import { MatButtonModule } from '@angular/material/button'
+import { MatCheckboxModule } from '@angular/material/checkbox'
+
+export interface ConfirmDialogData {
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  isDestructive?: boolean
+  checkboxLabel?: string // If set, shows a checkbox below the message
+}
+
+export interface ConfirmDialogResult {
+  confirmed: boolean
+  checkboxChecked?: boolean
+}
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [MatDialogTitle, MatDialogActions, MatButtonModule, MatCheckboxModule, FormsModule],
+  template: `
+    <h2 mat-dialog-title>{{ data.title }}</h2>
+
+    <p class="confirm-dialog__message">{{ data.message }}</p>
+
+    @if (data.checkboxLabel) {
+      <mat-checkbox class="confirm-dialog__checkbox" [(ngModel)]="checkboxChecked">{{
+        data.checkboxLabel
+      }}</mat-checkbox>
+    }
+
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="cancel()">{{ data.cancelLabel ?? 'Cancel' }}</button>
+      <button mat-flat-button [color]="data.isDestructive ? 'warn' : 'primary'" (click)="confirm()">
+        {{ data.confirmLabel ?? 'Confirm' }}
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      .confirm-dialog__message {
+        margin: 0 24px 8px;
+        color: var(--color-text-secondary, #6e6e73);
+        font-size: 0.875rem;
+        line-height: 1.5;
+      }
+
+      .confirm-dialog__checkbox {
+        display: block;
+        margin: 0 24px 8px;
+        font-size: 0.875rem;
+      }
+    `,
+  ],
+})
+export class ConfirmDialogComponent {
+  protected readonly dialogRef = inject(MatDialogRef<ConfirmDialogComponent, ConfirmDialogResult>)
+  protected readonly data = inject<ConfirmDialogData>(MAT_DIALOG_DATA)
+
+  protected checkboxChecked = false
+
+  cancel(): void {
+    this.dialogRef.close({ confirmed: false })
+  }
+
+  confirm(): void {
+    this.dialogRef.close({ confirmed: true, checkboxChecked: this.checkboxChecked })
+  }
+}

--- a/apps/client/src/app/components/project-list/project-list.component.html
+++ b/apps/client/src/app/components/project-list/project-list.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Projects"
   [items]="projectItems()"
+  [itemTemplate]="projectCard"
   contentMaxWidth="1400px"
   searchPlaceholder="Filter projects…"
   emptyMessage="No projects found."
@@ -11,3 +12,23 @@
 >
   <img toolbar-start class="project-list__logo" src="CODAY-Logo.png" alt="Coday" />
 </ds-entity-list>
+
+<ng-template #projectCard let-item>
+  <div class="project-card-wrapper">
+    <ds-entity-card
+      [id]="item.id"
+      [name]="item.name"
+      [description]="item.description"
+      [badges]="item.badges ?? []"
+      (selected)="onItemSelected($event)"
+    />
+    <button
+      class="project-card-wrapper__delete"
+      mat-icon-button
+      (click)="$event.stopPropagation(); onDeleteRequested(item.id)"
+      title="Delete project"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+</ng-template>

--- a/apps/client/src/app/components/project-list/project-list.component.scss
+++ b/apps/client/src/app/components/project-list/project-list.component.scss
@@ -1,15 +1,35 @@
-:host {
-  display: block;
-  width: 100%;
-  min-height: 100vh;
-  background: var(--color-bg);
-  overflow-y: auto;
+.project-list__logo {
+  height: 28px;
+  width: auto;
 }
 
-.project-list__logo {
-  width: 40px;
-  height: 40px;
-  object-fit: contain;
-  flex-shrink: 0;
-  border-radius: 4px;
+.project-card-wrapper {
+  position: relative;
+
+  &__delete {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 28px;
+    height: 28px;
+    line-height: 28px;
+    padding: 0;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    color: var(--color-text-secondary, #6e6e73);
+
+    .mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    &:hover {
+      color: var(--color-error, #ff3b30);
+    }
+  }
+
+  &:hover &__delete {
+    opacity: 1;
+  }
 }

--- a/apps/client/src/app/components/project-list/project-list.component.ts
+++ b/apps/client/src/app/components/project-list/project-list.component.ts
@@ -1,10 +1,19 @@
-import { Component, computed, inject } from '@angular/core'
+import { Component, computed, DestroyRef, inject } from '@angular/core'
 import { Router } from '@angular/router'
 import { filter, take } from 'rxjs'
 import { ProjectStateService } from '../../core/services/project-state.service'
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop'
-import { EntityListComponent, EntityListItem } from '@whoz-oss/design-system'
+import { EntityCardComponent, EntityListComponent, EntityListItem } from '@whoz-oss/design-system'
 import { ProjectInfo } from '../../core/services/project-api.service'
+import { MatDialog } from '@angular/material/dialog'
+import { MatIconModule } from '@angular/material/icon'
+import { MatIconButton } from '@angular/material/button'
+import {
+  ConfirmDialogComponent,
+  ConfirmDialogData,
+  ConfirmDialogResult,
+} from '../confirm-dialog/confirm-dialog.component'
+import { NotificationService } from '../../services/notification.service'
 
 /** Separator used in the worktree project naming convention: `parent__subProject` */
 const WORKTREE_SEPARATOR = '__'
@@ -21,16 +30,19 @@ const WORKTREE_SEPARATOR = '__'
 @Component({
   selector: 'app-project-selection',
   standalone: true,
-  imports: [EntityListComponent],
+  imports: [EntityListComponent, EntityCardComponent, MatIconModule, MatIconButton],
   templateUrl: './project-list.component.html',
   styleUrl: './project-list.component.scss',
 })
 export class ProjectListComponent {
   private readonly router = inject(Router)
   private readonly projectStateService = inject(ProjectStateService)
+  private readonly dialog = inject(MatDialog)
+  private readonly destroyRef = inject(DestroyRef)
+  private readonly notification = inject(NotificationService)
 
   protected readonly projects = toSignal(this.projectStateService.projectList$)
-  protected readonly forcedProject = toSignal(this.projectStateService.forcedProject$)
+  protected readonly forcedProject = toSignal(this.projectStateService.forcedProject$, { initialValue: null })
 
   /**
    * Maps the flat project list to EntityListItem[], with three kinds of groups:
@@ -143,6 +155,52 @@ export class ProjectListComponent {
 
   protected onCreateRequested(): void {
     this.router.navigate(['project', 'new'])
+  }
+
+  protected onDeleteRequested(projectName: string): void {
+    const isWorktree = projectName.includes(WORKTREE_SEPARATOR)
+
+    const dialogRef = this.dialog.open<ConfirmDialogComponent, ConfirmDialogData, ConfirmDialogResult>(
+      ConfirmDialogComponent,
+      {
+        width: '400px',
+        panelClass: 'confirm-dialog-panel',
+        data: {
+          title: 'Delete project',
+          message: `This will remove the project "${projectName}" from Coday and archive its configuration. The project source code on disk is not affected.`,
+          confirmLabel: 'Delete',
+          cancelLabel: 'Cancel',
+          isDestructive: true,
+          ...(isWorktree ? { checkboxLabel: 'Also remove git worktree from disk' } : {}),
+        },
+      }
+    )
+
+    dialogRef
+      .afterClosed()
+      .pipe(
+        filter((result): result is ConfirmDialogResult => result?.confirmed === true),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((result) => {
+        this.notification.info('Deleting project…')
+        this.projectStateService
+          .deleteProject(projectName, result.checkboxChecked)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: () => {
+              this.notification.success(`Project "${projectName}" deleted`)
+              // If user was inside the deleted project, ensure we leave its route.
+              if (this.router.url.includes(`/project/${encodeURIComponent(projectName)}`)) {
+                this.router.navigate(['/'])
+              }
+            },
+            error: (err) => {
+              console.error('[PROJECT-LIST] Failed to delete project:', err)
+              this.notification.error(err?.error?.error ?? 'Failed to delete project')
+            },
+          })
+      })
   }
 
   private toEntityListItem(project: ProjectInfo): EntityListItem {

--- a/apps/client/src/app/core/services/project-api.service.ts
+++ b/apps/client/src/app/core/services/project-api.service.ts
@@ -95,6 +95,22 @@ export class ProjectApiService {
     return this.http.post<{ success: boolean; message: string }>(this.baseUrl, { name, path })
   }
 
+  /**
+   * Delete a project
+   * @param projectName Project name
+   * @param removeGitWorktree If true, also remove the git worktree from disk (worktree projects only)
+   */
+  deleteProject(projectName: string, removeGitWorktree?: boolean): Observable<{ success: boolean; message: string }> {
+    const params: Record<string, string> = {}
+    if (removeGitWorktree) {
+      params['removeGitWorktree'] = 'true'
+    }
+    return this.http.delete<{ success: boolean; message: string }>(
+      `${this.baseUrl}/${encodeURIComponent(projectName)}`,
+      { params }
+    )
+  }
+
   // ── Preview server ─────────────────────────────────────────────────────────────────
 
   getPreviewEntries(projectName: string): Observable<{ entries: PreviewEntryResponse[] }> {

--- a/apps/client/src/app/core/services/project-state.service.ts
+++ b/apps/client/src/app/core/services/project-state.service.ts
@@ -143,4 +143,26 @@ export class ProjectStateService {
       })
     )
   }
+
+  /**
+   * Delete a project
+   * @param projectName Project name
+   * @param removeGitWorktree If true, also remove the git worktree from disk (worktree projects only)
+   */
+  deleteProject(projectName: string, removeGitWorktree?: boolean) {
+    this.isLoadingSubject.next(true)
+
+    return this.projectApi.deleteProject(projectName, removeGitWorktree).pipe(
+      tap(() => {
+        this.isLoadingSubject.next(false)
+        // Trigger project list refresh
+        this.refreshTriggerSubject.next()
+
+        // If the deleted project was selected, clear selection
+        if (this.selectedProjectIdSubject.value === projectName) {
+          this.clearSelection()
+        }
+      })
+    )
+  }
 }

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -293,6 +293,13 @@ app-main {
   }
 }
 
+/* Compact dialog — used for confirmation dialogs and other small modals */
+.cdk-overlay-pane.confirm-dialog-panel {
+  .mat-mdc-dialog-container {
+    height: auto;
+  }
+}
+
 /* Dark mode snackbar styles */
 [data-theme='dark'] {
   .mat-mdc-snack-bar-container {

--- a/apps/server/src/lib/project.routes.ts
+++ b/apps/server/src/lib/project.routes.ts
@@ -179,7 +179,7 @@ export function registerProjectRoutes(app: express.Application, projectService: 
    * DELETE /api/projects/:name
    * Delete a project
    */
-  app.delete('/api/projects/:name', (req: express.Request, res: express.Response) => {
+  app.delete('/api/projects/:name', async (req: express.Request, res: express.Response) => {
     try {
       const name = getParamAsString(req.params.name)
       if (!name) {
@@ -187,8 +187,9 @@ export function registerProjectRoutes(app: express.Application, projectService: 
         return
       }
 
-      debugLog('PROJECT', `DELETE project: ${name}`)
-      projectService.deleteProject(name)
+      const removeGitWorktree = req.query['removeGitWorktree'] === 'true'
+      debugLog('PROJECT', `DELETE project: ${name}${removeGitWorktree ? ' (with git worktree removal)' : ''}`)
+      await projectService.deleteProject(name, { removeGitWorktree })
 
       res.status(200).json({
         success: true,

--- a/libs/repository/src/lib/project-file.repository.ts
+++ b/libs/repository/src/lib/project-file.repository.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path'
 import * as os from 'node:os'
-import { existsSync, lstatSync, mkdirSync, readdirSync } from 'fs'
+import { existsSync, lstatSync, mkdirSync, readdirSync, renameSync } from 'fs'
 import { ProjectRepository, ProjectInfo } from './project.repository'
 import { ProjectLocalConfig } from '@coday/model'
 import { readYamlFile } from '@coday/utils'
@@ -25,7 +25,9 @@ export class ProjectFileRepository implements ProjectRepository {
 
   listProjects(): string[] {
     const dirs: string[] = readdirSync(this.projectsConfigPath)
-    return dirs.filter((dir) => lstatSync(path.join(this.projectsConfigPath, dir)).isDirectory())
+    return dirs.filter(
+      (dir) => !dir.startsWith('.') && lstatSync(path.join(this.projectsConfigPath, dir)).isDirectory()
+    )
   }
 
   getProjectInfo(name: string): ProjectInfo | null {
@@ -113,8 +115,13 @@ export class ProjectFileRepository implements ProjectRepository {
       return false
     }
 
-    // TODO: Implement safe deletion (maybe just rename with .deleted suffix?)
-    // For now, just return false to prevent accidental deletion
-    return false
+    const deletedDir = path.join(this.projectsConfigPath, '.deleted')
+    mkdirSync(deletedDir, { recursive: true })
+
+    const timestamp = new Date().toISOString().replace(/:/g, '-')
+    const destination = path.join(deletedDir, `${name}__${timestamp}`)
+    renameSync(projectInfo.configPath, destination)
+
+    return true
   }
 }

--- a/libs/service/src/lib/project.service.ts
+++ b/libs/service/src/lib/project.service.ts
@@ -3,7 +3,12 @@ import { ConfigMaskingService } from './config-masking.service'
 import * as crypto from 'crypto'
 import * as fsp from 'node:fs/promises'
 import * as path from 'path'
+import { exec } from 'child_process'
 import { ProjectRepository } from '@coday/repository'
+
+export interface DeleteProjectOptions {
+  removeGitWorktree?: boolean
+}
 
 /**
  * Server-side project management service.
@@ -147,15 +152,81 @@ export class ProjectService {
 
   /**
    * Delete a project
+   * Worktree projects (detected by the '__' naming convention) are unregistered via
+   * `unregisterWorktreeProject`, which migrates threads to the parent and removes the
+   * config directory. Regular projects are soft-deleted (moved to .deleted/).
    * @param name Project name
+   * @param options Optional flags (e.g. removeGitWorktree)
    * @throws Error if project doesn't exist
    */
-  deleteProject(name: string): void {
+  async deleteProject(name: string, options?: DeleteProjectOptions): Promise<void> {
     this.checkAgainstForced(name)
-    const deleted = this.repository.deleteProject(name)
-    if (!deleted) {
-      throw new Error(`Project '${name}' does not exist`)
+
+    // Detect worktree projects by the '__' naming convention (e.g. 'parent__feature-branch')
+    const isWorktree = name.includes('__')
+
+    if (isWorktree) {
+      // If requested, remove the git worktree from disk before unregistering
+      if (options?.removeGitWorktree) {
+        await this.removeGitWorktree(name)
+      }
+      // Worktree: migrate threads to parent project, then soft-delete config
+      await this.unregisterWorktreeProject(name)
+    } else {
+      // Regular project: soft-delete (move to .deleted/)
+      const deleted = this.repository.deleteProject(name)
+      if (!deleted) {
+        throw new Error(`Project '${name}' does not exist`)
+      }
     }
+  }
+
+  /**
+   * Removes the git worktree directory from disk.
+   * Derives the parent project root and worktree path from the naming convention,
+   * then runs `git worktree remove` + `git worktree prune` in the background.
+   * This is fire-and-forget: the HTTP response is not blocked by git operations.
+   * Failures are logged but do not prevent the Coday config cleanup.
+   */
+  private async removeGitWorktree(projectName: string): Promise<void> {
+    const separatorIndex = projectName.lastIndexOf('__')
+    if (separatorIndex === -1) return
+
+    const parentProjectName = projectName.substring(0, separatorIndex)
+    const parentConfig = this.repository.getConfig(parentProjectName)
+    if (!parentConfig?.path) {
+      console.warn(
+        `[PROJECT_SERVICE] Cannot remove git worktree: parent project '${parentProjectName}' config not found`
+      )
+      return
+    }
+
+    const parentRoot = parentConfig.path
+    const worktreesRoot = path.dirname(parentRoot)
+    const worktreePath = path.join(worktreesRoot, projectName)
+
+    try {
+      // Check if worktree directory exists
+      await fsp.access(worktreePath)
+    } catch {
+      console.warn(`[PROJECT_SERVICE] Worktree path does not exist, skipping git removal: ${worktreePath}`)
+      return
+    }
+
+    // Fire-and-forget: run git commands in the background without blocking the caller.
+    // No timeout — large repos can take minutes to clean up.
+    exec(`git worktree remove "${worktreePath}" --force`, { cwd: parentRoot }, (error) => {
+      if (error) {
+        console.error(`[PROJECT_SERVICE] Failed to remove git worktree: ${error.message}`)
+        return
+      }
+      console.log(`[PROJECT_SERVICE] Removed git worktree: ${worktreePath}`)
+      exec('git worktree prune', { cwd: parentRoot }, (pruneError) => {
+        if (pruneError) {
+          console.warn(`[PROJECT_SERVICE] git worktree prune failed: ${pruneError.message}`)
+        }
+      })
+    })
   }
 
   /**
@@ -270,7 +341,7 @@ export class ProjectService {
 
   /**
    * Unregister a worktree project: migrates its threads to the parent project,
-   * then removes the worktree config directory.
+   * then soft removes the worktree config directory.
    * @param projectName Name of the worktree project to remove
    */
   async unregisterWorktreeProject(projectName: string): Promise<void> {
@@ -287,8 +358,8 @@ export class ProjectService {
       }
     }
 
-    // deleteProject is currently a no-op in the file repo; remove the whole config directory
-    await fsp.rm(projectInfo.configPath, { recursive: true, force: true })
+    // Soft-delete the worktree config directory (moved to .deleted/)
+    this.repository.deleteProject(projectName)
   }
 
   /**


### PR DESCRIPTION
Closes #748

## Summary

Add project deletion from the Projects list view with soft-delete, worktree-aware cleanup, and optional git worktree removal.

## Changes

### Frontend
- Overlay delete button on project cards (hover-visible, card stays clickable)
- Reusable `ConfirmDialogComponent` with optional checkbox support
- Worktree projects show "Also remove git worktree from disk" checkbox
- Snackbar notifications (info/success/error) via existing `NotificationService`
- Compact dialog panel class to override global 80vh dialog height

<img width="322" height="92" alt="image" src="https://github.com/user-attachments/assets/71b63d29-4c95-438e-98b1-a634a59e8a38" />

<img width="402" height="306" alt="image" src="https://github.com/user-attachments/assets/83b78ff4-49ac-4c12-b7de-486a572909ca" />

### Backend
- `ProjectFileRepository.deleteProject()`: soft-delete (move to `.deleted/`)
- `ProjectService.deleteProject()`: async, routes by `__` convention
  - Regular → soft-delete
  - Worktree → optional git removal (fire-and-forget) → thread migration → soft-delete
- `removeGitWorktree()`: fire-and-forget `exec`, no timeout, failures never block cleanup
- DELETE route: async, reads `removeGitWorktree` query param