### PR TITLE
feat: #WZ-29564 Entity-level permission abstraction (Phase 1)

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/AccessDecision.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/AccessDecision.kt
@@ -1,0 +1,12 @@
+package io.whozoss.agentos.sdk.auth
+
+sealed class AccessDecision {
+    data class Granted(val effectiveRole: String) : AccessDecision()
+    data class Denied(
+        val reason: String,
+        val usersWithAccess: List<String> = emptyList(),
+    ) : AccessDecision()
+    data object Abstain : AccessDecision()
+
+    val isGranted: Boolean get() = this is Granted
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/CaseRole.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/CaseRole.kt
@@ -1,0 +1,10 @@
+package io.whozoss.agentos.sdk.auth
+
+enum class CaseRole(val level: Int) {
+    OBSERVER(1),
+    PARTICIPANT(2),
+    OWNER(3),
+    ;
+
+    fun satisfies(required: CaseRole): Boolean = this.level >= required.level
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/NamespaceRole.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/NamespaceRole.kt
@@ -1,0 +1,11 @@
+package io.whozoss.agentos.sdk.auth
+
+enum class NamespaceRole(val level: Int) {
+    VIEWER(1),
+    MEMBER(2),
+    ADMIN(3),
+    OWNER(4),
+    ;
+
+    fun satisfies(required: NamespaceRole): Boolean = this.level >= required.level
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/Operation.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/Operation.kt
@@ -1,0 +1,11 @@
+package io.whozoss.agentos.sdk.auth
+
+enum class Operation {
+    LIST,
+    READ,
+    CREATE,
+    WRITE,
+    DELETE,
+    MANAGE,
+    EXECUTE,
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/PermissionContext.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/PermissionContext.kt
@@ -1,0 +1,13 @@
+package io.whozoss.agentos.sdk.auth
+
+import java.util.UUID
+
+data class PermissionContext(
+    val userId: UUID,
+    val isRoot: Boolean,
+    val namespaceId: UUID? = null,
+    val namespaceRole: NamespaceRole? = null,
+    val caseId: UUID? = null,
+    val caseRole: CaseRole? = null,
+    val toolRestriction: ToolRestriction? = null,
+)

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/PermissionEvaluator.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/PermissionEvaluator.kt
@@ -1,0 +1,10 @@
+package io.whozoss.agentos.sdk.auth
+
+import org.pf4j.ExtensionPoint
+
+interface PermissionEvaluator : ExtensionPoint {
+    fun evaluateNamespaceAccess(ctx: PermissionContext, minRole: NamespaceRole): AccessDecision
+    fun evaluateCaseAccess(ctx: PermissionContext, operation: Operation): AccessDecision
+    fun evaluateToolAccess(ctx: PermissionContext, toolName: String, toolCategory: ToolCategory): AccessDecision
+    fun getAvailableToolCategories(ctx: PermissionContext): Set<ToolCategory>
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/ToolCategory.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/ToolCategory.kt
@@ -1,0 +1,8 @@
+package io.whozoss.agentos.sdk.auth
+
+enum class ToolCategory(val riskLabel: String, val minimumNamespaceRole: NamespaceRole) {
+    READ_ONLY("low risk", NamespaceRole.VIEWER),
+    WRITE("medium risk", NamespaceRole.MEMBER),
+    DESTRUCTIVE("high risk", NamespaceRole.ADMIN),
+    ADMIN("critical", NamespaceRole.ADMIN),
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/ToolRestriction.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/auth/ToolRestriction.kt
@@ -1,0 +1,12 @@
+package io.whozoss.agentos.sdk.auth
+
+data class ToolRestriction(
+    val mode: ToolRestrictionMode,
+    val tools: Set<String>,
+)
+
+enum class ToolRestrictionMode {
+    WHITELIST,
+    BLACKLIST,
+    NONE,
+}

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/AccessDecisionSpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/AccessDecisionSpec.kt
@@ -1,0 +1,39 @@
+package io.whozoss.agentos.sdk.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class AccessDecisionSpec : StringSpec() {
+    init {
+        "Granted isGranted returns true" {
+            AccessDecision.Granted("ADMIN").isGranted shouldBe true
+        }
+        "Denied isGranted returns false" {
+            AccessDecision.Denied("not authorized").isGranted shouldBe false
+        }
+        "Abstain isGranted returns false" {
+            AccessDecision.Abstain.isGranted shouldBe false
+        }
+        "Denied has default empty usersWithAccess" {
+            AccessDecision.Denied("no access").usersWithAccess shouldBe emptyList()
+        }
+        "Denied can have usersWithAccess" {
+            val denied = AccessDecision.Denied("no access", listOf("user1", "user2"))
+            denied.usersWithAccess shouldBe listOf("user1", "user2")
+        }
+        "exhaustive when covers all variants" {
+            val decisions = listOf(
+                AccessDecision.Granted("OWNER"),
+                AccessDecision.Denied("reason"),
+                AccessDecision.Abstain,
+            )
+            decisions.forEach { decision ->
+                when (decision) {
+                    is AccessDecision.Granted -> decision.effectiveRole.isNotEmpty() shouldBe true
+                    is AccessDecision.Denied -> decision.reason.isNotEmpty() shouldBe true
+                    is AccessDecision.Abstain -> Unit
+                }
+            }
+        }
+    }
+}

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/CaseRoleSpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/CaseRoleSpec.kt
@@ -1,0 +1,24 @@
+package io.whozoss.agentos.sdk.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class CaseRoleSpec : StringSpec() {
+    init {
+        "OWNER satisfies all case roles" {
+            CaseRole.OWNER.satisfies(CaseRole.OBSERVER) shouldBe true
+            CaseRole.OWNER.satisfies(CaseRole.PARTICIPANT) shouldBe true
+            CaseRole.OWNER.satisfies(CaseRole.OWNER) shouldBe true
+        }
+        "OBSERVER only satisfies OBSERVER" {
+            CaseRole.OBSERVER.satisfies(CaseRole.OBSERVER) shouldBe true
+            CaseRole.OBSERVER.satisfies(CaseRole.PARTICIPANT) shouldBe false
+            CaseRole.OBSERVER.satisfies(CaseRole.OWNER) shouldBe false
+        }
+        "PARTICIPANT satisfies OBSERVER and PARTICIPANT but not OWNER" {
+            CaseRole.PARTICIPANT.satisfies(CaseRole.OBSERVER) shouldBe true
+            CaseRole.PARTICIPANT.satisfies(CaseRole.PARTICIPANT) shouldBe true
+            CaseRole.PARTICIPANT.satisfies(CaseRole.OWNER) shouldBe false
+        }
+    }
+}

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/NamespaceRoleSpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/NamespaceRoleSpec.kt
@@ -1,0 +1,27 @@
+package io.whozoss.agentos.sdk.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class NamespaceRoleSpec : StringSpec() {
+    init {
+        "OWNER satisfies all roles" {
+            NamespaceRole.OWNER.satisfies(NamespaceRole.VIEWER) shouldBe true
+            NamespaceRole.OWNER.satisfies(NamespaceRole.MEMBER) shouldBe true
+            NamespaceRole.OWNER.satisfies(NamespaceRole.ADMIN) shouldBe true
+            NamespaceRole.OWNER.satisfies(NamespaceRole.OWNER) shouldBe true
+        }
+        "VIEWER only satisfies VIEWER" {
+            NamespaceRole.VIEWER.satisfies(NamespaceRole.VIEWER) shouldBe true
+            NamespaceRole.VIEWER.satisfies(NamespaceRole.MEMBER) shouldBe false
+            NamespaceRole.VIEWER.satisfies(NamespaceRole.ADMIN) shouldBe false
+            NamespaceRole.VIEWER.satisfies(NamespaceRole.OWNER) shouldBe false
+        }
+        "hierarchy is strictly ordered" {
+            NamespaceRole.MEMBER.satisfies(NamespaceRole.VIEWER) shouldBe true
+            NamespaceRole.MEMBER.satisfies(NamespaceRole.ADMIN) shouldBe false
+            NamespaceRole.ADMIN.satisfies(NamespaceRole.MEMBER) shouldBe true
+            NamespaceRole.ADMIN.satisfies(NamespaceRole.OWNER) shouldBe false
+        }
+    }
+}

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/PermissionContextSpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/PermissionContextSpec.kt
@@ -1,0 +1,55 @@
+package io.whozoss.agentos.sdk.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+
+class PermissionContextSpec : StringSpec() {
+    init {
+        "creates with required fields only" {
+            val userId = UUID.randomUUID()
+            val ctx = PermissionContext(userId = userId, isRoot = false)
+            ctx.userId shouldBe userId
+            ctx.isRoot shouldBe false
+            ctx.namespaceId shouldBe null
+            ctx.namespaceRole shouldBe null
+            ctx.caseId shouldBe null
+            ctx.caseRole shouldBe null
+            ctx.toolRestriction shouldBe null
+        }
+        "creates with all fields" {
+            val userId = UUID.randomUUID()
+            val nsId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val restriction = ToolRestriction(ToolRestrictionMode.WHITELIST, setOf("tool1"))
+            val ctx = PermissionContext(
+                userId = userId,
+                isRoot = true,
+                namespaceId = nsId,
+                namespaceRole = NamespaceRole.ADMIN,
+                caseId = caseId,
+                caseRole = CaseRole.PARTICIPANT,
+                toolRestriction = restriction,
+            )
+            ctx.userId shouldBe userId
+            ctx.isRoot shouldBe true
+            ctx.namespaceId shouldBe nsId
+            ctx.namespaceRole shouldBe NamespaceRole.ADMIN
+            ctx.caseId shouldBe caseId
+            ctx.caseRole shouldBe CaseRole.PARTICIPANT
+            ctx.toolRestriction shouldBe restriction
+        }
+        "is immutable via data class copy" {
+            val original = PermissionContext(userId = UUID.randomUUID(), isRoot = false)
+            val modified = original.copy(isRoot = true)
+            original.isRoot shouldBe false
+            modified.isRoot shouldBe true
+        }
+        "structural equality works" {
+            val userId = UUID.randomUUID()
+            val ctx1 = PermissionContext(userId = userId, isRoot = false)
+            val ctx2 = PermissionContext(userId = userId, isRoot = false)
+            (ctx1 == ctx2) shouldBe true
+        }
+    }
+}

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/ToolCategorySpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/ToolCategorySpec.kt
@@ -1,0 +1,32 @@
+package io.whozoss.agentos.sdk.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ToolCategorySpec : StringSpec() {
+    init {
+        "READ_ONLY has low risk and VIEWER minimum role" {
+            ToolCategory.READ_ONLY.riskLabel shouldBe "low risk"
+            ToolCategory.READ_ONLY.minimumNamespaceRole shouldBe NamespaceRole.VIEWER
+        }
+        "WRITE has medium risk and MEMBER minimum role" {
+            ToolCategory.WRITE.riskLabel shouldBe "medium risk"
+            ToolCategory.WRITE.minimumNamespaceRole shouldBe NamespaceRole.MEMBER
+        }
+        "DESTRUCTIVE has high risk and ADMIN minimum role" {
+            ToolCategory.DESTRUCTIVE.riskLabel shouldBe "high risk"
+            ToolCategory.DESTRUCTIVE.minimumNamespaceRole shouldBe NamespaceRole.ADMIN
+        }
+        "ADMIN has critical risk and ADMIN minimum role" {
+            ToolCategory.ADMIN.riskLabel shouldBe "critical"
+            ToolCategory.ADMIN.minimumNamespaceRole shouldBe NamespaceRole.ADMIN
+        }
+        "categories are ordered by increasing risk" {
+            val categories = ToolCategory.entries
+            categories[0] shouldBe ToolCategory.READ_ONLY
+            categories[1] shouldBe ToolCategory.WRITE
+            categories[2] shouldBe ToolCategory.DESTRUCTIVE
+            categories[3] shouldBe ToolCategory.ADMIN
+        }
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AccessDeniedException.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AccessDeniedException.kt
@@ -1,0 +1,6 @@
+package io.whozoss.agentos.auth
+
+class AccessDeniedException(
+    val reason: String,
+    val requiredRole: String? = null,
+) : RuntimeException(reason)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AccessDeniedExceptionHandler.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AccessDeniedExceptionHandler.kt
@@ -1,0 +1,43 @@
+package io.whozoss.agentos.auth
+
+import mu.KLogging
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ * Global exception handler for [AccessDeniedException] and [IllegalArgumentException].
+ *
+ * Returns structured error responses:
+ * - [AccessDeniedException] → 403 Forbidden with error code, reason, and required role.
+ * - [IllegalArgumentException] → 400 Bad Request with error code and reason.
+ *
+ * This ensures consistent error responses across all controllers that use [AuthorizationService].
+ */
+@RestControllerAdvice
+class AccessDeniedExceptionHandler {
+
+    @ExceptionHandler(AccessDeniedException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    fun handleAccessDenied(ex: AccessDeniedException): Map<String, String?> {
+        logger.warn { "Access denied: ${ex.reason}" }
+        return mapOf(
+            "error" to "ACCESS_DENIED",
+            "reason" to ex.reason,
+            "requiredRole" to ex.requiredRole,
+        )
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleIllegalArgument(ex: IllegalArgumentException): Map<String, String?> {
+        logger.warn { "Bad request: ${ex.message}" }
+        return mapOf(
+            "error" to "BAD_REQUEST",
+            "reason" to ex.message,
+        )
+    }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AuthorizationService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AuthorizationService.kt
@@ -1,0 +1,77 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.auth.Operation
+import io.whozoss.agentos.sdk.auth.ToolCategory
+
+/**
+ * Central authorization service that orchestrates permission checks
+ * via a pluggable [io.whozoss.agentos.sdk.auth.PermissionEvaluator].
+ *
+ * All access verification passes through this single point, extensible
+ * by PF4J plugin for enterprise integrations.
+ *
+ * All IDs are [String] to align with Neo4j node ID convention used
+ * throughout the codebase.
+ */
+interface AuthorizationService {
+
+    // -------------------------------------------------------------------------
+    // Namespace access
+    // -------------------------------------------------------------------------
+
+    /**
+     * Require at least [minRole] in the given namespace.
+     * @throws AccessDeniedException if the user does not satisfy the required role
+     */
+    fun requireNamespaceAccess(userId: String, namespaceId: String, minRole: NamespaceRole)
+
+    /**
+     * Return the set of namespace IDs accessible to the user.
+     */
+    fun filterAccessibleNamespaceIds(userId: String): Set<String>
+
+    // -------------------------------------------------------------------------
+    // Case access
+    // -------------------------------------------------------------------------
+
+    /**
+     * Require permission for the given [operation] on a case.
+     * @throws AccessDeniedException if the user is not allowed
+     */
+    fun requireCaseAccess(userId: String, caseId: String, operation: Operation)
+
+    /**
+     * Return the set of case IDs accessible to the user within a namespace.
+     */
+    fun filterAccessibleCaseIds(userId: String, namespaceId: String): Set<String>
+
+    // -------------------------------------------------------------------------
+    // Tool access
+    // -------------------------------------------------------------------------
+
+    /**
+     * Check whether the user can execute a specific tool in a case.
+     */
+    fun canExecuteTool(userId: String, caseId: String, toolName: String, toolCategory: ToolCategory): Boolean
+
+    /**
+     * Return the set of tool names the user can execute in a case.
+     */
+    fun getAvailableTools(userId: String, caseId: String, allTools: Map<String, ToolCategory>): Set<String>
+
+    // -------------------------------------------------------------------------
+    // Root status
+    // -------------------------------------------------------------------------
+
+    /**
+     * Check whether the user is a root (super-admin).
+     */
+    fun isRoot(userId: String): Boolean
+
+    /**
+     * Require root status.
+     * @throws AccessDeniedException if the user is not root
+     */
+    fun requireRoot(userId: String)
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AuthorizationServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/AuthorizationServiceImpl.kt
@@ -1,0 +1,266 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.caseFlow.CaseService
+import io.whozoss.agentos.namespace.NamespaceService
+import io.whozoss.agentos.sdk.auth.AccessDecision
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.auth.Operation
+import io.whozoss.agentos.sdk.auth.PermissionContext
+import io.whozoss.agentos.sdk.auth.PermissionEvaluator
+import io.whozoss.agentos.sdk.auth.ToolCategory
+import io.whozoss.agentos.security.SecurityConfigProperties
+import mu.KLogging
+import org.pf4j.PluginManager
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * Central authorization service implementation.
+ *
+ * Orchestrates [RoleRepository] + [PermissionEvaluator] to evaluate access.
+ * Builds an immutable [PermissionContext] per request, delegates evaluation
+ * to the evaluator, and interprets the [AccessDecision].
+ *
+ * The evaluator is resolved lazily: a PF4J plugin-provided evaluator takes
+ * priority over the built-in [CodayPermissionEvaluator].
+ *
+ * ## Fail-closed behavior (NFR9, NFR10)
+ *
+ * Any unexpected exception during a permission check is caught:
+ * - In permissive mode: access is granted (backward compatibility).
+ * - In strict mode: access is denied (fail-closed).
+ * The error is logged without causing service unavailability.
+ *
+ * ## No ThreadLocal (NFR12)
+ *
+ * All context is passed explicitly via method parameters.
+ */
+@Service
+class AuthorizationServiceImpl(
+    private val roleRepository: RoleRepository,
+    private val pluginManager: PluginManager,
+    private val securityConfigProperties: SecurityConfigProperties,
+    private val namespaceService: NamespaceService,
+    private val caseService: CaseService,
+) : AuthorizationService {
+
+    private val evaluator: PermissionEvaluator by lazy {
+        val pluginEvaluators = pluginManager.getExtensions(PermissionEvaluator::class.java)
+        val overrides = pluginEvaluators.filter { it !is CodayPermissionEvaluator }
+        when {
+            overrides.isNotEmpty() -> {
+                logger.info { "Using plugin-provided PermissionEvaluator: ${overrides.first()::class.qualifiedName}" }
+                overrides.first()
+            }
+            else -> {
+                logger.info { "Using built-in CodayPermissionEvaluator" }
+                CodayPermissionEvaluator()
+            }
+        }
+    }
+
+    private val permissive: Boolean get() = securityConfigProperties.permissive
+
+    // -------------------------------------------------------------------------
+    // Namespace access
+    // -------------------------------------------------------------------------
+
+    override fun requireNamespaceAccess(userId: String, namespaceId: String, minRole: NamespaceRole) {
+        try {
+            when {
+                roleRepository.isRoot(userId) -> return
+            }
+
+            val role = roleRepository.findNamespaceRole(userId, namespaceId)
+            when {
+                role == null && permissive -> return
+                role == null -> throw AccessDeniedException("No role assigned for user $userId in namespace $namespaceId")
+            }
+
+            val ctx = PermissionContext(
+                userId = UUID.fromString(userId),
+                isRoot = false,
+                namespaceId = UUID.fromString(namespaceId),
+                namespaceRole = role,
+            )
+
+            val decision = evaluator.evaluateNamespaceAccess(ctx, minRole)
+            handleDecision(decision)
+        } catch (e: AccessDeniedException) {
+            throw e
+        } catch (e: Exception) {
+            handleUnexpectedError(e, "requireNamespaceAccess(userId=$userId, namespaceId=$namespaceId)")
+        }
+    }
+
+    override fun filterAccessibleNamespaceIds(userId: String): Set<String> = try {
+        when {
+            roleRepository.isRoot(userId) -> namespaceService.findAll().map { it.id.toString() }.toSet()
+            else -> roleRepository.findNamespaceIdsForUser(userId)
+        }
+    } catch (e: Exception) {
+        logger.error(e) { "Failed to filter accessible namespace IDs for user $userId" }
+        when {
+            permissive -> namespaceService.findAll().map { it.id.toString() }.toSet()
+            else -> emptySet()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Case access
+    // -------------------------------------------------------------------------
+
+    override fun requireCaseAccess(userId: String, caseId: String, operation: Operation) {
+        try {
+            when {
+                roleRepository.isRoot(userId) -> return
+            }
+
+            val caseRole = roleRepository.findCaseRole(userId, caseId)
+            when {
+                caseRole == null && permissive -> return
+                caseRole == null -> throw AccessDeniedException("No role assigned for user $userId in case $caseId")
+            }
+
+            val ctx = PermissionContext(
+                userId = UUID.fromString(userId),
+                isRoot = false,
+                caseId = UUID.fromString(caseId),
+                caseRole = caseRole,
+            )
+
+            val decision = evaluator.evaluateCaseAccess(ctx, operation)
+            handleDecision(decision)
+        } catch (e: AccessDeniedException) {
+            throw e
+        } catch (e: Exception) {
+            handleUnexpectedError(e, "requireCaseAccess(userId=$userId, caseId=$caseId)")
+        }
+    }
+
+    override fun filterAccessibleCaseIds(userId: String, namespaceId: String): Set<String> = try {
+        when {
+            roleRepository.isRoot(userId) -> caseService.findByParent(UUID.fromString(namespaceId))
+                .map { it.id.toString() }.toSet()
+            else -> roleRepository.findAccessibleCaseIdsForUser(userId, namespaceId)
+        }
+    } catch (e: Exception) {
+        logger.error(e) { "Failed to filter accessible case IDs for user $userId in namespace $namespaceId" }
+        when {
+            permissive -> caseService.findByParent(UUID.fromString(namespaceId))
+                .map { it.id.toString() }.toSet()
+            else -> emptySet()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tool access
+    // -------------------------------------------------------------------------
+
+    override fun canExecuteTool(
+        userId: String,
+        caseId: String,
+        toolName: String,
+        toolCategory: ToolCategory,
+    ): Boolean = try {
+        when {
+            roleRepository.isRoot(userId) -> true
+            else -> {
+                val caseRole = roleRepository.findCaseRole(userId, caseId)
+                when (caseRole) {
+                    null -> permissive
+                    else -> {
+                        val ctx = PermissionContext(
+                            userId = UUID.fromString(userId),
+                            isRoot = false,
+                            caseId = UUID.fromString(caseId),
+                            caseRole = caseRole,
+                        )
+                        evaluator.evaluateToolAccess(ctx, toolName, toolCategory).isGranted
+                    }
+                }
+            }
+        }
+    } catch (e: Exception) {
+        logger.error(e) { "Failed to check tool access for user $userId, tool $toolName" }
+        permissive
+    }
+
+    override fun getAvailableTools(
+        userId: String,
+        caseId: String,
+        allTools: Map<String, ToolCategory>,
+    ): Set<String> = try {
+        when {
+            roleRepository.isRoot(userId) -> allTools.keys
+            else -> {
+                val caseRole = roleRepository.findCaseRole(userId, caseId)
+                when (caseRole) {
+                    null -> when {
+                        permissive -> allTools.keys
+                        else -> emptySet()
+                    }
+                    else -> {
+                        val ctx = PermissionContext(
+                            userId = UUID.fromString(userId),
+                            isRoot = false,
+                            caseId = UUID.fromString(caseId),
+                            caseRole = caseRole,
+                        )
+                        allTools.filter { (toolName, toolCategory) ->
+                            evaluator.evaluateToolAccess(ctx, toolName, toolCategory).isGranted
+                        }.keys
+                    }
+                }
+            }
+        }
+    } catch (e: Exception) {
+        logger.error(e) { "Failed to get available tools for user $userId in case $caseId" }
+        when {
+            permissive -> allTools.keys
+            else -> emptySet()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Root status
+    // -------------------------------------------------------------------------
+
+    override fun isRoot(userId: String): Boolean = try {
+        roleRepository.isRoot(userId)
+    } catch (e: Exception) {
+        logger.error(e) { "Failed to check root status for user $userId" }
+        false
+    }
+
+    override fun requireRoot(userId: String) {
+        when {
+            !isRoot(userId) -> throw AccessDeniedException("User $userId is not root")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private fun handleDecision(decision: AccessDecision) {
+        when (decision) {
+            is AccessDecision.Granted -> return
+            is AccessDecision.Denied -> throw AccessDeniedException(decision.reason)
+            is AccessDecision.Abstain -> when {
+                permissive -> return
+                else -> throw AccessDeniedException("Permission evaluation abstained and permissive mode is disabled")
+            }
+        }
+    }
+
+    private fun handleUnexpectedError(e: Exception, context: String) {
+        logger.error(e) { "Permission check failed: $context" }
+        when {
+            permissive -> return
+            else -> throw AccessDeniedException("Permission check failed: system error")
+        }
+    }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/BootstrapService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/BootstrapService.kt
@@ -1,0 +1,111 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.namespace.NamespaceService
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.security.SecurityConfigProperties
+import io.whozoss.agentos.security.SecurityMode
+import io.whozoss.agentos.security.SecurityService
+import io.whozoss.agentos.user.UserService
+import mu.KLogging
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+
+/**
+ * Bootstrap service that runs at application startup.
+ *
+ * Responsibilities:
+ * 1. **Auto-root** (LOCAL mode, FR33): resolve the OS user and grant root status.
+ * 2. **Migration** (FR36): assign ADMIN on all existing namespaces to every user
+ *    that has no role yet — ensures backward compatibility.
+ *
+ * The bootstrap is **idempotent**: it checks the current state before acting
+ * and can be re-executed without side effects.
+ */
+@Service
+class BootstrapService(
+    private val userService: UserService,
+    private val roleRepository: RoleRepository,
+    private val securityConfigProperties: SecurityConfigProperties,
+    private val namespaceService: NamespaceService,
+    private val securityService: SecurityService,
+) {
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun onApplicationReady() {
+        logger.info { "Bootstrap: starting..." }
+
+        val allUsers = userService.findAll()
+        val hasRoot = allUsers.any { it.isRoot }
+
+        when {
+            hasRoot -> logger.info { "Bootstrap: root user already exists — skipping auto-root" }
+            else -> bootstrapRoot()
+        }
+
+        migrateExistingUsers()
+
+        logger.info { "Bootstrap: completed" }
+    }
+
+    /**
+     * Auto-root logic based on security mode.
+     *
+     * - LOCAL: resolve the OS user, create if absent, grant isRoot=true.
+     * - AUTH: log a warning — root must be configured manually.
+     */
+    private fun bootstrapRoot() {
+        when (securityConfigProperties.mode) {
+            SecurityMode.LOCAL -> {
+                val externalId = securityService.resolveCurrentIdentity()
+                val user = userService.resolveOrCreateByExternalId(externalId)
+                val userId = user.id.toString()
+                roleRepository.setRoot(userId, true)
+                logger.info { "Bootstrap: auto-root granted to user $userId (externalId=$externalId) in LOCAL mode" }
+            }
+            SecurityMode.AUTH -> {
+                logger.warn { "Bootstrap: no root user configured — set one manually (AUTH mode)" }
+            }
+        }
+    }
+
+    /**
+     * Migration bootstrap: for every existing user, assign ADMIN on every
+     * existing namespace where the user has no role yet.
+     *
+     * This ensures backward compatibility when permissions are activated
+     * on a system with existing data (FR36, NFR11, NFR13).
+     */
+    private fun migrateExistingUsers() {
+        val allUsers = userService.findAll()
+        val allNamespaces = namespaceService.findAll()
+
+        when {
+            allNamespaces.isEmpty() -> {
+                logger.info { "Bootstrap: no namespaces found — skipping migration" }
+                return
+            }
+        }
+
+        var migratedCount = 0
+        allUsers.forEach { user ->
+            val userId = user.id.toString()
+            allNamespaces.forEach { namespace ->
+                val nsId = namespace.id.toString()
+                val existingRole = roleRepository.findNamespaceRole(userId, nsId)
+                when (existingRole) {
+                    null -> {
+                        roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.ADMIN, "bootstrap")
+                        migratedCount++
+                        logger.info { "Bootstrap: assigned ADMIN to user $userId on namespace $nsId" }
+                    }
+                    else -> { /* already has a role — skip */ }
+                }
+            }
+        }
+
+        logger.info { "Bootstrap: migration completed — $migratedCount role assignments created" }
+    }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/CodayPermissionEvaluator.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/CodayPermissionEvaluator.kt
@@ -1,0 +1,135 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.sdk.auth.AccessDecision
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.auth.Operation
+import io.whozoss.agentos.sdk.auth.PermissionContext
+import io.whozoss.agentos.sdk.auth.PermissionEvaluator
+import io.whozoss.agentos.sdk.auth.ToolCategory
+import org.pf4j.Extension
+
+/**
+ * Default RBAC permission evaluator for Coday.
+ *
+ * Pure function implementation — no I/O, no service injection.
+ * All data comes from [PermissionContext].
+ *
+ * Annotated [@Extension] for PF4J discovery as the built-in evaluator.
+ * A plugin-provided evaluator can override this by registering
+ * a different [PermissionEvaluator] extension.
+ *
+ * ## CaseRole x Operation matrix (FR5d)
+ *
+ * | Operation | OWNER | PARTICIPANT | OBSERVER |
+ * |-----------|-------|-------------|----------|
+ * | LIST      |  yes  |     yes     |   yes    |
+ * | READ      |  yes  |     yes     |   yes    |
+ * | CREATE    |  yes  |      no     |    no    |
+ * | WRITE     |  yes  |      no     |    no    |
+ * | DELETE    |  yes  |      no     |    no    |
+ * | MANAGE    |  yes  |      no     |    no    |
+ * | EXECUTE   |  yes  |     yes     |    no    |
+ *
+ * ## CaseRole x ToolCategory matrix
+ *
+ * | ToolCategory | OWNER | PARTICIPANT | OBSERVER |
+ * |--------------|-------|-------------|----------|
+ * | READ_ONLY    |  yes  |     yes     |   yes    |
+ * | WRITE        |  yes  |     yes     |    no    |
+ * | DESTRUCTIVE  |  yes  |      no     |    no    |
+ * | ADMIN        |  yes  |      no     |    no    |
+ */
+@Extension
+class CodayPermissionEvaluator : PermissionEvaluator {
+
+    override fun evaluateNamespaceAccess(ctx: PermissionContext, minRole: NamespaceRole): AccessDecision {
+        when {
+            ctx.isRoot -> return AccessDecision.Granted("ROOT")
+        }
+
+        val role = ctx.namespaceRole
+            ?: return AccessDecision.Abstain
+
+        return when {
+            role.satisfies(minRole) -> AccessDecision.Granted(role.name)
+            else -> AccessDecision.Denied(
+                "Role ${role.name} does not satisfy required ${minRole.name}",
+            )
+        }
+    }
+
+    override fun evaluateCaseAccess(ctx: PermissionContext, operation: Operation): AccessDecision {
+        when {
+            ctx.isRoot -> return AccessDecision.Granted("ROOT")
+        }
+
+        val role = ctx.caseRole
+            ?: return AccessDecision.Abstain
+
+        val allowed = when (role) {
+            CaseRole.OWNER -> true
+            CaseRole.PARTICIPANT -> operation in PARTICIPANT_OPERATIONS
+            CaseRole.OBSERVER -> operation in OBSERVER_OPERATIONS
+        }
+
+        return when {
+            allowed -> AccessDecision.Granted(role.name)
+            else -> AccessDecision.Denied(
+                "CaseRole ${role.name} cannot perform ${operation.name}",
+            )
+        }
+    }
+
+    override fun evaluateToolAccess(
+        ctx: PermissionContext,
+        toolName: String,
+        toolCategory: ToolCategory,
+    ): AccessDecision {
+        when {
+            ctx.isRoot -> return AccessDecision.Granted("ROOT")
+        }
+
+        val role = ctx.caseRole
+            ?: return AccessDecision.Abstain
+
+        val allowedCategories = availableToolCategoriesForRole(role)
+
+        return when {
+            toolCategory in allowedCategories -> AccessDecision.Granted(role.name)
+            else -> AccessDecision.Denied(
+                "CaseRole ${role.name} cannot use tool '$toolName' (category: ${toolCategory.name})",
+            )
+        }
+    }
+
+    override fun getAvailableToolCategories(ctx: PermissionContext): Set<ToolCategory> {
+        when {
+            ctx.isRoot -> return ToolCategory.entries.toSet()
+        }
+
+        val role = ctx.caseRole
+            ?: return emptySet()
+
+        return availableToolCategoriesForRole(role)
+    }
+
+    private fun availableToolCategoriesForRole(role: CaseRole): Set<ToolCategory> = when (role) {
+        CaseRole.OWNER -> ToolCategory.entries.toSet()
+        CaseRole.PARTICIPANT -> setOf(ToolCategory.READ_ONLY, ToolCategory.WRITE)
+        CaseRole.OBSERVER -> setOf(ToolCategory.READ_ONLY)
+    }
+
+    companion object {
+        private val PARTICIPANT_OPERATIONS = setOf(
+            Operation.LIST,
+            Operation.READ,
+            Operation.EXECUTE,
+        )
+
+        private val OBSERVER_OPERATIONS = setOf(
+            Operation.LIST,
+            Operation.READ,
+        )
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/InMemoryRoleRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/InMemoryRoleRepository.kt
@@ -1,0 +1,105 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory implementation of [RoleRepository].
+ *
+ * Active when `agentos.persistence.mode` is absent, `in-memory`, or any value
+ * other than `neo4j` or `embedded-neo4j`. This is the default fallback used by
+ * the openapi spec generation task and lightweight local runs.
+ *
+ * All data is stored in [ConcurrentHashMap] and lost on restart.
+ */
+@Repository
+@ConditionalOnExpression(
+    "'\${agentos.persistence.mode:in-memory}' != 'neo4j' " +
+        "and '\${agentos.persistence.mode:in-memory}' != 'embedded-neo4j'",
+)
+class InMemoryRoleRepository : RoleRepository {
+
+    private val rootUsers = ConcurrentHashMap.newKeySet<String>()
+    private val namespaceMemberships = ConcurrentHashMap<String, MembershipInfo>()
+    private val caseRoles = ConcurrentHashMap<String, CaseRole>()
+
+    // -------------------------------------------------------------------------
+    // Root status
+    // -------------------------------------------------------------------------
+
+    override fun isRoot(userId: String): Boolean = userId in rootUsers
+
+    override fun setRoot(userId: String, isRoot: Boolean) {
+        when {
+            isRoot -> rootUsers.add(userId)
+            else -> rootUsers.remove(userId)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Namespace roles (MEMBER_OF)
+    // -------------------------------------------------------------------------
+
+    override fun findNamespaceRole(userId: String, namespaceId: String): NamespaceRole? =
+        namespaceMemberships[namespaceRoleKey(userId, namespaceId)]?.role
+
+    override fun assignNamespaceRole(userId: String, namespaceId: String, role: NamespaceRole, grantedBy: String) {
+        namespaceMemberships[namespaceRoleKey(userId, namespaceId)] = MembershipInfo(
+            userId = userId,
+            role = role,
+            grantedAt = Instant.now(),
+            grantedBy = grantedBy,
+        )
+    }
+
+    override fun removeNamespaceRole(userId: String, namespaceId: String) {
+        namespaceMemberships.remove(namespaceRoleKey(userId, namespaceId))
+    }
+
+    override fun findMembersOfNamespace(namespaceId: String): List<MembershipInfo> =
+        namespaceMemberships.entries
+            .filter { it.key.endsWith(":$namespaceId") }
+            .map { it.value }
+
+    override fun countOwnersInNamespace(namespaceId: String): Int =
+        findMembersOfNamespace(namespaceId).count { it.role == NamespaceRole.OWNER }
+
+    override fun findNamespaceIdsForUser(userId: String): Set<String> =
+        namespaceMemberships.keys
+            .filter { it.startsWith("$userId:") }
+            .map { it.substringAfter(":") }
+            .toSet()
+
+    // -------------------------------------------------------------------------
+    // Case roles (PARTICIPANT_IN)
+    // -------------------------------------------------------------------------
+
+    override fun findCaseRole(userId: String, caseId: String): CaseRole? =
+        caseRoles[caseRoleKey(userId, caseId)]
+
+    override fun assignCaseRole(userId: String, caseId: String, role: CaseRole, grantedBy: String) {
+        caseRoles[caseRoleKey(userId, caseId)] = role
+    }
+
+    override fun removeCaseRole(userId: String, caseId: String) {
+        caseRoles.remove(caseRoleKey(userId, caseId))
+    }
+
+    override fun findAccessibleCaseIdsForUser(userId: String, namespaceId: String): Set<String> =
+        caseRoles.keys
+            .filter { it.startsWith("$userId:") }
+            .map { it.substringAfter(":") }
+            .toSet()
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private fun namespaceRoleKey(userId: String, namespaceId: String): String = "$userId:$namespaceId"
+
+    private fun caseRoleKey(userId: String, caseId: String): String = "$userId:$caseId"
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/MembershipInfo.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/MembershipInfo.kt
@@ -1,0 +1,17 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import java.time.Instant
+
+/**
+ * Internal data class representing a user's membership in a namespace.
+ *
+ * Returned by [RoleRepository.findMembersOfNamespace]. The controller maps
+ * this to [io.whozoss.agentos.namespace.MembershipResource] for the HTTP response.
+ */
+data class MembershipInfo(
+    val userId: String,
+    val role: NamespaceRole,
+    val grantedAt: Instant,
+    val grantedBy: String,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/RoleRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/RoleRepository.kt
@@ -1,0 +1,101 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import java.time.Instant
+
+/**
+ * Repository for managing role assignments on Namespaces and Cases.
+ *
+ * Roles are stored as graph relationships:
+ * - `(User)-[:MEMBER_OF {role, grantedAt, grantedBy}]->(Namespace)`
+ * - `(User)-[:PARTICIPANT_IN {role, grantedAt, grantedBy, allowedTools?, toolRestrictionMode?}]->(Case)`
+ *
+ * The `isRoot` flag is stored directly on the User node.
+ *
+ * All IDs are [String] to align with Neo4j node `@Id` convention used throughout
+ * the codebase (UUID → String conversion happens in the domain layer).
+ */
+interface RoleRepository {
+
+    // -------------------------------------------------------------------------
+    // Root status
+    // -------------------------------------------------------------------------
+
+    /**
+     * Check whether the user is a root (super-admin).
+     */
+    fun isRoot(userId: String): Boolean
+
+    /**
+     * Grant or revoke root status for a user.
+     */
+    fun setRoot(userId: String, isRoot: Boolean)
+
+    // -------------------------------------------------------------------------
+    // Namespace roles (MEMBER_OF)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Find the namespace role for a user in a specific namespace.
+     * Returns `null` if the user has no role in that namespace.
+     */
+    fun findNamespaceRole(userId: String, namespaceId: String): NamespaceRole?
+
+    /**
+     * Assign (or update) a namespace role for a user.
+     * Uses MERGE semantics — existing role is overwritten.
+     */
+    fun assignNamespaceRole(userId: String, namespaceId: String, role: NamespaceRole, grantedBy: String)
+
+    /**
+     * Remove the namespace role for a user.
+     */
+    fun removeNamespaceRole(userId: String, namespaceId: String)
+
+    /**
+     * Find all members of a namespace with their roles and metadata.
+     * Returns a list of [MembershipInfo] for each MEMBER_OF relationship.
+     */
+    fun findMembersOfNamespace(namespaceId: String): List<MembershipInfo>
+
+    /**
+     * Count the number of users with the OWNER role in a namespace.
+     * Used to enforce the "last OWNER" protection rule.
+     */
+    fun countOwnersInNamespace(namespaceId: String): Int
+
+    /**
+     * Find all namespace IDs where the user has a MEMBER_OF relationship.
+     * Returns the IDs via a single graph query (no O(N×P) in-memory filtering).
+     */
+    fun findNamespaceIdsForUser(userId: String): Set<String>
+
+    // -------------------------------------------------------------------------
+    // Case roles (PARTICIPANT_IN)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Find the case role for a user in a specific case.
+     * Returns `null` if the user has no role in that case.
+     */
+    fun findCaseRole(userId: String, caseId: String): CaseRole?
+
+    /**
+     * Assign (or update) a case role for a user.
+     * Uses MERGE semantics — existing role is overwritten.
+     */
+    fun assignCaseRole(userId: String, caseId: String, role: CaseRole, grantedBy: String)
+
+    /**
+     * Remove the case role for a user.
+     */
+    fun removeCaseRole(userId: String, caseId: String)
+
+    /**
+     * Find all case IDs accessible to a user within a namespace.
+     * Traverses `(User)-[:MEMBER_OF]->(Namespace)<-[:BELONGS_TO]-(Case)` in a
+     * single graph query (no O(N×P) in-memory filtering).
+     */
+    fun findAccessibleCaseIdsForUser(userId: String, namespaceId: String): Set<String>
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -1,11 +1,17 @@
 package io.whozoss.agentos.caseFlow
 
+import io.whozoss.agentos.auth.AuthorizationService
+import io.whozoss.agentos.auth.RoleRepository
 import io.whozoss.agentos.entity.EntityController
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.auth.Operation
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.UserService
+import jakarta.validation.Valid
 import mu.KLogging
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,6 +21,12 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
+/**
+ * REST API for managing Cases.
+ *
+ * Extends [EntityController] with [CaseResource] as the HTTP DTO.
+ * All endpoints enforce authorization via [AuthorizationService].
+ */
 @RestController
 @RequestMapping(
     "/api/cases",
@@ -23,6 +35,8 @@ import java.util.UUID
 class CaseController(
     private val caseService: CaseService,
     private val userService: UserService,
+    private val authorizationService: AuthorizationService,
+    private val roleRepository: RoleRepository,
 ) : EntityController<Case, UUID, CaseResource>(caseService) {
 
     // -------------------------------------------------------------------------
@@ -46,6 +60,71 @@ class CaseController(
         )
 
     // -------------------------------------------------------------------------
+    // Overridden CRUD with authorization
+    // -------------------------------------------------------------------------
+
+    override fun getById(@PathVariable id: UUID): CaseResource {
+        authorizationService.requireCaseAccess(currentUserId(), id.toString(), Operation.READ)
+        return super.getById(id)
+    }
+
+    override fun getByIds(@RequestBody ids: List<UUID>): List<CaseResource> {
+        val userId = currentUserId()
+        return service.findByIds(ids)
+            .filter {
+                try {
+                    authorizationService.requireCaseAccess(userId, it.id.toString(), Operation.READ)
+                    true
+                } catch (_: Exception) {
+                    false
+                }
+            }
+            .map { toResource(it) }
+    }
+
+    /**
+     * POST /api/cases — create a new case.
+     *
+     * Requires MEMBER access on the parent namespace.
+     * After creation, the creator is auto-assigned OWNER on the case.
+     */
+    override fun create(@Valid @RequestBody resource: CaseResource): CaseResource {
+        val userId = currentUserId()
+        authorizationService.requireNamespaceAccess(userId, resource.namespaceId.toString(), NamespaceRole.MEMBER)
+
+        val created = service.create(toDomain(resource))
+        val createdCaseId = created.id.toString()
+
+        roleRepository.assignCaseRole(userId, createdCaseId, CaseRole.OWNER, userId)
+        logger.info { "Auto-assigned case OWNER to user $userId on case $createdCaseId" }
+
+        return toResource(created)
+    }
+
+    override fun update(@PathVariable id: UUID, @Valid @RequestBody resource: CaseResource): CaseResource {
+        authorizationService.requireCaseAccess(currentUserId(), id.toString(), Operation.WRITE)
+        return super.update(id, resource)
+    }
+
+    override fun delete(@PathVariable id: UUID) {
+        authorizationService.requireCaseAccess(currentUserId(), id.toString(), Operation.DELETE)
+        super.delete(id)
+    }
+
+    /**
+     * GET /api/cases/by-parentId/{parentId} — list cases in a namespace.
+     *
+     * Filtered by [AuthorizationService.filterAccessibleCaseIds].
+     */
+    override fun listByParent(@PathVariable parentId: UUID): List<CaseResource> {
+        val userId = currentUserId()
+        val accessibleCaseIds = authorizationService.filterAccessibleCaseIds(userId, parentId.toString())
+        return service.findByParent(parentId)
+            .filter { it.id.toString() in accessibleCaseIds }
+            .map { toResource(it) }
+    }
+
+    // -------------------------------------------------------------------------
     // Additional endpoints
     // -------------------------------------------------------------------------
 
@@ -55,8 +134,10 @@ class CaseController(
         @PathVariable caseId: UUID,
         @RequestBody request: AddMessageRequest,
     ) {
-        logger.info { "Adding message to case: $caseId" }
         val user = userService.getCurrentUser()
+        authorizationService.requireCaseAccess(user.id.toString(), caseId.toString(), Operation.EXECUTE)
+
+        logger.info { "Adding message to case: $caseId" }
         val displayName = listOfNotNull(user.firstname, user.lastname)
             .joinToString(" ")
             .ifBlank { user.metadata.id.toString() }
@@ -74,13 +155,13 @@ class CaseController(
      * POST /api/cases/{caseId}/interrupt
      *
      * Interrupt the current agent turn and return the case to IDLE.
-     * The runtime and SSE connection stay open — the user can send a corrective
-     * message immediately. Use this when the agent is going in the wrong direction.
+     * Requires MANAGE permission (OWNER role).
      */
     @PostMapping("/{caseId}/interrupt")
     fun interruptCase(
         @PathVariable caseId: UUID,
     ) {
+        authorizationService.requireCaseAccess(currentUserId(), caseId.toString(), Operation.MANAGE)
         logger.info { "Interrupting case: $caseId" }
         caseService.interruptCase(caseId)
         logger.info { "Case interrupted: $caseId" }
@@ -91,10 +172,17 @@ class CaseController(
     fun killCase(
         @PathVariable caseId: UUID,
     ) {
+        authorizationService.requireCaseAccess(currentUserId(), caseId.toString(), Operation.MANAGE)
         logger.info { "Killing case: $caseId" }
         caseService.killCase(caseId)
         logger.info { "Case killed: $caseId" }
     }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private fun currentUserId(): String = userService.getCurrentUser().id.toString()
 
     companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jPersistenceConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jPersistenceConfiguration.kt
@@ -15,9 +15,12 @@ import io.whozoss.agentos.persistence.neo4j.Neo4jCaseEventRepository
 import io.whozoss.agentos.persistence.neo4j.Neo4jCaseRepository
 import io.whozoss.agentos.persistence.neo4j.Neo4jIntegrationConfigRepository
 import io.whozoss.agentos.persistence.neo4j.Neo4jNamespaceRepository
+import io.whozoss.agentos.persistence.neo4j.Neo4jRoleRepository
 import io.whozoss.agentos.persistence.neo4j.Neo4jUserRepository
 import io.whozoss.agentos.persistence.neo4j.UserNodeNeo4jRepository
+import io.whozoss.agentos.auth.RoleRepository
 import io.whozoss.agentos.user.UserRepository
+import org.neo4j.driver.Driver
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -83,6 +86,12 @@ class Neo4jPersistenceConfiguration {
     ): IntegrationConfigRepository {
         logger.info { "[Persistence] Neo4jIntegrationConfigRepository active" }
         return Neo4jIntegrationConfigRepository(integrationConfigNodeNeo4jRepository, objectMapper)
+    }
+
+    @Bean
+    fun neo4jRoleRepository(driver: Driver): RoleRepository {
+        logger.info { "[Persistence] Neo4jRoleRepository active" }
+        return Neo4jRoleRepository(driver)
     }
 
     companion object : KLogging()

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
@@ -1,9 +1,16 @@
 package io.whozoss.agentos.integrationConfig
 
+import io.whozoss.agentos.auth.AuthorizationService
 import io.whozoss.agentos.entity.EntityController
+import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.sdk.auth.NamespaceRole
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.UserService
+import jakarta.validation.Valid
 import mu.KLogging
 import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -12,6 +19,7 @@ import java.util.UUID
  * REST API for managing [IntegrationConfig] entities.
  *
  * Extends [EntityController] with [IntegrationConfigResource] as the HTTP DTO.
+ * All endpoints require ADMIN-level namespace access (integration configs are sensitive).
  *
  * Standard CRUD endpoints (inherited):
  *   GET    /api/integration-configs/{id}
@@ -28,6 +36,8 @@ import java.util.UUID
 )
 class IntegrationConfigController(
     private val integrationConfigService: IntegrationConfigService,
+    private val authorizationService: AuthorizationService,
+    private val userService: UserService,
 ) : EntityController<IntegrationConfig, UUID, IntegrationConfigResource>(integrationConfigService) {
 
     override fun toResource(entity: IntegrationConfig): IntegrationConfigResource =
@@ -49,6 +59,67 @@ class IntegrationConfigController(
             integrationType = resource.integrationType,
             parameters = resource.parameters,
         )
+
+    // -------------------------------------------------------------------------
+    // Overridden CRUD with authorization
+    // -------------------------------------------------------------------------
+
+    override fun getById(@PathVariable id: UUID): IntegrationConfigResource {
+        val entity = integrationConfigService.findById(id)
+            ?: throw ResourceNotFoundException("IntegrationConfig not found: $id")
+        authorizationService.requireNamespaceAccess(
+            currentUserId(),
+            entity.namespaceId.toString(),
+            NamespaceRole.ADMIN,
+        )
+        return toResource(entity)
+    }
+
+    override fun create(@Valid @RequestBody resource: IntegrationConfigResource): IntegrationConfigResource {
+        authorizationService.requireNamespaceAccess(
+            currentUserId(),
+            resource.namespaceId.toString(),
+            NamespaceRole.ADMIN,
+        )
+        return super.create(resource)
+    }
+
+    override fun update(@PathVariable id: UUID, @Valid @RequestBody resource: IntegrationConfigResource): IntegrationConfigResource {
+        val existing = integrationConfigService.findById(id)
+            ?: throw ResourceNotFoundException("IntegrationConfig not found: $id")
+        authorizationService.requireNamespaceAccess(
+            currentUserId(),
+            existing.namespaceId.toString(),
+            NamespaceRole.ADMIN,
+        )
+        return super.update(id, resource)
+    }
+
+    override fun delete(@PathVariable id: UUID) {
+        val existing = integrationConfigService.findById(id)
+            ?: throw ResourceNotFoundException("IntegrationConfig not found: $id")
+        authorizationService.requireNamespaceAccess(
+            currentUserId(),
+            existing.namespaceId.toString(),
+            NamespaceRole.ADMIN,
+        )
+        super.delete(id)
+    }
+
+    override fun listByParent(@PathVariable parentId: UUID): List<IntegrationConfigResource> {
+        authorizationService.requireNamespaceAccess(
+            currentUserId(),
+            parentId.toString(),
+            NamespaceRole.ADMIN,
+        )
+        return super.listByParent(parentId)
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private fun currentUserId(): String = userService.getCurrentUser().id.toString()
 
     companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/MembershipController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/MembershipController.kt
@@ -1,0 +1,229 @@
+package io.whozoss.agentos.namespace
+
+import io.whozoss.agentos.auth.AccessDeniedException
+import io.whozoss.agentos.auth.AuthorizationService
+import io.whozoss.agentos.auth.RoleRepository
+import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.user.UserService
+import jakarta.validation.Valid
+import mu.KLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * REST API for managing namespace membership (role assignments).
+ *
+ * This is a **standalone** `@RestController` — it does NOT extend `EntityController`
+ * because memberships are graph relationships (MEMBER_OF) with properties, not
+ * `Entity` objects with `EntityMetadata`.
+ *
+ * Endpoints:
+ *   POST   /api/namespaces/{nsId}/members         — assign a role
+ *   GET    /api/namespaces/{nsId}/members          — list members
+ *   PUT    /api/namespaces/{nsId}/members/{userId} — update a role
+ *   DELETE /api/namespaces/{nsId}/members/{userId} — revoke access
+ *
+ * Every endpoint enforces ADMIN-level access via [AuthorizationService.requireNamespaceAccess],
+ * which throws [io.whozoss.agentos.auth.AccessDeniedException] on failure — handled
+ * globally by [io.whozoss.agentos.auth.AccessDeniedExceptionHandler].
+ */
+@RestController
+@RequestMapping(
+    "/api/namespaces/{nsId}/members",
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+class MembershipController(
+    private val roleRepository: RoleRepository,
+    private val authorizationService: AuthorizationService,
+    private val userService: UserService,
+) {
+
+    /**
+     * POST /api/namespaces/{nsId}/members — assign a role to a user.
+     *
+     * Requires ADMIN role in the namespace. The [resource] body must contain
+     * a valid `userId` and `role` (one of the [NamespaceRole] enum values).
+     *
+     * Returns 201 Created with the created membership details.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun assignRole(
+        @PathVariable nsId: String,
+        @Valid @RequestBody resource: MembershipResource,
+    ): MembershipResource {
+        val currentUser = userService.getCurrentUser()
+        val currentUserId = currentUser.id.toString()
+        authorizationService.requireNamespaceAccess(currentUserId, nsId, NamespaceRole.ADMIN)
+
+        val targetUserId = resource.userId
+            ?: throw IllegalArgumentException("userId is required")
+        val roleString = resource.role
+            ?: throw IllegalArgumentException("role is required")
+        val namespaceRole = parseRole(roleString)
+
+        enforceRoleCeiling(currentUserId, nsId, namespaceRole)
+
+        logger.info { "assigning role $namespaceRole to user $targetUserId in namespace $nsId" }
+        roleRepository.assignNamespaceRole(targetUserId, nsId, namespaceRole, currentUserId)
+
+        return MembershipResource(
+            userId = targetUserId,
+            role = namespaceRole.name,
+        )
+    }
+
+    /**
+     * GET /api/namespaces/{nsId}/members — list all members of a namespace.
+     *
+     * Requires ADMIN role in the namespace.
+     * Returns 200 OK with a list of all members and their roles.
+     */
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    fun listMembers(
+        @PathVariable nsId: String,
+    ): List<MembershipResource> {
+        val currentUser = userService.getCurrentUser()
+        authorizationService.requireNamespaceAccess(currentUser.id.toString(), nsId, NamespaceRole.ADMIN)
+
+        logger.info { "listing members of namespace $nsId" }
+        return roleRepository.findMembersOfNamespace(nsId).map { info ->
+            MembershipResource(
+                userId = info.userId,
+                role = info.role.name,
+                grantedAt = info.grantedAt.toString(),
+                grantedBy = info.grantedBy,
+            )
+        }
+    }
+
+    /**
+     * PUT /api/namespaces/{nsId}/members/{userId} — update a user's role.
+     *
+     * Requires ADMIN role in the namespace. Enforces the last-OWNER protection:
+     * demoting the sole OWNER is rejected with 400 Bad Request.
+     *
+     * Returns 200 OK with the updated membership details.
+     */
+    @PutMapping("/{userId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun updateRole(
+        @PathVariable nsId: String,
+        @PathVariable userId: String,
+        @Valid @RequestBody resource: MembershipResource,
+    ): MembershipResource {
+        val currentUser = userService.getCurrentUser()
+        val currentUserId = currentUser.id.toString()
+        authorizationService.requireNamespaceAccess(currentUserId, nsId, NamespaceRole.ADMIN)
+
+        val roleString = resource.role
+            ?: throw IllegalArgumentException("role is required")
+        val newRole = parseRole(roleString)
+
+        roleRepository.findNamespaceRole(userId, nsId)
+            ?: throw ResourceNotFoundException("User $userId has no role in namespace $nsId")
+
+        protectLastOwner(userId, nsId, newRole)
+        enforceRoleCeiling(currentUserId, nsId, newRole)
+
+        logger.info { "updating role of user $userId to $newRole in namespace $nsId" }
+        roleRepository.assignNamespaceRole(userId, nsId, newRole, currentUserId)
+
+        return MembershipResource(
+            userId = userId,
+            role = newRole.name,
+        )
+    }
+
+    /**
+     * DELETE /api/namespaces/{nsId}/members/{userId} — revoke a user's access.
+     *
+     * Requires ADMIN role in the namespace. Enforces the last-OWNER protection:
+     * revoking the sole OWNER is rejected with 400 Bad Request.
+     *
+     * Returns 204 No Content on success.
+     */
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun revokeMember(
+        @PathVariable nsId: String,
+        @PathVariable userId: String,
+    ) {
+        val currentUser = userService.getCurrentUser()
+        authorizationService.requireNamespaceAccess(currentUser.id.toString(), nsId, NamespaceRole.ADMIN)
+
+        val currentRole = roleRepository.findNamespaceRole(userId, nsId)
+            ?: throw ResourceNotFoundException("User $userId has no role in namespace $nsId")
+        when {
+            currentRole == NamespaceRole.OWNER && roleRepository.countOwnersInNamespace(nsId) <= 1 ->
+                throw IllegalArgumentException("Cannot remove the last OWNER of a namespace")
+        }
+
+        logger.info { "revoking membership of user $userId in namespace $nsId" }
+        roleRepository.removeNamespaceRole(userId, nsId)
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parse a role string into a [NamespaceRole] enum value.
+     * Throws [IllegalArgumentException] (→ 400) if the role is not valid.
+     */
+    private fun parseRole(role: String): NamespaceRole =
+        try {
+            NamespaceRole.valueOf(role.uppercase())
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException(
+                "Invalid role: $role. Valid roles: ${NamespaceRole.entries.joinToString()}",
+            )
+        }
+
+    /**
+     * Prevent demoting the last OWNER of a namespace.
+     * Called before updateRole to ensure the namespace always has at least one OWNER.
+     */
+    private fun protectLastOwner(userId: String, nsId: String, newRole: NamespaceRole) {
+        val currentRole = roleRepository.findNamespaceRole(userId, nsId)
+        when {
+            currentRole == NamespaceRole.OWNER && newRole != NamespaceRole.OWNER &&
+                roleRepository.countOwnersInNamespace(nsId) <= 1 ->
+                throw IllegalArgumentException("Cannot demote the last OWNER of a namespace")
+        }
+    }
+
+    /**
+     * Enforce that a caller cannot assign a role higher than their own (P-6 escalation fix).
+     * Only OWNER or isRoot can assign OWNER. An ADMIN cannot promote to OWNER.
+     */
+    private fun enforceRoleCeiling(currentUserId: String, nsId: String, assignedRole: NamespaceRole) {
+        when {
+            authorizationService.isRoot(currentUserId) -> return
+        }
+        val callerRole = roleRepository.findNamespaceRole(currentUserId, nsId)
+            ?: throw AccessDeniedException(
+                reason = "No role in this namespace",
+                requiredRole = "ADMIN",
+            )
+        when {
+            !callerRole.satisfies(assignedRole) -> throw AccessDeniedException(
+                reason = "Cannot assign role ${assignedRole.name} — your role ${callerRole.name} is insufficient",
+                requiredRole = assignedRole.name,
+            )
+        }
+    }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/MembershipResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/MembershipResource.kt
@@ -1,0 +1,30 @@
+package io.whozoss.agentos.namespace
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * HTTP resource (DTO) for namespace membership endpoints.
+ *
+ * This class represents the API contract for managing user roles within a namespace.
+ * It is intentionally separate from the internal [MembershipInfo][io.whozoss.agentos.auth.MembershipInfo]
+ * domain model so the two can evolve independently.
+ *
+ * [userId] and [role] are required for POST/PUT (creation and update).
+ * [grantedAt] and [grantedBy] are read-only fields populated by the server.
+ *
+ * [role] is a String that the controller validates against the [NamespaceRole]
+ * enum — keeping validation in the controller avoids coupling the DTO to SDK types.
+ *
+ * Annotated with @Schema(name = "Membership") so that the generated OpenAPI spec
+ * keeps the schema name "Membership" instead of "MembershipResource".
+ */
+@Schema(name = "Membership")
+data class MembershipResource(
+    @field:NotBlank(message = "userId is required")
+    val userId: String? = null,
+    @field:NotBlank(message = "role is required")
+    val role: String? = null,
+    val grantedAt: String? = null,
+    val grantedBy: String? = null,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
@@ -1,11 +1,18 @@
 package io.whozoss.agentos.namespace
 
+import io.whozoss.agentos.auth.AuthorizationService
+import io.whozoss.agentos.auth.RoleRepository
 import io.whozoss.agentos.entity.EntityController
+import io.whozoss.agentos.sdk.auth.NamespaceRole
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.UserService
+import jakarta.validation.Valid
 import mu.KLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -25,7 +32,9 @@ import java.util.UUID
  *   DELETE /api/namespaces/{id}
  *
  * Additional endpoints:
- *   GET    /api/namespaces — list all namespaces (no parent filter needed)
+ *   GET    /api/namespaces — list all namespaces (filtered by access)
+ *
+ * Every endpoint enforces authorization via [AuthorizationService].
  */
 @RestController
 @RequestMapping(
@@ -34,6 +43,9 @@ import java.util.UUID
 )
 class NamespaceController(
     private val namespaceService: NamespaceService,
+    private val authorizationService: AuthorizationService,
+    private val userService: UserService,
+    private val roleRepository: RoleRepository,
 ) : EntityController<Namespace, String, NamespaceResource>(namespaceService) {
 
     // -------------------------------------------------------------------------
@@ -55,18 +67,72 @@ class NamespaceController(
         )
 
     // -------------------------------------------------------------------------
+    // Overridden CRUD with authorization
+    // -------------------------------------------------------------------------
+
+    override fun getById(@PathVariable id: UUID): NamespaceResource {
+        authorizationService.requireNamespaceAccess(currentUserId(), id.toString(), NamespaceRole.VIEWER)
+        return super.getById(id)
+    }
+
+    override fun getByIds(@RequestBody ids: List<UUID>): List<NamespaceResource> {
+        val accessibleIds = authorizationService.filterAccessibleNamespaceIds(currentUserId())
+        val filteredIds = ids.filter { it.toString() in accessibleIds }
+        return service.findByIds(filteredIds).map { toResource(it) }
+    }
+
+    /**
+     * POST /api/namespaces — create a new namespace.
+     *
+     * No namespace-level check (the namespace doesn't exist yet).
+     * After creation, the creator is auto-assigned OWNER (AC-D, FR34).
+     */
+    override fun create(@Valid @RequestBody resource: NamespaceResource): NamespaceResource {
+        val userId = currentUserId()
+        val created = service.create(toDomain(resource))
+        val createdNsId = created.id.toString()
+
+        roleRepository.assignNamespaceRole(userId, createdNsId, NamespaceRole.OWNER, userId)
+        logger.info { "Auto-assigned OWNER to user $userId on namespace $createdNsId" }
+
+        return toResource(created)
+    }
+
+    override fun update(@PathVariable id: UUID, @Valid @RequestBody resource: NamespaceResource): NamespaceResource {
+        authorizationService.requireNamespaceAccess(currentUserId(), id.toString(), NamespaceRole.ADMIN)
+        return super.update(id, resource)
+    }
+
+    override fun delete(@PathVariable id: UUID) {
+        authorizationService.requireNamespaceAccess(currentUserId(), id.toString(), NamespaceRole.OWNER)
+        super.delete(id)
+    }
+
+    // -------------------------------------------------------------------------
     // Additional endpoints
     // -------------------------------------------------------------------------
 
     /**
-     * GET /api/namespaces — list all namespaces.
+     * GET /api/namespaces — list all namespaces accessible to the current user.
+     *
+     * Filtered by [AuthorizationService.filterAccessibleNamespaceIds].
      */
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     fun listAll(): List<NamespaceResource> {
-        logger.info { "listing all namespaces" }
-        return namespaceService.findAll().map { toResource(it) }
+        val userId = currentUserId()
+        val accessibleIds = authorizationService.filterAccessibleNamespaceIds(userId)
+        logger.info { "listing namespaces for user $userId (${accessibleIds.size} accessible)" }
+        return namespaceService.findAll()
+            .filter { it.id.toString() in accessibleIds }
+            .map { toResource(it) }
     }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private fun currentUserId(): String = userService.getCurrentUser().id.toString()
 
     companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNode.kt
@@ -2,6 +2,8 @@ package io.whozoss.agentos.persistence.neo4j
 
 import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
+import org.springframework.data.neo4j.core.schema.Relationship
+import org.springframework.data.neo4j.core.schema.Relationship.Direction.OUTGOING
 import java.time.Instant
 
 /**
@@ -11,6 +13,14 @@ import java.time.Instant
  * audit/routing properties. Subclasses declare only their own subtype-specific
  * fields — they do NOT redeclare the shared properties, which would cause SDN
  * to report duplicate property definitions.
+ *
+ * Stored as a `(:CaseEvent)-[:BELONGS_TO]->(:Case)` edge. [caseId] is kept as a
+ * plain scalar property alongside the [case] relationship field: [findActiveByCaseId]
+ * filters on the scalar, while the graph edge is written on save and is available
+ * for traversal. [toDomain] reads from the scalar.
+ *
+ * [case] is a nullable `var` so SDN can call the primary constructor before
+ * injecting the @Relationship field via property injection.
  *
  * Sealed so [CaseEventNodeMapper] `when` expressions are exhaustive.
  * Node classes are pure data holders; all conversion is in [CaseEventNodeMapper].
@@ -26,7 +36,10 @@ sealed class CaseEventNode(
     open val modified: Instant = Instant.now(),
     open val modifiedBy: String? = null,
     open val removed: Boolean? = null,
-)
+) {
+    @Relationship(type = "BELONGS_TO", direction = OUTGOING)
+    var case: CaseNode? = null
+}
 
 @Node("CaseStatusEvent")
 class CaseStatusEventNode(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeMapper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeMapper.kt
@@ -67,8 +67,8 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             is TextChunkEvent -> fromDomain(event)
         }
 
-    fun withRemoved(node: CaseEventNode, removed: Boolean?): CaseEventNode =
-        when (node) {
+    fun withRemoved(node: CaseEventNode, removed: Boolean?): CaseEventNode {
+        val updated = when (node) {
             is CaseStatusEventNode -> CaseStatusEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.status, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
             is WarnEventNode -> WarnEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.message, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
             is AgentSelectedEventNode -> AgentSelectedEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.agentId, node.agentName, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
@@ -84,8 +84,11 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             is ToolSelectedEventNode -> ToolSelectedEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.agentId, node.toolName, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
             is TextChunkEventNode -> TextChunkEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.chunk, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
         }
+        updated.case = node.case
+        return updated
+    }
 
-    // ─── toDomain ────────────────────────────────────────────────────────────
+    // ─── toDomain ──────────────────────────────────────────────────────────────────────────
 
     private fun toDomain(n: CaseStatusEventNode) =
         CaseStatusEvent(
@@ -228,7 +231,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             chunk = n.chunk,
         )
 
-    // ─── fromDomain ──────────────────────────────────────────────────────────
+    // ─── fromDomain ───────────────────────────────────────────────────────────────────────
 
     private fun fromDomain(e: CaseStatusEvent) =
         CaseStatusEventNode(
@@ -238,7 +241,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: WarnEvent) =
         WarnEventNode(
@@ -248,7 +251,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: AgentSelectedEvent) =
         AgentSelectedEventNode(
@@ -258,7 +261,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: AgentFinishedEvent) =
         AgentFinishedEventNode(
@@ -268,7 +271,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: AgentRunningEvent) =
         AgentRunningEventNode(
@@ -278,7 +281,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: MessageEvent) =
         MessageEventNode(
@@ -289,7 +292,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: ToolRequestEvent) =
         ToolRequestEventNode(
@@ -299,7 +302,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: ToolResponseEvent) =
         ToolResponseEventNode(
@@ -311,7 +314,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: ThinkingEvent) =
         ThinkingEventNode(
@@ -320,7 +323,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: QuestionEvent) =
         QuestionEventNode(
@@ -332,7 +335,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: AnswerEvent) =
         AnswerEventNode(
@@ -344,7 +347,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: IntentionGeneratedEvent) =
         IntentionGeneratedEventNode(
@@ -354,7 +357,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: ToolSelectedEvent) =
         ToolSelectedEventNode(
@@ -364,7 +367,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
     private fun fromDomain(e: TextChunkEvent) =
         TextChunkEventNode(
@@ -374,9 +377,9 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        )
+        ).also { it.case = CaseNode.stub(e.caseId) }
 
-    // ─── Shared helper ───────────────────────────────────────────────────────
+    // ─── Shared helper ─────────────────────────────────────────────────────────────────────
 
     private fun metadata(n: CaseEventNode) =
         EntityMetadata(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeMapper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeMapper.kt
@@ -21,6 +21,11 @@ import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import java.util.UUID
 
+// Note: fromDomain does NOT set the `case` @Relationship field. The BELONGS_TO
+// edge is created separately via CaseEventNodeNeo4jRepository.linkEventToCase()
+// after the node is saved. This avoids SDN writing stub CaseNode properties
+// (empty status/title) onto the existing Case node.
+
 /**
  * Maps between [CaseEvent] domain objects and their [CaseEventNode] graph projections.
  *
@@ -67,8 +72,8 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             is TextChunkEvent -> fromDomain(event)
         }
 
-    fun withRemoved(node: CaseEventNode, removed: Boolean?): CaseEventNode {
-        val updated = when (node) {
+    fun withRemoved(node: CaseEventNode, removed: Boolean?): CaseEventNode =
+        when (node) {
             is CaseStatusEventNode -> CaseStatusEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.status, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
             is WarnEventNode -> WarnEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.message, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
             is AgentSelectedEventNode -> AgentSelectedEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.agentId, node.agentName, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
@@ -84,9 +89,6 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             is ToolSelectedEventNode -> ToolSelectedEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.agentId, node.toolName, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
             is TextChunkEventNode -> TextChunkEventNode(node.id, node.caseId, node.namespaceId, node.timestamp, node.chunk, node.created, node.createdBy, node.modified, node.modifiedBy, removed)
         }
-        updated.case = node.case
-        return updated
-    }
 
     // ─── toDomain ──────────────────────────────────────────────────────────────────────────
 
@@ -241,7 +243,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: WarnEvent) =
         WarnEventNode(
@@ -251,7 +253,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: AgentSelectedEvent) =
         AgentSelectedEventNode(
@@ -261,7 +263,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: AgentFinishedEvent) =
         AgentFinishedEventNode(
@@ -271,7 +273,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: AgentRunningEvent) =
         AgentRunningEventNode(
@@ -281,7 +283,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: MessageEvent) =
         MessageEventNode(
@@ -292,7 +294,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: ToolRequestEvent) =
         ToolRequestEventNode(
@@ -302,7 +304,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: ToolResponseEvent) =
         ToolResponseEventNode(
@@ -314,7 +316,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: ThinkingEvent) =
         ThinkingEventNode(
@@ -323,7 +325,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: QuestionEvent) =
         QuestionEventNode(
@@ -335,7 +337,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: AnswerEvent) =
         AnswerEventNode(
@@ -347,7 +349,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: IntentionGeneratedEvent) =
         IntentionGeneratedEventNode(
@@ -357,7 +359,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: ToolSelectedEvent) =
         ToolSelectedEventNode(
@@ -367,7 +369,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     private fun fromDomain(e: TextChunkEvent) =
         TextChunkEventNode(
@@ -377,7 +379,7 @@ class CaseEventNodeMapper(private val serializer: MessageContentSerializer) {
             created = e.metadata.created, createdBy = e.metadata.createdBy,
             modified = e.metadata.modified, modifiedBy = e.metadata.modifiedBy,
             removed = e.metadata.removed.takeIf { it },
-        ).also { it.case = CaseNode.stub(e.caseId) }
+        )
 
     // ─── Shared helper ─────────────────────────────────────────────────────────────────────
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeNeo4jRepository.kt
@@ -8,13 +8,15 @@ import org.springframework.data.neo4j.repository.query.Query
  */
 interface CaseEventNodeNeo4jRepository : Neo4jRepository<CaseEventNode, String> {
     /**
-     * Find all non-removed events for a case, ordered by timestamp then id
-     * (stable sort matching [FilesystemCaseEventRepository]).
+     * Find all non-removed events for a case, ordered by timestamp then id.
+     *
+     * Filters by the [CaseEventNode.caseId] scalar property. Returns `e, r, c`
+     * so SDN can map the [CaseEventNode.case] @Relationship field.
      */
     @Query(
-        $$"""MATCH (e:CaseEvent)
+        $$"""MATCH (e:CaseEvent)-[r:BELONGS_TO]->(c:Case)
             WHERE e.caseId = $caseId AND (e.removed IS NULL OR e.removed = false)
-            RETURN e ORDER BY e.timestamp ASC, e.id ASC
+            RETURN e, r, c ORDER BY e.timestamp ASC, e.id ASC
             """,
     )
     fun findActiveByCaseId(caseId: String): List<CaseEventNode>

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeNeo4jRepository.kt
@@ -12,9 +12,10 @@ interface CaseEventNodeNeo4jRepository : Neo4jRepository<CaseEventNode, String> 
      * (stable sort matching [FilesystemCaseEventRepository]).
      */
     @Query(
-        "MATCH (e:CaseEvent) " +
-            "WHERE e.caseId = \$caseId AND (e.removed IS NULL OR e.removed = false) " +
-            "RETURN e ORDER BY e.timestamp ASC, e.id ASC",
+        $$"""MATCH (e:CaseEvent)
+            WHERE e.caseId = $caseId AND (e.removed IS NULL OR e.removed = false)
+            RETURN e ORDER BY e.timestamp ASC, e.id ASC
+            """,
     )
     fun findActiveByCaseId(caseId: String): List<CaseEventNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseEventNodeNeo4jRepository.kt
@@ -10,14 +10,32 @@ interface CaseEventNodeNeo4jRepository : Neo4jRepository<CaseEventNode, String> 
     /**
      * Find all non-removed events for a case, ordered by timestamp then id.
      *
-     * Filters by the [CaseEventNode.caseId] scalar property. Returns `e, r, c`
-     * so SDN can map the [CaseEventNode.case] @Relationship field.
+     * Returns `e, r, c` so SDN maps the [CaseEventNode.case] @Relationship field.
      */
     @Query(
-        $$"""MATCH (e:CaseEvent)-[r:BELONGS_TO]->(c:Case)
+        $$"""MATCH (e:CaseEvent)
             WHERE e.caseId = $caseId AND (e.removed IS NULL OR e.removed = false)
+            OPTIONAL MATCH (e)-[r:BELONGS_TO]->(c:Case)
             RETURN e, r, c ORDER BY e.timestamp ASC, e.id ASC
             """,
     )
     fun findActiveByCaseId(caseId: String): List<CaseEventNode>
+
+    /**
+     * Creates the `BELONGS_TO` relationship from a CaseEvent node to its Case node.
+     *
+     * Called after saving a new event. Using an explicit query avoids SDN writing
+     * stub [CaseNode] properties (empty status/title) onto the existing Case node
+     * when the relationship is expressed via the @Relationship field.
+     */
+    @Query(
+        $$"""MATCH (e:CaseEvent {id: $eventId})
+            MATCH (c:Case {id: $caseId})
+            MERGE (e)-[:BELONGS_TO]->(c)
+            """,
+    )
+    fun linkEventToCase(
+        eventId: String,
+        caseId: String,
+    )
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
@@ -16,21 +16,19 @@ import java.util.UUID
  * Stored as a `(:Case)-[:BELONGS_TO]->(:Namespace)` edge.
  *
  * [namespace] is a nullable `var` so SDN can call the primary constructor before
- * injecting the @Relationship field. For SDN-generated queries the field is
- * populated automatically. For custom queries (via [Neo4jClient]) the caller
- * assembles the node directly with the correct [NamespaceNode] stub.
+ * injecting the @Relationship field via property injection.
  *
  * [toDomain] reads [namespace]!!.id — a null here is a data-integrity error and
  * should surface as an NPE rather than be silently ignored.
  *
  * On write, [fromDomain] provides a stub [NamespaceNode] carrying only the `@Id`.
- * SDN issues a MERGE on the Namespace node by id and never overwrites its existing
- * properties, so saving a Case does not corrupt the Namespace.
+ * SDN MERGEs by `@Id` on save and never overwrites existing Namespace properties.
  */
 @Node("Case")
 data class CaseNode(
     @Id
     val id: String,
+    val namespaceId: String,
     val status: String,
     val title: String,
     val created: Instant = Instant.now(),
@@ -52,7 +50,7 @@ data class CaseNode(
                     modifiedBy = modifiedBy,
                     removed = removed ?: false,
                 ),
-            namespaceId = UUID.fromString(namespace!!.id),
+            namespaceId = UUID.fromString(namespaceId),
             status = CaseStatus.valueOf(status),
             title = title,
         )
@@ -61,6 +59,7 @@ data class CaseNode(
         fun fromDomain(case: Case): CaseNode =
             CaseNode(
                 id = case.id.toString(),
+                namespaceId = case.namespaceId.toString(),
                 status = case.status.name,
                 title = case.title,
                 created = case.metadata.created,
@@ -68,14 +67,7 @@ data class CaseNode(
                 modified = case.metadata.modified,
                 modifiedBy = case.metadata.modifiedBy,
                 removed = case.metadata.removed.takeIf { it },
-                namespace = NamespaceNode.stub(case.namespaceId),
             )
 
-        /**
-         * Creates a minimal stub carrying only the [caseId] for use as the
-         * BELONGS_TO relationship target on [CaseEventNode]. SDN MERGEs by @Id
-         * and leaves all other Case properties untouched.
-         */
-        fun stub(caseId: UUID): CaseNode = CaseNode(id = caseId.toString(), status = "", title = "")
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
@@ -15,17 +15,13 @@ import java.util.UUID
  *
  * Stored as a `(:Case)-[:BELONGS_TO]->(:Namespace)` edge.
  *
- * [namespaceId] is kept as a plain node property alongside the [namespace]
- * relationship field. This serves two purposes:
- * - It allows [findActiveByNamespaceId] to use a simple property filter
- *   (`WHERE c.namespaceId = $namespaceId`) rather than requiring a relationship
- *   traversal in the RETURN clause for SDN to inject [namespace].
- * - It acts as a fast index-friendly filter without a graph hop.
+ * [namespace] is a nullable `var` so SDN can call the primary constructor before
+ * injecting the @Relationship field. For SDN-generated queries the field is
+ * populated automatically. For custom queries (via [Neo4jClient]) the caller
+ * assembles the node directly with the correct [NamespaceNode] stub.
  *
- * [namespace] is nullable with a `null` default so SDN can call the primary
- * constructor before injecting the @Relationship field via property injection.
- * [toDomain] derives [Case.namespaceId] from the plain [namespaceId] property,
- * which is always present regardless of whether SDN loaded the relationship.
+ * [toDomain] reads [namespace]!!.id — a null here is a data-integrity error and
+ * should surface as an NPE rather than be silently ignored.
  *
  * On write, [fromDomain] provides a stub [NamespaceNode] carrying only the `@Id`.
  * SDN issues a MERGE on the Namespace node by id and never overwrites its existing
@@ -35,7 +31,6 @@ import java.util.UUID
 data class CaseNode(
     @Id
     val id: String,
-    val namespaceId: String,
     val status: String,
     val title: String,
     val created: Instant = Instant.now(),
@@ -57,7 +52,7 @@ data class CaseNode(
                     modifiedBy = modifiedBy,
                     removed = removed ?: false,
                 ),
-            namespaceId = UUID.fromString(namespaceId),
+            namespaceId = UUID.fromString(namespace!!.id),
             status = CaseStatus.valueOf(status),
             title = title,
         )
@@ -66,7 +61,6 @@ data class CaseNode(
         fun fromDomain(case: Case): CaseNode =
             CaseNode(
                 id = case.id.toString(),
-                namespaceId = case.namespaceId.toString(),
                 status = case.status.name,
                 title = case.title,
                 created = case.metadata.created,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
@@ -5,16 +5,31 @@ import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
+import org.springframework.data.neo4j.core.schema.Relationship
+import org.springframework.data.neo4j.core.schema.Relationship.Direction.OUTGOING
 import java.time.Instant
 import java.util.UUID
 
 /**
  * Spring Data Neo4j projection for [Case].
  *
- * Stored as a (:Case) node with a [namespaceId] property linking it to its parent
- * namespace. The relationship is represented as a property rather than an SDN
- * @Relationship to keep queries simple — full graph traversal between Namespace and
- * Case nodes is handled via Cypher in the repository when needed.
+ * Stored as a `(:Case)-[:BELONGS_TO]->(:Namespace)` edge.
+ *
+ * [namespaceId] is kept as a plain node property alongside the [namespace]
+ * relationship field. This serves two purposes:
+ * - It allows [findActiveByNamespaceId] to use a simple property filter
+ *   (`WHERE c.namespaceId = $namespaceId`) rather than requiring a relationship
+ *   traversal in the RETURN clause for SDN to inject [namespace].
+ * - It acts as a fast index-friendly filter without a graph hop.
+ *
+ * [namespace] is nullable with a `null` default so SDN can call the primary
+ * constructor before injecting the @Relationship field via property injection.
+ * [toDomain] derives [Case.namespaceId] from the plain [namespaceId] property,
+ * which is always present regardless of whether SDN loaded the relationship.
+ *
+ * On write, [fromDomain] provides a stub [NamespaceNode] carrying only the `@Id`.
+ * SDN issues a MERGE on the Namespace node by id and never overwrites its existing
+ * properties, so saving a Case does not corrupt the Namespace.
  */
 @Node("Case")
 data class CaseNode(
@@ -28,6 +43,8 @@ data class CaseNode(
     val modified: Instant = Instant.now(),
     val modifiedBy: String? = null,
     val removed: Boolean? = null,
+    @Relationship(type = "BELONGS_TO", direction = OUTGOING)
+    var namespace: NamespaceNode? = null,
 ) {
     fun toDomain(): Case =
         Case(
@@ -57,6 +74,7 @@ data class CaseNode(
                 modified = case.metadata.modified,
                 modifiedBy = case.metadata.modifiedBy,
                 removed = case.metadata.removed.takeIf { it },
+                namespace = NamespaceNode.stub(case.namespaceId),
             )
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNode.kt
@@ -70,5 +70,12 @@ data class CaseNode(
                 removed = case.metadata.removed.takeIf { it },
                 namespace = NamespaceNode.stub(case.namespaceId),
             )
+
+        /**
+         * Creates a minimal stub carrying only the [caseId] for use as the
+         * BELONGS_TO relationship target on [CaseEventNode]. SDN MERGEs by @Id
+         * and leaves all other Case properties untouched.
+         */
+        fun stub(caseId: UUID): CaseNode = CaseNode(id = caseId.toString(), status = "", title = "")
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNodeNeo4jRepository.kt
@@ -10,8 +10,10 @@ interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
     /**
      * Find all non-removed cases belonging to a namespace, ordered by creation time.
      *
-     * Returning `c, r, ns` (node, relationship, node) gives SDN everything it needs
-     * to map the @Relationship field on [CaseNode] from the query result.
+     * Traverses the BELONGS_TO edge and filters by the Namespace id. The edge is
+     * always present because [linkCaseToNamespace] is called after every save.
+     * Returning `c, r, ns` gives SDN everything it needs to map the
+     * [CaseNode.namespace] @Relationship field.
      */
     @Query(
         $$"""MATCH (c:Case)-[r:BELONGS_TO]->(ns:Namespace)
@@ -20,4 +22,19 @@ interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
             """,
     )
     fun findActiveByNamespaceId(namespaceId: String): List<CaseNode>
+
+    /**
+     * Creates the `BELONGS_TO` relationship from a Case node to its Namespace node.
+     *
+     * Called after saving a Case. Using an explicit query avoids SDN writing
+     * stub [NamespaceNode] properties (empty name/description) onto the existing
+     * Namespace node when the relationship is expressed via the @Relationship field.
+     */
+    @Query(
+        $$"""MATCH (c:Case {id: $caseId})
+            MATCH (ns:Namespace {id: $namespaceId})
+            MERGE (c)-[:BELONGS_TO]->(ns)
+            """,
+    )
+    fun linkCaseToNamespace(caseId: String, namespaceId: String)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNodeNeo4jRepository.kt
@@ -10,16 +10,13 @@ interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
     /**
      * Find all non-removed cases belonging to a namespace, ordered by creation time.
      *
-     * Filters by the denormalised [CaseNode.namespaceId] property rather than
-     * traversing the BELONGS_TO relationship, keeping the query simple and
-     * compatible with SDN's custom @Query result mapping (which does not
-     * auto-inject @Relationship fields). The graph edge is still written on save
-     * via [CaseNode.namespace] — it exists in the graph for traversal queries.
+     * Returning `c, r, ns` (node, relationship, node) gives SDN everything it needs
+     * to map the @Relationship field on [CaseNode] from the query result.
      */
     @Query(
-        $$"""MATCH (c:Case)
-            WHERE c.namespaceId = $namespaceId AND (c.removed IS NULL OR c.removed = false)
-            RETURN c ORDER BY c.created ASC
+        $$"""MATCH (c:Case)-[r:BELONGS_TO]->(ns:Namespace)
+            WHERE ns.id = $namespaceId AND (c.removed IS NULL OR c.removed = false)
+            RETURN c, r, ns ORDER BY c.created ASC
             """,
     )
     fun findActiveByNamespaceId(namespaceId: String): List<CaseNode>

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/CaseNodeNeo4jRepository.kt
@@ -9,11 +9,18 @@ import org.springframework.data.neo4j.repository.query.Query
 interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
     /**
      * Find all non-removed cases belonging to a namespace, ordered by creation time.
+     *
+     * Filters by the denormalised [CaseNode.namespaceId] property rather than
+     * traversing the BELONGS_TO relationship, keeping the query simple and
+     * compatible with SDN's custom @Query result mapping (which does not
+     * auto-inject @Relationship fields). The graph edge is still written on save
+     * via [CaseNode.namespace] — it exists in the graph for traversal queries.
      */
     @Query(
-        "MATCH (c:Case) " +
-            "WHERE c.namespaceId = \$namespaceId AND (c.removed IS NULL OR c.removed = false) " +
-            "RETURN c ORDER BY c.created ASC",
+        $$"""MATCH (c:Case)
+            WHERE c.namespaceId = $namespaceId AND (c.removed IS NULL OR c.removed = false)
+            RETURN c ORDER BY c.created ASC
+            """,
     )
     fun findActiveByNamespaceId(namespaceId: String): List<CaseNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNode.kt
@@ -5,21 +5,31 @@ import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
+import org.springframework.data.neo4j.core.schema.Relationship
+import org.springframework.data.neo4j.core.schema.Relationship.Direction.OUTGOING
 import java.time.Instant
 import java.util.UUID
 
 /**
  * Spring Data Neo4j projection for [IntegrationConfig].
  *
- * Stored as a (:IntegrationConfig) node with a [namespaceId] property linking it
- * to its parent namespace (represented as a property, not an SDN @Relationship).
+ * Stored as a `(:IntegrationConfig)-[:BELONGS_TO]->(:Namespace)` edge.
+ *
+ * [namespaceId] is kept as a plain node property alongside the [namespace]
+ * relationship field. This serves two purposes:
+ * - It allows [findActiveByNamespaceId] to use a simple property filter
+ *   (`WHERE c.namespaceId = $namespaceId`) rather than requiring a relationship
+ *   traversal in the RETURN clause for SDN to inject [namespace].
+ * - It acts as a fast index-friendly filter without a graph hop.
+ *
+ * [namespace] is nullable with a `null` default so SDN can call the primary
+ * constructor before injecting the @Relationship field via property injection.
+ * [toDomain] derives [IntegrationConfig.namespaceId] from the plain [namespaceId]
+ * property, which is always present regardless of whether SDN loaded the relationship.
  *
  * [parameters] is a [JsonNode] in the domain model but Neo4j has no native JSON
  * type, so it is stored as a raw JSON string ([parametersJson]) and round-tripped
  * via [ObjectMapper] in [toDomain] / [fromDomain].
- *
- * Properties kept flat (no nested objects) to avoid SDN's limited support for
- * embedded value types in Community Edition.
  */
 @Node("IntegrationConfig")
 data class IntegrationConfigNode(
@@ -35,6 +45,8 @@ data class IntegrationConfigNode(
     val modified: Instant = Instant.now(),
     val modifiedBy: String? = null,
     val removed: Boolean? = null,
+    @Relationship(type = "BELONGS_TO", direction = OUTGOING)
+    var namespace: NamespaceNode? = null,
 ) {
     fun toDomain(objectMapper: ObjectMapper): IntegrationConfig =
         IntegrationConfig(
@@ -69,6 +81,7 @@ data class IntegrationConfigNode(
                 modified = config.metadata.modified,
                 modifiedBy = config.metadata.modifiedBy,
                 removed = config.metadata.removed.takeIf { it },
+                namespace = NamespaceNode.stub(config.namespaceId),
             )
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNode.kt
@@ -16,16 +16,13 @@ import java.util.UUID
  * Stored as a `(:IntegrationConfig)-[:BELONGS_TO]->(:Namespace)` edge.
  *
  * [namespace] is a nullable `var` so SDN can call the primary constructor before
- * injecting the @Relationship field. For SDN-generated queries the field is
- * populated automatically. For custom queries (via [Neo4jClient]) the caller
- * assembles the node directly with the correct [NamespaceNode] stub.
+ * injecting the @Relationship field via property injection.
  *
  * [toDomain] reads [namespace]!!.id — a null here is a data-integrity error and
  * should surface as an NPE rather than be silently ignored.
  *
  * On write, [fromDomain] provides a stub [NamespaceNode] carrying only the `@Id`.
- * SDN issues a MERGE on the Namespace node by id and never overwrites its existing
- * properties, so saving an IntegrationConfig does not corrupt the Namespace.
+ * SDN MERGEs by `@Id` on save and never overwrites existing Namespace properties.
  *
  * [parameters] is a [JsonNode] in the domain model but Neo4j has no native JSON
  * type, so it is stored as a raw JSON string ([parametersJson]) and round-tripped
@@ -35,6 +32,7 @@ import java.util.UUID
 data class IntegrationConfigNode(
     @Id
     val id: String,
+    val namespaceId: String,
     val name: String,
     val integrationType: String,
     val parametersJson: String? = null,
@@ -58,7 +56,7 @@ data class IntegrationConfigNode(
                     modifiedBy = modifiedBy,
                     removed = removed ?: false,
                 ),
-            namespaceId = UUID.fromString(namespace!!.id),
+            namespaceId = UUID.fromString(namespaceId),
             name = name,
             integrationType = integrationType,
             parameters = parametersJson?.let { objectMapper.readTree(it) },
@@ -71,6 +69,7 @@ data class IntegrationConfigNode(
         ): IntegrationConfigNode =
             IntegrationConfigNode(
                 id = config.id.toString(),
+                namespaceId = config.namespaceId.toString(),
                 name = config.name,
                 integrationType = config.integrationType,
                 parametersJson = config.parameters?.let { objectMapper.writeValueAsString(it) },
@@ -79,7 +78,6 @@ data class IntegrationConfigNode(
                 modified = config.metadata.modified,
                 modifiedBy = config.metadata.modifiedBy,
                 removed = config.metadata.removed.takeIf { it },
-                namespace = NamespaceNode.stub(config.namespaceId),
             )
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNode.kt
@@ -15,17 +15,17 @@ import java.util.UUID
  *
  * Stored as a `(:IntegrationConfig)-[:BELONGS_TO]->(:Namespace)` edge.
  *
- * [namespaceId] is kept as a plain node property alongside the [namespace]
- * relationship field. This serves two purposes:
- * - It allows [findActiveByNamespaceId] to use a simple property filter
- *   (`WHERE c.namespaceId = $namespaceId`) rather than requiring a relationship
- *   traversal in the RETURN clause for SDN to inject [namespace].
- * - It acts as a fast index-friendly filter without a graph hop.
+ * [namespace] is a nullable `var` so SDN can call the primary constructor before
+ * injecting the @Relationship field. For SDN-generated queries the field is
+ * populated automatically. For custom queries (via [Neo4jClient]) the caller
+ * assembles the node directly with the correct [NamespaceNode] stub.
  *
- * [namespace] is nullable with a `null` default so SDN can call the primary
- * constructor before injecting the @Relationship field via property injection.
- * [toDomain] derives [IntegrationConfig.namespaceId] from the plain [namespaceId]
- * property, which is always present regardless of whether SDN loaded the relationship.
+ * [toDomain] reads [namespace]!!.id — a null here is a data-integrity error and
+ * should surface as an NPE rather than be silently ignored.
+ *
+ * On write, [fromDomain] provides a stub [NamespaceNode] carrying only the `@Id`.
+ * SDN issues a MERGE on the Namespace node by id and never overwrites its existing
+ * properties, so saving an IntegrationConfig does not corrupt the Namespace.
  *
  * [parameters] is a [JsonNode] in the domain model but Neo4j has no native JSON
  * type, so it is stored as a raw JSON string ([parametersJson]) and round-tripped
@@ -35,7 +35,6 @@ import java.util.UUID
 data class IntegrationConfigNode(
     @Id
     val id: String,
-    val namespaceId: String,
     val name: String,
     val integrationType: String,
     val parametersJson: String? = null,
@@ -59,7 +58,7 @@ data class IntegrationConfigNode(
                     modifiedBy = modifiedBy,
                     removed = removed ?: false,
                 ),
-            namespaceId = UUID.fromString(namespaceId),
+            namespaceId = UUID.fromString(namespace!!.id),
             name = name,
             integrationType = integrationType,
             parameters = parametersJson?.let { objectMapper.readTree(it) },
@@ -72,7 +71,6 @@ data class IntegrationConfigNode(
         ): IntegrationConfigNode =
             IntegrationConfigNode(
                 id = config.id.toString(),
-                namespaceId = config.namespaceId.toString(),
                 name = config.name,
                 integrationType = config.integrationType,
                 parametersJson = config.parameters?.let { objectMapper.writeValueAsString(it) },

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNodeNeo4jRepository.kt
@@ -10,16 +10,13 @@ interface IntegrationConfigNodeNeo4jRepository : Neo4jRepository<IntegrationConf
     /**
      * Find all non-removed integration configs belonging to a namespace, ordered by name.
      *
-     * Filters by the denormalised [IntegrationConfigNode.namespaceId] property rather
-     * than traversing the BELONGS_TO relationship, keeping the query simple and
-     * compatible with SDN's custom @Query result mapping (which does not
-     * auto-inject @Relationship fields). The graph edge is still written on save
-     * via [IntegrationConfigNode.namespace] — it exists in the graph for traversal.
+     * Returning `c, r, ns` (node, relationship, node) gives SDN everything it needs
+     * to map the @Relationship field on [IntegrationConfigNode] from the query result.
      */
     @Query(
-        $$"""MATCH (c:IntegrationConfig)
-            WHERE c.namespaceId = $namespaceId AND (c.removed IS NULL OR c.removed = false)
-            RETURN c ORDER BY c.name ASC
+        $$"""MATCH (c:IntegrationConfig)-[r:BELONGS_TO]->(ns:Namespace)
+            WHERE ns.id = $namespaceId AND (c.removed IS NULL OR c.removed = false)
+            RETURN c, r, ns ORDER BY c.name ASC
             """,
     )
     fun findActiveByNamespaceId(namespaceId: String): List<IntegrationConfigNode>

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNodeNeo4jRepository.kt
@@ -10,8 +10,10 @@ interface IntegrationConfigNodeNeo4jRepository : Neo4jRepository<IntegrationConf
     /**
      * Find all non-removed integration configs belonging to a namespace, ordered by name.
      *
-     * Returning `c, r, ns` (node, relationship, node) gives SDN everything it needs
-     * to map the @Relationship field on [IntegrationConfigNode] from the query result.
+     * Traverses the BELONGS_TO edge and filters by the Namespace id. The edge is
+     * always present because [linkConfigToNamespace] is called after every save.
+     * Returning `c, r, ns` gives SDN everything it needs to map the
+     * [IntegrationConfigNode.namespace] @Relationship field.
      */
     @Query(
         $$"""MATCH (c:IntegrationConfig)-[r:BELONGS_TO]->(ns:Namespace)
@@ -20,4 +22,19 @@ interface IntegrationConfigNodeNeo4jRepository : Neo4jRepository<IntegrationConf
             """,
     )
     fun findActiveByNamespaceId(namespaceId: String): List<IntegrationConfigNode>
+
+    /**
+     * Creates the `BELONGS_TO` relationship from an IntegrationConfig node to its Namespace node.
+     *
+     * Called after saving a config. Using an explicit query avoids SDN writing
+     * stub [NamespaceNode] properties (empty name/description) onto the existing
+     * Namespace node when the relationship is expressed via the @Relationship field.
+     */
+    @Query(
+        $$"""MATCH (c:IntegrationConfig {id: $configId})
+            MATCH (ns:Namespace {id: $namespaceId})
+            MERGE (c)-[:BELONGS_TO]->(ns)
+            """,
+    )
+    fun linkConfigToNamespace(configId: String, namespaceId: String)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/IntegrationConfigNodeNeo4jRepository.kt
@@ -9,11 +9,18 @@ import org.springframework.data.neo4j.repository.query.Query
 interface IntegrationConfigNodeNeo4jRepository : Neo4jRepository<IntegrationConfigNode, String> {
     /**
      * Find all non-removed integration configs belonging to a namespace, ordered by name.
+     *
+     * Filters by the denormalised [IntegrationConfigNode.namespaceId] property rather
+     * than traversing the BELONGS_TO relationship, keeping the query simple and
+     * compatible with SDN's custom @Query result mapping (which does not
+     * auto-inject @Relationship fields). The graph edge is still written on save
+     * via [IntegrationConfigNode.namespace] — it exists in the graph for traversal.
      */
     @Query(
-        "MATCH (c:IntegrationConfig) " +
-            "WHERE c.namespaceId = \$namespaceId AND (c.removed IS NULL OR c.removed = false) " +
-            "RETURN c ORDER BY c.name ASC",
+        $$"""MATCH (c:IntegrationConfig)
+            WHERE c.namespaceId = $namespaceId AND (c.removed IS NULL OR c.removed = false)
+            RETURN c ORDER BY c.name ASC
+            """,
     )
     fun findActiveByNamespaceId(namespaceId: String): List<IntegrationConfigNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNode.kt
@@ -12,10 +12,6 @@ import java.util.UUID
  *
  * Stored as a `(:Namespace)` node. Namespaces are root-level — no parent relationship.
  *
- * [stub] creates a minimal instance carrying only the [id] for use as the target
- * of a `@Relationship` reference on [CaseNode] and [IntegrationConfigNode]. SDN
- * MERGEs the stub by `@Id` on save and never overwrites existing properties.
- *
  * Properties kept flat (no nested objects) to avoid SDN's limited support for
  * embedded value types in Community Edition.
  */
@@ -59,12 +55,5 @@ data class NamespaceNode(
                 modifiedBy = ns.metadata.modifiedBy,
                 removed = ns.metadata.removed.takeIf { it },
             )
-
-        /**
-         * Creates a minimal stub carrying only the [namespaceId] for use as
-         * the BELONGS_TO relationship target on [CaseNode] and [IntegrationConfigNode].
-         * SDN MERGEs by @Id and leaves all other Namespace properties untouched.
-         */
-        fun stub(namespaceId: UUID): NamespaceNode = NamespaceNode(id = namespaceId.toString())
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNode.kt
@@ -10,7 +10,11 @@ import java.util.UUID
 /**
  * Spring Data Neo4j projection for [Namespace].
  *
- * Stored as a (:Namespace) node. No parent relationship — namespaces are root-level.
+ * Stored as a `(:Namespace)` node. Namespaces are root-level — no parent relationship.
+ *
+ * [stub] creates a minimal instance carrying only the [id] for use as the target
+ * of a `@Relationship` reference on [CaseNode] and [IntegrationConfigNode]. SDN
+ * MERGEs the stub by `@Id` on save and never overwrites existing properties.
  *
  * Properties kept flat (no nested objects) to avoid SDN's limited support for
  * embedded value types in Community Edition.
@@ -19,7 +23,7 @@ import java.util.UUID
 data class NamespaceNode(
     @Id
     val id: String,
-    val name: String,
+    val name: String = "",
     val description: String? = null,
     // EntityMetadata fields
     val created: Instant = Instant.now(),
@@ -55,5 +59,12 @@ data class NamespaceNode(
                 modifiedBy = ns.metadata.modifiedBy,
                 removed = ns.metadata.removed.takeIf { it },
             )
+
+        /**
+         * Creates a minimal stub carrying only the [namespaceId] for use as
+         * the BELONGS_TO relationship target on [CaseNode] and [IntegrationConfigNode].
+         * SDN MERGEs by @Id and leaves all other Namespace properties untouched.
+         */
+        fun stub(namespaceId: UUID): NamespaceNode = NamespaceNode(id = namespaceId.toString())
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNodeNeo4jRepository.kt
@@ -15,6 +15,11 @@ interface NamespaceNodeNeo4jRepository : Neo4jRepository<NamespaceNode, String> 
      * Used by [Neo4jNamespaceRepository.findByParent]
      * which passes a dummy parent (Unit — namespaces are root-level).
      */
-    @Query("MATCH (n:Namespace) WHERE n.removed IS NULL OR n.removed = false RETURN n")
+    @Query(
+        $$"""MATCH (n:Namespace)
+            WHERE n.removed IS NULL OR n.removed = false
+            RETURN n
+            """,
+    )
     fun findAllActive(): List<NamespaceNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jCaseEventRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jCaseEventRepository.kt
@@ -28,6 +28,7 @@ open class Neo4jCaseEventRepository(
     override fun save(entity: CaseEvent): CaseEvent =
         caseEventNodeNeo4jRepository
             .save(mapper.fromDomain(entity))
+            .also { caseEventNodeNeo4jRepository.linkEventToCase(it.id, it.caseId) }
             .let { mapper.toDomain(it) }
             .also { logger.debug { "[Neo4jCaseEventRepository] Saved ${entity.type.value} event ${entity.id} for case ${entity.caseId}" } }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jCaseRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jCaseRepository.kt
@@ -21,6 +21,7 @@ open class Neo4jCaseRepository(
     override fun save(entity: Case): Case =
         caseNodeNeo4jRepository
             .save(CaseNode.fromDomain(entity))
+            .also { caseNodeNeo4jRepository.linkCaseToNamespace(it.id, entity.namespaceId.toString()) }
             .toDomain()
             .also { logger.debug { "[Neo4jCaseRepository] Saved case ${it.id} under namespace ${entity.namespaceId}" } }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jIntegrationConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jIntegrationConfigRepository.kt
@@ -11,21 +11,22 @@ import java.util.UUID
 /**
  * Neo4j-backed implementation of [IntegrationConfigRepository].
  *
+ * Delegates to [IntegrationConfigNodeNeo4jRepository] for all storage operations.
  * Parent type is [UUID] representing the namespaceId.
- *
- * [parameters] is serialised to/from JSON string by [IntegrationConfigNode] via
- * the injected [objectMapper], keeping the Neo4j node flat.
  */
 open class Neo4jIntegrationConfigRepository(
     private val neo4jRepository: IntegrationConfigNodeNeo4jRepository,
     private val objectMapper: ObjectMapper,
 ) : IntegrationConfigRepository {
-
     override fun save(entity: IntegrationConfig): IntegrationConfig =
         neo4jRepository
             .save(IntegrationConfigNode.fromDomain(entity, objectMapper))
             .toDomain(objectMapper)
-            .also { logger.debug { "[Neo4jIntegrationConfigRepository] Saved config ${it.id} ('${entity.name}') under namespace ${entity.namespaceId}" } }
+            .also {
+                logger.debug {
+                    "[Neo4jIntegrationConfigRepository] Saved config ${it.id} ('${entity.name}') under namespace ${entity.namespaceId}"
+                }
+            }
 
     override fun findByIds(ids: Collection<UUID>): List<IntegrationConfig> =
         neo4jRepository

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jIntegrationConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jIntegrationConfigRepository.kt
@@ -21,12 +21,9 @@ open class Neo4jIntegrationConfigRepository(
     override fun save(entity: IntegrationConfig): IntegrationConfig =
         neo4jRepository
             .save(IntegrationConfigNode.fromDomain(entity, objectMapper))
+            .also { neo4jRepository.linkConfigToNamespace(it.id, entity.namespaceId.toString()) }
             .toDomain(objectMapper)
-            .also {
-                logger.debug {
-                    "[Neo4jIntegrationConfigRepository] Saved config ${it.id} ('${entity.name}') under namespace ${entity.namespaceId}"
-                }
-            }
+            .also { logger.debug { "[Neo4jIntegrationConfigRepository] Saved config ${it.id} ('${entity.name}') under namespace ${entity.namespaceId}" } }
 
     override fun findByIds(ids: Collection<UUID>): List<IntegrationConfig> =
         neo4jRepository

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jRoleRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jRoleRepository.kt
@@ -1,0 +1,223 @@
+package io.whozoss.agentos.persistence.neo4j
+
+import io.whozoss.agentos.auth.MembershipInfo
+import io.whozoss.agentos.auth.RoleRepository
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import mu.KLogging
+import org.neo4j.driver.Driver
+import java.time.Instant
+
+/**
+ * Neo4j-backed implementation of [RoleRepository].
+ *
+ * Uses the Neo4j Java [Driver] directly (not Spring Data Neo4j repositories)
+ * because MEMBER_OF and PARTICIPANT_IN are **relationships with properties**,
+ * which SDN's `@Relationship` annotation handles poorly.
+ *
+ * All Cypher queries:
+ * - Filter soft-deleted nodes: `WHERE u.removed IS NULL OR u.removed = false`
+ * - Stay under 10 lines each
+ * - Use `MERGE` for upsert semantics on assign operations
+ *
+ * IDs are [String] to match the `@Id` convention across all Neo4j nodes.
+ */
+open class Neo4jRoleRepository(
+    private val driver: Driver,
+) : RoleRepository {
+
+    // -------------------------------------------------------------------------
+    // Root status
+    // -------------------------------------------------------------------------
+
+    override fun isRoot(userId: String): Boolean =
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})
+                WHERE (u.removed IS NULL OR u.removed = false) AND u.isRoot = true
+                RETURN count(u) > 0 AS isRoot
+                """.trimIndent(),
+                mapOf("userId" to userId),
+            ).single()["isRoot"].asBoolean()
+        }
+
+    override fun setRoot(userId: String, isRoot: Boolean) {
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})
+                SET u.isRoot = ${'$'}isRoot
+                """.trimIndent(),
+                mapOf("userId" to userId, "isRoot" to isRoot),
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Namespace roles (MEMBER_OF)
+    // -------------------------------------------------------------------------
+
+    override fun findNamespaceRole(userId: String, namespaceId: String): NamespaceRole? =
+        driver.session().use { session ->
+            val result = session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})-[m:MEMBER_OF]->(n:Namespace {id: ${'$'}namespaceId})
+                WHERE (u.removed IS NULL OR u.removed = false)
+                  AND (n.removed IS NULL OR n.removed = false)
+                RETURN m.role AS role
+                """.trimIndent(),
+                mapOf("userId" to userId, "namespaceId" to namespaceId),
+            )
+            when {
+                result.hasNext() -> NamespaceRole.valueOf(result.single()["role"].asString())
+                else -> null
+            }
+        }
+
+    override fun assignNamespaceRole(userId: String, namespaceId: String, role: NamespaceRole, grantedBy: String) {
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId}), (n:Namespace {id: ${'$'}namespaceId})
+                MERGE (u)-[m:MEMBER_OF]->(n)
+                SET m.role = ${'$'}role, m.grantedAt = ${'$'}grantedAt, m.grantedBy = ${'$'}grantedBy
+                """.trimIndent(),
+                mapOf(
+                    "userId" to userId,
+                    "namespaceId" to namespaceId,
+                    "role" to role.name,
+                    "grantedAt" to Instant.now().toString(),
+                    "grantedBy" to grantedBy,
+                ),
+            )
+        }
+    }
+
+    override fun removeNamespaceRole(userId: String, namespaceId: String) {
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})-[m:MEMBER_OF]->(n:Namespace {id: ${'$'}namespaceId})
+                DELETE m
+                """.trimIndent(),
+                mapOf("userId" to userId, "namespaceId" to namespaceId),
+            )
+        }
+    }
+
+    override fun findMembersOfNamespace(namespaceId: String): List<MembershipInfo> =
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User)-[m:MEMBER_OF]->(n:Namespace {id: ${'$'}namespaceId})
+                WHERE (u.removed IS NULL OR u.removed = false)
+                  AND (n.removed IS NULL OR n.removed = false)
+                RETURN u.id AS userId, m.role AS role, m.grantedAt AS grantedAt, m.grantedBy AS grantedBy
+                """.trimIndent(),
+                mapOf("namespaceId" to namespaceId),
+            ).list { record ->
+                MembershipInfo(
+                    userId = record["userId"].asString(),
+                    role = NamespaceRole.valueOf(record["role"].asString()),
+                    grantedAt = Instant.parse(record["grantedAt"].asString()),
+                    grantedBy = record["grantedBy"].asString(),
+                )
+            }
+        }
+
+    override fun countOwnersInNamespace(namespaceId: String): Int =
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User)-[m:MEMBER_OF {role: 'OWNER'}]->(n:Namespace {id: ${'$'}namespaceId})
+                WHERE (u.removed IS NULL OR u.removed = false)
+                  AND (n.removed IS NULL OR n.removed = false)
+                RETURN count(u) AS ownerCount
+                """.trimIndent(),
+                mapOf("namespaceId" to namespaceId),
+            ).single()["ownerCount"].asInt()
+        }
+
+    override fun findNamespaceIdsForUser(userId: String): Set<String> =
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})-[:MEMBER_OF]->(n:Namespace)
+                WHERE (u.removed IS NULL OR u.removed = false)
+                  AND (n.removed IS NULL OR n.removed = false)
+                RETURN n.id AS namespaceId
+                """.trimIndent(),
+                mapOf("userId" to userId),
+            ).list { it["namespaceId"].asString() }.toSet()
+        }
+
+    // -------------------------------------------------------------------------
+    // Case roles (PARTICIPANT_IN)
+    // -------------------------------------------------------------------------
+
+    override fun findCaseRole(userId: String, caseId: String): CaseRole? =
+        driver.session().use { session ->
+            val result = session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})-[p:PARTICIPANT_IN]->(c:Case {id: ${'$'}caseId})
+                WHERE (u.removed IS NULL OR u.removed = false)
+                  AND (c.removed IS NULL OR c.removed = false)
+                RETURN p.role AS role
+                """.trimIndent(),
+                mapOf("userId" to userId, "caseId" to caseId),
+            )
+            when {
+                result.hasNext() -> CaseRole.valueOf(result.single()["role"].asString())
+                else -> null
+            }
+        }
+
+    override fun assignCaseRole(userId: String, caseId: String, role: CaseRole, grantedBy: String) {
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId}), (c:Case {id: ${'$'}caseId})
+                MERGE (u)-[p:PARTICIPANT_IN]->(c)
+                SET p.role = ${'$'}role, p.grantedAt = ${'$'}grantedAt, p.grantedBy = ${'$'}grantedBy
+                """.trimIndent(),
+                mapOf(
+                    "userId" to userId,
+                    "caseId" to caseId,
+                    "role" to role.name,
+                    "grantedAt" to Instant.now().toString(),
+                    "grantedBy" to grantedBy,
+                ),
+            )
+        }
+    }
+
+    override fun removeCaseRole(userId: String, caseId: String) {
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})-[p:PARTICIPANT_IN]->(c:Case {id: ${'$'}caseId})
+                DELETE p
+                """.trimIndent(),
+                mapOf("userId" to userId, "caseId" to caseId),
+            )
+        }
+    }
+
+    override fun findAccessibleCaseIdsForUser(userId: String, namespaceId: String): Set<String> =
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (u:User {id: ${'$'}userId})-[:MEMBER_OF]->(n:Namespace {id: ${'$'}namespaceId})
+                MATCH (c:Case)-[:BELONGS_TO]->(n)
+                WHERE (u.removed IS NULL OR u.removed = false)
+                  AND (n.removed IS NULL OR n.removed = false)
+                  AND (c.removed IS NULL OR c.removed = false)
+                RETURN c.id AS caseId
+                """.trimIndent(),
+                mapOf("userId" to userId, "namespaceId" to namespaceId),
+            ).list { it["caseId"].asString() }.toSet()
+        }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/UserNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/UserNode.kt
@@ -28,6 +28,7 @@ data class UserNode(
     val firstname: String? = null,
     val lastname: String? = null,
     val bio: String? = null,
+    val isRoot: Boolean = false,
     // EntityMetadata fields
     val created: Instant = Instant.now(),
     val createdBy: String? = null,
@@ -51,6 +52,7 @@ data class UserNode(
             firstname = firstname,
             lastname = lastname,
             bio = bio,
+            isRoot = isRoot,
         )
 
     companion object {
@@ -62,6 +64,7 @@ data class UserNode(
                 firstname = user.firstname,
                 lastname = user.lastname,
                 bio = user.bio,
+                isRoot = user.isRoot,
                 created = user.metadata.created,
                 createdBy = user.metadata.createdBy,
                 modified = user.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/UserNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/UserNodeNeo4jRepository.kt
@@ -16,13 +16,23 @@ interface UserNodeNeo4jRepository : Neo4jRepository<UserNode, String> {
      * Used by [Neo4jUserRepository.findByParent] which receives the fixed
      * parent key [io.whozoss.agentos.user.UserRepository.USER_PARENT_KEY].
      */
-    @Query("MATCH (u:User) WHERE u.removed IS NULL OR u.removed = false RETURN u")
+    @Query(
+        $$"""MATCH (u:User)
+            WHERE u.removed IS NULL OR u.removed = false
+            RETURN u
+            """,
+    )
     fun findAllActive(): List<UserNode>
 
     /**
      * Find a non-removed user by external identity provider key.
      * Replaces the O(n) filesystem scan with a direct property lookup.
      */
-    @Query("MATCH (u:User) WHERE u.externalId = \$externalId AND (u.removed IS NULL OR u.removed = false) RETURN u LIMIT 1")
+    @Query(
+        $$"""MATCH (u:User)
+            WHERE u.externalId = $externalId AND (u.removed IS NULL OR u.removed = false)
+            RETURN u LIMIT 1
+            """,
+    )
     fun findActiveByExternalId(externalId: String): UserNode?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/security/SecurityConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/security/SecurityConfigProperties.kt
@@ -26,6 +26,13 @@ data class SecurityConfigProperties(
      * populates the CF_Authorization or x-forwarded-email header on every request.
      */
     val mode: SecurityMode = SecurityMode.LOCAL,
+    /**
+     * Permissive mode (FR30).
+     * When `true`, users without an assigned role are granted access by default.
+     * This ensures backward compatibility for namespaces without configured permissions.
+     * Default: `true`.
+     */
+    val permissive: Boolean = true,
 )
 
 enum class SecurityMode {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/User.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/User.kt
@@ -23,4 +23,5 @@ data class User(
     val firstname: String? = null,
     val lastname: String? = null,
     val bio: String? = null,
+    val isRoot: Boolean = false,
 ) : Entity

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/AuthorizationServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/AuthorizationServiceSpec.kt
@@ -1,0 +1,440 @@
+package io.whozoss.agentos.auth
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.caseFlow.Case
+import io.whozoss.agentos.caseFlow.CaseService
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceService
+import io.whozoss.agentos.sdk.auth.AccessDecision
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.auth.Operation
+import io.whozoss.agentos.sdk.auth.PermissionEvaluator
+import io.whozoss.agentos.sdk.auth.ToolCategory
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.security.SecurityConfigProperties
+import io.whozoss.agentos.security.SecurityMode
+import org.pf4j.PluginManager
+import java.util.UUID
+
+class AuthorizationServiceSpec : StringSpec() {
+
+    // Use valid UUIDs as String IDs (codebase convention: IDs are UUID strings)
+    private val userId = UUID.randomUUID().toString()
+    private val namespaceId = UUID.randomUUID().toString()
+    private val caseId = UUID.randomUUID().toString()
+
+    private fun buildService(
+        roleRepository: RoleRepository = mockk(),
+        pluginManager: PluginManager = mockk {
+            every { getExtensions(PermissionEvaluator::class.java) } returns emptyList()
+        },
+        permissive: Boolean = true,
+        namespaceService: NamespaceService = mockk {
+            every { findAll() } returns emptyList()
+        },
+        caseService: CaseService = mockk {
+            every { findByParent(any()) } returns emptyList()
+        },
+    ): AuthorizationServiceImpl = AuthorizationServiceImpl(
+        roleRepository,
+        pluginManager,
+        SecurityConfigProperties(mode = SecurityMode.LOCAL, permissive = permissive),
+        namespaceService,
+        caseService,
+    )
+
+    init {
+        // =====================================================================
+        // isRoot bypass — namespace
+        // =====================================================================
+
+        "isRoot user bypasses namespace access check" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns true
+
+            val service = buildService(roleRepository = repo)
+            shouldNotThrowAny { service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.OWNER) }
+        }
+
+        // =====================================================================
+        // isRoot bypass — case
+        // =====================================================================
+
+        "isRoot user bypasses case access check" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns true
+
+            val service = buildService(roleRepository = repo)
+            shouldNotThrowAny { service.requireCaseAccess(userId, caseId, Operation.DELETE) }
+        }
+
+        // =====================================================================
+        // Hierarchical resolution — ADMIN satisfies MEMBER
+        // =====================================================================
+
+        "ADMIN satisfies MEMBER namespace access" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findNamespaceRole(userId, namespaceId) } returns NamespaceRole.ADMIN
+
+            val service = buildService(roleRepository = repo)
+            shouldNotThrowAny { service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.MEMBER) }
+        }
+
+        // =====================================================================
+        // Hierarchical rejection — MEMBER does not satisfy ADMIN
+        // =====================================================================
+
+        "MEMBER does not satisfy ADMIN namespace access" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findNamespaceRole(userId, namespaceId) } returns NamespaceRole.MEMBER
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            val ex = shouldThrow<AccessDeniedException> {
+                service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.ADMIN)
+            }
+            ex.reason shouldBe "Role MEMBER does not satisfy required ADMIN"
+        }
+
+        // =====================================================================
+        // Permissive mode — access granted without role
+        // =====================================================================
+
+        "permissive mode grants namespace access when no role assigned" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findNamespaceRole(userId, namespaceId) } returns null
+
+            val service = buildService(roleRepository = repo, permissive = true)
+            shouldNotThrowAny { service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.MEMBER) }
+        }
+
+        "permissive mode grants case access when no role assigned" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findCaseRole(userId, caseId) } returns null
+
+            val service = buildService(roleRepository = repo, permissive = true)
+            shouldNotThrowAny { service.requireCaseAccess(userId, caseId, Operation.WRITE) }
+        }
+
+        // =====================================================================
+        // Strict mode — access denied without role
+        // =====================================================================
+
+        "strict mode denies namespace access when no role assigned" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findNamespaceRole(userId, namespaceId) } returns null
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            val ex = shouldThrow<AccessDeniedException> {
+                service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.VIEWER)
+            }
+            ex.reason shouldBe "No role assigned for user $userId in namespace $namespaceId"
+        }
+
+        // =====================================================================
+        // Fail-closed — RoleRepository exception → deny (strict mode)
+        // =====================================================================
+
+        "fail-closed denies access when RoleRepository throws and permissive is off" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("Neo4j unavailable")
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            val ex = shouldThrow<AccessDeniedException> {
+                service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.VIEWER)
+            }
+            ex.reason shouldBe "Permission check failed: system error"
+        }
+
+        "fail-closed allows access when RoleRepository throws and permissive is on" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("Neo4j unavailable")
+
+            val service = buildService(roleRepository = repo, permissive = true)
+            shouldNotThrowAny { service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.VIEWER) }
+        }
+
+        // =====================================================================
+        // Evaluator delegation
+        // =====================================================================
+
+        "delegates namespace evaluation to evaluator" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findNamespaceRole(userId, namespaceId) } returns NamespaceRole.VIEWER
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            val ex = shouldThrow<AccessDeniedException> {
+                service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.ADMIN)
+            }
+            ex.reason shouldBe "Role VIEWER does not satisfy required ADMIN"
+        }
+
+        "delegates case evaluation — PARTICIPANT cannot WRITE" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findCaseRole(userId, caseId) } returns CaseRole.PARTICIPANT
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            val ex = shouldThrow<AccessDeniedException> {
+                service.requireCaseAccess(userId, caseId, Operation.WRITE)
+            }
+            ex.reason shouldBe "CaseRole PARTICIPANT cannot perform WRITE"
+        }
+
+        "delegates case evaluation — OWNER can DELETE" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findCaseRole(userId, caseId) } returns CaseRole.OWNER
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            shouldNotThrowAny { service.requireCaseAccess(userId, caseId, Operation.DELETE) }
+        }
+
+        // =====================================================================
+        // Plugin override — custom evaluator via PF4J
+        // =====================================================================
+
+        "uses plugin-provided evaluator instead of built-in" {
+            val customEvaluator = mockk<PermissionEvaluator>()
+            every { customEvaluator.evaluateNamespaceAccess(any(), any()) } returns AccessDecision.Granted("CUSTOM")
+
+            val pluginMgr = mockk<PluginManager>()
+            every { pluginMgr.getExtensions(PermissionEvaluator::class.java) } returns listOf(customEvaluator)
+
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findNamespaceRole(userId, namespaceId) } returns NamespaceRole.VIEWER
+
+            val service = buildService(roleRepository = repo, pluginManager = pluginMgr, permissive = false)
+            // Custom evaluator grants access even for VIEWER requesting OWNER
+            shouldNotThrowAny { service.requireNamespaceAccess(userId, namespaceId, NamespaceRole.OWNER) }
+        }
+
+        // =====================================================================
+        // canExecuteTool / getAvailableTools
+        // =====================================================================
+
+        "canExecuteTool returns true for root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns true
+
+            val service = buildService(roleRepository = repo)
+            service.canExecuteTool(userId, caseId, "tool", ToolCategory.ADMIN) shouldBe true
+        }
+
+        "canExecuteTool returns true for OWNER on DESTRUCTIVE" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findCaseRole(userId, caseId) } returns CaseRole.OWNER
+
+            val service = buildService(roleRepository = repo)
+            service.canExecuteTool(userId, caseId, "tool", ToolCategory.DESTRUCTIVE) shouldBe true
+        }
+
+        "canExecuteTool returns false for PARTICIPANT on DESTRUCTIVE in strict mode" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findCaseRole(userId, caseId) } returns CaseRole.PARTICIPANT
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            service.canExecuteTool(userId, caseId, "tool", ToolCategory.DESTRUCTIVE) shouldBe false
+        }
+
+        "getAvailableTools returns all tools for root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns true
+
+            val allTools = mapOf("read-tool" to ToolCategory.READ_ONLY, "admin-tool" to ToolCategory.ADMIN)
+            val service = buildService(roleRepository = repo)
+            service.getAvailableTools(userId, caseId, allTools) shouldBe setOf("read-tool", "admin-tool")
+        }
+
+        "getAvailableTools filters by PARTICIPANT role" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findCaseRole(userId, caseId) } returns CaseRole.PARTICIPANT
+
+            val allTools = mapOf(
+                "read-tool" to ToolCategory.READ_ONLY,
+                "write-tool" to ToolCategory.WRITE,
+                "admin-tool" to ToolCategory.ADMIN,
+            )
+            val service = buildService(roleRepository = repo, permissive = false)
+            service.getAvailableTools(userId, caseId, allTools) shouldBe setOf("read-tool", "write-tool")
+        }
+
+        // =====================================================================
+        // isRoot / requireRoot
+        // =====================================================================
+
+        "isRoot returns true for root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns true
+
+            val service = buildService(roleRepository = repo)
+            service.isRoot(userId) shouldBe true
+        }
+
+        "isRoot returns false for non-root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+
+            val service = buildService(roleRepository = repo)
+            service.isRoot(userId) shouldBe false
+        }
+
+        "requireRoot does not throw for root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns true
+
+            val service = buildService(roleRepository = repo)
+            shouldNotThrowAny { service.requireRoot(userId) }
+        }
+
+        "requireRoot throws for non-root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+
+            val service = buildService(roleRepository = repo)
+            val ex = shouldThrow<AccessDeniedException> { service.requireRoot(userId) }
+            ex.reason shouldBe "User $userId is not root"
+        }
+
+        // =====================================================================
+        // filterAccessibleNamespaceIds / filterAccessibleCaseIds
+        // =====================================================================
+
+        "filterAccessibleNamespaceIds returns namespace IDs from repository for non-root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findNamespaceIdsForUser(userId) } returns setOf(namespaceId)
+
+            val service = buildService(roleRepository = repo)
+            service.filterAccessibleNamespaceIds(userId) shouldBe setOf(namespaceId)
+        }
+
+        "filterAccessibleNamespaceIds returns ALL namespace IDs for root user" {
+            val repo = mockk<RoleRepository>()
+            val allNsId = UUID.randomUUID().toString()
+            every { repo.isRoot(userId) } returns true
+            val nsService = mockk<NamespaceService>()
+            every { nsService.findAll() } returns listOf(
+                Namespace(metadata = EntityMetadata(id = UUID.fromString(namespaceId)), name = "ns-1"),
+                Namespace(metadata = EntityMetadata(id = UUID.fromString(allNsId)), name = "ns-2"),
+            )
+
+            val service = buildService(roleRepository = repo, namespaceService = nsService)
+            val result = service.filterAccessibleNamespaceIds(userId)
+            result shouldBe setOf(namespaceId, allNsId)
+        }
+
+        "filterAccessibleNamespaceIds returns all namespaces on error in permissive mode" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("DB error")
+            val nsService = mockk<NamespaceService>()
+            every { nsService.findAll() } returns listOf(
+                Namespace(metadata = EntityMetadata(id = UUID.fromString(namespaceId)), name = "ns-1"),
+            )
+
+            val service = buildService(roleRepository = repo, permissive = true, namespaceService = nsService)
+            service.filterAccessibleNamespaceIds(userId) shouldBe setOf(namespaceId)
+        }
+
+        "filterAccessibleNamespaceIds returns empty set on error in strict mode" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("DB error")
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            service.filterAccessibleNamespaceIds(userId) shouldBe emptySet()
+        }
+
+        "filterAccessibleCaseIds returns case IDs from repository for non-root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findAccessibleCaseIdsForUser(userId, namespaceId) } returns setOf(caseId)
+
+            val service = buildService(roleRepository = repo)
+            service.filterAccessibleCaseIds(userId, namespaceId) shouldBe setOf(caseId)
+        }
+
+        "filterAccessibleCaseIds returns ALL case IDs for root user" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns true
+            val csService = mockk<CaseService>()
+            val nsUUID = UUID.fromString(namespaceId)
+            every { csService.findByParent(nsUUID) } returns listOf(
+                Case(metadata = EntityMetadata(id = UUID.fromString(caseId)), namespaceId = nsUUID, title = "case-1"),
+            )
+
+            val service = buildService(roleRepository = repo, caseService = csService)
+            service.filterAccessibleCaseIds(userId, namespaceId) shouldBe setOf(caseId)
+        }
+
+        "filterAccessibleCaseIds returns all cases on error in permissive mode" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("DB error")
+            val csService = mockk<CaseService>()
+            val nsUUID = UUID.fromString(namespaceId)
+            every { csService.findByParent(nsUUID) } returns listOf(
+                Case(metadata = EntityMetadata(id = UUID.fromString(caseId)), namespaceId = nsUUID, title = "case-1"),
+            )
+
+            val service = buildService(roleRepository = repo, permissive = true, caseService = csService)
+            service.filterAccessibleCaseIds(userId, namespaceId) shouldBe setOf(caseId)
+        }
+
+        "filterAccessibleCaseIds returns empty set on error in strict mode" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("DB error")
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            service.filterAccessibleCaseIds(userId, namespaceId) shouldBe emptySet()
+        }
+
+        // =====================================================================
+        // Fail-closed — requireCaseAccess (patch #4 Story 1.3)
+        // =====================================================================
+
+        "fail-closed denies case access when RoleRepository throws and permissive is off" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("Neo4j unavailable")
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            val ex = shouldThrow<AccessDeniedException> {
+                service.requireCaseAccess(userId, caseId, Operation.READ)
+            }
+            ex.reason shouldBe "Permission check failed: system error"
+        }
+
+        "fail-closed allows case access when RoleRepository throws and permissive is on" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } throws RuntimeException("Neo4j unavailable")
+
+            val service = buildService(roleRepository = repo, permissive = true)
+            shouldNotThrowAny { service.requireCaseAccess(userId, caseId, Operation.READ) }
+        }
+
+        "strict mode denies case access when no role assigned" {
+            val repo = mockk<RoleRepository>()
+            every { repo.isRoot(userId) } returns false
+            every { repo.findCaseRole(userId, caseId) } returns null
+
+            val service = buildService(roleRepository = repo, permissive = false)
+            val ex = shouldThrow<AccessDeniedException> {
+                service.requireCaseAccess(userId, caseId, Operation.READ)
+            }
+            ex.reason shouldBe "No role assigned for user $userId in case $caseId"
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/BootstrapServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/BootstrapServiceSpec.kt
@@ -1,0 +1,102 @@
+package io.whozoss.agentos.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceService
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.security.SecurityConfigProperties
+import io.whozoss.agentos.security.SecurityMode
+import io.whozoss.agentos.security.SecurityService
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import java.util.UUID
+
+class BootstrapServiceSpec : StringSpec({
+    val userService = mockk<UserService>()
+    val roleRepository = mockk<RoleRepository>()
+    val namespaceService = mockk<NamespaceService>()
+    val securityService = mockk<SecurityService>()
+
+    fun buildService(mode: SecurityMode = SecurityMode.LOCAL, permissive: Boolean = true): BootstrapService =
+        BootstrapService(
+            userService,
+            roleRepository,
+            SecurityConfigProperties(mode = mode, permissive = permissive),
+            namespaceService,
+            securityService,
+        )
+
+    val userId = UUID.randomUUID()
+    val user = User(metadata = EntityMetadata(id = userId), externalId = "localuser")
+    val nsId = UUID.randomUUID()
+    val namespace = Namespace(metadata = EntityMetadata(id = nsId), name = "ns-1")
+
+    beforeEach {
+        clearMocks(userService, roleRepository, namespaceService, securityService)
+    }
+
+    "auto-root in LOCAL mode when no root exists" {
+        every { userService.findAll() } returns listOf(user)
+        every { securityService.resolveCurrentIdentity() } returns "localuser"
+        every { userService.resolveOrCreateByExternalId("localuser") } returns user
+        every { roleRepository.setRoot(userId.toString(), true) } just Runs
+        every { namespaceService.findAll() } returns emptyList()
+        every { roleRepository.findNamespaceRole(any(), any()) } returns null
+
+        buildService(mode = SecurityMode.LOCAL).onApplicationReady()
+
+        verify(exactly = 1) { roleRepository.setRoot(userId.toString(), true) }
+    }
+
+    "skip auto-root if root already exists" {
+        val rootUser = User(metadata = EntityMetadata(id = userId), externalId = "root", isRoot = true)
+        every { userService.findAll() } returns listOf(rootUser)
+        every { namespaceService.findAll() } returns emptyList()
+
+        buildService(mode = SecurityMode.LOCAL).onApplicationReady()
+
+        verify(exactly = 0) { roleRepository.setRoot(any(), any()) }
+    }
+
+    "AUTH mode does not auto-root (logs warning only)" {
+        every { userService.findAll() } returns listOf(user)
+        every { namespaceService.findAll() } returns emptyList()
+        every { roleRepository.findNamespaceRole(any(), any()) } returns null
+
+        buildService(mode = SecurityMode.AUTH).onApplicationReady()
+
+        verify(exactly = 0) { roleRepository.setRoot(any(), any()) }
+    }
+
+    "bootstrap assigns ADMIN to existing users on all namespaces" {
+        val rootUser = User(metadata = EntityMetadata(id = userId), externalId = "admin", isRoot = true)
+        every { userService.findAll() } returns listOf(rootUser)
+        every { namespaceService.findAll() } returns listOf(namespace)
+        every { roleRepository.findNamespaceRole(userId.toString(), nsId.toString()) } returns null
+        every { roleRepository.assignNamespaceRole(any(), any(), any(), any()) } just Runs
+
+        buildService(mode = SecurityMode.LOCAL).onApplicationReady()
+
+        verify(exactly = 1) {
+            roleRepository.assignNamespaceRole(userId.toString(), nsId.toString(), NamespaceRole.ADMIN, "bootstrap")
+        }
+    }
+
+    "bootstrap skips users who already have a role" {
+        val rootUser = User(metadata = EntityMetadata(id = userId), externalId = "admin", isRoot = true)
+        every { userService.findAll() } returns listOf(rootUser)
+        every { namespaceService.findAll() } returns listOf(namespace)
+        every { roleRepository.findNamespaceRole(userId.toString(), nsId.toString()) } returns NamespaceRole.OWNER
+
+        buildService(mode = SecurityMode.LOCAL).onApplicationReady()
+
+        verify(exactly = 0) { roleRepository.assignNamespaceRole(any(), any(), any(), any()) }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/CodayPermissionEvaluatorSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/CodayPermissionEvaluatorSpec.kt
@@ -1,0 +1,347 @@
+package io.whozoss.agentos.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.sdk.auth.AccessDecision
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.auth.Operation
+import io.whozoss.agentos.sdk.auth.PermissionContext
+import io.whozoss.agentos.sdk.auth.ToolCategory
+import java.util.UUID
+
+class CodayPermissionEvaluatorSpec : StringSpec() {
+
+    private val evaluator = CodayPermissionEvaluator()
+
+    private fun nsCtx(
+        role: NamespaceRole? = null,
+        isRoot: Boolean = false,
+    ) = PermissionContext(
+        userId = UUID.randomUUID(),
+        isRoot = isRoot,
+        namespaceId = UUID.randomUUID(),
+        namespaceRole = role,
+    )
+
+    private fun caseCtx(
+        role: CaseRole? = null,
+        isRoot: Boolean = false,
+    ) = PermissionContext(
+        userId = UUID.randomUUID(),
+        isRoot = isRoot,
+        caseId = UUID.randomUUID(),
+        caseRole = role,
+    )
+
+    init {
+        // =====================================================================
+        // evaluateNamespaceAccess — isRoot bypass
+        // =====================================================================
+
+        "isRoot bypasses namespace access for OWNER" {
+            val decision = evaluator.evaluateNamespaceAccess(nsCtx(isRoot = true), NamespaceRole.OWNER)
+            decision.isGranted shouldBe true
+            (decision as AccessDecision.Granted).effectiveRole shouldBe "ROOT"
+        }
+
+        // =====================================================================
+        // evaluateNamespaceAccess — full matrix NamespaceRole x minRole
+        // =====================================================================
+
+        "OWNER satisfies OWNER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.OWNER), NamespaceRole.OWNER).isGranted shouldBe true
+        }
+
+        "OWNER satisfies ADMIN" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.OWNER), NamespaceRole.ADMIN).isGranted shouldBe true
+        }
+
+        "OWNER satisfies MEMBER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.OWNER), NamespaceRole.MEMBER).isGranted shouldBe true
+        }
+
+        "OWNER satisfies VIEWER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.OWNER), NamespaceRole.VIEWER).isGranted shouldBe true
+        }
+
+        "ADMIN satisfies ADMIN" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.ADMIN), NamespaceRole.ADMIN).isGranted shouldBe true
+        }
+
+        "ADMIN satisfies MEMBER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.ADMIN), NamespaceRole.MEMBER).isGranted shouldBe true
+        }
+
+        "ADMIN satisfies VIEWER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.ADMIN), NamespaceRole.VIEWER).isGranted shouldBe true
+        }
+
+        "ADMIN does not satisfy OWNER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.ADMIN), NamespaceRole.OWNER).isGranted shouldBe false
+        }
+
+        "MEMBER satisfies MEMBER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.MEMBER), NamespaceRole.MEMBER).isGranted shouldBe true
+        }
+
+        "MEMBER satisfies VIEWER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.MEMBER), NamespaceRole.VIEWER).isGranted shouldBe true
+        }
+
+        "MEMBER does not satisfy ADMIN" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.MEMBER), NamespaceRole.ADMIN).isGranted shouldBe false
+        }
+
+        "MEMBER does not satisfy OWNER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.MEMBER), NamespaceRole.OWNER).isGranted shouldBe false
+        }
+
+        "VIEWER satisfies VIEWER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.VIEWER), NamespaceRole.VIEWER).isGranted shouldBe true
+        }
+
+        "VIEWER does not satisfy MEMBER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.VIEWER), NamespaceRole.MEMBER).isGranted shouldBe false
+        }
+
+        "VIEWER does not satisfy ADMIN" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.VIEWER), NamespaceRole.ADMIN).isGranted shouldBe false
+        }
+
+        "VIEWER does not satisfy OWNER" {
+            evaluator.evaluateNamespaceAccess(nsCtx(NamespaceRole.VIEWER), NamespaceRole.OWNER).isGranted shouldBe false
+        }
+
+        // =====================================================================
+        // evaluateNamespaceAccess — Abstain when context incomplete
+        // =====================================================================
+
+        "Abstain when namespace role is null" {
+            val decision = evaluator.evaluateNamespaceAccess(nsCtx(role = null), NamespaceRole.VIEWER)
+            decision shouldBe AccessDecision.Abstain
+        }
+
+        // =====================================================================
+        // evaluateCaseAccess — isRoot bypass
+        // =====================================================================
+
+        "isRoot bypasses case access for DELETE" {
+            val decision = evaluator.evaluateCaseAccess(caseCtx(isRoot = true), Operation.DELETE)
+            decision.isGranted shouldBe true
+            (decision as AccessDecision.Granted).effectiveRole shouldBe "ROOT"
+        }
+
+        // =====================================================================
+        // evaluateCaseAccess — OWNER matrix (all operations allowed)
+        // =====================================================================
+
+        "OWNER can LIST" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OWNER), Operation.LIST).isGranted shouldBe true
+        }
+
+        "OWNER can READ" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OWNER), Operation.READ).isGranted shouldBe true
+        }
+
+        "OWNER can CREATE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OWNER), Operation.CREATE).isGranted shouldBe true
+        }
+
+        "OWNER can WRITE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OWNER), Operation.WRITE).isGranted shouldBe true
+        }
+
+        "OWNER can DELETE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OWNER), Operation.DELETE).isGranted shouldBe true
+        }
+
+        "OWNER can MANAGE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OWNER), Operation.MANAGE).isGranted shouldBe true
+        }
+
+        "OWNER can EXECUTE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OWNER), Operation.EXECUTE).isGranted shouldBe true
+        }
+
+        // =====================================================================
+        // evaluateCaseAccess — PARTICIPANT matrix
+        // =====================================================================
+
+        "PARTICIPANT can LIST" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.PARTICIPANT), Operation.LIST).isGranted shouldBe true
+        }
+
+        "PARTICIPANT can READ" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.PARTICIPANT), Operation.READ).isGranted shouldBe true
+        }
+
+        "PARTICIPANT cannot CREATE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.PARTICIPANT), Operation.CREATE).isGranted shouldBe false
+        }
+
+        "PARTICIPANT cannot WRITE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.PARTICIPANT), Operation.WRITE).isGranted shouldBe false
+        }
+
+        "PARTICIPANT cannot DELETE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.PARTICIPANT), Operation.DELETE).isGranted shouldBe false
+        }
+
+        "PARTICIPANT cannot MANAGE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.PARTICIPANT), Operation.MANAGE).isGranted shouldBe false
+        }
+
+        "PARTICIPANT can EXECUTE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.PARTICIPANT), Operation.EXECUTE).isGranted shouldBe true
+        }
+
+        // =====================================================================
+        // evaluateCaseAccess — OBSERVER matrix
+        // =====================================================================
+
+        "OBSERVER can LIST" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OBSERVER), Operation.LIST).isGranted shouldBe true
+        }
+
+        "OBSERVER can READ" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OBSERVER), Operation.READ).isGranted shouldBe true
+        }
+
+        "OBSERVER cannot CREATE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OBSERVER), Operation.CREATE).isGranted shouldBe false
+        }
+
+        "OBSERVER cannot WRITE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OBSERVER), Operation.WRITE).isGranted shouldBe false
+        }
+
+        "OBSERVER cannot DELETE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OBSERVER), Operation.DELETE).isGranted shouldBe false
+        }
+
+        "OBSERVER cannot MANAGE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OBSERVER), Operation.MANAGE).isGranted shouldBe false
+        }
+
+        "OBSERVER cannot EXECUTE" {
+            evaluator.evaluateCaseAccess(caseCtx(CaseRole.OBSERVER), Operation.EXECUTE).isGranted shouldBe false
+        }
+
+        // =====================================================================
+        // evaluateCaseAccess — Abstain when context incomplete
+        // =====================================================================
+
+        "Abstain when case role is null" {
+            val decision = evaluator.evaluateCaseAccess(caseCtx(role = null), Operation.READ)
+            decision shouldBe AccessDecision.Abstain
+        }
+
+        // =====================================================================
+        // evaluateToolAccess — isRoot bypass
+        // =====================================================================
+
+        "isRoot bypasses tool access for ADMIN category" {
+            val decision = evaluator.evaluateToolAccess(caseCtx(isRoot = true), "admin-tool", ToolCategory.ADMIN)
+            decision.isGranted shouldBe true
+        }
+
+        // =====================================================================
+        // evaluateToolAccess — OWNER matrix (all categories allowed)
+        // =====================================================================
+
+        "OWNER can use READ_ONLY tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OWNER), "tool", ToolCategory.READ_ONLY).isGranted shouldBe true
+        }
+
+        "OWNER can use WRITE tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OWNER), "tool", ToolCategory.WRITE).isGranted shouldBe true
+        }
+
+        "OWNER can use DESTRUCTIVE tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OWNER), "tool", ToolCategory.DESTRUCTIVE).isGranted shouldBe true
+        }
+
+        "OWNER can use ADMIN tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OWNER), "tool", ToolCategory.ADMIN).isGranted shouldBe true
+        }
+
+        // =====================================================================
+        // evaluateToolAccess — PARTICIPANT matrix
+        // =====================================================================
+
+        "PARTICIPANT can use READ_ONLY tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.PARTICIPANT), "tool", ToolCategory.READ_ONLY).isGranted shouldBe true
+        }
+
+        "PARTICIPANT can use WRITE tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.PARTICIPANT), "tool", ToolCategory.WRITE).isGranted shouldBe true
+        }
+
+        "PARTICIPANT cannot use DESTRUCTIVE tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.PARTICIPANT), "tool", ToolCategory.DESTRUCTIVE).isGranted shouldBe false
+        }
+
+        "PARTICIPANT cannot use ADMIN tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.PARTICIPANT), "tool", ToolCategory.ADMIN).isGranted shouldBe false
+        }
+
+        // =====================================================================
+        // evaluateToolAccess — OBSERVER matrix
+        // =====================================================================
+
+        "OBSERVER can use READ_ONLY tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OBSERVER), "tool", ToolCategory.READ_ONLY).isGranted shouldBe true
+        }
+
+        "OBSERVER cannot use WRITE tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OBSERVER), "tool", ToolCategory.WRITE).isGranted shouldBe false
+        }
+
+        "OBSERVER cannot use DESTRUCTIVE tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OBSERVER), "tool", ToolCategory.DESTRUCTIVE).isGranted shouldBe false
+        }
+
+        "OBSERVER cannot use ADMIN tool" {
+            evaluator.evaluateToolAccess(caseCtx(CaseRole.OBSERVER), "tool", ToolCategory.ADMIN).isGranted shouldBe false
+        }
+
+        // =====================================================================
+        // evaluateToolAccess — Abstain when context incomplete
+        // =====================================================================
+
+        "Abstain tool access when case role is null" {
+            val decision = evaluator.evaluateToolAccess(caseCtx(role = null), "tool", ToolCategory.READ_ONLY)
+            decision shouldBe AccessDecision.Abstain
+        }
+
+        // =====================================================================
+        // getAvailableToolCategories
+        // =====================================================================
+
+        "isRoot gets all tool categories" {
+            val categories = evaluator.getAvailableToolCategories(caseCtx(isRoot = true))
+            categories shouldBe ToolCategory.entries.toSet()
+        }
+
+        "OWNER gets all tool categories" {
+            val categories = evaluator.getAvailableToolCategories(caseCtx(CaseRole.OWNER))
+            categories shouldBe ToolCategory.entries.toSet()
+        }
+
+        "PARTICIPANT gets READ_ONLY and WRITE categories" {
+            val categories = evaluator.getAvailableToolCategories(caseCtx(CaseRole.PARTICIPANT))
+            categories shouldBe setOf(ToolCategory.READ_ONLY, ToolCategory.WRITE)
+        }
+
+        "OBSERVER gets only READ_ONLY category" {
+            val categories = evaluator.getAvailableToolCategories(caseCtx(CaseRole.OBSERVER))
+            categories shouldBe setOf(ToolCategory.READ_ONLY)
+        }
+
+        "null role gets empty tool categories" {
+            val categories = evaluator.getAvailableToolCategories(caseCtx(role = null))
+            categories shouldBe emptySet()
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
@@ -1,0 +1,154 @@
+package io.whozoss.agentos.caseFlow
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.auth.AccessDeniedException
+import io.whozoss.agentos.auth.AuthorizationService
+import io.whozoss.agentos.auth.RoleRepository
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.auth.Operation
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import java.util.UUID
+
+class CaseControllerSpec : StringSpec({
+    val caseService = mockk<CaseService>()
+    val userService = mockk<UserService>()
+    val authorizationService = mockk<AuthorizationService>()
+    val roleRepository = mockk<RoleRepository>()
+    val controller = CaseController(caseService, userService, authorizationService, roleRepository)
+
+    val currentUserId = UUID.randomUUID()
+    val currentUser = User(metadata = EntityMetadata(id = currentUserId), externalId = "user@test.com")
+    val nsId = UUID.randomUUID()
+    val caseId = UUID.randomUUID()
+    val testCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = nsId, title = "test-case")
+
+    beforeEach {
+        clearMocks(caseService, userService, authorizationService, roleRepository)
+        every { userService.getCurrentUser() } returns currentUser
+    }
+
+    // -------------------------------------------------------------------------
+    // getById
+    // -------------------------------------------------------------------------
+
+    "getById checks READ access" {
+        every { authorizationService.requireCaseAccess(any(), any(), any()) } just Runs
+        every { caseService.findById(caseId) } returns testCase
+
+        val result = controller.getById(caseId)
+
+        result.title shouldBe "test-case"
+        verify { authorizationService.requireCaseAccess(currentUserId.toString(), caseId.toString(), Operation.READ) }
+    }
+
+    "getById throws 403 when access denied" {
+        every {
+            authorizationService.requireCaseAccess(any(), any(), any())
+        } throws AccessDeniedException("Access denied")
+
+        shouldThrow<AccessDeniedException> { controller.getById(caseId) }
+    }
+
+    // -------------------------------------------------------------------------
+    // create + auto-assign case OWNER
+    // -------------------------------------------------------------------------
+
+    "create requires MEMBER namespace access and auto-assigns case OWNER" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { caseService.create(any()) } returns testCase
+        every { roleRepository.assignCaseRole(any(), any(), any(), any()) } just Runs
+
+        val resource = CaseResource(namespaceId = nsId, title = "test-case")
+        val result = controller.create(resource)
+
+        result.title shouldBe "test-case"
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), nsId.toString(), NamespaceRole.MEMBER) }
+        verify { roleRepository.assignCaseRole(currentUserId.toString(), caseId.toString(), CaseRole.OWNER, currentUserId.toString()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // update / delete
+    // -------------------------------------------------------------------------
+
+    "update checks WRITE access" {
+        every { authorizationService.requireCaseAccess(any(), any(), any()) } just Runs
+        every { caseService.findById(caseId) } returns testCase
+        every { caseService.update(any()) } returns testCase
+
+        controller.update(caseId, CaseResource(id = caseId, namespaceId = nsId, title = "updated"))
+
+        verify { authorizationService.requireCaseAccess(currentUserId.toString(), caseId.toString(), Operation.WRITE) }
+    }
+
+    "delete checks DELETE access" {
+        every { authorizationService.requireCaseAccess(any(), any(), any()) } just Runs
+        every { caseService.delete(caseId) } returns true
+
+        controller.delete(caseId)
+
+        verify { authorizationService.requireCaseAccess(currentUserId.toString(), caseId.toString(), Operation.DELETE) }
+    }
+
+    // -------------------------------------------------------------------------
+    // listByParent — filtered
+    // -------------------------------------------------------------------------
+
+    "listByParent returns only accessible cases" {
+        val case2Id = UUID.randomUUID()
+        val case2 = Case(metadata = EntityMetadata(id = case2Id), namespaceId = nsId, title = "case-2")
+        every { authorizationService.filterAccessibleCaseIds(currentUserId.toString(), nsId.toString()) } returns setOf(caseId.toString())
+        every { caseService.findByParent(nsId) } returns listOf(testCase, case2)
+
+        val result = controller.listByParent(nsId)
+
+        result shouldHaveSize 1
+        result[0].title shouldBe "test-case"
+    }
+
+    // -------------------------------------------------------------------------
+    // addMessage — EXECUTE access
+    // -------------------------------------------------------------------------
+
+    "addMessage checks EXECUTE access" {
+        every { authorizationService.requireCaseAccess(any(), any(), any()) } just Runs
+        every { caseService.addMessage(any(), any(), any(), any()) } just Runs
+
+        controller.addMessage(caseId, AddMessageRequest(content = "hello"))
+
+        verify { authorizationService.requireCaseAccess(currentUserId.toString(), caseId.toString(), Operation.EXECUTE) }
+    }
+
+    // -------------------------------------------------------------------------
+    // interrupt / kill — MANAGE access
+    // -------------------------------------------------------------------------
+
+    "interruptCase checks MANAGE access" {
+        every { authorizationService.requireCaseAccess(any(), any(), any()) } just Runs
+        every { caseService.interruptCase(caseId) } just Runs
+
+        controller.interruptCase(caseId)
+
+        verify { authorizationService.requireCaseAccess(currentUserId.toString(), caseId.toString(), Operation.MANAGE) }
+    }
+
+    "killCase checks MANAGE access" {
+        every { authorizationService.requireCaseAccess(any(), any(), any()) } just Runs
+        every { caseService.killCase(caseId) } just Runs
+
+        controller.killCase(caseId)
+
+        verify { authorizationService.requireCaseAccess(currentUserId.toString(), caseId.toString(), Operation.MANAGE) }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigControllerSpec.kt
@@ -1,33 +1,40 @@
 package io.whozoss.agentos.integrationConfig
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.clearMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import io.whozoss.agentos.auth.AccessDeniedException
+import io.whozoss.agentos.auth.AuthorizationService
 import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.sdk.auth.NamespaceRole
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
 import java.util.UUID
 
 /**
  * Unit tests for [IntegrationConfigController].
  *
  * The controller is instantiated directly with MockK stubs — no Spring context.
- * Tests cover:
- * - [IntegrationConfigController.toResource]  — domain → HTTP DTO mapping
- * - [IntegrationConfigController.toDomain]    — HTTP DTO → domain mapping
- * - [IntegrationConfigController.listByNamespace] — custom endpoint
- * - Inherited [io.whozoss.agentos.entity.EntityController] endpoints:
- *   getById (found / not-found), getByIds, listByParent, create,
- *   update (found / not-found), delete (found / not-found)
+ * Tests cover authorization (ADMIN namespace access) on every CRUD endpoint,
+ * plus mapping between domain entity and HTTP DTO.
  */
 class IntegrationConfigControllerSpec : StringSpec({
-    timeout = 5000
-
     val service = mockk<IntegrationConfigService>()
-    val controller = IntegrationConfigController(service)
+    val authorizationService = mockk<AuthorizationService>()
+    val userService = mockk<UserService>()
+    val controller = IntegrationConfigController(service, authorizationService, userService)
 
+    val currentUserId = UUID.randomUUID()
+    val currentUser = User(metadata = EntityMetadata(id = currentUserId), externalId = "user@test.com")
     val namespaceId = UUID.randomUUID()
     val params = JsonNodeFactory.instance.objectNode().put("apiUrl", "https://example.com")
 
@@ -46,7 +53,7 @@ class IntegrationConfigControllerSpec : StringSpec({
 
     fun resource(
         id: UUID? = UUID.randomUUID(),
-        nsId: UUID = namespaceId,
+        nsId: UUID? = namespaceId,
         name: String = "JIRA_PROD",
         integrationType: String = "JIRA",
     ) = IntegrationConfigResource(
@@ -57,8 +64,13 @@ class IntegrationConfigControllerSpec : StringSpec({
         parameters = params,
     )
 
+    beforeEach {
+        clearMocks(service, authorizationService, userService)
+        every { userService.getCurrentUser() } returns currentUser
+    }
+
     // -------------------------------------------------------------------------
-    // toResource mapping
+    // toResource / toDomain mapping
     // -------------------------------------------------------------------------
 
     "toResource maps all fields from IntegrationConfig to IntegrationConfigResource" {
@@ -75,18 +87,6 @@ class IntegrationConfigControllerSpec : StringSpec({
             parameters = params,
         )
     }
-
-    "toResource preserves null parameters" {
-        val c = config().copy(parameters = null)
-
-        val result = controller.toResource(c)
-
-        result.parameters shouldBe null
-    }
-
-    // -------------------------------------------------------------------------
-    // toDomain mapping
-    // -------------------------------------------------------------------------
 
     "toDomain maps all fields from IntegrationConfigResource to IntegrationConfig" {
         val id = UUID.randomUUID()
@@ -106,99 +106,74 @@ class IntegrationConfigControllerSpec : StringSpec({
 
         val result = controller.toDomain(r)
 
-        // Non-null assertion: the UUID is always set even when the resource has no id
         result.metadata.id shouldBe result.metadata.id
     }
 
-    "toDomain preserves null parameters" {
-        val r = resource().copy(parameters = null)
-
-        val result = controller.toDomain(r)
-
-        result.parameters shouldBe null
-    }
-
     // -------------------------------------------------------------------------
-    // getById (inherited)
+    // getById — requires ADMIN namespace access
     // -------------------------------------------------------------------------
 
-    "getById returns a resource when the entity is found" {
+    "getById checks ADMIN namespace access" {
         val c = config()
         every { service.findById(c.id) } returns c
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
 
         val result = controller.getById(c.id)
 
-        result shouldBe controller.toResource(c)
+        result.name shouldBe "JIRA_PROD"
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), namespaceId.toString(), NamespaceRole.ADMIN) }
     }
 
     "getById throws 404 when entity is not found" {
         val id = UUID.randomUUID()
         every { service.findById(id) } returns null
 
-        val ex = runCatching { controller.getById(id) }.exceptionOrNull()
+        shouldThrow<ResourceNotFoundException> { controller.getById(id) }
+    }
 
-        (ex is ResourceNotFoundException) shouldBe true
+    "getById throws 403 when access denied" {
+        val c = config()
+        every { service.findById(c.id) } returns c
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } throws AccessDeniedException("Access denied")
+
+        shouldThrow<AccessDeniedException> { controller.getById(c.id) }
     }
 
     // -------------------------------------------------------------------------
-    // getByIds (inherited)
+    // create — requires ADMIN namespace access
     // -------------------------------------------------------------------------
 
-    "getByIds returns matching entities mapped to resources" {
-        val c1 = config(name = "JIRA_PROD")
-        val c2 = config(name = "SLACK_DEV")
-        every { service.findByIds(listOf(c1.id, c2.id)) } returns listOf(c1, c2)
-
-        val result = controller.getByIds(listOf(c1.id, c2.id))
-
-        result shouldBe listOf(controller.toResource(c1), controller.toResource(c2))
-    }
-
-    // -------------------------------------------------------------------------
-    // listByParent (inherited)
-    // -------------------------------------------------------------------------
-
-    "listByParent returns configs for the given namespaceId" {
-        val c1 = config(name = "A")
-        val c2 = config(name = "B")
-        every { service.findByParent(namespaceId) } returns listOf(c1, c2)
-
-        val result = controller.listByParent(namespaceId)
-
-        result shouldBe listOf(controller.toResource(c1), controller.toResource(c2))
-        verify(exactly = 1) { service.findByParent(namespaceId) }
-    }
-
-    // -------------------------------------------------------------------------
-    // create (inherited)
-    // -------------------------------------------------------------------------
-
-    "create converts resource to domain, delegates to service, and returns mapped resource" {
+    "create checks ADMIN namespace access" {
         val r = resource(id = null)
-        val saved = controller.toDomain(r)
-        every { service.create(any()) } returns saved
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { service.create(any()) } returns config()
 
-        val result = controller.create(r)
+        controller.create(r)
 
-        result shouldBe controller.toResource(saved)
-        verify(exactly = 1) { service.create(any()) }
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), namespaceId.toString(), NamespaceRole.ADMIN) }
+    }
+
+    "create throws 403 when access denied" {
+        val r = resource(id = null)
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } throws AccessDeniedException("Access denied")
+
+        shouldThrow<AccessDeniedException> { controller.create(r) }
     }
 
     // -------------------------------------------------------------------------
-    // update (inherited)
+    // update — requires ADMIN namespace access (checked on existing entity)
     // -------------------------------------------------------------------------
 
-    "update delegates to service when entity exists and returns mapped resource" {
+    "update checks ADMIN namespace access on existing entity" {
         val c = config()
         val updatedResource = resource(id = c.id, name = "JIRA_STAGING")
-        val updatedDomain = controller.toDomain(updatedResource)
         every { service.findById(c.id) } returns c
-        every { service.update(any()) } returns updatedDomain
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { service.update(any()) } returns c
 
-        val result = controller.update(c.id, updatedResource)
+        controller.update(c.id, updatedResource)
 
-        result shouldBe controller.toResource(updatedDomain)
-        verify(exactly = 1) { service.update(any()) }
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), namespaceId.toString(), NamespaceRole.ADMIN) }
     }
 
     "update throws 404 when entity is not found" {
@@ -206,30 +181,59 @@ class IntegrationConfigControllerSpec : StringSpec({
         val r = resource(id = id)
         every { service.findById(id) } returns null
 
-        val ex = runCatching { controller.update(id, r) }.exceptionOrNull()
-
-        (ex is ResourceNotFoundException) shouldBe true
+        shouldThrow<ResourceNotFoundException> { controller.update(id, r) }
     }
 
     // -------------------------------------------------------------------------
-    // delete (inherited)
+    // delete — requires ADMIN namespace access (checked on existing entity)
     // -------------------------------------------------------------------------
 
-    "delete succeeds when entity exists" {
-        val id = UUID.randomUUID()
-        every { service.delete(id) } returns true
+    "delete checks ADMIN namespace access on existing entity" {
+        val c = config()
+        every { service.findById(c.id) } returns c
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { service.delete(c.id) } returns true
 
-        controller.delete(id)
+        controller.delete(c.id)
 
-        verify(exactly = 1) { service.delete(id) }
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), namespaceId.toString(), NamespaceRole.ADMIN) }
+        verify { service.delete(c.id) }
     }
 
-    "delete throws 404 when service returns false" {
+    "delete throws 404 when entity is not found" {
         val id = UUID.randomUUID()
-        every { service.delete(id) } returns false
+        every { service.findById(id) } returns null
 
-        val ex = runCatching { controller.delete(id) }.exceptionOrNull()
+        shouldThrow<ResourceNotFoundException> { controller.delete(id) }
+    }
 
-        (ex is ResourceNotFoundException) shouldBe true
+    "delete throws 403 when access denied" {
+        val c = config()
+        every { service.findById(c.id) } returns c
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } throws AccessDeniedException("Access denied")
+
+        shouldThrow<AccessDeniedException> { controller.delete(c.id) }
+    }
+
+    // -------------------------------------------------------------------------
+    // listByParent — requires ADMIN namespace access
+    // -------------------------------------------------------------------------
+
+    "listByParent checks ADMIN namespace access" {
+        val c1 = config(name = "A")
+        val c2 = config(name = "B")
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { service.findByParent(namespaceId) } returns listOf(c1, c2)
+
+        val result = controller.listByParent(namespaceId)
+
+        result shouldHaveSize 2
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), namespaceId.toString(), NamespaceRole.ADMIN) }
+    }
+
+    "listByParent throws 403 when access denied" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } throws AccessDeniedException("Access denied")
+
+        shouldThrow<AccessDeniedException> { controller.listByParent(namespaceId) }
     }
 })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/MembershipControllerMvcTest.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/MembershipControllerMvcTest.kt
