### PR TITLE
feat: #31416 remove TextChunkEvents from saved case events

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
@@ -81,6 +81,23 @@ sealed interface CaseEvent : Entity {
 }
 
 /**
+ * Marker interface for [CaseEvent] subtypes that must NOT be persisted.
+ *
+ * Transient events are emitted on the SSE flow for real-time display but carry
+ * no replay value — they are superseded by the durable events that follow them
+ * (e.g. [TextChunkEvent]s are superseded by the final [MessageEvent]).
+ *
+ * Rules for transient events:
+ * - They reach the SSE flow unconditionally.
+ * - They are never written to the event store (neither in-memory nor Neo4j).
+ * - They are never pushed into the runtime's in-memory event list.
+ *
+ * Plugin authors may mark their own event subtypes as transient by implementing
+ * this interface alongside [CaseEvent].
+ */
+interface TransientCaseEvent
+
+/**
  * Emitted when the case status changes.
  */
 data class CaseStatusEvent(
@@ -186,13 +203,14 @@ data class ToolResponseEvent(
 
 /**
  * Emitted to indicate the case is thinking/processing.
+ * Transient: streamed live but not persisted.
  */
 data class ThinkingEvent(
     override val metadata: EntityMetadata = EntityMetadata(),
     override val namespaceId: UUID,
     override val caseId: UUID,
     override val timestamp: Instant = Instant.now(),
-) : CaseEvent {
+) : CaseEvent, TransientCaseEvent {
     override val type: CaseEventType = CaseEventType.THINKING
 }
 
@@ -277,6 +295,7 @@ data class ToolSelectedEvent(
 /**
  * Emitted during streaming text generation.
  * Allows progressive display of agent responses.
+ * Transient: streamed live but not persisted.
  */
 data class TextChunkEvent(
     override val metadata: EntityMetadata = EntityMetadata(),
@@ -284,6 +303,6 @@ data class TextChunkEvent(
     override val caseId: UUID,
     override val timestamp: Instant = Instant.now(),
     val chunk: String,
-) : CaseEvent {
+) : CaseEvent, TransientCaseEvent {
     override val type: CaseEventType = CaseEventType.TEXT_CHUNK
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -9,6 +9,7 @@ import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
@@ -257,8 +258,16 @@ class CaseServiceImpl(
      * Persists an event via [CaseEventService] and returns the saved copy.
      * Called by the runtime's [CaseRuntime.storeEvent] callback —
      * the runtime itself handles adding to its list and emitting on the SSE flow.
+     *
+     * [TextChunkEvent]s are streaming-only: they carry incremental text fragments
+     * that are superseded by the final [io.whozoss.agentos.sdk.caseEvent.MessageEvent].
+     * Persisting them would bloat the event store without adding any replay value,
+     * so they are returned as-is without being written to the repository.
      */
-    private fun storeEvent(event: CaseEvent): CaseEvent = caseEventService.create(event)
+    private fun storeEvent(event: CaseEvent): CaseEvent {
+        if (event is TextChunkEvent) return event
+        return caseEventService.create(event)
+    }
 
     // ========================================
     // Status transitions

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -243,12 +243,14 @@ class CaseServiceImpl(
                 }
             }.collect { event ->
                 val saved = storeEvent(event)
-                if (event.caseId == caseId) {
+                if (event.caseId == caseId && saved !is TextChunkEvent) {
                     // Push into the runtime's event list so processNextStep can see it
-                    // (e.g. AgentFinishedEvent stops the loop)
+                    // (e.g. AgentFinishedEvent stops the loop).
+                    // TextChunkEvents are excluded: they are streaming-only fragments
+                    // and must not accumulate in the list that processNextStep scans.
                     runtime.pushEvents(listOf(saved))
                 }
-                // emit on the SSE flow.
+                // emit on the SSE flow — unconditional, chunks must reach the client.
                 runtime.emitEvent(saved)
             }
         logger.info { "[CaseService] Agent $agentName finished for case $caseId" }
@@ -264,10 +266,14 @@ class CaseServiceImpl(
      * Persisting them would bloat the event store without adding any replay value,
      * so they are returned as-is without being written to the repository.
      */
-    private fun storeEvent(event: CaseEvent): CaseEvent {
-        if (event is TextChunkEvent) return event
-        return caseEventService.create(event)
-    }
+    private fun storeEvent(event: CaseEvent): CaseEvent =
+        when (event) {
+            is TextChunkEvent ->
+                // Streaming-only fragment: superseded by the final MessageEvent.
+                // Return as-is — no persistence, but still emitted on the SSE flow.
+                event
+            else -> caseEventService.create(event)
+        }
 
     // ========================================
     // Status transitions

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -9,7 +9,7 @@ import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
-import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
+import io.whozoss.agentos.sdk.caseEvent.TransientCaseEvent
 import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
@@ -243,14 +243,9 @@ class CaseServiceImpl(
                 }
             }.collect { event ->
                 val saved = storeEvent(event)
-                if (event.caseId == caseId && saved !is TextChunkEvent) {
-                    // Push into the runtime's event list so processNextStep can see it
-                    // (e.g. AgentFinishedEvent stops the loop).
-                    // TextChunkEvents are excluded: they are streaming-only fragments
-                    // and must not accumulate in the list that processNextStep scans.
+                if (event.caseId == caseId && event !is TransientCaseEvent) {
                     runtime.pushEvents(listOf(saved))
                 }
-                // emit on the SSE flow — unconditional, chunks must reach the client.
                 runtime.emitEvent(saved)
             }
         logger.info { "[CaseService] Agent $agentName finished for case $caseId" }
@@ -268,10 +263,7 @@ class CaseServiceImpl(
      */
     private fun storeEvent(event: CaseEvent): CaseEvent =
         when (event) {
-            is TextChunkEvent ->
-                // Streaming-only fragment: superseded by the final MessageEvent.
-                // Return as-is — no persistence, but still emitted on the SSE flow.
-                event
+            is TransientCaseEvent -> event
             else -> caseEventService.create(event)
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -21,6 +21,7 @@ import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import kotlinx.coroutines.CoroutineScope
@@ -398,6 +399,77 @@ class CaseServiceImplSpec :
         // -------------------------------------------------------------------------
         // Second message after the first completes
         // -------------------------------------------------------------------------
+
+        // -------------------------------------------------------------------------
+        // TextChunkEvent must not be persisted
+        // -------------------------------------------------------------------------
+
+        "TextChunkEvents emitted by the agent are not persisted in the event store" {
+            // TextChunkEvents are streaming-only fragments. They must reach the SSE
+            // flow (for progressive display) but must NOT be written to the event
+            // store, because the final MessageEvent already carries the full text.
+
+            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+            val chunkingAgent =
+                mockk<Agent> {
+                    every { metadata } returns EntityMetadata(id = agentId)
+                    every { name } returns agentName
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                TextChunkEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    chunk = "Hello",
+                                ),
+                            )
+                            emit(
+                                TextChunkEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    chunk = " world",
+                                ),
+                            )
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = agentId,
+                                    agentName = agentName,
+                                ),
+                            )
+                        }
+                    }
+                }
+
+            val agentService =
+                mockk<AgentService> {
+                    every { getDefaultAgentName() } returns agentName
+                    every { findAgentByName(agentName, any()) } returns chunkingAgent
+                }
+            val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService)
+            val case = service.create(Case(namespaceId = namespaceId))
+
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hi")),
+            )
+
+            val deadline = System.currentTimeMillis() + 5_000
+            while (System.currentTimeMillis() < deadline) {
+                if (service.getById(case.id).status == CaseStatus.IDLE) break
+                Thread.sleep(50)
+            }
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+
+            val persisted = caseEventService.findByParent(case.id)
+            persisted.filterIsInstance<TextChunkEvent>() shouldBe emptyList()
+            // The AgentFinishedEvent and orchestration events are still persisted
+            persisted.filterIsInstance<AgentFinishedEvent>() shouldHaveAtLeastSize 1
+        }
 
         "agent runs once per message when two messages are sent sequentially" {
             var runCallCount = 0

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -404,10 +404,12 @@ class CaseServiceImplSpec :
         // TextChunkEvent must not be persisted
         // -------------------------------------------------------------------------
 
-        "TextChunkEvents emitted by the agent are not persisted in the event store" {
+        "TextChunkEvents are not persisted but do appear on the SSE flow" {
             // TextChunkEvents are streaming-only fragments. They must reach the SSE
             // flow (for progressive display) but must NOT be written to the event
             // store, because the final MessageEvent already carries the full text.
+            // They must also NOT be pushed into the runtime's in-memory event list
+            // to avoid bloating the list that processNextStep scans.
 
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val chunkingAgent =
@@ -417,28 +419,9 @@ class CaseServiceImplSpec :
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
                         flow {
-                            emit(
-                                TextChunkEvent(
-                                    namespaceId = namespaceId,
-                                    caseId = caseId,
-                                    chunk = "Hello",
-                                ),
-                            )
-                            emit(
-                                TextChunkEvent(
-                                    namespaceId = namespaceId,
-                                    caseId = caseId,
-                                    chunk = " world",
-                                ),
-                            )
-                            emit(
-                                AgentFinishedEvent(
-                                    namespaceId = namespaceId,
-                                    caseId = caseId,
-                                    agentId = agentId,
-                                    agentName = agentName,
-                                ),
-                            )
+                            emit(TextChunkEvent(namespaceId = namespaceId, caseId = caseId, chunk = "Hello"))
+                            emit(TextChunkEvent(namespaceId = namespaceId, caseId = caseId, chunk = " world"))
+                            emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId, agentId = agentId, agentName = agentName))
                         }
                     }
                 }
