### PR TITLE
fix: #752 use chooseOption for tool confirmation prompt instead of promptText

### DIFF
--- a/libs/function/src/lib/run-bash.ts
+++ b/libs/function/src/lib/run-bash.ts
@@ -46,11 +46,15 @@ export const runBash = async ({
 
     // If confirmation is required, ask for it
     if (requireConfirmation) {
-      const rejectReason = await interactor.promptText(
-        `\nPlease type the reason to reject this command (nothing = validate)`
+      const answer = await interactor.chooseOption(
+        ['OK', 'Cancel'],
+        `Confirm execution of: \`${command}\``,
+        undefined,
+        true
       )
-      if (rejectReason) {
-        return `Command execution was cancelled by user with following reason: ${rejectReason}`
+      if (answer !== 'OK') {
+        const reason = answer && answer !== 'Cancel' ? ` with reason: ${answer}` : ''
+        return `Command execution was cancelled by user${reason}`
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #752

Replaces `interactor.promptText()` with `interactor.chooseOption()` in the confirmation path of `run-bash.ts`.

## Changes

- `libs/function/src/lib/run-bash.ts` — confirmation now emits a `ChoiceEvent` with `OK` / `Cancel` options and `allowFreeText: true`, so the user can also type a custom rejection reason.

## Behaviour

- **OK** → command executes
- **Cancel** → command cancelled (no reason)
- **Custom text** → command cancelled with the typed reason forwarded
- Terminal interface unaffected (graceful degradation via existing `chooseOption` implementation)
- No new event types or components introduced — reuses existing `ChoiceEvent` infrastructure