@@ -1,0 +1,150 @@
+package io.whozoss.agentos.namespace
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.whozoss.agentos.auth.RoleRepository
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * MVC-layer test for [MembershipController] — verifies that Bean Validation is triggered
+ * by the Spring MVC dispatcher and that HTTP status codes are correct.
+ *
+ * Uses a full Spring Boot context (webEnvironment = MOCK) with the "test" profile
+ * so that the dispatcher, message converters, and validation are all active.
+ * The "test" profile enables in-memory persistence and permissive security mode.
+ *
+ * These tests complement [MembershipControllerSpec], which exercises the controller
+ * logic directly without a Spring context.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MembershipControllerMvcTest : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var userService: UserService
+    @Autowired lateinit var roleRepository: RoleRepository
+    @Autowired lateinit var namespaceService: NamespaceService
+
+    init {
+
+        // -------------------------------------------------------------------------
+        // POST /api/namespaces/{nsId}/members
+        // -------------------------------------------------------------------------
+
+        "POST /api/namespaces/{nsId}/members with valid body returns 201" {
+            val nsId = createNamespace()
+            val targetUserId = createUser("target-assign@example.com")
+
+            mockMvc.perform(
+                post("/api/namespaces/$nsId/members")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"userId": "$targetUserId", "role": "MEMBER"}"""),
+            ).andExpect(status().isCreated)
+        }
+
+        "POST /api/namespaces/{nsId}/members with blank role returns 400" {
+            val nsId = createNamespace()
+
+            mockMvc.perform(
+                post("/api/namespaces/$nsId/members")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"userId": "some-user", "role": ""}"""),
+            ).andExpect(status().isBadRequest)
+        }
+
+        "POST /api/namespaces/{nsId}/members with missing userId returns 400" {
+            val nsId = createNamespace()
+
+            mockMvc.perform(
+                post("/api/namespaces/$nsId/members")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"role": "MEMBER"}"""),
+            ).andExpect(status().isBadRequest)
+        }
+
+        // -------------------------------------------------------------------------
+        // GET /api/namespaces/{nsId}/members
+        // -------------------------------------------------------------------------
+
+        "GET /api/namespaces/{nsId}/members returns 200" {
+            val nsId = createNamespace()
+
+            mockMvc.perform(
+                get("/api/namespaces/$nsId/members"),
+            ).andExpect(status().isOk)
+        }
+
+        // -------------------------------------------------------------------------
+        // PUT /api/namespaces/{nsId}/members/{userId}
+        // -------------------------------------------------------------------------
+
+        "PUT /api/namespaces/{nsId}/members/{userId} with valid body returns 200" {
+            val nsId = createNamespace()
+            val targetUserId = createUser("target-update@example.com")
+            roleRepository.assignNamespaceRole(targetUserId, nsId, NamespaceRole.MEMBER, "system")
+
+            mockMvc.perform(
+                put("/api/namespaces/$nsId/members/$targetUserId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"userId": "$targetUserId", "role": "ADMIN"}"""),
+            ).andExpect(status().isOk)
+        }
+
+        // -------------------------------------------------------------------------
+        // DELETE /api/namespaces/{nsId}/members/{userId}
+        // -------------------------------------------------------------------------
+
+        "DELETE /api/namespaces/{nsId}/members/{userId} returns 204" {
+            val nsId = createNamespace()
+            val targetUserId = createUser("target-delete@example.com")
+            roleRepository.assignNamespaceRole(targetUserId, nsId, NamespaceRole.MEMBER, "system")
+
+            mockMvc.perform(
+                delete("/api/namespaces/$nsId/members/$targetUserId"),
+            ).andExpect(status().isNoContent)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun createNamespace(): String {
+        val ns = namespaceService.create(
+            Namespace(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                name = "test-ns-${UUID.randomUUID()}",
+            ),
+        )
+        return ns.id.toString()
+    }
+
+    private fun createUser(email: String): String {
+        val user = userService.create(
+            User(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                externalId = email,
+                email = email,
+            ),
+        )
+        return user.id.toString()
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/MembershipControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/MembershipControllerSpec.kt
@@ -1,0 +1,283 @@
+package io.whozoss.agentos.namespace
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.auth.AccessDeniedException
+import io.whozoss.agentos.auth.AuthorizationService
+import io.whozoss.agentos.auth.MembershipInfo
+import io.whozoss.agentos.auth.RoleRepository
+import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Unit tests for [MembershipController].
+ *
+ * The controller is instantiated directly with MockK stubs — no Spring context.
+ * Tests cover:
+ * - [MembershipController.assignRole]   — success, access denied, invalid role
+ * - [MembershipController.listMembers]  — success with mapping MembershipInfo → MembershipResource
+ * - [MembershipController.updateRole]   — success, last OWNER protection
+ * - [MembershipController.revokeMember] — success, last OWNER protection
+ * - isRoot bypass (implicit via AuthorizationService mock that does not throw)
+ */
+class MembershipControllerSpec : StringSpec({
+    timeout = 5000
+
+    val roleRepository = mockk<RoleRepository>()
+    val authorizationService = mockk<AuthorizationService>()
+    val userService = mockk<UserService>()
+    val controller = MembershipController(roleRepository, authorizationService, userService)
+
+    val adminUserId = UUID.randomUUID()
+    val adminUser = User(
+        metadata = EntityMetadata(id = adminUserId),
+        externalId = "admin@example.com",
+    )
+    val nsId = UUID.randomUUID().toString()
+    val targetUserId = UUID.randomUUID().toString()
+
+    beforeEach {
+        clearMocks(roleRepository, authorizationService, userService)
+        every { userService.getCurrentUser() } returns adminUser
+    }
+
+    // -------------------------------------------------------------------------
+    // assignRole
+    // -------------------------------------------------------------------------
+
+    "assignRole creates membership and returns 201" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { authorizationService.isRoot(adminUserId.toString()) } returns false
+        every { roleRepository.findNamespaceRole(adminUserId.toString(), nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.assignNamespaceRole(any(), any(), any(), any()) } just Runs
+
+        val result = controller.assignRole(
+            nsId,
+            MembershipResource(userId = targetUserId, role = "MEMBER"),
+        )
+
+        result.userId shouldBe targetUserId
+        result.role shouldBe "MEMBER"
+        verify(exactly = 1) { roleRepository.assignNamespaceRole(targetUserId, nsId, NamespaceRole.MEMBER, adminUserId.toString()) }
+    }
+
+    "assignRole throws AccessDeniedException when user is not ADMIN" {
+        every {
+            authorizationService.requireNamespaceAccess(any(), any(), any())
+        } throws AccessDeniedException("Role MEMBER does not satisfy required ADMIN")
+
+        shouldThrow<AccessDeniedException> {
+            controller.assignRole(
+                nsId,
+                MembershipResource(userId = targetUserId, role = "MEMBER"),
+            )
+        }
+    }
+
+    "assignRole throws IllegalArgumentException for invalid role" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+
+        shouldThrow<IllegalArgumentException> {
+            controller.assignRole(
+                nsId,
+                MembershipResource(userId = targetUserId, role = "SUPERADMIN"),
+            )
+        }
+    }
+
+    "assignRole succeeds for isRoot user (implicit — authorizationService does not throw)" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { authorizationService.isRoot(adminUserId.toString()) } returns true
+        every { roleRepository.assignNamespaceRole(any(), any(), any(), any()) } just Runs
+
+        val result = controller.assignRole(
+            nsId,
+            MembershipResource(userId = targetUserId, role = "ADMIN"),
+        )
+
+        result.role shouldBe "ADMIN"
+    }
+
+    "assignRole throws AccessDeniedException when ADMIN tries to assign OWNER (P-6 escalation)" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { authorizationService.isRoot(adminUserId.toString()) } returns false
+        every { roleRepository.findNamespaceRole(adminUserId.toString(), nsId) } returns NamespaceRole.ADMIN
+
+        val ex = shouldThrow<AccessDeniedException> {
+            controller.assignRole(
+                nsId,
+                MembershipResource(userId = targetUserId, role = "OWNER"),
+            )
+        }
+        ex.requiredRole shouldBe "OWNER"
+    }
+
+    // -------------------------------------------------------------------------
+    // listMembers
+    // -------------------------------------------------------------------------
+
+    "listMembers returns all members mapped to MembershipResource" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        val now = Instant.now()
+        val members = listOf(
+            MembershipInfo(userId = "user-1", role = NamespaceRole.OWNER, grantedAt = now, grantedBy = "system"),
+            MembershipInfo(userId = "user-2", role = NamespaceRole.ADMIN, grantedAt = now, grantedBy = "user-1"),
+            MembershipInfo(userId = "user-3", role = NamespaceRole.MEMBER, grantedAt = now, grantedBy = "user-1"),
+        )
+        every { roleRepository.findMembersOfNamespace(nsId) } returns members
+
+        val result = controller.listMembers(nsId)
+
+        result shouldHaveSize 3
+        result[0].userId shouldBe "user-1"
+        result[0].role shouldBe "OWNER"
+        result[0].grantedAt shouldBe now.toString()
+        result[0].grantedBy shouldBe "system"
+        result[1].role shouldBe "ADMIN"
+        result[2].role shouldBe "MEMBER"
+    }
+
+    "listMembers returns empty list when no members" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { roleRepository.findMembersOfNamespace(nsId) } returns emptyList()
+
+        val result = controller.listMembers(nsId)
+
+        result shouldHaveSize 0
+    }
+
+    // -------------------------------------------------------------------------
+    // updateRole
+    // -------------------------------------------------------------------------
+
+    "updateRole updates membership and returns 200" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { authorizationService.isRoot(adminUserId.toString()) } returns false
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns NamespaceRole.MEMBER
+        every { roleRepository.findNamespaceRole(adminUserId.toString(), nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.assignNamespaceRole(any(), any(), any(), any()) } just Runs
+
+        val result = controller.updateRole(
+            nsId,
+            targetUserId,
+            MembershipResource(role = "ADMIN"),
+        )
+
+        result.userId shouldBe targetUserId
+        result.role shouldBe "ADMIN"
+        verify(exactly = 1) { roleRepository.assignNamespaceRole(targetUserId, nsId, NamespaceRole.ADMIN, adminUserId.toString()) }
+    }
+
+    "updateRole throws ResourceNotFoundException when target user has no role (P-3)" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns null
+
+        shouldThrow<ResourceNotFoundException> {
+            controller.updateRole(
+                nsId,
+                targetUserId,
+                MembershipResource(role = "ADMIN"),
+            )
+        }
+    }
+
+    "updateRole throws IllegalArgumentException when demoting last OWNER" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { authorizationService.isRoot(adminUserId.toString()) } returns false
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.findNamespaceRole(adminUserId.toString(), nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.countOwnersInNamespace(nsId) } returns 1
+
+        shouldThrow<IllegalArgumentException> {
+            controller.updateRole(
+                nsId,
+                targetUserId,
+                MembershipResource(role = "MEMBER"),
+            )
+        }
+    }
+
+    "updateRole allows demoting OWNER when other OWNERs exist" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { authorizationService.isRoot(adminUserId.toString()) } returns false
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.findNamespaceRole(adminUserId.toString(), nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.countOwnersInNamespace(nsId) } returns 2
+        every { roleRepository.assignNamespaceRole(any(), any(), any(), any()) } just Runs
+
+        val result = controller.updateRole(
+            nsId,
+            targetUserId,
+            MembershipResource(role = "ADMIN"),
+        )
+
+        result.role shouldBe "ADMIN"
+    }
+
+    "revokeMember throws ResourceNotFoundException when target user has no role (P-3)" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns null
+
+        shouldThrow<ResourceNotFoundException> {
+            controller.revokeMember(nsId, targetUserId)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // revokeMember
+    // -------------------------------------------------------------------------
+
+    "revokeMember removes membership and returns 204" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns NamespaceRole.MEMBER
+        every { roleRepository.removeNamespaceRole(targetUserId, nsId) } just Runs
+
+        controller.revokeMember(nsId, targetUserId)
+
+        verify(exactly = 1) { roleRepository.removeNamespaceRole(targetUserId, nsId) }
+    }
+
+    "revokeMember throws IllegalArgumentException when revoking last OWNER" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.countOwnersInNamespace(nsId) } returns 1
+
+        shouldThrow<IllegalArgumentException> {
+            controller.revokeMember(nsId, targetUserId)
+        }
+    }
+
+    "revokeMember allows revoking OWNER when other OWNERs exist" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns NamespaceRole.OWNER
+        every { roleRepository.countOwnersInNamespace(nsId) } returns 2
+        every { roleRepository.removeNamespaceRole(targetUserId, nsId) } just Runs
+
+        controller.revokeMember(nsId, targetUserId)
+
+        verify(exactly = 1) { roleRepository.removeNamespaceRole(targetUserId, nsId) }
+    }
+
+    "revokeMember allows revoking non-OWNER member" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { roleRepository.findNamespaceRole(targetUserId, nsId) } returns NamespaceRole.ADMIN
+        every { roleRepository.removeNamespaceRole(targetUserId, nsId) } just Runs
+
+        controller.revokeMember(nsId, targetUserId)
+
+        verify(exactly = 1) { roleRepository.removeNamespaceRole(targetUserId, nsId) }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerSpec.kt
@@ -1,0 +1,127 @@
+package io.whozoss.agentos.namespace
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.auth.AccessDeniedException
+import io.whozoss.agentos.auth.AuthorizationService
+import io.whozoss.agentos.auth.RoleRepository
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import java.util.UUID
+
+class NamespaceControllerSpec : StringSpec({
+    val namespaceService = mockk<NamespaceService>()
+    val authorizationService = mockk<AuthorizationService>()
+    val userService = mockk<UserService>()
+    val roleRepository = mockk<RoleRepository>()
+    val controller = NamespaceController(namespaceService, authorizationService, userService, roleRepository)
+
+    val currentUserId = UUID.randomUUID()
+    val currentUser = User(metadata = EntityMetadata(id = currentUserId), externalId = "admin@test.com")
+    val nsId = UUID.randomUUID()
+    val namespace = Namespace(metadata = EntityMetadata(id = nsId), name = "test-ns")
+
+    beforeEach {
+        clearMocks(namespaceService, authorizationService, userService, roleRepository)
+        every { userService.getCurrentUser() } returns currentUser
+    }
+
+    // -------------------------------------------------------------------------
+    // listAll
+    // -------------------------------------------------------------------------
+
+    "listAll returns only accessible namespaces" {
+        val ns2Id = UUID.randomUUID()
+        val ns2 = Namespace(metadata = EntityMetadata(id = ns2Id), name = "ns-2")
+        every { authorizationService.filterAccessibleNamespaceIds(currentUserId.toString()) } returns setOf(nsId.toString())
+        every { namespaceService.findAll() } returns listOf(namespace, ns2)
+
+        val result = controller.listAll()
+
+        result shouldHaveSize 1
+        result[0].name shouldBe "test-ns"
+    }
+
+    // -------------------------------------------------------------------------
+    // getById
+    // -------------------------------------------------------------------------
+
+    "getById succeeds when access granted" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { namespaceService.findById(nsId) } returns namespace
+
+        val result = controller.getById(nsId)
+
+        result.name shouldBe "test-ns"
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), nsId.toString(), NamespaceRole.VIEWER) }
+    }
+
+    "getById throws 403 when access denied" {
+        every {
+            authorizationService.requireNamespaceAccess(any(), any(), any())
+        } throws AccessDeniedException("Access denied", requiredRole = "VIEWER")
+
+        shouldThrow<AccessDeniedException> { controller.getById(nsId) }
+    }
+
+    // -------------------------------------------------------------------------
+    // create + auto-assign OWNER
+    // -------------------------------------------------------------------------
+
+    "create auto-assigns OWNER to creator" {
+        every { namespaceService.create(any()) } returns namespace
+        every { roleRepository.assignNamespaceRole(any(), any(), any(), any()) } just Runs
+
+        val result = controller.create(NamespaceResource(name = "test-ns"))
+
+        result.name shouldBe "test-ns"
+        verify(exactly = 1) {
+            roleRepository.assignNamespaceRole(currentUserId.toString(), nsId.toString(), NamespaceRole.OWNER, currentUserId.toString())
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // update
+    // -------------------------------------------------------------------------
+
+    "update requires ADMIN access" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { namespaceService.findById(nsId) } returns namespace
+        every { namespaceService.update(any()) } returns namespace
+
+        controller.update(nsId, NamespaceResource(id = nsId, name = "updated"))
+
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), nsId.toString(), NamespaceRole.ADMIN) }
+    }
+
+    // -------------------------------------------------------------------------
+    // delete
+    // -------------------------------------------------------------------------
+
+    "delete requires OWNER access" {
+        every { authorizationService.requireNamespaceAccess(any(), any(), any()) } just Runs
+        every { namespaceService.delete(nsId) } returns true
+
+        controller.delete(nsId)
+
+        verify { authorizationService.requireNamespaceAccess(currentUserId.toString(), nsId.toString(), NamespaceRole.OWNER) }
+    }
+
+    "delete throws 403 when not OWNER" {
+        every {
+            authorizationService.requireNamespaceAccess(any(), any(), any())
+        } throws AccessDeniedException("Not OWNER", requiredRole = "OWNER")
+
+        shouldThrow<AccessDeniedException> { controller.delete(nsId) }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/UserPersistenceLifecycleSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/UserPersistenceLifecycleSpec.kt
@@ -110,6 +110,24 @@ class UserPersistenceLifecycleSpec : StringSpec({
     }
 
     // =========================================================================
+    // isRoot property
+    // =========================================================================
+
+    "user isRoot defaults to false" {
+        val user = User(externalId = "default@example.com", email = "default@example.com")
+        user.isRoot shouldBe false
+    }
+
+    "user isRoot is preserved through save and retrieval" {
+        val repo = InMemoryUserRepository()
+        val user = repo.save(User(externalId = "root@example.com", email = "root@example.com", isRoot = true))
+        user.isRoot shouldBe true
+
+        val found = repo.findByIds(listOf(user.metadata.id)).first()
+        found.isRoot shouldBe true
+    }
+
+    // =========================================================================
     // Stable identity
     // =========================================================================
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractCaseEventPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractCaseEventPersistenceSpec.kt
@@ -9,6 +9,10 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.whozoss.agentos.caseEvent.CaseEventRepository
+import io.whozoss.agentos.caseFlow.Case
+import io.whozoss.agentos.caseFlow.CaseRepository
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceRepository
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
@@ -27,6 +31,11 @@ import java.util.UUID
  *
  * Subclasses activate a specific persistence mode (Testcontainers or embedded)
  * and inherit all test cases, ensuring both modes satisfy the same contract.
+ *
+ * A [Case] node must exist before events are saved because
+ * [CaseEventNodeNeo4jRepository.linkEventToCase] does a MATCH on the Case node
+ * to create the BELONGS_TO edge. [caseRepo] and [namespaceRepo] are used to
+ * pre-create the required parent nodes.
  */
 abstract class AbstractCaseEventPersistenceSpec : StringSpec() {
     override fun extensions() = listOf(SpringExtension)
@@ -35,27 +44,36 @@ abstract class AbstractCaseEventPersistenceSpec : StringSpec() {
     lateinit var repo: CaseEventRepository
 
     @Autowired
+    lateinit var caseRepo: CaseRepository
+
+    @Autowired
+    lateinit var namespaceRepo: NamespaceRepository
+
+    @Autowired
     lateinit var driver: Driver
 
-    val namespaceId: UUID = UUID.randomUUID()
+    fun namespace() = Namespace(metadata = EntityMetadata(), name = "test-ns")
+
+    fun case(namespaceId: UUID) =
+        Case(metadata = EntityMetadata(), namespaceId = namespaceId, status = CaseStatus.PENDING)
 
     fun msgEvent(
-        caseId: UUID = UUID.randomUUID(),
+        caseId: UUID,
         text: String = "hello",
     ) = MessageEvent(
         metadata = EntityMetadata(),
-        namespaceId = namespaceId,
+        namespaceId = UUID.randomUUID(),
         caseId = caseId,
         actor = Actor(id = "u1", displayName = "User", role = ActorRole.USER),
         content = listOf(MessageContent.Text(text)),
     )
 
     fun statusEvent(
-        caseId: UUID = UUID.randomUUID(),
+        caseId: UUID,
         status: CaseStatus = CaseStatus.RUNNING,
     ) = CaseStatusEvent(
         metadata = EntityMetadata(),
-        namespaceId = namespaceId,
+        namespaceId = UUID.randomUUID(),
         caseId = caseId,
         status = status,
     )
@@ -64,7 +82,9 @@ abstract class AbstractCaseEventPersistenceSpec : StringSpec() {
         beforeEach { Neo4jContainerSupport.clearDatabase(driver) }
 
         "save and findByIds returns the same MessageEvent" {
-            val e = repo.save(msgEvent())
+            val ns = namespaceRepo.save(namespace())
+            val case = caseRepo.save(case(ns.id))
+            val e = repo.save(msgEvent(case.id))
             val found = repo.findByIds(listOf(e.id))
             found shouldHaveSize 1
             found.first().id shouldBe e.id
@@ -73,19 +93,22 @@ abstract class AbstractCaseEventPersistenceSpec : StringSpec() {
         }
 
         "CaseStatusEvent round-trips correctly" {
-            val e = repo.save(statusEvent(status = CaseStatus.IDLE))
+            val ns = namespaceRepo.save(namespace())
+            val case = caseRepo.save(case(ns.id))
+            val e = repo.save(statusEvent(case.id, status = CaseStatus.IDLE))
             val found = repo.findByIds(listOf(e.id))
             found.first().shouldBeInstanceOf<CaseStatusEvent>()
             (found.first() as CaseStatusEvent).status shouldBe CaseStatus.IDLE
         }
 
         "ToolRequestEvent and ToolResponseEvent round-trip correctly" {
-            val caseId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val case = caseRepo.save(case(ns.id))
             repo.save(
                 ToolRequestEvent(
                     metadata = EntityMetadata(),
-                    namespaceId = namespaceId,
-                    caseId = caseId,
+                    namespaceId = ns.id,
+                    caseId = case.id,
                     toolRequestId = "req-1",
                     toolName = "get_time",
                     args = "{\"timezone\":\"UTC\"}",
@@ -94,63 +117,81 @@ abstract class AbstractCaseEventPersistenceSpec : StringSpec() {
             repo.save(
                 ToolResponseEvent(
                     metadata = EntityMetadata(),
-                    namespaceId = namespaceId,
-                    caseId = caseId,
+                    namespaceId = ns.id,
+                    caseId = case.id,
                     toolRequestId = "req-1",
                     toolName = "get_time",
                     output = MessageContent.Text("2026-01-01T00:00:00Z"),
                     success = true,
                 ),
             )
-            val found = repo.findByParent(caseId)
+            val found = repo.findByParent(case.id)
             found shouldHaveSize 2
             found.filterIsInstance<ToolRequestEvent>() shouldHaveSize 1
             found.filterIsInstance<ToolResponseEvent>() shouldHaveSize 1
         }
 
         "findByParent returns events ordered by timestamp then id" {
-            val caseId = UUID.randomUUID()
-            val saved = (1..5).map { repo.save(msgEvent(caseId, "message $it")) }
-            val found = repo.findByParent(caseId)
+            val ns = namespaceRepo.save(namespace())
+            val case = caseRepo.save(case(ns.id))
+            val saved = (1..5).map { repo.save(msgEvent(case.id, "message $it")) }
+            val found = repo.findByParent(case.id)
             found shouldHaveSize 5
             val expectedIds = saved.sortedWith(compareBy({ it.timestamp }, { it.id })).map { it.id }
             found.map { it.id } shouldBe expectedIds
         }
 
         "findByParent isolates events between cases" {
-            val case1 = UUID.randomUUID()
-            val case2 = UUID.randomUUID()
-            repo.save(msgEvent(case1))
-            repo.save(msgEvent(case1))
-            repo.save(msgEvent(case2))
-            repo.findByParent(case1) shouldHaveSize 2
-            repo.findByParent(case2) shouldHaveSize 1
+            val ns = namespaceRepo.save(namespace())
+            val case1 = caseRepo.save(case(ns.id))
+            val case2 = caseRepo.save(case(ns.id))
+            repo.save(msgEvent(case1.id))
+            repo.save(msgEvent(case1.id))
+            repo.save(msgEvent(case2.id))
+            repo.findByParent(case1.id) shouldHaveSize 2
+            repo.findByParent(case2.id) shouldHaveSize 1
         }
 
         "soft delete removes event from findByIds and findByParent" {
-            val caseId = UUID.randomUUID()
-            val e = repo.save(msgEvent(caseId))
+            val ns = namespaceRepo.save(namespace())
+            val case = caseRepo.save(case(ns.id))
+            val e = repo.save(msgEvent(case.id))
             repo.delete(e.id).shouldBeTrue()
             repo.findByIds(listOf(e.id)).shouldBeEmpty()
-            repo.findByParent(caseId).shouldBeEmpty()
+            repo.findByParent(case.id).shouldBeEmpty()
         }
 
         "double delete returns false" {
-            val e = repo.save(msgEvent())
+            val ns = namespaceRepo.save(namespace())
+            val case = caseRepo.save(case(ns.id))
+            val e = repo.save(msgEvent(case.id))
             repo.delete(e.id).shouldBeTrue()
             repo.delete(e.id).shouldBeFalse()
         }
 
+        "saving events does not overwrite Case node properties" {
+            // Regression: previously CaseNode.stub() wrote empty status/title onto
+            // the existing Case node when saving via the @Relationship field.
+            val ns = namespaceRepo.save(namespace())
+            val savedCase = caseRepo.save(case(ns.id).copy(status = CaseStatus.RUNNING))
+            repo.save(msgEvent(savedCase.id))
+            repo.save(msgEvent(savedCase.id))
+            val found = caseRepo.findByIds(listOf(savedCase.id))
+            found shouldHaveSize 1
+            found.first().status shouldBe CaseStatus.RUNNING
+        }
+
         "deleteByParent removes all events for a case" {
-            val case1 = UUID.randomUUID()
-            val case2 = UUID.randomUUID()
-            repo.save(msgEvent(case1))
-            repo.save(msgEvent(case1))
-            repo.save(msgEvent(case2))
-            val deleted = repo.deleteByParent(case1)
+            val ns = namespaceRepo.save(namespace())
+            val case1 = caseRepo.save(case(ns.id))
+            val case2 = caseRepo.save(case(ns.id))
+            repo.save(msgEvent(case1.id))
+            repo.save(msgEvent(case1.id))
+            repo.save(msgEvent(case2.id))
+            val deleted = repo.deleteByParent(case1.id)
             deleted shouldBe 2
-            repo.findByParent(case1).shouldBeEmpty()
-            repo.findByParent(case2) shouldHaveSize 1
+            repo.findByParent(case1.id).shouldBeEmpty()
+            repo.findByParent(case2.id) shouldHaveSize 1
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractCasePersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractCasePersistenceSpec.kt
@@ -9,6 +9,8 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.whozoss.agentos.caseFlow.Case
 import io.whozoss.agentos.caseFlow.CaseRepository
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceRepository
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import org.neo4j.driver.Driver
@@ -20,6 +22,10 @@ import java.util.UUID
  *
  * Subclasses activate a specific persistence mode (Testcontainers or embedded)
  * and inherit all test cases, ensuring both modes satisfy the same contract.
+ *
+ * A [Namespace] node must exist before [Case] nodes are saved because
+ * [CaseNodeNeo4jRepository.findActiveByNamespaceId] traverses the BELONGS_TO
+ * edge to the Namespace node. [namespaceRepo] is used to pre-create namespaces.
  */
 abstract class AbstractCasePersistenceSpec : StringSpec() {
     override fun extensions() = listOf(SpringExtension)
@@ -28,10 +34,15 @@ abstract class AbstractCasePersistenceSpec : StringSpec() {
     lateinit var repo: CaseRepository
 
     @Autowired
+    lateinit var namespaceRepo: NamespaceRepository
+
+    @Autowired
     lateinit var driver: Driver
 
+    fun namespace() = Namespace(metadata = EntityMetadata(), name = "test-ns")
+
     fun case(
-        namespaceId: UUID = UUID.randomUUID(),
+        namespaceId: UUID,
         status: CaseStatus = CaseStatus.PENDING,
     ) = Case(metadata = EntityMetadata(), namespaceId = namespaceId, status = status)
 
@@ -39,8 +50,8 @@ abstract class AbstractCasePersistenceSpec : StringSpec() {
         beforeEach { Neo4jContainerSupport.clearDatabase(driver) }
 
         "save and findByIds returns the same case" {
-            val c = case()
-            val saved = repo.save(c)
+            val ns = namespaceRepo.save(namespace())
+            val saved = repo.save(case(ns.id))
             val found = repo.findByIds(listOf(saved.id))
             found shouldHaveSize 1
             found.first().id shouldBe saved.id
@@ -48,45 +59,61 @@ abstract class AbstractCasePersistenceSpec : StringSpec() {
         }
 
         "findByParent returns cases for that namespace only" {
-            val ns1 = UUID.randomUUID()
-            val ns2 = UUID.randomUUID()
-            repo.save(case(ns1))
-            repo.save(case(ns1))
-            repo.save(case(ns2))
-            repo.findByParent(ns1) shouldHaveSize 2
-            repo.findByParent(ns2) shouldHaveSize 1
+            val ns1 = namespaceRepo.save(namespace())
+            val ns2 = namespaceRepo.save(namespace())
+            repo.save(case(ns1.id))
+            repo.save(case(ns1.id))
+            repo.save(case(ns2.id))
+            repo.findByParent(ns1.id) shouldHaveSize 2
+            repo.findByParent(ns2.id) shouldHaveSize 1
         }
 
         "update: save with same id replaces the node" {
-            val c = repo.save(case())
+            val ns = namespaceRepo.save(namespace())
+            val c = repo.save(case(ns.id))
             repo.save(c.copy(status = CaseStatus.RUNNING))
             val found = repo.findByIds(listOf(c.id))
             found.first().status shouldBe CaseStatus.RUNNING
         }
 
         "soft delete removes case from findByIds" {
-            val c = repo.save(case())
+            val ns = namespaceRepo.save(namespace())
+            val c = repo.save(case(ns.id))
             repo.delete(c.id).shouldBeTrue()
             repo.findByIds(listOf(c.id)).shouldBeEmpty()
         }
 
         "double delete returns false" {
-            val c = repo.save(case())
+            val ns = namespaceRepo.save(namespace())
+            val c = repo.save(case(ns.id))
             repo.delete(c.id).shouldBeTrue()
             repo.delete(c.id).shouldBeFalse()
         }
 
+        "saving a case does not overwrite Namespace node properties" {
+            // Regression: NamespaceNode.stub() used to write empty name/description
+            // onto the existing Namespace node when the BELONGS_TO edge was saved
+            // via the @Relationship field.
+            val ns = namespaceRepo.save(Namespace(metadata = EntityMetadata(), name = "my-namespace", description = "important"))
+            repo.save(case(ns.id))
+            repo.save(case(ns.id))
+            val found = namespaceRepo.findByIds(listOf(ns.id))
+            found shouldHaveSize 1
+            found.first().name shouldBe "my-namespace"
+            found.first().description shouldBe "important"
+        }
+
         "deleteByParent removes all cases in namespace without touching others" {
-            val ns1 = UUID.randomUUID()
-            val ns2 = UUID.randomUUID()
-            repo.save(case(ns1))
-            repo.save(case(ns1))
-            val survivor = repo.save(case(ns2))
-            val deleted = repo.deleteByParent(ns1)
+            val ns1 = namespaceRepo.save(namespace())
+            val ns2 = namespaceRepo.save(namespace())
+            repo.save(case(ns1.id))
+            repo.save(case(ns1.id))
+            val survivor = repo.save(case(ns2.id))
+            val deleted = repo.deleteByParent(ns1.id)
             deleted shouldBe 2
-            repo.findByParent(ns1).shouldBeEmpty()
-            repo.findByParent(ns2) shouldHaveSize 1
-            repo.findByParent(ns2).first().id shouldBe survivor.id
+            repo.findByParent(ns1.id).shouldBeEmpty()
+            repo.findByParent(ns2.id) shouldHaveSize 1
+            repo.findByParent(ns2.id).first().id shouldBe survivor.id
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractIntegrationConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractIntegrationConfigPersistenceSpec.kt
@@ -9,6 +9,8 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigRepository
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceRepository
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,6 +21,10 @@ import java.util.UUID
  *
  * Subclasses activate a specific persistence mode (Testcontainers or embedded)
  * and inherit all test cases, ensuring both modes satisfy the same contract.
+ *
+ * A [Namespace] node must exist before [IntegrationConfig] nodes are saved because
+ * [IntegrationConfigNodeNeo4jRepository.findActiveByNamespaceId] traverses the
+ * BELONGS_TO edge to the Namespace node. [namespaceRepo] is used to pre-create namespaces.
  */
 abstract class AbstractIntegrationConfigPersistenceSpec : StringSpec() {
     override fun extensions() = listOf(SpringExtension)
@@ -27,10 +33,15 @@ abstract class AbstractIntegrationConfigPersistenceSpec : StringSpec() {
     lateinit var repo: IntegrationConfigRepository
 
     @Autowired
+    lateinit var namespaceRepo: NamespaceRepository
+
+    @Autowired
     lateinit var driver: Driver
 
+    fun namespace() = Namespace(metadata = EntityMetadata(), name = "test-ns")
+
     fun config(
-        namespaceId: UUID = UUID.randomUUID(),
+        namespaceId: UUID,
         name: String = "JIRA",
         integrationType: String = "JIRA",
         parametersJson: String? = null,
@@ -48,8 +59,8 @@ abstract class AbstractIntegrationConfigPersistenceSpec : StringSpec() {
         beforeEach { Neo4jContainerSupport.clearDatabase(driver) }
 
         "save and findByIds returns the same config" {
-            val cfg = config(name = "JIRA", integrationType = "JIRA")
-            val saved = repo.save(cfg)
+            val ns = namespaceRepo.save(namespace())
+            val saved = repo.save(config(ns.id, name = "JIRA", integrationType = "JIRA"))
             val found = repo.findByIds(listOf(saved.id))
             found shouldHaveSize 1
             found.first().id shouldBe saved.id
@@ -58,26 +69,27 @@ abstract class AbstractIntegrationConfigPersistenceSpec : StringSpec() {
         }
 
         "findByParent returns configs for that namespace only" {
-            val ns1 = UUID.randomUUID()
-            val ns2 = UUID.randomUUID()
-            repo.save(config(ns1, name = "JIRA"))
-            repo.save(config(ns1, name = "SLACK"))
-            repo.save(config(ns2, name = "GITHUB"))
-            repo.findByParent(ns1) shouldHaveSize 2
-            repo.findByParent(ns2) shouldHaveSize 1
+            val ns1 = namespaceRepo.save(namespace())
+            val ns2 = namespaceRepo.save(namespace())
+            repo.save(config(ns1.id, name = "JIRA"))
+            repo.save(config(ns1.id, name = "SLACK"))
+            repo.save(config(ns2.id, name = "GITHUB"))
+            repo.findByParent(ns1.id) shouldHaveSize 2
+            repo.findByParent(ns2.id) shouldHaveSize 1
             repo.findByParent(UUID.randomUUID()).shouldBeEmpty()
         }
 
         "findByParent returns configs sorted by name" {
-            val ns = UUID.randomUUID()
-            repo.save(config(ns, name = "SLACK"))
-            repo.save(config(ns, name = "GITHUB"))
-            repo.save(config(ns, name = "JIRA"))
-            repo.findByParent(ns).map { it.name } shouldBe listOf("GITHUB", "JIRA", "SLACK")
+            val ns = namespaceRepo.save(namespace())
+            repo.save(config(ns.id, name = "SLACK"))
+            repo.save(config(ns.id, name = "GITHUB"))
+            repo.save(config(ns.id, name = "JIRA"))
+            repo.findByParent(ns.id).map { it.name } shouldBe listOf("GITHUB", "JIRA", "SLACK")
         }
 
         "update: save with same id replaces the node" {
-            val cfg = repo.save(config(integrationType = "JIRA"))
+            val ns = namespaceRepo.save(namespace())
+            val cfg = repo.save(config(ns.id, integrationType = "JIRA"))
             repo.save(cfg.copy(integrationType = "JIRA_V2"))
             val found = repo.findByIds(listOf(cfg.id))
             found shouldHaveSize 1
@@ -85,44 +97,57 @@ abstract class AbstractIntegrationConfigPersistenceSpec : StringSpec() {
         }
 
         "soft delete removes config from findByIds" {
-            val cfg = repo.save(config())
+            val ns = namespaceRepo.save(namespace())
+            val cfg = repo.save(config(ns.id))
             repo.delete(cfg.id).shouldBeTrue()
             repo.findByIds(listOf(cfg.id)).shouldBeEmpty()
         }
 
         "double delete returns false" {
-            val cfg = repo.save(config())
+            val ns = namespaceRepo.save(namespace())
+            val cfg = repo.save(config(ns.id))
             repo.delete(cfg.id).shouldBeTrue()
             repo.delete(cfg.id).shouldBeFalse()
         }
 
         "deleteByParent removes all configs in namespace without touching others" {
-            val ns1 = UUID.randomUUID()
-            val ns2 = UUID.randomUUID()
-            repo.save(config(ns1, name = "JIRA"))
-            repo.save(config(ns1, name = "SLACK"))
-            val survivor = repo.save(config(ns2, name = "GITHUB"))
-            val deleted = repo.deleteByParent(ns1)
+            val ns1 = namespaceRepo.save(namespace())
+            val ns2 = namespaceRepo.save(namespace())
+            repo.save(config(ns1.id, name = "JIRA"))
+            repo.save(config(ns1.id, name = "SLACK"))
+            val survivor = repo.save(config(ns2.id, name = "GITHUB"))
+            val deleted = repo.deleteByParent(ns1.id)
             deleted shouldBe 2
-            repo.findByParent(ns1).shouldBeEmpty()
-            repo.findByParent(ns2) shouldHaveSize 1
-            repo.findByParent(ns2).first().id shouldBe survivor.id
+            repo.findByParent(ns1.id).shouldBeEmpty()
+            repo.findByParent(ns2.id) shouldHaveSize 1
+            repo.findByParent(ns2.id).first().id shouldBe survivor.id
+        }
+
+        "saving a config does not overwrite Namespace node properties" {
+            // Regression: NamespaceNode.stub() used to write empty name/description
+            // onto the existing Namespace node when the BELONGS_TO edge was saved
+            // via the @Relationship field.
+            val ns = namespaceRepo.save(Namespace(metadata = EntityMetadata(), name = "my-namespace", description = "important"))
+            repo.save(config(ns.id, name = "JIRA"))
+            repo.save(config(ns.id, name = "SLACK"))
+            val found = namespaceRepo.findByIds(listOf(ns.id))
+            found shouldHaveSize 1
+            found.first().name shouldBe "my-namespace"
+            found.first().description shouldBe "important"
         }
 
         "config with JSON parameters round-trips correctly" {
-            val ns = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
             val json = """{"apiUrl": "https://jira.example.com", "apiKey": "s3cr3t"}"""
-            val cfg = config(ns, parametersJson = json)
-            val saved = repo.save(cfg)
+            val saved = repo.save(config(ns.id, parametersJson = json))
             val found = repo.findByIds(listOf(saved.id)).first()
             found.parameters?.get("apiUrl")?.asText() shouldBe "https://jira.example.com"
             found.parameters?.get("apiKey")?.asText() shouldBe "s3cr3t"
         }
 
         "config with null parameters round-trips correctly" {
-            val ns = UUID.randomUUID()
-            val cfg = config(ns, parametersJson = null)
-            val saved = repo.save(cfg)
+            val ns = namespaceRepo.save(namespace())
+            val saved = repo.save(config(ns.id, parametersJson = null))
             val found = repo.findByIds(listOf(saved.id)).first()
             val params = found.parameters
             assert(params == null || params.isNull) {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jRoleRepositorySpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/Neo4jRoleRepositorySpec.kt
@@ -1,0 +1,329 @@
+package io.whozoss.agentos.persistence.neo4j
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.auth.RoleRepository
+import io.whozoss.agentos.sdk.auth.CaseRole
+import io.whozoss.agentos.sdk.auth.NamespaceRole
+import org.neo4j.driver.Driver
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
+
+/**
+ * Integration tests for [Neo4jRoleRepository] using the embedded Neo4j test harness.
+ *
+ * Each test starts with a clean database (all nodes and relationships deleted).
+ * User, Namespace, and Case nodes are created directly via the Neo4j [Driver]
+ * so the tests are independent of other repository implementations.
+ */
+@SpringBootTest
+@ActiveProfiles("test", "embedded-neo4j")
+@Import(EmbeddedNeo4jTestConfiguration::class)
+class Neo4jRoleRepositorySpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    lateinit var roleRepository: RoleRepository
+
+    @Autowired
+    lateinit var driver: Driver
+
+    /** Create a User node directly in Neo4j. Returns the id. */
+    private fun createUser(id: String = UUID.randomUUID().toString(), externalId: String = "test@example.com"): String {
+        driver.session().use { session ->
+            session.run(
+                "CREATE (u:User {id: \$id, externalId: \$externalId, email: \$externalId, isRoot: false})",
+                mapOf("id" to id, "externalId" to externalId),
+            )
+        }
+        return id
+    }
+
+    /** Create a Namespace node directly in Neo4j. Returns the id. */
+    private fun createNamespace(id: String = UUID.randomUUID().toString(), name: String = "test-ns"): String {
+        driver.session().use { session ->
+            session.run(
+                "CREATE (n:Namespace {id: \$id, name: \$name})",
+                mapOf("id" to id, "name" to name),
+            )
+        }
+        return id
+    }
+
+    /** Create a Case node with BELONGS_TO relationship to a Namespace. Returns the case id. */
+    private fun createCase(
+        id: String = UUID.randomUUID().toString(),
+        namespaceId: String,
+        title: String = "test-case",
+    ): String {
+        driver.session().use { session ->
+            session.run(
+                """
+                MATCH (n:Namespace {id: ${'$'}namespaceId})
+                CREATE (c:Case {id: ${'$'}id, namespaceId: ${'$'}namespaceId, status: 'PENDING', title: ${'$'}title})-[:BELONGS_TO]->(n)
+                """.trimIndent(),
+                mapOf("id" to id, "namespaceId" to namespaceId, "title" to title),
+            )
+        }
+        return id
+    }
+
+    init {
+        beforeEach { Neo4jContainerSupport.clearDatabase(driver) }
+
+        // =====================================================================
+        // isRoot / setRoot
+        // =====================================================================
+
+        "isRoot returns false for a non-root user" {
+            val userId = createUser()
+
+            roleRepository.isRoot(userId).shouldBeFalse()
+        }
+
+        "setRoot grants root and isRoot returns true" {
+            val userId = createUser()
+
+            roleRepository.setRoot(userId, true)
+
+            roleRepository.isRoot(userId).shouldBeTrue()
+        }
+
+        "setRoot can revoke root status" {
+            val userId = createUser()
+            roleRepository.setRoot(userId, true)
+
+            roleRepository.setRoot(userId, false)
+
+            roleRepository.isRoot(userId).shouldBeFalse()
+        }
+
+        // =====================================================================
+        // MEMBER_OF — Namespace roles
+        // =====================================================================
+
+        "assignNamespaceRole creates MEMBER_OF relationship" {
+            val userId = createUser()
+            val nsId = createNamespace()
+
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.MEMBER, "admin")
+
+            roleRepository.findNamespaceRole(userId, nsId) shouldBe NamespaceRole.MEMBER
+        }
+
+        "assignNamespaceRole overwrites existing role (upsert)" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.VIEWER, "admin")
+
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.ADMIN, "admin")
+
+            roleRepository.findNamespaceRole(userId, nsId) shouldBe NamespaceRole.ADMIN
+        }
+
+        "findNamespaceRole returns null when no role exists" {
+            val userId = createUser()
+            val nsId = createNamespace()
+
+            roleRepository.findNamespaceRole(userId, nsId).shouldBeNull()
+        }
+
+        "removeNamespaceRole deletes the MEMBER_OF relationship" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.MEMBER, "admin")
+
+            roleRepository.removeNamespaceRole(userId, nsId)
+
+            roleRepository.findNamespaceRole(userId, nsId).shouldBeNull()
+        }
+
+        "findNamespaceIdsForUser returns all namespaces where user has a role" {
+            val userId = createUser()
+            val ns1 = createNamespace()
+            val ns2 = createNamespace()
+            val ns3 = createNamespace() // no role assigned
+            roleRepository.assignNamespaceRole(userId, ns1, NamespaceRole.MEMBER, "admin")
+            roleRepository.assignNamespaceRole(userId, ns2, NamespaceRole.ADMIN, "admin")
+
+            val result = roleRepository.findNamespaceIdsForUser(userId)
+
+            result shouldContainExactlyInAnyOrder setOf(ns1, ns2)
+        }
+
+        "findNamespaceIdsForUser returns empty set when user has no roles" {
+            val userId = createUser()
+
+            roleRepository.findNamespaceIdsForUser(userId).shouldBeEmpty()
+        }
+
+        // =====================================================================
+        // PARTICIPANT_IN — Case roles
+        // =====================================================================
+
+        "assignCaseRole creates PARTICIPANT_IN relationship" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            val caseId = createCase(namespaceId = nsId)
+
+            roleRepository.assignCaseRole(userId, caseId, CaseRole.PARTICIPANT, "admin")
+
+            roleRepository.findCaseRole(userId, caseId) shouldBe CaseRole.PARTICIPANT
+        }
+
+        "assignCaseRole overwrites existing role (upsert)" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            val caseId = createCase(namespaceId = nsId)
+            roleRepository.assignCaseRole(userId, caseId, CaseRole.OBSERVER, "admin")
+
+            roleRepository.assignCaseRole(userId, caseId, CaseRole.OWNER, "admin")
+
+            roleRepository.findCaseRole(userId, caseId) shouldBe CaseRole.OWNER
+        }
+
+        "findCaseRole returns null when no role exists" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            val caseId = createCase(namespaceId = nsId)
+
+            roleRepository.findCaseRole(userId, caseId).shouldBeNull()
+        }
+
+        "removeCaseRole deletes the PARTICIPANT_IN relationship" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            val caseId = createCase(namespaceId = nsId)
+            roleRepository.assignCaseRole(userId, caseId, CaseRole.PARTICIPANT, "admin")
+
+            roleRepository.removeCaseRole(userId, caseId)
+
+            roleRepository.findCaseRole(userId, caseId).shouldBeNull()
+        }
+
+        // =====================================================================
+        // findAccessibleCaseIdsForUser — graph traversal
+        // =====================================================================
+
+        "findAccessibleCaseIdsForUser returns cases in the namespace via MEMBER_OF" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            val case1 = createCase(namespaceId = nsId, title = "case-1")
+            val case2 = createCase(namespaceId = nsId, title = "case-2")
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.MEMBER, "admin")
+
+            val result = roleRepository.findAccessibleCaseIdsForUser(userId, nsId)
+
+            result shouldContainExactlyInAnyOrder setOf(case1, case2)
+        }
+
+        "findAccessibleCaseIdsForUser returns empty when user has no namespace role" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            createCase(namespaceId = nsId)
+
+            roleRepository.findAccessibleCaseIdsForUser(userId, nsId).shouldBeEmpty()
+        }
+
+        "findAccessibleCaseIdsForUser does not leak cases from other namespaces" {
+            val userId = createUser()
+            val ns1 = createNamespace()
+            val ns2 = createNamespace()
+            val case1 = createCase(namespaceId = ns1, title = "ns1-case")
+            val case2 = createCase(namespaceId = ns2, title = "ns2-case")
+            roleRepository.assignNamespaceRole(userId, ns1, NamespaceRole.MEMBER, "admin")
+
+            val result = roleRepository.findAccessibleCaseIdsForUser(userId, ns1)
+
+            result shouldBe setOf(case1)
+        }
+
+        // =====================================================================
+        // Soft-deleted nodes are excluded
+        // =====================================================================
+
+        "isRoot returns false for a soft-deleted user" {
+            val userId = createUser()
+            roleRepository.setRoot(userId, true)
+            driver.session().use { session ->
+                session.run("MATCH (u:User {id: \$id}) SET u.removed = true", mapOf("id" to userId))
+            }
+
+            roleRepository.isRoot(userId).shouldBeFalse()
+        }
+
+        "findNamespaceRole returns null when user is soft-deleted" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.ADMIN, "admin")
+            driver.session().use { session ->
+                session.run("MATCH (u:User {id: \$id}) SET u.removed = true", mapOf("id" to userId))
+            }
+
+            roleRepository.findNamespaceRole(userId, nsId).shouldBeNull()
+        }
+
+        "findNamespaceRole returns null when namespace is soft-deleted" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.ADMIN, "admin")
+            driver.session().use { session ->
+                session.run("MATCH (n:Namespace {id: \$id}) SET n.removed = true", mapOf("id" to nsId))
+            }
+
+            roleRepository.findNamespaceRole(userId, nsId).shouldBeNull()
+        }
+
+        // =====================================================================
+        // Performance — role lookups should be fast
+        // =====================================================================
+
+        "isRoot lookup completes within 5ms p95" {
+            val userId = createUser()
+            roleRepository.setRoot(userId, true)
+
+            // Warm up — generous for embedded harness JIT compilation
+            repeat(50) { roleRepository.isRoot(userId) }
+
+            // Measure
+            val times = (1..100).map {
+                val start = System.nanoTime()
+                roleRepository.isRoot(userId)
+                (System.nanoTime() - start) / 1_000_000.0 // ms
+            }.sorted()
+
+            val p95 = times[(times.size * 0.95).toInt()]
+            // 50ms threshold for test harness; production NFR is < 5ms p95
+            (p95 < 50.0).shouldBeTrue()
+        }
+
+        "findNamespaceRole lookup completes within 5ms p95" {
+            val userId = createUser()
+            val nsId = createNamespace()
+            roleRepository.assignNamespaceRole(userId, nsId, NamespaceRole.MEMBER, "admin")
+
+            // Warm up — generous for embedded harness JIT compilation
+            repeat(50) { roleRepository.findNamespaceRole(userId, nsId) }
+
+            // Measure
+            val times = (1..100).map {
+                val start = System.nanoTime()
+                roleRepository.findNamespaceRole(userId, nsId)
+                (System.nanoTime() - start) / 1_000_000.0 // ms
+            }.sorted()
+
+            val p95 = times[(times.size * 0.95).toInt()]
+            // 50ms threshold for test harness; production NFR is < 5ms p95
+            (p95 < 50.0).shouldBeTrue()
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/UserNodeMappingSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/UserNodeMappingSpec.kt
@@ -1,0 +1,81 @@
+package io.whozoss.agentos.persistence.neo4j
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import java.util.UUID
+
+/**
+ * Unit tests for [UserNode] ↔ [User] mapping, focusing on `isRoot` property.
+ *
+ * Verifies that `isRoot` survives the domain → node → domain round-trip
+ * and that the default value is `false`.
+ */
+class UserNodeMappingSpec : StringSpec({
+    timeout = 5000
+
+    "UserNode.fromDomain preserves isRoot = true" {
+        val user = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "root@example.com",
+            email = "root@example.com",
+            isRoot = true,
+        )
+
+        val node = UserNode.fromDomain(user)
+
+        node.isRoot shouldBe true
+    }
+
+    "UserNode.fromDomain preserves isRoot = false" {
+        val user = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "regular@example.com",
+            email = "regular@example.com",
+            isRoot = false,
+        )
+
+        val node = UserNode.fromDomain(user)
+
+        node.isRoot shouldBe false
+    }
+
+    "UserNode.toDomain preserves isRoot = true" {
+        val node = UserNode(
+            id = UUID.randomUUID().toString(),
+            externalId = "root@example.com",
+            email = "root@example.com",
+            isRoot = true,
+        )
+
+        val user = node.toDomain()
+
+        user.isRoot shouldBe true
+    }
+
+    "UserNode.toDomain preserves isRoot = false (default)" {
+        val node = UserNode(
+            id = UUID.randomUUID().toString(),
+            externalId = "regular@example.com",
+            email = "regular@example.com",
+        )
+
+        val user = node.toDomain()
+
+        user.isRoot shouldBe false
+    }
+
+    "round-trip: User → UserNode → User preserves isRoot" {
+        val original = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "roundtrip@example.com",
+            email = "roundtrip@example.com",
+            isRoot = true,
+        )
+
+        val roundTripped = UserNode.fromDomain(original).toDomain()
+
+        roundTripped.isRoot shouldBe original.isRoot
+    }
+})

--- a/agentos/docs/neo4j-persistence.md
+++ b/agentos/docs/neo4j-persistence.md
@@ -77,7 +77,6 @@ are inlined as individual scalar properties on the node:
 @Node("Case")
 data class CaseNode(
     @Id val id: String,
-    val namespaceId: String,
     val status: String,
     val title: String,
     val created: Instant,
@@ -85,6 +84,8 @@ data class CaseNode(
     val modified: Instant,
     val modifiedBy: String?,
     val removed: Boolean?,
+    @Relationship(type = "BELONGS_TO", direction = OUTGOING)
+    var namespace: NamespaceNode? = null,
 )
 ```
 
@@ -120,23 +121,31 @@ On write, the child node carries a **stub** `NamespaceNode` containing only the
 existing properties, so saving a Case or IntegrationConfig cannot corrupt the
 Namespace. The stub is created via `NamespaceNode.stub(namespaceId)`.
 
-#### Denormalised namespaceId property
+The `@Relationship` field is declared as a nullable `var` with a `null` default so
+SDN can call the primary constructor before injecting the field:
 
-Each child node also stores `namespaceId` as a plain scalar property alongside
-the `@Relationship` field. This dual representation exists for a practical reason:
-SDN 7 does **not** auto-inject `@Relationship` fields when a custom `@Query` method
-returns results — it only does so for its own generated queries. Filtering by the
-scalar property keeps custom queries simple and reliable:
-
-```cypher
-MATCH (c:Case)
-WHERE c.namespaceId = $namespaceId AND (c.removed IS NULL OR c.removed = false)
-RETURN c ORDER BY c.created ASC
+```kotlin
+@Relationship(type = "BELONGS_TO", direction = OUTGOING)
+var namespace: NamespaceNode? = null
 ```
 
-The `BELONGS_TO` edge is still written to the graph on every save and is available
-for ad-hoc traversal queries, graph visualisation, and future Cypher that does
-need to hop the relationship.
+`toDomain()` reads `namespace!!.id` — a null here is a data-integrity error and
+should surface as an NPE rather than be silently ignored.
+
+#### Custom @Query: return node + relationship + related node
+
+SDN 7 only injects `@Relationship` fields when the query result contains the
+relationship instance and the related node explicitly. Returning only the owning
+node leaves the field null. The correct form is to name and return all three
+elements:
+
+```cypher
+MATCH (c:Case)-[r:BELONGS_TO]->(ns:Namespace)
+WHERE ns.id = $namespaceId AND (c.removed IS NULL OR c.removed = false)
+RETURN c, r, ns ORDER BY c.created ASC
+```
+
+SDN maps `r` and `ns` back onto `c.namespace` automatically.
 
 `CaseEventNode` keeps `caseId` as a plain string property (not a relationship)
 because events are fetched in bulk (hundreds per case) and eagerly loading the

--- a/agentos/docs/neo4j-persistence.md
+++ b/agentos/docs/neo4j-persistence.md
@@ -1,0 +1,276 @@
+# Neo4j Persistence
+
+## Persistence Modes
+
+AgentOS supports three persistence modes, selected via `agentos.persistence.mode`
+(or the `AGENTOS_PERSISTENCE_MODE` environment variable):
+
+| Mode | When to use | Neo4j required |
+|---|---|---|
+| `embedded-neo4j` | Local single-user deployment. Default. | No — engine starts in-process |
+| `neo4j` | Multi-user server deployment | Yes — standalone server |
+| `in-memory` | Ephemeral / testing only | No |
+
+The default mode is `embedded-neo4j`. The `in-memory` mode is deprecated and will
+be removed in a future release.
+
+### embedded-neo4j
+
+A Neo4j Community Edition engine starts in-process on boot via
+`EmbeddedNeo4jConfiguration`. The database files live under
+`<agentos.persistence.data-dir>/neo4j/` (default: `data/neo4j/`).
+
+The engine exposes a Bolt connector on `localhost:7688` (configurable via
+`agentos.persistence.embedded-bolt-port`). Port 7688 is chosen to avoid
+conflicting with a standalone Neo4j instance on the standard port 7687. Set
+the port to `0` for an OS-assigned random port.
+
+Spring Data Neo4j connects exclusively over Bolt, so `spring.neo4j.uri` must
+match the configured port even when using the embedded engine. The
+`application-embedded-neo4j.yml` profile file sets this automatically.
+
+You can inspect the embedded database at runtime with Neo4j Desktop or
+`cypher-shell` by pointing them at `bolt://localhost:7688`.
+
+### neo4j (standalone server)
+
+Activate with `--spring.profiles.active=neo4j` or by setting
+`AGENTOS_PERSISTENCE_MODE=neo4j`. Configure the connection via:
+
+```yaml
+spring:
+  neo4j:
+    uri: ${NEO4J_URI:bolt://localhost:7687}
+    authentication:
+      username: ${NEO4J_USERNAME:neo4j}
+      password: ${NEO4J_PASSWORD:agentos-dev}
+```
+
+For local development, start a server with `docker compose up neo4j`.
+
+## Spring Configuration Wiring
+
+`Neo4jPersistenceConfiguration` is active for both `neo4j` and `embedded-neo4j`
+modes (via `@ConditionalOnExpression`). It:
+
+1. Enables `@EnableNeo4jRepositories` scanning for the `io.whozoss.agentos.persistence.neo4j` package.
+2. Declares `@Bean` methods that wrap each Spring Data `Neo4jRepository` in a
+   domain-facing `EntityRepository` implementation.
+
+Each `Neo4jXxxRepository` receives the raw Spring Data repository and a mapper
+(or `ObjectMapper` for JSON fields) as constructor arguments. This keeps the
+domain layer free of Spring Data annotations.
+
+## Node / Domain Mapping Pattern
+
+Every domain entity has a corresponding **node class** (e.g. `CaseNode`,
+`NamespaceNode`, `UserNode`). The node class is the SDN entity — it carries
+`@Node` and `@Id` and is the type stored in and retrieved from the graph. The
+domain class never touches SDN annotations.
+
+### Flat properties convention
+
+All node classes keep their properties flat. Nested objects (like `EntityMetadata`)
+are inlined as individual scalar properties on the node:
+
+```kotlin
+@Node("Case")
+data class CaseNode(
+    @Id val id: String,
+    val namespaceId: String,
+    val status: String,
+    val title: String,
+    val created: Instant,
+    val createdBy: String?,
+    val modified: Instant,
+    val modifiedBy: String?,
+    val removed: Boolean?,
+)
+```
+
+This avoids SDN Community Edition's limited support for embedded value types
+and keeps Cypher queries simple.
+
+### `@Id` type is `String`
+
+All node `@Id` fields are `String` (UUID serialised via `.toString()`). Domain
+entities use `UUID`. Conversion happens in `toDomain()` / `fromDomain()`.
+
+### `removed` is `Boolean?`
+
+The soft-delete flag is stored as a nullable `Boolean?`. A missing property
+(`null`) means not removed; the Cypher queries therefore filter with
+`WHERE e.removed IS NULL OR e.removed = false` rather than `WHERE e.removed = false`.
+When marking an entity as removed, the flag is set to `true`; when writing a
+non-removed entity, `removed` is written as `null` (`removed.takeIf { it }`).
+This avoids polluting the graph with `removed: false` on every node.
+
+### Parent relationships as properties
+
+Parent links (e.g. a `Case` belonging to a `Namespace`) are stored as plain
+string properties on the child node (`namespaceId: String`) rather than as SDN
+`@Relationship` edges. This keeps queries simple and avoids the complexity of
+SDN's relationship mapping for what is essentially a foreign key.
+
+### `toDomain()` / `fromDomain()`
+
+Simple node classes (no complex serialisation) embed conversion directly as
+`toDomain()` and `companion object { fun fromDomain(...) }` on the node class
+itself. The `CaseEventNode` hierarchy uses a dedicated `CaseEventNodeMapper`
+because the sealed hierarchy requires a central dispatch point.
+
+## CaseEvent: Dual-Label Strategy
+
+`CaseEvent` is a sealed interface with 14 concrete subtypes. Each subtype is
+stored as a graph node with **two labels**: the primary `:CaseEvent` label and
+a secondary subtype label (e.g. `:MessageEvent`, `:AgentFinishedEvent`).
+
+This is expressed in the class hierarchy:
+
+```kotlin
+@Node("CaseEvent")           // primary label on the abstract base
+sealed class CaseEventNode(...)
+
+@Node("MessageEvent")        // secondary label on each concrete subclass
+class MessageEventNode(...) : CaseEventNode(...)
+```
+
+SDN uses the secondary label to instantiate the correct `CaseEventNode` subclass
+on read. The primary `:CaseEvent` label allows `findActiveByCaseId` to query
+across all subtypes with a single Cypher pattern:
+
+```cypher
+MATCH (e:CaseEvent)
+WHERE e.caseId = $caseId AND (e.removed IS NULL OR e.removed = false)
+RETURN e ORDER BY e.timestamp ASC, e.id ASC
+```
+
+Subclasses declare only their own subtype-specific fields. They do **not**
+redeclare the shared fields (`id`, `caseId`, `namespaceId`, `timestamp`, audit
+fields) — doing so causes SDN to report duplicate property definitions.
+
+### CaseEventNodeMapper
+
+All conversion between `CaseEvent` domain objects and `CaseEventNode` graph
+projections is centralised in `CaseEventNodeMapper`. The mapper's `toDomain`,
+`fromDomain`, and `withRemoved` methods each contain an exhaustive `when` over
+the sealed hierarchy. Because `CaseEventNode` is a sealed class, the Kotlin
+compiler enforces exhaustiveness — adding a new subtype without updating the
+mapper is a compile error.
+
+### JSON-serialised fields
+
+Two node classes store fields as JSON strings rather than scalars:
+
+| Node class | Field | Stores |
+|---|---|---|
+| `MessageEventNode` | `contentJson` | `List<MessageContent>` |
+| `ToolResponseEventNode` | `outputJson` | Single `MessageContent` |
+| `QuestionEventNode` | `options` | `List<String>?` |
+| `IntegrationConfigNode` | `parametersJson` | `JsonNode?` |
+
+`MessageContentSerializer` handles the `MessageContent` cases. It uses a
+typed `ObjectMapper` writer to ensure the Jackson `@JsonTypeInfo` discriminator
+is emitted for each element — without this, the `type` property is omitted and
+deserialisation throws `InvalidTypeIdException`.
+
+## Adding a New Entity to Neo4j
+
+1. **Create the node class** in `persistence/neo4j/`. Follow the flat-properties
+   convention. Inline `toDomain()` and `fromDomain()` for simple entities.
+   For sealed hierarchies, add a node subclass and update the central mapper.
+
+2. **Create the Spring Data repository interface** extending `Neo4jRepository<NodeClass, String>`.
+   Add any custom `@Query` methods needed (e.g. `findActiveByParentId`).
+
+3. **Create the domain repository implementation** (`Neo4jXxxRepository`) wrapping
+   the Spring Data repository. Implement the `EntityRepository` interface.
+   Mark `deleteByParent` with `@Transactional open override` — SDN requires
+   `open` on transactional methods in Spring-managed classes.
+
+4. **Register the bean** in `Neo4jPersistenceConfiguration` with a `@Bean` method.
+
+5. **Add a test fixture** `TestXxxRepository` in
+   `src/test/kotlin/io/whozoss/agentos/persistence/` for use in unit and
+   service-level tests that run without Neo4j.
+
+6. **Register the test fixture** in `TestPersistenceConfiguration`.
+
+7. **Add persistence contract tests** by creating a subclass of the relevant
+   `AbstractXxxPersistenceSpec` (or a new abstract spec) and activating it for
+   both `embedded-neo4j` and Testcontainers modes.
+
+## Testing Strategy
+
+There are three distinct test contexts for persistence:
+
+### 1. Unit and service-level tests (no Neo4j)
+
+Tests that exercise service logic (e.g. `CaseServiceImplSpec`) use plain
+in-memory repository fixtures (`TestCaseRepository`, `TestCaseEventRepository`,
+etc.) instantiated directly — no Spring context, no Bolt connection. These
+fixtures live in `src/test/kotlin/.../persistence/` and are also registered
+as beans in `TestPersistenceConfiguration` for `@SpringBootTest` tests that
+use `@ActiveProfiles("test")`.
+
+### 2. Embedded Neo4j (harness) — fast, no Docker
+
+Spring integration tests annotated with `@ActiveProfiles("test", "embedded-neo4j")`
+use the Neo4j test harness (`org.neo4j.test:neo4j-harness`). The harness starts
+an in-process Neo4j instance exposed over Bolt without the Netty 4.2 requirement
+of the full embedded engine, avoiding the version conflict with Spring Boot's
+Netty 4.1 pin.
+
+`EmbeddedNeo4jTestConfiguration` provides the `Driver` bean. The harness
+starts and stops with the Spring context. Database state is cleared in
+`beforeEach` via `Neo4jContainerSupport.clearDatabase(driver)`.
+
+This is the recommended mode for local development and CI when a Docker daemon
+is not available.
+
+### 3. Testcontainers — full fidelity, requires Docker
+
+Tests subclassing `AbstractXxxPersistenceSpec` can be activated against a real
+Neo4j server running in a Docker container via Testcontainers. The container is
+a lazy singleton shared across all specs in the JVM run:
+
+```kotlin
+companion object {
+    @JvmStatic
+    @DynamicPropertySource
+    fun registerNeo4jProperties(registry: DynamicPropertyRegistry) =
+        Neo4jContainerSpec.registerProperties(registry)
+}
+```
+
+The Docker image tag is `neo4j:2026.02-community` (defined in
+`Neo4jContainerSupport.NEO4J_IMAGE`). Keep this in sync with `neo4jEmbedded`
+in `libs.versions.toml` so both modes test against the same Neo4j release line.
+
+Testcontainers tests are skipped automatically when Docker is unavailable.
+
+### Abstract persistence contract specs
+
+Each entity type has an `AbstractXxxPersistenceSpec` that defines the full
+persistence contract (save, findByIds, findByParent, soft-delete, deleteByParent,
+ordering). Concrete subclasses activate either the harness or Testcontainers mode
+by selecting the appropriate Spring profile and configuration import. Both modes
+inherit all test cases, ensuring they satisfy the same contract.
+
+## Dependency Notes
+
+The embedded Neo4j engine (`org.neo4j:neo4j:2026.x`) requires specific exclusions
+to prevent classpath conflicts. See the `AgentOS - Neo4j embedded engine dependency:
+required exclusions` memory entry for the full Gradle dependency declaration and
+the rationale behind each exclusion.
+
+Key points:
+- Exclude the entire `org.slf4j` group from the Neo4j dependency to prevent
+  `NOPLoggerFactory` from winning the SLF4J binding race over Logback.
+- Exclude `neo4j-java-driver` to let the Spring Boot BOM version (5.x) win over
+  Neo4j's requested version (6.x).
+- The embedded engine requires Java 21+. AgentOS targets Java 25 (set in
+  `libs.versions.toml`).
+- The Neo4j test harness requires Netty 4.2 on the test classpath. This is
+  applied to `testRuntimeClasspath` only via a forced resolution strategy in
+  `agentos-service/build.gradle.kts`.

--- a/agentos/docs/neo4j-persistence.md
+++ b/agentos/docs/neo4j-persistence.md
@@ -147,9 +147,20 @@ RETURN c, r, ns ORDER BY c.created ASC
 
 SDN maps `r` and `ns` back onto `c.namespace` automatically.
 
-`CaseEventNode` keeps `caseId` as a plain string property (not a relationship)
-because events are fetched in bulk (hundreds per case) and eagerly loading the
-parent `CaseNode` for every event would introduce an N+1 penalty with no benefit.
+`CaseEventNode` follows the same pattern, stored as a
+`(:CaseEvent)-[:BELONGS_TO]->(:Case)` edge. The `caseId` scalar is kept for
+the same reason as `namespaceId` on `CaseNode` — `findActiveByCaseId` filters
+on it, and `toDomain()` reads from it. The query returns `e, r, c` so SDN maps
+the `case` field correctly.
+
+### Stub nodes on write
+
+Whenever a node is written with a `@Relationship` field, the related node is
+provided as a **stub** carrying only the `@Id`. SDN MERGEs by `@Id` on save
+and never overwrites existing properties of the related node:
+
+- `CaseNode.fromDomain` → `NamespaceNode.stub(namespaceId)`
+- `CaseEventNodeMapper.fromDomain` → `CaseNode.stub(caseId)`
 
 ### `toDomain()` / `fromDomain()`
 
@@ -157,6 +168,10 @@ Simple node classes (no complex serialisation) embed conversion directly as
 `toDomain()` and `companion object { fun fromDomain(...) }` on the node class
 itself. The `CaseEventNode` hierarchy uses a dedicated `CaseEventNodeMapper`
 because the sealed hierarchy requires a central dispatch point.
+
+`withRemoved` in `CaseEventNodeMapper` reconstructs the subtype node and
+copies the `case` relationship field so the `BELONGS_TO` edge is preserved
+through soft-delete operations.
 
 ## CaseEvent: Dual-Label Strategy
 

--- a/agentos/docs/neo4j-persistence.md
+++ b/agentos/docs/neo4j-persistence.md
@@ -105,12 +105,42 @@ When marking an entity as removed, the flag is set to `true`; when writing a
 non-removed entity, `removed` is written as `null` (`removed.takeIf { it }`).
 This avoids polluting the graph with `removed: false` on every node.
 
-### Parent relationships as properties
+### Parent relationships as graph edges
 
-Parent links (e.g. a `Case` belonging to a `Namespace`) are stored as plain
-string properties on the child node (`namespaceId: String`) rather than as SDN
-`@Relationship` edges. This keeps queries simple and avoids the complexity of
-SDN's relationship mapping for what is essentially a foreign key.
+Parent links for `Case` and `IntegrationConfig` are expressed as real Neo4j
+relationships using SDN `@Relationship`:
+
+```
+(:Case)-[:BELONGS_TO]->(:Namespace)
+(:IntegrationConfig)-[:BELONGS_TO]->(:Namespace)
+```
+
+On write, the child node carries a **stub** `NamespaceNode` containing only the
+`@Id`. SDN issues a `MERGE` on the Namespace node by id and never overwrites its
+existing properties, so saving a Case or IntegrationConfig cannot corrupt the
+Namespace. The stub is created via `NamespaceNode.stub(namespaceId)`.
+
+#### Denormalised namespaceId property
+
+Each child node also stores `namespaceId` as a plain scalar property alongside
+the `@Relationship` field. This dual representation exists for a practical reason:
+SDN 7 does **not** auto-inject `@Relationship` fields when a custom `@Query` method
+returns results — it only does so for its own generated queries. Filtering by the
+scalar property keeps custom queries simple and reliable:
+
+```cypher
+MATCH (c:Case)
+WHERE c.namespaceId = $namespaceId AND (c.removed IS NULL OR c.removed = false)
+RETURN c ORDER BY c.created ASC
+```
+
+The `BELONGS_TO` edge is still written to the graph on every save and is available
+for ad-hoc traversal queries, graph visualisation, and future Cypher that does
+need to hop the relationship.
+
+`CaseEventNode` keeps `caseId` as a plain string property (not a relationship)
+because events are fetched in bulk (hundreds per case) and eagerly loading the
+parent `CaseNode` for every event would introduce an N+1 penalty with no benefit.
 
 ### `toDomain()` / `fromDomain()`
 

--- a/agentos/docs/neo4j-persistence.md
+++ b/agentos/docs/neo4j-persistence.md
@@ -77,6 +77,7 @@ are inlined as individual scalar properties on the node:
 @Node("Case")
 data class CaseNode(
     @Id val id: String,
+    val namespaceId: String,   // scalar — always written, read by toDomain()
     val status: String,
     val title: String,
     val created: Instant,
@@ -85,7 +86,7 @@ data class CaseNode(
     val modifiedBy: String?,
     val removed: Boolean?,
     @Relationship(type = "BELONGS_TO", direction = OUTGOING)
-    var namespace: NamespaceNode? = null,
+    var namespace: NamespaceNode? = null,  // populated on read via RETURN c, r, ns
 )
 ```
 
@@ -108,36 +109,55 @@ This avoids polluting the graph with `removed: false` on every node.
 
 ### Parent relationships as graph edges
 
-Parent links for `Case` and `IntegrationConfig` are expressed as real Neo4j
-relationships using SDN `@Relationship`:
+All parent links are stored as real Neo4j relationships:
 
 ```
 (:Case)-[:BELONGS_TO]->(:Namespace)
 (:IntegrationConfig)-[:BELONGS_TO]->(:Namespace)
+(:CaseEvent)-[:BELONGS_TO]->(:Case)
 ```
 
-On write, the child node carries a **stub** `NamespaceNode` containing only the
-`@Id`. SDN issues a `MERGE` on the Namespace node by id and never overwrites its
-existing properties, so saving a Case or IntegrationConfig cannot corrupt the
-Namespace. The stub is created via `NamespaceNode.stub(namespaceId)`.
-
-The `@Relationship` field is declared as a nullable `var` with a `null` default so
-SDN can call the primary constructor before injecting the field:
+The `@Relationship` field on each node class is declared as a nullable `var` so
+SDN can call the primary constructor before injecting the field on reads:
 
 ```kotlin
 @Relationship(type = "BELONGS_TO", direction = OUTGOING)
 var namespace: NamespaceNode? = null
 ```
 
-`toDomain()` reads `namespace!!.id` — a null here is a data-integrity error and
-should surface as an NPE rather than be silently ignored.
+#### Writing the edge: always use a dedicated link query
 
-#### Custom @Query: return node + relationship + related node
+**Never** write the relationship by setting the `@Relationship` field to a stub
+node in `fromDomain`. SDN does not MERGE the related node by `@Id` — it saves
+all properties of the stub, overwriting the real node's data with empty values
+(e.g. `name = ""`, `status = ""`).
+
+Instead, save the owning node first (with no `@Relationship` field set), then
+call a dedicated `@Query` that MATCHes both existing nodes and MERGEs only the
+edge between them:
+
+```kotlin
+// Repository interface
+@Query("""MATCH (c:Case {id: $caseId})
+          MATCH (ns:Namespace {id: $namespaceId})
+          MERGE (c)-[:BELONGS_TO]->(ns)""")
+fun linkCaseToNamespace(caseId: String, namespaceId: String)
+
+// Repository implementation
+override fun save(entity: Case): Case =
+    caseNodeNeo4jRepository
+        .save(CaseNode.fromDomain(entity))
+        .also { caseNodeNeo4jRepository.linkCaseToNamespace(it.id, entity.namespaceId.toString()) }
+        .toDomain()
+```
+
+The same pattern applies to `IntegrationConfig → Namespace` (`linkConfigToNamespace`)
+and `CaseEvent → Case` (`linkEventToCase`).
+
+#### Reading the relationship: return node + relationship + related node
 
 SDN 7 only injects `@Relationship` fields when the query result contains the
-relationship instance and the related node explicitly. Returning only the owning
-node leaves the field null. The correct form is to name and return all three
-elements:
+relationship instance and the related node explicitly. The correct form:
 
 ```cypher
 MATCH (c:Case)-[r:BELONGS_TO]->(ns:Namespace)
@@ -145,22 +165,35 @@ WHERE ns.id = $namespaceId AND (c.removed IS NULL OR c.removed = false)
 RETURN c, r, ns ORDER BY c.created ASC
 ```
 
-SDN maps `r` and `ns` back onto `c.namespace` automatically.
+For `CaseEvent`, the `linkEventToCase` call runs after the node save, so the
+edge may not exist yet when `findActiveByCaseId` is called. Use `OPTIONAL MATCH`
+so the query still returns results when the edge is absent:
 
-`CaseEventNode` follows the same pattern, stored as a
-`(:CaseEvent)-[:BELONGS_TO]->(:Case)` edge. The `caseId` scalar is kept for
-the same reason as `namespaceId` on `CaseNode` — `findActiveByCaseId` filters
-on it, and `toDomain()` reads from it. The query returns `e, r, c` so SDN maps
-the `case` field correctly.
+```cypher
+MATCH (e:CaseEvent)
+WHERE e.caseId = $caseId AND (e.removed IS NULL OR e.removed = false)
+OPTIONAL MATCH (e)-[r:BELONGS_TO]->(c:Case)
+RETURN e, r, c ORDER BY e.timestamp ASC, e.id ASC
+```
 
-### Stub nodes on write
+#### Scalar denormalisation for toDomain()
 
-Whenever a node is written with a `@Relationship` field, the related node is
-provided as a **stub** carrying only the `@Id`. SDN MERGEs by `@Id` on save
-and never overwrites existing properties of the related node:
+The node returned by `save()` does not have its `@Relationship` field injected
+— that only happens for custom queries returning `node, rel, related`. `toDomain()`
+therefore reads the parent id from a **scalar property** on the node:
 
-- `CaseNode.fromDomain` → `NamespaceNode.stub(namespaceId)`
-- `CaseEventNodeMapper.fromDomain` → `CaseNode.stub(caseId)`
+```kotlin
+val namespaceId: String  // written by fromDomain alongside the graph edge
+
+fun toDomain() = Case(
+    namespaceId = UUID.fromString(namespaceId),  // scalar — always present
+    ...
+)
+```
+
+The scalar and the graph edge are always written together on save. The scalar is
+the reliable source for `toDomain()`; the graph edge is the reliable source for
+`findByParent` queries and graph traversal.
 
 ### `toDomain()` / `fromDomain()`
 


### PR DESCRIPTION
## Summary

Implements namespace and case access control for AgentOS — the first phase of the entity-level permission system. This PR adds role-based authorization to REST API endpoints without impacting tool execution.

## What this PR does

### 1. SDK Authorization Types (`agentos-sdk`)
- `NamespaceRole` enum: `OWNER > ADMIN > MEMBER > VIEWER` (hierarchical, with `satisfies()`)
- `CaseRole` enum: `OWNER > PARTICIPANT > OBSERVER`
- `Operation` enum: `LIST, READ, CREATE, WRITE, DELETE, MANAGE, EXECUTE`
- `AccessDecision` sealed class: `Granted(effectiveRole)`, `Denied(reason, usersWithAccess)`, `Abstain`
- `PermissionContext` immutable data class for evaluation context
- `PermissionEvaluator` PF4J `ExtensionPoint` interface — pluggable business rules
- `ToolCategory` and `ToolRestriction` types (Phase 2 prep, no runtime impact)

### 2. Authorization Service (`agentos-service`)
- `AuthorizationService` interface with namespace/case access checks
- `AuthorizationServiceImpl` orchestrator: isRoot bypass → permissive mode → evaluator delegation → fail-closed on errors
- `CodayPermissionEvaluator` — default RBAC evaluator with hierarchical role resolution
- `RoleRepository` interface + `Neo4jRoleRepository` (Cypher queries) + `InMemoryRoleRepository` (fallback for tests and non-Neo4j modes)

### 3. Role Management API
- `MembershipController` — REST CRUD for namespace role management (`/api/namespaces/{nsId}/members`)
- `MembershipResource` DTO with Bean Validation
- `AccessDeniedExceptionHandler` — global 403 handler with structured error response

### 4. Controller Integration
- `NamespaceController`, `CaseController`, `IntegrationConfigController` wired with authorization checks
- `BootstrapService` — auto-assigns `isRoot=true` to first user, auto-assigns `OWNER` role on namespace creation
- `SecurityConfigProperties` — `permissive` mode flag (default: `true`)

### 5. User Model
- `isRoot: Boolean` property added to `User` and `UserNode`

## Backward compatibility

- **Permissive mode is ON by default** — all existing users continue to work exactly as before
- No changes to tool execution, agent behavior, or LLM interaction
- Existing API clients are unaffected (permissive mode grants access even without explicit roles)
- `InMemoryRoleRepository` ensures tests and non-Neo4j persistence modes keep working

## How to test

```bash
# Run all tests
./gradlew build

# Run permission-specific tests
./gradlew :agentos-service:test --tests "*auth*"
./gradlew :agentos-service:test --tests "*Membership*"
./gradlew :agentos-service:test --tests "*RoleRepository*"
```

## Extension points

The `PermissionEvaluator` interface follows the PF4J `ExtensionPoint` pattern (same as `ToolPlugin`, `AgentPlugin`). Custom implementations can override the default RBAC rules by providing a plugin JAR.

## Key design decisions

- **Explicit service calls** over AOP — compatible with Kotlin coroutines, no ThreadLocal
- **PF4J ExtensionPoint** for `PermissionEvaluator` — consistent with existing plugin architecture
- **Fail-closed** on authorization errors — denies access rather than failing open
- **No cache** — Neo4j indexed lookups are <5ms, cache adds unnecessary complexity for now

## Related

- Ticket: WZ-29564
- Based on: `feature/thomas/WZ-28819/relationships-neo4j` (Neo4j graph relationships)