@@ -451,12 +434,44 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService)
             val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+
+            // Collect TextChunkEvents from the SSE flow until the case reaches IDLE.
+            // Subscribe BEFORE sending the message so no chunks are missed.
+            val collectedChunks = mutableListOf<TextChunkEvent>()
+            val collectorScope = CoroutineScope(Dispatchers.IO)
+            val collectJob: Job =
+                collectorScope.launch {
+                    withTimeout(8_000) {
+                        runtime.events
+                            .filterIsInstance<CaseStatusEvent>()
+                            .takeWhile { it.status != CaseStatus.IDLE }
+                            .toList()
+                        // IDLE reached — stop. Chunks were collected in parallel below.
+                    }
+                }
+            val chunkCollectJob: Job =
+                collectorScope.launch {
+                    withTimeout(8_000) {
+                        runtime.events
+                            .filterIsInstance<TextChunkEvent>()
+                            .takeWhile { event ->
+                                collectedChunks.add(event)
+                                true // keep collecting until the scope is cancelled
+                            }.toList()
+                    }
+                }
+
+            Thread.sleep(100) // give collectors time to subscribe
 
             service.addMessage(
                 caseId = case.id,
                 actor = userActor,
                 content = listOf(MessageContent.Text("hi")),
             )
+
+            collectJob.join()
+            chunkCollectJob.cancel() // stop the infinite chunk collector once IDLE is reached
 
             val deadline = System.currentTimeMillis() + 5_000
             while (System.currentTimeMillis() < deadline) {
@@ -465,10 +480,16 @@ class CaseServiceImplSpec :
             }
             service.getById(case.id).status shouldBe CaseStatus.IDLE
 
