### PR TITLE
feat: #WZ-29564 Tool-level permissions — proposed defense-in-depth pattern (Phase 2)

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.sdk.tool
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.whozoss.agentos.sdk.auth.ToolCategory
 
 interface StandardTool<T> {
     val name: String
@@ -8,6 +9,8 @@ interface StandardTool<T> {
     val inputSchema: String
     val version: String
     val paramType: Class<T>?
+
+    val category: ToolCategory get() = ToolCategory.READ_ONLY
 
     fun execute(input: T?): String
 

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/ToolCategorySpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/auth/ToolCategorySpec.kt
@@ -28,5 +28,15 @@ class ToolCategorySpec : StringSpec() {
             categories[2] shouldBe ToolCategory.DESTRUCTIVE
             categories[3] shouldBe ToolCategory.ADMIN
         }
+        "ordinals are strictly increasing: READ_ONLY < WRITE < DESTRUCTIVE < ADMIN" {
+            (ToolCategory.READ_ONLY.ordinal < ToolCategory.WRITE.ordinal) shouldBe true
+            (ToolCategory.WRITE.ordinal < ToolCategory.DESTRUCTIVE.ordinal) shouldBe true
+            (ToolCategory.DESTRUCTIVE.ordinal < ToolCategory.ADMIN.ordinal) shouldBe true
+        }
+        "every category has a non-empty riskLabel" {
+            ToolCategory.entries.forEach { category ->
+                category.riskLabel.isNotBlank() shouldBe true
+            }
+        }
     }
 }

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolCategorySpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolCategorySpec.kt
@@ -1,0 +1,54 @@
+package io.whozoss.agentos.sdk.tool
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.sdk.auth.ToolCategory
+
+class StandardToolCategorySpec : StringSpec() {
+
+    private class TestTool : StandardTool<Unit> {
+        override val name = "test-tool"
+        override val description = "A test tool"
+        override val inputSchema = "{}"
+        override val version = "1.0"
+        override val paramType: Class<Unit>? = null
+        override fun execute(input: Unit?): String = "executed"
+    }
+
+    private class TestWriteTool : StandardTool<Unit> {
+        override val name = "test-write-tool"
+        override val description = "A write tool"
+        override val inputSchema = "{}"
+        override val version = "1.0"
+        override val paramType: Class<Unit>? = null
+        override val category = ToolCategory.WRITE
+        override fun execute(input: Unit?): String = "executed"
+    }
+
+    private class TestDestructiveTool : StandardTool<Unit> {
+        override val name = "test-destructive-tool"
+        override val description = "A destructive tool"
+        override val inputSchema = "{}"
+        override val version = "1.0"
+        override val paramType: Class<Unit>? = null
+        override val category = ToolCategory.DESTRUCTIVE
+        override fun execute(input: Unit?): String = "executed"
+    }
+
+    init {
+        "StandardTool without category override defaults to READ_ONLY" {
+            val tool = TestTool()
+            tool.category shouldBe ToolCategory.READ_ONLY
+        }
+
+        "StandardTool with category override WRITE returns WRITE" {
+            val tool = TestWriteTool()
+            tool.category shouldBe ToolCategory.WRITE
+        }
+
+        "StandardTool with category override DESTRUCTIVE returns DESTRUCTIVE" {
+            val tool = TestDestructiveTool()
+            tool.category shouldBe ToolCategory.DESTRUCTIVE
+        }
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -1,5 +1,7 @@
 package io.whozoss.agentos.agent
 
+import io.whozoss.agentos.auth.GuardedToolResult
+import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.aiProvider.AiModel
@@ -44,6 +46,8 @@ class AgentAdvanced(
     private val chatClient: ChatClient,
     private val tools: List<StandardTool<*>>,
     private val agentService: AgentService,
+    private val guard: ToolExecutionGuard,
+    private val executionContext: AgentExecutionContext,
     private val maxIterations: Int = 20,
 ) : Agent {
     override val name: String get() = model.name
@@ -273,6 +277,7 @@ Generate the JSON parameters for this tool call.
 
     /**
      * Execute the tool with the generated parameters.
+     * All tool execution goes through [ToolExecutionGuard] for permission enforcement.
      */
     private fun executeTool(
         toolRequest: ToolRequestEvent,
@@ -290,24 +295,47 @@ Generate the JSON parameters for this tool call.
                     success = false,
                 )
 
-        return try {
-            val result = tool.executeWithJson(toolRequest.args)
-
-            ToolResponseEvent(
+        val callerId = executionContext.userId?.toString()
+            ?: return ToolResponseEvent(
                 namespaceId = namespaceId,
                 caseId = caseId,
                 toolRequestId = toolRequest.toolRequestId,
                 toolName = toolRequest.toolName,
-                output = MessageContent.Text(result),
+                output = MessageContent.Text("Error: no authenticated caller"),
+                success = false,
+            )
+
+        val guardResult = guard.executeWithPermissionCheck(
+            tool = tool,
+            args = toolRequest.args,
+            callerId = callerId,
+            caseId = executionContext.caseId.toString(),
+            namespaceId = executionContext.namespaceId.toString(),
+        )
+
+        return when (guardResult) {
+            is GuardedToolResult.Success -> ToolResponseEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                toolRequestId = toolRequest.toolRequestId,
+                toolName = toolRequest.toolName,
+                output = MessageContent.Text(guardResult.output),
                 success = true,
             )
-        } catch (e: Exception) {
-            ToolResponseEvent(
+            is GuardedToolResult.Denied -> ToolResponseEvent(
                 namespaceId = namespaceId,
                 caseId = caseId,
                 toolRequestId = toolRequest.toolRequestId,
                 toolName = toolRequest.toolName,
-                output = MessageContent.Text("Error executing tool: ${e.message}"),
+                output = MessageContent.Text("Permission denied: ${guardResult.reason}"),
+                success = false,
+            )
+            is GuardedToolResult.Error -> ToolResponseEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                toolRequestId = toolRequest.toolRequestId,
+                toolName = toolRequest.toolName,
+                output = MessageContent.Text("Error: ${guardResult.error}"),
                 success = false,
             )
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -311,6 +311,7 @@ Generate the JSON parameters for this tool call.
             callerId = callerId,
             caseId = executionContext.caseId.toString(),
             namespaceId = executionContext.namespaceId.toString(),
+            callerDisplayName = executionContext.callerDisplayName,
         )
 
         return when (guardResult) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
@@ -14,4 +14,5 @@ data class AgentExecutionContext(
     val namespaceId: UUID,
     val caseId: UUID,
     val userId: UUID? = null,
+    val callerDisplayName: String? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -1,12 +1,14 @@
 package io.whozoss.agentos.agent
 
 import io.whozoss.agentos.aiModel.AiModelRegistry
+import io.whozoss.agentos.auth.PermissionManifestBuilder
 import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.chat.ChatClientProvider
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.user.UserService
 import mu.KLogging
@@ -38,6 +40,7 @@ class AgentServiceImpl(
     private val namespaceService: NamespaceService,
     private val userService: UserService,
     @Lazy private val toolExecutionGuard: ToolExecutionGuard,
+    @Lazy private val manifestBuilder: PermissionManifestBuilder,
 ) : AgentService {
     override fun findAgentByName(
         namePart: String,
@@ -88,7 +91,7 @@ class AgentServiceImpl(
         val chatClient = chatClientProvider.getChatClient(model.name)
         logger.debug { "[AgentService] ChatClient created for model: ${model.name} via provider: ${model.providerName}" }
 
-        val instructions = buildInstructions(model, context)
+        val instructions = buildInstructions(model, context, resolved)
 
         return AgentSimple(
             metadata = EntityMetadata(id = UUID.nameUUIDFromBytes(model.name.toByteArray())),
@@ -113,6 +116,7 @@ class AgentServiceImpl(
     private fun buildInstructions(
         model: AiModel,
         context: AgentExecutionContext,
+        tools: Collection<StandardTool<*>>,
     ): String {
         val namespace = namespaceService.findById(context.namespaceId)
         val namespaceBlock =
@@ -139,8 +143,18 @@ class AgentServiceImpl(
                     }
                 }
 
+        val permissionBlock =
+            context.userId?.let { userId ->
+                manifestBuilder.buildManifest(
+                    userId = userId.toString(),
+                    caseId = context.caseId.toString(),
+                    allTools = tools,
+                )
+            }?.takeIf { it.isNotBlank() }
+
         val base = if (model.instructions.isNullOrBlank()) namespaceBlock else "${model.instructions}\n$namespaceBlock"
-        return if (userBlock != null) "$base\n$userBlock" else base
+        val withUser = if (userBlock != null) "$base\n$userBlock" else base
+        return if (permissionBlock != null) "$withUser\n$permissionBlock" else withUser
     }
 
     companion object : KLogging()

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.agent
 
 import io.whozoss.agentos.aiModel.AiModelRegistry
+import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.chat.ChatClientProvider
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.agent.Agent
@@ -9,6 +10,7 @@ import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.user.UserService
 import mu.KLogging
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -35,6 +37,7 @@ class AgentServiceImpl(
     private val aiModelRegistry: AiModelRegistry,
     private val namespaceService: NamespaceService,
     private val userService: UserService,
+    @Lazy private val toolExecutionGuard: ToolExecutionGuard,
 ) : AgentService {
     override fun findAgentByName(
         namePart: String,
@@ -92,6 +95,8 @@ class AgentServiceImpl(
             model = model.copy(instructions = instructions),
             chatClient = chatClient,
             tools = resolved,
+            guard = toolExecutionGuard,
+            executionContext = context,
         )
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -444,6 +444,7 @@ class AgentSimple(
                             callerId = callerId,
                             caseId = executionContext.caseId.toString(),
                             namespaceId = executionContext.namespaceId.toString(),
+                            callerDisplayName = executionContext.callerDisplayName,
                         )
                         result = when (guardResult) {
                             is GuardedToolResult.Success -> guardResult.output

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -1,5 +1,7 @@
 package io.whozoss.agentos.agent
 
+import io.whozoss.agentos.auth.GuardedToolResult
+import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
@@ -55,6 +57,8 @@ class AgentSimple(
     private val model: AiModel,
     private val chatClient: ChatClient,
     private val tools: Collection<StandardTool<*>>,
+    private val guard: ToolExecutionGuard,
+    private val executionContext: AgentExecutionContext,
 ) : Agent {
     override val name: String get() = model.name
 
@@ -417,10 +421,33 @@ class AgentSimple(
                 val result: String
                 val toolDuration =
                     measureTime {
-                        result =
-                            try {
-                                tool.executeWithJson(toolInput)
-                            } catch (e: Exception) {
+                        val callerId = executionContext.userId?.toString()
+                        if (callerId == null) {
+                            runBlocking {
+                                eventChannel.send(
+                                    ToolResponseEvent(
+                                        namespaceId = namespaceId,
+                                        caseId = caseId,
+                                        toolRequestId = toolRequestId,
+                                        toolName = tool.name,
+                                        output = MessageContent.Text("Error: no authenticated caller"),
+                                        success = false,
+                                    ),
+                                )
+                            }
+                            throw IllegalStateException("No authenticated caller for tool execution")
+                        }
+
+                        val guardResult = guard.executeWithPermissionCheck(
+                            tool = tool,
+                            args = toolInput,
+                            callerId = callerId,
+                            caseId = executionContext.caseId.toString(),
+                            namespaceId = executionContext.namespaceId.toString(),
+                        )
+                        result = when (guardResult) {
+                            is GuardedToolResult.Success -> guardResult.output
+                            is GuardedToolResult.Denied -> {
                                 runBlocking {
                                     eventChannel.send(
                                         ToolResponseEvent(
@@ -428,13 +455,29 @@ class AgentSimple(
                                             caseId = caseId,
                                             toolRequestId = toolRequestId,
                                             toolName = tool.name,
-                                            output = MessageContent.Text("Error: ${e.message}"),
+                                            output = MessageContent.Text("Permission denied: ${guardResult.reason}"),
                                             success = false,
                                         ),
                                     )
                                 }
-                                throw e
+                                throw IllegalStateException("Permission denied: ${guardResult.reason}")
                             }
+                            is GuardedToolResult.Error -> {
+                                runBlocking {
+                                    eventChannel.send(
+                                        ToolResponseEvent(
+                                            namespaceId = namespaceId,
+                                            caseId = caseId,
+                                            toolRequestId = toolRequestId,
+                                            toolName = tool.name,
+                                            output = MessageContent.Text("Error: ${guardResult.error}"),
+                                            success = false,
+                                        ),
+                                    )
+                                }
+                                throw Exception(guardResult.error)
+                            }
+                        }
                     }
                 logger.info { "[AgentSimple] tool ${tool.name} executed in $toolDuration" }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/CallerContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/CallerContext.kt
@@ -1,0 +1,26 @@
+package io.whozoss.agentos.auth
+
+/**
+ * Tracks the last authenticated message sender in a Case.
+ * Updated exclusively by the authenticated layer (controllers/SecurityService).
+ * Agents and plugins MUST NOT modify this context.
+ *
+ * Uses @Volatile for thread-safety in coroutine context (Decision D9, NFR12).
+ * No ThreadLocal, no CoroutineContext.Key.
+ */
+class CallerContext {
+    @Volatile
+    private var lastSenderId: String? = null
+
+    @Volatile
+    private var lastSenderName: String? = null
+
+    fun setLastMessageSender(userId: String, displayName: String) {
+        lastSenderId = userId
+        lastSenderName = displayName
+    }
+
+    fun getCallerId(): String? = lastSenderId
+
+    fun getCallerDisplayName(): String? = lastSenderName
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/PermissionAuditService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/PermissionAuditService.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.auth
 
+import java.time.Instant
 import mu.KLogging
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -10,14 +11,61 @@ class PermissionAuditService(
 ) {
     companion object : KLogging()
 
-    fun logGranted(callerId: String, namespaceId: String, toolName: String, caseId: String) {
-        logger.info { "PERMISSION_GRANTED user=$callerId ns=$namespaceId tool=$toolName case=$caseId" }
-        eventPublisher.publishEvent(PermissionAuditEvent(callerId, namespaceId, toolName, caseId, granted = true))
+    fun logGranted(
+        callerId: String,
+        namespaceId: String,
+        toolName: String,
+        caseId: String,
+        toolCategory: String,
+        callerDisplayName: String?,
+    ) {
+        val timestamp = Instant.now()
+        logger.info {
+            "PERMISSION_GRANTED user=$callerId ns=$namespaceId tool=$toolName case=$caseId " +
+                "category=$toolCategory caller=$callerDisplayName ts=$timestamp"
+        }
+        eventPublisher.publishEvent(
+            PermissionAuditEvent(
+                callerId = callerId,
+                namespaceId = namespaceId,
+                toolName = toolName,
+                caseId = caseId,
+                granted = true,
+                reason = null,
+                toolCategory = toolCategory,
+                callerDisplayName = callerDisplayName,
+                timestamp = timestamp,
+            ),
+        )
     }
 
-    fun logDenied(callerId: String, namespaceId: String, toolName: String, caseId: String) {
-        logger.warn { "PERMISSION_DENIED user=$callerId ns=$namespaceId tool=$toolName case=$caseId" }
-        eventPublisher.publishEvent(PermissionAuditEvent(callerId, namespaceId, toolName, caseId, granted = false))
+    fun logDenied(
+        callerId: String,
+        namespaceId: String,
+        toolName: String,
+        caseId: String,
+        reason: String,
+        toolCategory: String,
+        callerDisplayName: String?,
+    ) {
+        val timestamp = Instant.now()
+        logger.warn {
+            "PERMISSION_DENIED user=$callerId ns=$namespaceId tool=$toolName case=$caseId " +
+                "reason=$reason category=$toolCategory caller=$callerDisplayName ts=$timestamp"
+        }
+        eventPublisher.publishEvent(
+            PermissionAuditEvent(
+                callerId = callerId,
+                namespaceId = namespaceId,
+                toolName = toolName,
+                caseId = caseId,
+                granted = false,
+                reason = reason,
+                toolCategory = toolCategory,
+                callerDisplayName = callerDisplayName,
+                timestamp = timestamp,
+            ),
+        )
     }
 }
 
@@ -27,4 +75,8 @@ data class PermissionAuditEvent(
     val toolName: String,
     val caseId: String,
     val granted: Boolean,
+    val reason: String?,
+    val toolCategory: String,
+    val callerDisplayName: String?,
+    val timestamp: Instant,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/PermissionAuditService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/PermissionAuditService.kt
@@ -1,0 +1,30 @@
+package io.whozoss.agentos.auth
+
+import mu.KLogging
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class PermissionAuditService(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    companion object : KLogging()
+
+    fun logGranted(callerId: String, namespaceId: String, toolName: String, caseId: String) {
+        logger.info { "PERMISSION_GRANTED user=$callerId ns=$namespaceId tool=$toolName case=$caseId" }
+        eventPublisher.publishEvent(PermissionAuditEvent(callerId, namespaceId, toolName, caseId, granted = true))
+    }
+
+    fun logDenied(callerId: String, namespaceId: String, toolName: String, caseId: String) {
+        logger.warn { "PERMISSION_DENIED user=$callerId ns=$namespaceId tool=$toolName case=$caseId" }
+        eventPublisher.publishEvent(PermissionAuditEvent(callerId, namespaceId, toolName, caseId, granted = false))
+    }
+}
+
+data class PermissionAuditEvent(
+    val callerId: String,
+    val namespaceId: String,
+    val toolName: String,
+    val caseId: String,
+    val granted: Boolean,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/PermissionManifestBuilder.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/PermissionManifestBuilder.kt
@@ -1,0 +1,62 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.sdk.tool.StandardTool
+import mu.KLogging
+import org.springframework.stereotype.Service
+
+/**
+ * Builds a structured text block describing tool permissions for the current user.
+ *
+ * The manifest is injected into the agent's system prompt so the LLM knows which
+ * tools it may call and which are forbidden. This is the guidance layer of the
+ * defense-in-depth model — the backend [ToolExecutionGuard] remains the enforcement
+ * layer regardless of what the LLM decides.
+ *
+ * **Privacy (NFR6):** Only tool names and categories are included in the manifest.
+ * User IDs, internal roles, and permission levels are never exposed to the LLM.
+ */
+@Service
+class PermissionManifestBuilder(
+    private val authorizationService: AuthorizationService,
+) {
+    companion object : KLogging()
+
+    /**
+     * Generate the permission manifest for injection into system instructions.
+     *
+     * @param userId  current user identity (String, not UUID)
+     * @param caseId  current case identity (String, not UUID)
+     * @param allTools complete collection of tools resolved for the namespace
+     * @return a structured text block, or empty string when [allTools] is empty
+     */
+    fun buildManifest(
+        userId: String,
+        caseId: String,
+        allTools: Collection<StandardTool<*>>,
+    ): String {
+        if (allTools.isEmpty()) return ""
+
+        val toolCategoryMap = allTools.associate { it.name to it.category }
+        val allowedToolNames = authorizationService.getAvailableTools(userId, caseId, toolCategoryMap)
+
+        val allowed = allTools.filter { it.name in allowedToolNames }
+        val forbidden = allTools.filter { it.name !in allowedToolNames }
+
+        return buildString {
+            appendLine("## Tool Permissions")
+            appendLine("You MUST respect these permissions. Never attempt to call a forbidden tool.")
+            appendLine()
+            appendLine("### Allowed tools:")
+            allowed.forEach { tool ->
+                appendLine("- ${tool.name} (${tool.category.name})")
+            }
+            if (forbidden.isNotEmpty()) {
+                appendLine()
+                appendLine("### Forbidden tools (do NOT call these):")
+                forbidden.forEach { tool ->
+                    appendLine("- ${tool.name} (${tool.category.name}) — Requires ${tool.category.minimumNamespaceRole.name} role")
+                }
+            }
+        }.trim()
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/ToolExecutionGuard.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/ToolExecutionGuard.kt
@@ -1,0 +1,54 @@
+package io.whozoss.agentos.auth
+
+import io.whozoss.agentos.sdk.tool.StandardTool
+import mu.KLogging
+import org.springframework.stereotype.Service
+
+@Service
+class ToolExecutionGuard(
+    private val authorizationService: AuthorizationService,
+    private val auditService: PermissionAuditService,
+) {
+    companion object : KLogging()
+
+    fun executeWithPermissionCheck(
+        tool: StandardTool<*>,
+        args: String?,
+        callerId: String,
+        caseId: String,
+        namespaceId: String,
+    ): GuardedToolResult {
+        val category = tool.category
+        val allowed = try {
+            authorizationService.canExecuteTool(callerId, caseId, tool.name, category)
+        } catch (e: Exception) {
+            logger.error(e) { "Permission check failed for tool ${tool.name}" }
+            false // fail-closed (NFR9)
+        }
+
+        return when {
+            !allowed -> {
+                auditService.logDenied(callerId, namespaceId, tool.name, caseId)
+                GuardedToolResult.Denied(
+                    toolName = tool.name,
+                    reason = "Permission denied for tool '${tool.name}'",
+                )
+            }
+            else -> {
+                auditService.logGranted(callerId, namespaceId, tool.name, caseId)
+                try {
+                    val output = tool.executeWithJson(args)
+                    GuardedToolResult.Success(tool.name, output)
+                } catch (e: Exception) {
+                    GuardedToolResult.Error(tool.name, e.message ?: "Unknown error")
+                }
+            }
+        }
+    }
+}
+
+sealed class GuardedToolResult {
+    data class Success(val toolName: String, val output: String) : GuardedToolResult()
+    data class Denied(val toolName: String, val reason: String) : GuardedToolResult()
+    data class Error(val toolName: String, val error: String) : GuardedToolResult()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/ToolExecutionGuard.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/auth/ToolExecutionGuard.kt
@@ -17,6 +17,7 @@ class ToolExecutionGuard(
         callerId: String,
         caseId: String,
         namespaceId: String,
+        callerDisplayName: String? = null,
     ): GuardedToolResult {
         val category = tool.category
         val allowed = try {
@@ -28,14 +29,27 @@ class ToolExecutionGuard(
 
         return when {
             !allowed -> {
-                auditService.logDenied(callerId, namespaceId, tool.name, caseId)
-                GuardedToolResult.Denied(
+                val reason = "Permission denied for tool '${tool.name}'"
+                auditService.logDenied(
+                    callerId = callerId,
+                    namespaceId = namespaceId,
                     toolName = tool.name,
-                    reason = "Permission denied for tool '${tool.name}'",
+                    caseId = caseId,
+                    reason = reason,
+                    toolCategory = category.name,
+                    callerDisplayName = callerDisplayName,
                 )
+                GuardedToolResult.Denied(toolName = tool.name, reason = reason)
             }
             else -> {
-                auditService.logGranted(callerId, namespaceId, tool.name, caseId)
+                auditService.logGranted(
+                    callerId = callerId,
+                    namespaceId = namespaceId,
+                    toolName = tool.name,
+                    caseId = caseId,
+                    toolCategory = category.name,
+                    callerDisplayName = callerDisplayName,
+                )
                 try {
                     val output = tool.executeWithJson(args)
                     GuardedToolResult.Success(tool.name, output)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.caseFlow
 
+import io.whozoss.agentos.auth.CallerContext
 import io.whozoss.agentos.caseEvent.DefaultCaseEventEmitter
 import io.whozoss.agentos.caseEvent.InMemoryCaseEventList
 import io.whozoss.agentos.orchestration.CaseEventEmitter
@@ -47,6 +48,7 @@ class CaseRuntime(
     inputEvents: List<CaseEvent> = emptyList(),
 ) : CaseEventEmitter by DefaultCaseEventEmitter() {
     private val eventList = InMemoryCaseEventList(inputEvents)
+    val callerContext: CallerContext = CallerContext()
 
     /**
      * Set by [processNextStep] when it finds an [AgentFinishedEvent] for the current
@@ -151,6 +153,9 @@ class CaseRuntime(
             "[CaseRuntime $id] addUserMessage - actor: ${actor.id}, " +
                 "content: ${content.size} part(s), answerTo: $answerToEventId"
         }
+
+        // Update caller context BEFORE any event storage — security invariant FR22
+        callerContext.setLastMessageSender(actor.id, actor.displayName)
 
         if (answerToEventId != null) {
             val questionEvent = eventList.getById(answerToEventId)
@@ -282,7 +287,8 @@ class CaseRuntime(
 
                 is AgentRunningEvent -> {
                     logger.info { "[CaseRuntime $id] Found AgentRunningEvent for agent: ${event.agentName}" }
-                    runAgent(event.agentName, eventList.getAll(), resolveUserId(events)) { !interruptRequested.get() }
+                    val userId = callerContext.getCallerId()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+                    runAgent(event.agentName, eventList.getAll(), userId) { !interruptRequested.get() }
                     return
                 }
 
@@ -314,18 +320,6 @@ class CaseRuntime(
         logger.warn { "[CaseRuntime $id] No agent selection found in history, stopping" }
         interruptRequested.set(true)
     }
-
-    /**
-     * Scans the event history backward and returns the UUID of the last user actor,
-     * or null if no user message is found or the actor id is not a valid UUID.
-     */
-    private fun resolveUserId(events: List<CaseEvent>): UUID? =
-        events
-            .filterIsInstance<MessageEvent>()
-            .lastOrNull { it.actor.role == ActorRole.USER }
-            ?.actor
-            ?.id
-            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
 
     companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -225,7 +225,12 @@ class CaseServiceImpl(
         }
 
         logger.info { "[CaseService] Running agent: $agentName for case $caseId" }
-        val context = AgentExecutionContext(namespaceId = runtime.namespaceId, caseId = caseId, userId = userId)
+        val context = AgentExecutionContext(
+            namespaceId = runtime.namespaceId,
+            caseId = caseId,
+            userId = userId,
+            callerDisplayName = runtime.callerContext.getCallerDisplayName(),
+        )
         agentService
             .findAgentByName(agentName, context)
             .run(events, shouldContinue)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -18,6 +18,7 @@ import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolSelectedEvent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.sdk.tool.StandardTool
 import kotlinx.coroutines.flow.toList
 import org.springframework.ai.chat.client.ChatClient
@@ -71,6 +72,12 @@ class AgentAdvancedSpec :
                     modelName = "gpt-4o",
                     providerName = "openai",
                 )
+            val mockGuard = mockk<ToolExecutionGuard>(relaxed = true)
+            val executionContext = AgentExecutionContext(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                userId = UUID.randomUUID(),
+            )
             val agent =
                 AgentAdvanced(
                     metadata = EntityMetadata(id = agentId),
@@ -78,6 +85,8 @@ class AgentAdvancedSpec :
                     chatClient = mockChatClient,
                     tools = tools,
                     agentService = mockAgentService,
+                    guard = mockGuard,
+                    executionContext = executionContext,
                     maxIterations = 5,
                 )
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplSpec.kt
@@ -14,6 +14,7 @@ import io.whozoss.agentos.namespace.Namespace
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
@@ -26,7 +27,8 @@ class AgentServiceImplSpec : StringSpec() {
     private val aiModelRegistry: AiModelRegistry = mockk()
     private val namespaceService: NamespaceService = mockk()
     private val userService: UserService = mockk(relaxed = true)
-    private val agentService = AgentServiceImpl(chatClientProvider, toolRegistryService, aiModelRegistry, namespaceService, userService)
+    private val toolExecutionGuard: ToolExecutionGuard = mockk(relaxed = true)
+    private val agentService = AgentServiceImpl(chatClientProvider, toolRegistryService, aiModelRegistry, namespaceService, userService, toolExecutionGuard)
 
     // A context and matching namespace used across most tests
     private val namespaceId: UUID = UUID.randomUUID()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplSpec.kt
@@ -14,6 +14,7 @@ import io.whozoss.agentos.namespace.Namespace
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.auth.PermissionManifestBuilder
 import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.user.User
@@ -28,7 +29,8 @@ class AgentServiceImplSpec : StringSpec() {
     private val namespaceService: NamespaceService = mockk()
     private val userService: UserService = mockk(relaxed = true)
     private val toolExecutionGuard: ToolExecutionGuard = mockk(relaxed = true)
-    private val agentService = AgentServiceImpl(chatClientProvider, toolRegistryService, aiModelRegistry, namespaceService, userService, toolExecutionGuard)
+    private val manifestBuilder: PermissionManifestBuilder = mockk(relaxed = true)
+    private val agentService = AgentServiceImpl(chatClientProvider, toolRegistryService, aiModelRegistry, namespaceService, userService, toolExecutionGuard, manifestBuilder)
 
     // A context and matching namespace used across most tests
     private val namespaceId: UUID = UUID.randomUUID()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleTest.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleTest.kt
@@ -50,7 +50,7 @@ class AgentSimpleTest :
                     instructions = instructions,
                 )
             val guard = mockk<ToolExecutionGuard> {
-                every { executeWithPermissionCheck(any(), any(), any(), any(), any()) } answers {
+                every { executeWithPermissionCheck(any(), any(), any(), any(), any(), any()) } answers {
                     val tool = firstArg<StandardTool<*>>()
                     val args = secondArg<String?>()
                     GuardedToolResult.Success(tool.name, tool.executeWithJson(args))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleTest.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleTest.kt
@@ -18,6 +18,8 @@ import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
 import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.auth.GuardedToolResult
+import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.sdk.tool.StandardTool
 import kotlinx.coroutines.flow.toList
 import org.springframework.ai.chat.client.ChatClient
@@ -35,6 +37,8 @@ class AgentSimpleTest :
             name: String = "SimpleAgent",
             tools: Collection<StandardTool<*>> = emptyList(),
             instructions: String? = null,
+            namespaceId: UUID = UUID.randomUUID(),
+            caseId: UUID = UUID.randomUUID(),
         ): AgentSimple {
             val model =
                 AiModel(
@@ -45,11 +49,25 @@ class AgentSimpleTest :
                     providerName = "openai",
                     instructions = instructions,
                 )
+            val guard = mockk<ToolExecutionGuard> {
+                every { executeWithPermissionCheck(any(), any(), any(), any(), any()) } answers {
+                    val tool = firstArg<StandardTool<*>>()
+                    val args = secondArg<String?>()
+                    GuardedToolResult.Success(tool.name, tool.executeWithJson(args))
+                }
+            }
+            val executionContext = AgentExecutionContext(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                userId = UUID.randomUUID(),
+            )
             return AgentSimple(
                 metadata = EntityMetadata(id = agentId),
                 model = model,
                 chatClient = chatClient,
                 tools = tools,
+                guard = guard,
+                executionContext = executionContext,
             )
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackTest.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackTest.kt
@@ -17,6 +17,8 @@ import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.auth.GuardedToolResult
+import io.whozoss.agentos.auth.ToolExecutionGuard
 import io.whozoss.agentos.sdk.tool.StandardTool
 import kotlinx.coroutines.flow.toList
 import org.springframework.ai.chat.client.ChatClient
@@ -61,11 +63,25 @@ class AgentSimpleToolCallbackTest :
                     modelName = "claude-opus",
                     providerName = "anthropic",
                 )
+            val guard = mockk<ToolExecutionGuard> {
+                every { executeWithPermissionCheck(any(), any(), any(), any(), any()) } answers {
+                    val tool = firstArg<StandardTool<*>>()
+                    val args = secondArg<String?>()
+                    GuardedToolResult.Success(tool.name, tool.executeWithJson(args))
+                }
+            }
+            val executionContext = AgentExecutionContext(
+                namespaceId = UUID.randomUUID(),
+                caseId = UUID.randomUUID(),
+                userId = UUID.randomUUID(),
+            )
             return AgentSimple(
                 metadata = EntityMetadata(id = agentId),
                 model = model,
                 chatClient = chatClient,
                 tools = tools,
+                guard = guard,
+                executionContext = executionContext,
             )
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackTest.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackTest.kt
@@ -64,7 +64,7 @@ class AgentSimpleToolCallbackTest :
                     providerName = "anthropic",
                 )
             val guard = mockk<ToolExecutionGuard> {
-                every { executeWithPermissionCheck(any(), any(), any(), any(), any()) } answers {
+                every { executeWithPermissionCheck(any(), any(), any(), any(), any(), any()) } answers {
                     val tool = firstArg<StandardTool<*>>()
                     val args = secondArg<String?>()
                     GuardedToolResult.Success(tool.name, tool.executeWithJson(args))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/CallerContextSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/CallerContextSpec.kt
@@ -1,0 +1,70 @@
+package io.whozoss.agentos.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.coroutineScope
+
+class CallerContextSpec : StringSpec({
+
+    "getCallerId and getCallerDisplayName return null before any update" {
+        val ctx = CallerContext()
+
+        ctx.getCallerId().shouldBeNull()
+        ctx.getCallerDisplayName().shouldBeNull()
+    }
+
+    "setLastMessageSender updates getCallerId and getCallerDisplayName" {
+        val ctx = CallerContext()
+
+        ctx.setLastMessageSender("user-42", "Alice Dupont")
+
+        ctx.getCallerId() shouldBe "user-42"
+        ctx.getCallerDisplayName() shouldBe "Alice Dupont"
+    }
+
+    "successive calls to setLastMessageSender — last sender wins" {
+        val ctx = CallerContext()
+
+        ctx.setLastMessageSender("user-1", "First User")
+        ctx.setLastMessageSender("user-2", "Second User")
+        ctx.setLastMessageSender("user-3", "Third User")
+
+        ctx.getCallerId() shouldBe "user-3"
+        ctx.getCallerDisplayName() shouldBe "Third User"
+    }
+
+    "concurrent reads during a write do not crash" {
+        val ctx = CallerContext()
+        ctx.setLastMessageSender("initial-id", "Initial Name")
+
+        coroutineScope {
+            // Writer coroutine
+            val writer = launch(Dispatchers.Default) {
+                repeat(1000) { i ->
+                    ctx.setLastMessageSender("user-$i", "User $i")
+                }
+            }
+
+            // Reader coroutines
+            val readers = (1..4).map {
+                launch(Dispatchers.Default) {
+                    repeat(1000) {
+                        // Just read — we verify no crash, not specific values
+                        ctx.getCallerId()
+                        ctx.getCallerDisplayName()
+                    }
+                }
+            }
+
+            writer.join()
+            readers.forEach { it.join() }
+        }
+
+        // After all writes, the last sender should be user-999
+        ctx.getCallerId() shouldBe "user-999"
+        ctx.getCallerDisplayName() shouldBe "User 999"
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/PermissionAuditServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/PermissionAuditServiceSpec.kt
@@ -1,0 +1,55 @@
+package io.whozoss.agentos.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+
+class PermissionAuditServiceSpec : StringSpec() {
+
+    private val callerId = "user-123"
+    private val namespaceId = "ns-456"
+    private val toolName = "readFile"
+    private val caseId = "case-789"
+
+    init {
+        "logGranted publishes PermissionAuditEvent with granted=true" {
+            val eventSlot = slot<PermissionAuditEvent>()
+            val publisher = mockk<ApplicationEventPublisher> {
+                every { publishEvent(capture(eventSlot)) } returns Unit
+            }
+            val service = PermissionAuditService(publisher)
+
+            service.logGranted(callerId, namespaceId, toolName, caseId)
+
+            verify(exactly = 1) { publisher.publishEvent(any<PermissionAuditEvent>()) }
+            val captured = eventSlot.captured
+            captured.callerId shouldBe callerId
+            captured.namespaceId shouldBe namespaceId
+            captured.toolName shouldBe toolName
+            captured.caseId shouldBe caseId
+            captured.granted shouldBe true
+        }
+
+        "logDenied publishes PermissionAuditEvent with granted=false" {
+            val eventSlot = slot<PermissionAuditEvent>()
+            val publisher = mockk<ApplicationEventPublisher> {
+                every { publishEvent(capture(eventSlot)) } returns Unit
+            }
+            val service = PermissionAuditService(publisher)
+
+            service.logDenied(callerId, namespaceId, toolName, caseId)
+
+            verify(exactly = 1) { publisher.publishEvent(any<PermissionAuditEvent>()) }
+            val captured = eventSlot.captured
+            captured.callerId shouldBe callerId
+            captured.namespaceId shouldBe namespaceId
+            captured.toolName shouldBe toolName
+            captured.caseId shouldBe caseId
+            captured.granted shouldBe false
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/PermissionAuditServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/PermissionAuditServiceSpec.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.auth
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -14,16 +15,18 @@ class PermissionAuditServiceSpec : StringSpec() {
     private val namespaceId = "ns-456"
     private val toolName = "readFile"
     private val caseId = "case-789"
+    private val toolCategory = "READ_ONLY"
+    private val callerDisplayName = "Alice Smith"
 
     init {
-        "logGranted publishes PermissionAuditEvent with granted=true" {
+        "logGranted publishes PermissionAuditEvent with granted=true and all context fields" {
             val eventSlot = slot<PermissionAuditEvent>()
             val publisher = mockk<ApplicationEventPublisher> {
                 every { publishEvent(capture(eventSlot)) } returns Unit
             }
             val service = PermissionAuditService(publisher)
 
-            service.logGranted(callerId, namespaceId, toolName, caseId)
+            service.logGranted(callerId, namespaceId, toolName, caseId, toolCategory, callerDisplayName)
 
             verify(exactly = 1) { publisher.publishEvent(any<PermissionAuditEvent>()) }
             val captured = eventSlot.captured
@@ -32,16 +35,21 @@ class PermissionAuditServiceSpec : StringSpec() {
             captured.toolName shouldBe toolName
             captured.caseId shouldBe caseId
             captured.granted shouldBe true
+            captured.reason shouldBe null
+            captured.toolCategory shouldBe toolCategory
+            captured.callerDisplayName shouldBe callerDisplayName
+            captured.timestamp shouldNotBe null
         }
 
-        "logDenied publishes PermissionAuditEvent with granted=false" {
+        "logDenied publishes PermissionAuditEvent with granted=false and reason" {
             val eventSlot = slot<PermissionAuditEvent>()
             val publisher = mockk<ApplicationEventPublisher> {
                 every { publishEvent(capture(eventSlot)) } returns Unit
             }
             val service = PermissionAuditService(publisher)
+            val reason = "Permission denied for tool 'readFile'"
 
-            service.logDenied(callerId, namespaceId, toolName, caseId)
+            service.logDenied(callerId, namespaceId, toolName, caseId, reason, toolCategory, callerDisplayName)
 
             verify(exactly = 1) { publisher.publishEvent(any<PermissionAuditEvent>()) }
             val captured = eventSlot.captured
@@ -49,6 +57,77 @@ class PermissionAuditServiceSpec : StringSpec() {
             captured.namespaceId shouldBe namespaceId
             captured.toolName shouldBe toolName
             captured.caseId shouldBe caseId
+            captured.granted shouldBe false
+            captured.reason shouldBe reason
+            captured.toolCategory shouldBe toolCategory
+            captured.callerDisplayName shouldBe callerDisplayName
+            captured.timestamp shouldNotBe null
+        }
+
+        "logGranted event contains non-null timestamp" {
+            val eventSlot = slot<PermissionAuditEvent>()
+            val publisher = mockk<ApplicationEventPublisher> {
+                every { publishEvent(capture(eventSlot)) } returns Unit
+            }
+            val service = PermissionAuditService(publisher)
+
+            service.logGranted(callerId, namespaceId, toolName, caseId, toolCategory, callerDisplayName)
+
+            eventSlot.captured.timestamp shouldNotBe null
+        }
+
+        "logGranted event contains toolCategory and callerDisplayName" {
+            val eventSlot = slot<PermissionAuditEvent>()
+            val publisher = mockk<ApplicationEventPublisher> {
+                every { publishEvent(capture(eventSlot)) } returns Unit
+            }
+            val service = PermissionAuditService(publisher)
+
+            service.logGranted(callerId, namespaceId, toolName, caseId, "WRITE", "Bob Builder")
+
+            val captured = eventSlot.captured
+            captured.toolCategory shouldBe "WRITE"
+            captured.callerDisplayName shouldBe "Bob Builder"
+        }
+
+        "logDenied event contains reason" {
+            val eventSlot = slot<PermissionAuditEvent>()
+            val publisher = mockk<ApplicationEventPublisher> {
+                every { publishEvent(capture(eventSlot)) } returns Unit
+            }
+            val service = PermissionAuditService(publisher)
+            val reason = "Insufficient permissions for DANGEROUS tool"
+
+            service.logDenied(callerId, namespaceId, toolName, caseId, reason, toolCategory, callerDisplayName)
+
+            eventSlot.captured.reason shouldBe reason
+        }
+
+        "callerDisplayName null is correctly handled in logGranted" {
+            val eventSlot = slot<PermissionAuditEvent>()
+            val publisher = mockk<ApplicationEventPublisher> {
+                every { publishEvent(capture(eventSlot)) } returns Unit
+            }
+            val service = PermissionAuditService(publisher)
+
+            service.logGranted(callerId, namespaceId, toolName, caseId, toolCategory, null)
+
+            val captured = eventSlot.captured
+            captured.callerDisplayName shouldBe null
+            captured.granted shouldBe true
+        }
+
+        "callerDisplayName null is correctly handled in logDenied" {
+            val eventSlot = slot<PermissionAuditEvent>()
+            val publisher = mockk<ApplicationEventPublisher> {
+                every { publishEvent(capture(eventSlot)) } returns Unit
+            }
+            val service = PermissionAuditService(publisher)
+
+            service.logDenied(callerId, namespaceId, toolName, caseId, "denied", toolCategory, null)
+
+            val captured = eventSlot.captured
+            captured.callerDisplayName shouldBe null
             captured.granted shouldBe false
         }
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/PermissionManifestBuilderSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/PermissionManifestBuilderSpec.kt
@@ -1,0 +1,190 @@
+package io.whozoss.agentos.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.sdk.auth.ToolCategory
+import io.whozoss.agentos.sdk.tool.StandardTool
+
+class PermissionManifestBuilderSpec : StringSpec() {
+
+    private val userId = "user-123"
+    private val caseId = "case-456"
+
+    private fun buildTool(
+        name: String,
+        category: ToolCategory = ToolCategory.READ_ONLY,
+    ): StandardTool<*> = mockk {
+        every { this@mockk.name } returns name
+        every { this@mockk.category } returns category
+    }
+
+    private fun buildBuilder(
+        availableToolNames: Set<String>,
+    ): PermissionManifestBuilder {
+        val authorizationService = mockk<AuthorizationService> {
+            every { getAvailableTools(userId, caseId, any()) } returns availableToolNames
+        }
+        return PermissionManifestBuilder(authorizationService)
+    }
+
+    init {
+
+        // -------------------------------------------------------------------------
+        // AC-F: Allowed + forbidden tools correctly listed
+        // -------------------------------------------------------------------------
+
+        "manifest lists allowed and forbidden tools correctly" {
+            val readTool = buildTool("readFile", ToolCategory.READ_ONLY)
+            val writeTool = buildTool("writeFile", ToolCategory.WRITE)
+            val destructiveTool = buildTool("deleteFile", ToolCategory.DESTRUCTIVE)
+
+            val builder = buildBuilder(setOf("readFile", "writeFile"))
+            val manifest = builder.buildManifest(userId, caseId, listOf(readTool, writeTool, destructiveTool))
+
+            manifest shouldContain "readFile"
+            manifest shouldContain "writeFile"
+            manifest shouldContain "deleteFile"
+            manifest shouldContain "Allowed tools:"
+            manifest shouldContain "Forbidden tools (do NOT call these):"
+            manifest shouldContain "DESTRUCTIVE"
+            manifest shouldContain "Requires ADMIN role"
+        }
+
+        // -------------------------------------------------------------------------
+        // AC-F: Permissive mode — all tools allowed, no Forbidden section
+        // -------------------------------------------------------------------------
+
+        "permissive mode lists all tools as allowed with no Forbidden section" {
+            val readTool = buildTool("readFile", ToolCategory.READ_ONLY)
+            val writeTool = buildTool("writeFile", ToolCategory.WRITE)
+            val destructiveTool = buildTool("deleteFile", ToolCategory.DESTRUCTIVE)
+
+            val allTools = listOf(readTool, writeTool, destructiveTool)
+            val builder = buildBuilder(setOf("readFile", "writeFile", "deleteFile"))
+            val manifest = builder.buildManifest(userId, caseId, allTools)
+
+            manifest shouldContain "readFile"
+            manifest shouldContain "writeFile"
+            manifest shouldContain "deleteFile"
+            manifest shouldContain "Allowed tools:"
+            manifest shouldNotContain "Forbidden tools"
+        }
+
+        // -------------------------------------------------------------------------
+        // AC-F: All tools blocked — none allowed
+        // -------------------------------------------------------------------------
+
+        "all tools blocked when getAvailableTools returns empty set" {
+            val readTool = buildTool("readFile", ToolCategory.READ_ONLY)
+            val writeTool = buildTool("writeFile", ToolCategory.WRITE)
+
+            val builder = buildBuilder(emptySet())
+            val manifest = builder.buildManifest(userId, caseId, listOf(readTool, writeTool))
+
+            manifest shouldContain "Allowed tools:"
+            manifest shouldContain "Forbidden tools (do NOT call these):"
+            manifest shouldNotContain "- readFile (READ_ONLY)\n" // not in allowed
+            // Both should appear in forbidden
+            manifest shouldContain "readFile (READ_ONLY) — Requires VIEWER role"
+            manifest shouldContain "writeFile (WRITE) — Requires MEMBER role"
+        }
+
+        // -------------------------------------------------------------------------
+        // AC-F: Format contains expected sections
+        // -------------------------------------------------------------------------
+
+        "manifest format contains required sections" {
+            val tool = buildTool("testTool", ToolCategory.READ_ONLY)
+            val forbiddenTool = buildTool("adminTool", ToolCategory.ADMIN)
+
+            val builder = buildBuilder(setOf("testTool"))
+            val manifest = builder.buildManifest(userId, caseId, listOf(tool, forbiddenTool))
+
+            manifest shouldContain "## Tool Permissions"
+            manifest shouldContain "You MUST respect these permissions. Never attempt to call a forbidden tool."
+            manifest shouldContain "### Allowed tools:"
+            manifest shouldContain "### Forbidden tools (do NOT call these):"
+        }
+
+        // -------------------------------------------------------------------------
+        // AC-F: Tool names and categories appear in manifest
+        // -------------------------------------------------------------------------
+
+        "tool names and categories appear in manifest" {
+            val readTool = buildTool("listFiles", ToolCategory.READ_ONLY)
+            val writeTool = buildTool("editFile", ToolCategory.WRITE)
+            val adminTool = buildTool("manageUsers", ToolCategory.ADMIN)
+
+            val builder = buildBuilder(setOf("listFiles", "editFile"))
+            val manifest = builder.buildManifest(userId, caseId, listOf(readTool, writeTool, adminTool))
+
+            manifest shouldContain "listFiles (READ_ONLY)"
+            manifest shouldContain "editFile (WRITE)"
+            manifest shouldContain "manageUsers (ADMIN)"
+        }
+
+        // -------------------------------------------------------------------------
+        // AC-F: userId and internal roles do NOT appear in manifest (NFR6)
+        // -------------------------------------------------------------------------
+
+        "userId and internal roles do not appear in manifest" {
+            val tool = buildTool("readFile", ToolCategory.READ_ONLY)
+            val forbidden = buildTool("deleteFile", ToolCategory.DESTRUCTIVE)
+
+            val builder = buildBuilder(setOf("readFile"))
+            val manifest = builder.buildManifest(userId, caseId, listOf(tool, forbidden))
+
+            manifest shouldNotContain userId
+            manifest shouldNotContain caseId
+            manifest shouldNotContain "VIEWER" // user's actual role should not appear
+            // Note: ADMIN appears as minimumNamespaceRole for DESTRUCTIVE, which is the required role, not the user's role
+        }
+
+        // -------------------------------------------------------------------------
+        // AC-F: Empty tool collection returns empty string
+        // -------------------------------------------------------------------------
+
+        "empty tool collection returns empty string" {
+            val builder = buildBuilder(emptySet())
+            val manifest = builder.buildManifest(userId, caseId, emptyList())
+
+            manifest shouldBe ""
+        }
+
+        // -------------------------------------------------------------------------
+        // Additional edge cases
+        // -------------------------------------------------------------------------
+
+        "manifest with only allowed tools has no Forbidden section" {
+            val tool = buildTool("readFile", ToolCategory.READ_ONLY)
+
+            val builder = buildBuilder(setOf("readFile"))
+            val manifest = builder.buildManifest(userId, caseId, listOf(tool))
+
+            manifest shouldContain "Allowed tools:"
+            manifest shouldContain "readFile (READ_ONLY)"
+            manifest shouldNotContain "Forbidden tools"
+        }
+
+        "manifest with 10 tools — 6 READ_ONLY, 3 WRITE, 1 DESTRUCTIVE (AC-D scenario)" {
+            val readTools = (1..6).map { buildTool("readTool$it", ToolCategory.READ_ONLY) }
+            val writeTools = (1..3).map { buildTool("writeTool$it", ToolCategory.WRITE) }
+            val destructiveTool = buildTool("destructiveTool1", ToolCategory.DESTRUCTIVE)
+            val allTools = readTools + writeTools + listOf(destructiveTool)
+
+            val allowedNames = (readTools + writeTools).map { it.name }.toSet()
+            val builder = buildBuilder(allowedNames)
+            val manifest = builder.buildManifest(userId, caseId, allTools)
+
+            // 9 allowed tools
+            readTools.forEach { manifest shouldContain "${it.name} (READ_ONLY)" }
+            writeTools.forEach { manifest shouldContain "${it.name} (WRITE)" }
+            // 1 forbidden tool
+            manifest shouldContain "destructiveTool1 (DESTRUCTIVE) — Requires ADMIN role"
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/ToolExecutionGuardSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/ToolExecutionGuardSpec.kt
@@ -18,6 +18,7 @@ class ToolExecutionGuardSpec : StringSpec() {
     private val toolName = "testTool"
     private val toolArgs = """{"key":"value"}"""
     private val toolOutput = "tool executed successfully"
+    private val callerDisplayName = "Test User"
 
     private fun buildTool(
         name: String = toolName,
@@ -52,36 +53,43 @@ class ToolExecutionGuardSpec : StringSpec() {
 
     init {
         // =====================================================================
-        // AC-H: Authorized execution -> Success + logGranted
+        // AC-H: Authorized execution -> Success + logGranted with enriched params
         // =====================================================================
 
-        "authorized execution returns Success and calls logGranted" {
+        "authorized execution returns Success and calls logGranted with enriched params" {
             val tool = buildTool()
             val (guard, auditService) = buildGuard(canExecute = true)
 
-            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId, callerDisplayName)
 
             result.shouldBeInstanceOf<GuardedToolResult.Success>()
             result.toolName shouldBe toolName
             result.output shouldBe toolOutput
-            verify(exactly = 1) { auditService.logGranted(callerId, namespaceId, toolName, caseId) }
-            verify(exactly = 0) { auditService.logDenied(any(), any(), any(), any()) }
+            verify(exactly = 1) {
+                auditService.logGranted(callerId, namespaceId, toolName, caseId, "READ_ONLY", callerDisplayName)
+            }
+            verify(exactly = 0) { auditService.logDenied(any(), any(), any(), any(), any(), any(), any()) }
         }
 
         // =====================================================================
-        // AC-H: Denied execution -> Denied + logDenied + tool NOT executed
+        // AC-H: Denied execution -> Denied + logDenied with reason, category, callerDisplayName
         // =====================================================================
 
-        "denied execution returns Denied, calls logDenied and does NOT execute tool" {
+        "denied execution returns Denied, calls logDenied with enriched params and does NOT execute tool" {
             val tool = buildTool()
             val (guard, auditService) = buildGuard(canExecute = false)
 
-            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId, callerDisplayName)
 
             result.shouldBeInstanceOf<GuardedToolResult.Denied>()
             result.toolName shouldBe toolName
-            verify(exactly = 1) { auditService.logDenied(callerId, namespaceId, toolName, caseId) }
-            verify(exactly = 0) { auditService.logGranted(any(), any(), any(), any()) }
+            verify(exactly = 1) {
+                auditService.logDenied(
+                    callerId, namespaceId, toolName, caseId,
+                    "Permission denied for tool '$toolName'", "READ_ONLY", callerDisplayName,
+                )
+            }
+            verify(exactly = 0) { auditService.logGranted(any(), any(), any(), any(), any(), any()) }
             verify(exactly = 0) { tool.executeWithJson(any()) }
         }
 
@@ -93,12 +101,14 @@ class ToolExecutionGuardSpec : StringSpec() {
             val tool = buildTool(throwOnExecute = RuntimeException("tool crash"))
             val (guard, auditService) = buildGuard(canExecute = true)
 
-            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId, callerDisplayName)
 
             result.shouldBeInstanceOf<GuardedToolResult.Error>()
             result.toolName shouldBe toolName
             result.error shouldBe "tool crash"
-            verify(exactly = 1) { auditService.logGranted(callerId, namespaceId, toolName, caseId) }
+            verify(exactly = 1) {
+                auditService.logGranted(callerId, namespaceId, toolName, caseId, "READ_ONLY", callerDisplayName)
+            }
         }
 
         // =====================================================================
@@ -125,24 +135,46 @@ class ToolExecutionGuardSpec : StringSpec() {
             val tool = buildTool()
             val (guard, auditService) = buildGuard(throwOnCheck = RuntimeException("auth service down"))
 
-            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId, callerDisplayName)
 
             result.shouldBeInstanceOf<GuardedToolResult.Denied>()
-            verify(exactly = 1) { auditService.logDenied(callerId, namespaceId, toolName, caseId) }
+            verify(exactly = 1) {
+                auditService.logDenied(
+                    callerId, namespaceId, toolName, caseId,
+                    "Permission denied for tool '$toolName'", "READ_ONLY", callerDisplayName,
+                )
+            }
             verify(exactly = 0) { tool.executeWithJson(any()) }
         }
 
         // =====================================================================
-        // AC-H: Correct audit calls in each scenario
+        // AC-G: Correct audit calls with enriched parameters
         // =====================================================================
 
-        "audit service receives correct parameters for granted execution" {
+        "audit service receives correct enriched parameters for granted execution" {
             val tool = buildTool(name = "specificTool", category = ToolCategory.WRITE)
             val (guard, auditService) = buildGuard(canExecute = true)
 
-            guard.executeWithPermissionCheck(tool, toolArgs, "caller-abc", "case-def", "ns-ghi")
+            guard.executeWithPermissionCheck(tool, toolArgs, "caller-abc", "case-def", "ns-ghi", "Admin User")
 
-            verify(exactly = 1) { auditService.logGranted("caller-abc", "ns-ghi", "specificTool", "case-def") }
+            verify(exactly = 1) {
+                auditService.logGranted("caller-abc", "ns-ghi", "specificTool", "case-def", "WRITE", "Admin User")
+            }
+        }
+
+        // =====================================================================
+        // AC-G: callerDisplayName null is handled correctly
+        // =====================================================================
+
+        "callerDisplayName defaults to null and is passed correctly" {
+            val tool = buildTool()
+            val (guard, auditService) = buildGuard(canExecute = true)
+
+            guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+
+            verify(exactly = 1) {
+                auditService.logGranted(callerId, namespaceId, toolName, caseId, "READ_ONLY", null)
+            }
         }
 
         // =====================================================================

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/ToolExecutionGuardSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/auth/ToolExecutionGuardSpec.kt
@@ -1,0 +1,191 @@
+package io.whozoss.agentos.auth
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.sdk.auth.ToolCategory
+import io.whozoss.agentos.sdk.tool.StandardTool
+import java.io.File
+
+class ToolExecutionGuardSpec : StringSpec() {
+
+    private val callerId = "user-123"
+    private val caseId = "case-456"
+    private val namespaceId = "ns-789"
+    private val toolName = "testTool"
+    private val toolArgs = """{"key":"value"}"""
+    private val toolOutput = "tool executed successfully"
+
+    private fun buildTool(
+        name: String = toolName,
+        category: ToolCategory = ToolCategory.READ_ONLY,
+        executeResult: String = toolOutput,
+        throwOnExecute: Exception? = null,
+    ): StandardTool<*> = mockk {
+        every { this@mockk.name } returns name
+        every { this@mockk.category } returns category
+        if (throwOnExecute != null) {
+            every { executeWithJson(any()) } throws throwOnExecute
+        } else {
+            every { executeWithJson(any()) } returns executeResult
+        }
+    }
+
+    private fun buildGuard(
+        canExecute: Boolean = true,
+        throwOnCheck: Exception? = null,
+    ): Pair<ToolExecutionGuard, PermissionAuditService> {
+        val authService = mockk<AuthorizationService>()
+        val auditService = mockk<PermissionAuditService>(relaxed = true)
+
+        if (throwOnCheck != null) {
+            every { authService.canExecuteTool(any(), any(), any(), any()) } throws throwOnCheck
+        } else {
+            every { authService.canExecuteTool(any(), any(), any(), any()) } returns canExecute
+        }
+
+        return ToolExecutionGuard(authService, auditService) to auditService
+    }
+
+    init {
+        // =====================================================================
+        // AC-H: Authorized execution -> Success + logGranted
+        // =====================================================================
+
+        "authorized execution returns Success and calls logGranted" {
+            val tool = buildTool()
+            val (guard, auditService) = buildGuard(canExecute = true)
+
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+
+            result.shouldBeInstanceOf<GuardedToolResult.Success>()
+            result.toolName shouldBe toolName
+            result.output shouldBe toolOutput
+            verify(exactly = 1) { auditService.logGranted(callerId, namespaceId, toolName, caseId) }
+            verify(exactly = 0) { auditService.logDenied(any(), any(), any(), any()) }
+        }
+
+        // =====================================================================
+        // AC-H: Denied execution -> Denied + logDenied + tool NOT executed
+        // =====================================================================
+
+        "denied execution returns Denied, calls logDenied and does NOT execute tool" {
+            val tool = buildTool()
+            val (guard, auditService) = buildGuard(canExecute = false)
+
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+
+            result.shouldBeInstanceOf<GuardedToolResult.Denied>()
+            result.toolName shouldBe toolName
+            verify(exactly = 1) { auditService.logDenied(callerId, namespaceId, toolName, caseId) }
+            verify(exactly = 0) { auditService.logGranted(any(), any(), any(), any()) }
+            verify(exactly = 0) { tool.executeWithJson(any()) }
+        }
+
+        // =====================================================================
+        // AC-H: Execution error -> Error + logGranted (permission was ok)
+        // =====================================================================
+
+        "execution error returns Error and calls logGranted (permission was granted)" {
+            val tool = buildTool(throwOnExecute = RuntimeException("tool crash"))
+            val (guard, auditService) = buildGuard(canExecute = true)
+
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+
+            result.shouldBeInstanceOf<GuardedToolResult.Error>()
+            result.toolName shouldBe toolName
+            result.error shouldBe "tool crash"
+            verify(exactly = 1) { auditService.logGranted(callerId, namespaceId, toolName, caseId) }
+        }
+
+        // =====================================================================
+        // AC-H: Default category READ_ONLY used when tool.category not overridden
+        // =====================================================================
+
+        "default category READ_ONLY is passed to authorizationService" {
+            val tool = buildTool(category = ToolCategory.READ_ONLY)
+            val authService = mockk<AuthorizationService>()
+            val auditService = mockk<PermissionAuditService>(relaxed = true)
+            every { authService.canExecuteTool(any(), any(), any(), any()) } returns true
+            val guard = ToolExecutionGuard(authService, auditService)
+
+            guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+
+            verify(exactly = 1) { authService.canExecuteTool(callerId, caseId, toolName, ToolCategory.READ_ONLY) }
+        }
+
+        // =====================================================================
+        // NFR9: Fail-closed when canExecuteTool throws
+        // =====================================================================
+
+        "fail-closed when canExecuteTool throws exception" {
+            val tool = buildTool()
+            val (guard, auditService) = buildGuard(throwOnCheck = RuntimeException("auth service down"))
+
+            val result = guard.executeWithPermissionCheck(tool, toolArgs, callerId, caseId, namespaceId)
+
+            result.shouldBeInstanceOf<GuardedToolResult.Denied>()
+            verify(exactly = 1) { auditService.logDenied(callerId, namespaceId, toolName, caseId) }
+            verify(exactly = 0) { tool.executeWithJson(any()) }
+        }
+
+        // =====================================================================
+        // AC-H: Correct audit calls in each scenario
+        // =====================================================================
+
+        "audit service receives correct parameters for granted execution" {
+            val tool = buildTool(name = "specificTool", category = ToolCategory.WRITE)
+            val (guard, auditService) = buildGuard(canExecute = true)
+
+            guard.executeWithPermissionCheck(tool, toolArgs, "caller-abc", "case-def", "ns-ghi")
+
+            verify(exactly = 1) { auditService.logGranted("caller-abc", "ns-ghi", "specificTool", "case-def") }
+        }
+
+        // =====================================================================
+        // AC-G: Lint/grep test — no direct executeWithJson in AgentSimple/AgentAdvanced
+        // =====================================================================
+
+        "no direct executeWithJson or executeWithAny calls in AgentSimple.kt or AgentAdvanced.kt" {
+            val agentDir = File("src/main/kotlin/io/whozoss/agentos/agent")
+            val agentSimple = File(agentDir, "AgentSimple.kt")
+            val agentAdvanced = File(agentDir, "AgentAdvanced.kt")
+
+            val filesToCheck = listOf(agentSimple, agentAdvanced).filter { it.exists() }
+
+            filesToCheck.forEach { file ->
+                val content = file.readText()
+                val lines = content.lines()
+
+                lines.forEachIndexed { index, line ->
+                    // Skip comments and import statements
+                    val trimmed = line.trim()
+                    if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("import")) {
+                        return@forEachIndexed
+                    }
+
+                    val hasDirectExecuteWithJson = line.contains("executeWithJson(") &&
+                        !line.contains("guard.executeWithPermissionCheck")
+                    val hasDirectExecuteWithAny = line.contains("executeWithAny(") &&
+                        !line.contains("guard.executeWithPermissionCheck")
+
+                    if (hasDirectExecuteWithJson) {
+                        throw AssertionError(
+                            "Direct executeWithJson() call found in ${file.name} at line ${index + 1}: " +
+                                "'${trimmed}'. All tool execution must go through ToolExecutionGuard.",
+                        )
+                    }
+                    if (hasDirectExecuteWithAny) {
+                        throw AssertionError(
+                            "Direct executeWithAny() call found in ${file.name} at line ${index + 1}: " +
+                                "'${trimmed}'. All tool execution must go through ToolExecutionGuard.",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -431,6 +431,80 @@ class CaseRuntimeSpec : StringSpec() {
             lambdaResultDuringRun shouldBe true
         }
 
+        // -------------------------------------------------------------------------
+        // CallerContext integration
+        // -------------------------------------------------------------------------
+
+        "addUserMessage updates callerContext with the actor's id and displayName" {
+            val (runtime) = buildRuntime()
+
+            runtime.addUserMessage(userActor, userMessage)
+
+            runtime.callerContext.getCallerId() shouldBe userActor.id
+            runtime.callerContext.getCallerDisplayName() shouldBe userActor.displayName
+        }
+
+        "callerContext is updated BEFORE the MessageEvent is stored" {
+            val runtimeId = UUID.randomUUID()
+            var callerIdAtStoreTime: String? = "NOT_SET"
+
+            lateinit var runtime: CaseRuntime
+            runtime =
+                CaseRuntime(
+                    id = runtimeId,
+                    namespaceId = namespaceId,
+                    updateStatus = { _, _ -> },
+                    storeEvent = { event ->
+                        if (event is MessageEvent && event.actor.role == ActorRole.USER) {
+                            callerIdAtStoreTime = runtime.callerContext.getCallerId()
+                        }
+                        event
+                    },
+                    selectAgent = { listOf(agentSelectedEvent(runtimeId, "default-agent")) },
+                    runAgent = { _, _, _, _ -> },
+                )
+
+            runtime.addUserMessage(userActor, userMessage)
+
+            callerIdAtStoreTime shouldBe userActor.id
+        }
+
+        "runAgent receives the callerContext userId as UUID" {
+            val runtimeId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val actor = Actor(id = userId.toString(), displayName = "Caller User", role = ActorRole.USER)
+            var capturedUserId: UUID? = null
+
+            lateinit var runtime: CaseRuntime
+            runtime =
+                CaseRuntime(
+                    id = runtimeId,
+                    namespaceId = namespaceId,
+                    updateStatus = { _, _ -> },
+                    storeEvent = { it },
+                    selectAgent = { listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    runAgent = { _, _, uid, _ ->
+                        capturedUserId = uid
+                        // Push AgentFinishedEvent so the loop exits cleanly
+                        runtime.pushEvents(
+                            listOf(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = runtimeId,
+                                    agentId = UUID.nameUUIDFromBytes("agent".toByteArray()),
+                                    agentName = "agent",
+                                ),
+                            ),
+                        )
+                    },
+                )
+
+            runtime.addUserMessage(actor, userMessage)
+            runtime.run()
+
+            capturedUserId shouldBe userId
+        }
+
         "runAgent is called exactly once when AgentRunningEvent is already in the event list" {
             val agentName = "gemini-flash"
             val caseId = UUID.randomUUID()


### PR DESCRIPTION
## Summary

Proposes a defense-in-depth pattern for tool-level permission enforcement in AgentOS. This PR introduces a design where the LLM is informed of permission constraints (PermissionManifest) and the backend enforces them independently (ToolExecutionGuard).

> **Note:** This is a pattern proposal — the implementation may evolve based on team review and real-world usage. The goal is to establish the architectural direction for tool-level security in a multi-user agent context.

**Depends on:** PR #755 (Phase 1 — namespace/case access control)

## What this PR proposes

### 1. Tool Categorization (`agentos-sdk`)
- `category` property added to `StandardTool` interface (default: `READ_ONLY`)
- Categories: `READ_ONLY`, `WRITE`, `DESTRUCTIVE`, `ADMIN` — each with a risk label and minimum namespace role

### 2. CallerContext — Multi-user Tracking
- Tracks the last message sender in multi-user cases via `@Volatile` fields on `CaseRuntime`
- Updated on every `addUserMessage()` call, populated exclusively from the authenticated controller layer
- Enables per-user permission evaluation when the agent executes tools

### 3. ToolExecutionGuard — Backend Enforcement
- Wraps every `executeWithJson()` call in both `AgentSimple` and `AgentAdvanced`
- Returns sealed `GuardedToolResult`: `Success`, `Denied(reason)`, or `Error`
- Denied executions return a structured message the LLM can relay to the user
- `@Lazy` injection resolves circular dependency

### 4. PermissionManifestBuilder — LLM Guidance
- Generates a structured text block injected into the agent system prompt
- Lists allowed and forbidden tools (with reasons) per user
- Graceful degradation: returns empty string if userId is unavailable

### 5. PermissionAuditService — Audit Trail
- Structured SLF4J logging + Spring `ApplicationEventPublisher` for every tool execution decision
- Full context per entry: userId, namespaceId, caseId, toolName, toolCategory, decision, reason, timestamp

## Key design decisions

- **Defense-in-depth**: The LLM is an untrusted intermediary — even with the manifest guiding it, the guard blocks unauthorized execution at the backend level
- **CallerContext with `@Volatile`**: Simple last-writer-wins pattern — compatible with Kotlin coroutines, no ThreadLocal
- **Dual audit**: SLF4J logging (queryable via log aggregation) + Spring events (extensible for custom listeners)
- **Backward compatible**: `StandardTool.category` defaults to `READ_ONLY`, all new parameters have defaults

## How to test

```bash
./gradlew build

# Phase 2 specific tests
./gradlew :agentos-service:test --tests "*ToolExecutionGuard*"
./gradlew :agentos-service:test --tests "*CallerContext*"
./gradlew :agentos-service:test --tests "*PermissionManifest*"
./gradlew :agentos-service:test --tests "*PermissionAudit*"
./gradlew :agentos-sdk:test --tests "*ToolCategory*"
```

## Files changed (22 files, +1165/-30)

**New (10):** CallerContext, ToolExecutionGuard, PermissionManifestBuilder, PermissionAuditService + specs
**Modified (12):** StandardTool, AgentSimple, AgentAdvanced, AgentServiceImpl, CaseRuntime + test files

## Related

- Ticket: WZ-29564
- Depends on: PR #755 (Phase 1)