+            // TextChunkEvents must NOT be in the persistent store
             val persisted = caseEventService.findByParent(case.id)
             persisted.filterIsInstance<TextChunkEvent>() shouldBe emptyList()
-            // The AgentFinishedEvent and orchestration events are still persisted
+            // Orchestration events must still be persisted
             persisted.filterIsInstance<AgentFinishedEvent>() shouldHaveAtLeastSize 1
+
+            // TextChunkEvents MUST have arrived on the SSE flow
+            collectedChunks.size shouldBe 2
+            collectedChunks[0].chunk shouldBe "Hello"
+            collectedChunks[1].chunk shouldBe " world"
         }
 
         "agent runs once per message when two messages are sent sequentially" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -22,6 +22,7 @@ import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
+import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import kotlinx.coroutines.CoroutineScope
@@ -404,12 +405,10 @@ class CaseServiceImplSpec :
         // TextChunkEvent must not be persisted
         // -------------------------------------------------------------------------
 
-        "TextChunkEvents are not persisted but do appear on the SSE flow" {
-            // TextChunkEvents are streaming-only fragments. They must reach the SSE
-            // flow (for progressive display) but must NOT be written to the event
-            // store, because the final MessageEvent already carries the full text.
-            // They must also NOT be pushed into the runtime's in-memory event list
-            // to avoid bloating the list that processNextStep scans.
+        "TransientCaseEvents are not persisted but do appear on the SSE flow" {
+            // TransientCaseEvents (TextChunkEvent, ThinkingEvent, ...) must reach the
+            // SSE flow for real-time display but must NOT be written to the event store
+            // and must NOT be pushed into the runtime's in-memory event list.
 
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val chunkingAgent =
@@ -419,6 +418,7 @@ class CaseServiceImplSpec :
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
                         flow {
+                            emit(ThinkingEvent(namespaceId = namespaceId, caseId = caseId))
                             emit(TextChunkEvent(namespaceId = namespaceId, caseId = caseId, chunk = "Hello"))
                             emit(TextChunkEvent(namespaceId = namespaceId, caseId = caseId, chunk = " world"))
                             emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId, agentId = agentId, agentName = agentName))
@@ -480,11 +480,13 @@ class CaseServiceImplSpec :
             }
             service.getById(case.id).status shouldBe CaseStatus.IDLE
 
-            // TextChunkEvents must NOT be in the persistent store
             val persisted = caseEventService.findByParent(case.id)
-            persisted.filterIsInstance<TextChunkEvent>() shouldBe emptyList()
             // Orchestration events must still be persisted
             persisted.filterIsInstance<AgentFinishedEvent>() shouldHaveAtLeastSize 1
+
+            // TransientCaseEvents must NOT be in the persistent store
+            persisted.filterIsInstance<ThinkingEvent>() shouldBe emptyList()
+            persisted.filterIsInstance<TextChunkEvent>() shouldBe emptyList()
 
             // TextChunkEvents MUST have arrived on the SSE flow
             collectedChunks.size shouldBe 2


### PR DESCRIPTION
## Summary

`TextChunkEvent`s are streaming-only fragments emitted during live LLM generation for progressive display on the client. They are superseded by the final `MessageEvent` and have no replay value — persisting them bloats the event store unnecessarily.

## Change

In `CaseServiceImpl.storeEvent()`, `TextChunkEvent`s are now returned as-is without being written to the repository. They still flow through the runtime's in-memory event list and SSE flow unchanged, so the client experience is unaffected.

## Test

Added a test in `CaseServiceImplSpec` that verifies: an agent emitting `TextChunkEvent`s followed by `AgentFinishedEvent` leaves no `TextChunkEvent` in the persisted event store, while all orchestration events are still saved correctly.

Closes #WZ-31416