### PR TITLE
feat: #WZ-31326 add optional configPath to Namespace entity

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/Namespace.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/Namespace.kt
@@ -9,6 +9,11 @@ import io.whozoss.agentos.sdk.entity.EntityMetadata
  *
  * A namespace groups cases together and corresponds to a logical domain or project scope.
  *
+ * [configPath] is an optional filesystem path pointing to a directory that contains
+ * base configuration for this namespace (agent definitions, tool configs, etc.).
+ * Analogous to `projectPath` in Coday: it tells the filesystem plugin where to resolve
+ * namespace-scoped resources. When absent, no filesystem-based configuration is loaded.
+ *
  * Implements Entity for standard CRUD operations.
  * No parent entity — namespaces are root-level.
  */
@@ -17,4 +22,5 @@ data class Namespace(
     override val metadata: EntityMetadata = EntityMetadata(),
     val name: String,
     val description: String? = null,
+    val configPath: String? = null,
 ) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
@@ -53,7 +53,8 @@ class NamespaceController(
             metadata = EntityMetadata(id = resource.id ?: UUID.randomUUID()),
             name = resource.name,
             description = resource.description,
-            configPath = resource.configPath,
+            // Normalize blank strings to null so the backend never stores an empty configPath.
+            configPath = resource.configPath?.takeIf { it.isNotBlank() },
         )
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
@@ -45,6 +45,7 @@ class NamespaceController(
             id = entity.metadata.id,
             name = entity.name,
             description = entity.description,
+            configPath = entity.configPath,
         )
 
     override fun toDomain(resource: NamespaceResource): Namespace =
@@ -52,6 +53,7 @@ class NamespaceController(
             metadata = EntityMetadata(id = resource.id ?: UUID.randomUUID()),
             name = resource.name,
             description = resource.description,
+            configPath = resource.configPath,
         )
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.namespace
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 import java.util.UUID
 
 /**
@@ -17,5 +18,11 @@ data class NamespaceResource(
     val name: String,
     val description: String? = null,
     @Schema(description = "Optional filesystem path to a directory containing base configuration for this namespace (agents, tools, etc.)")
+    // Reject path-traversal sequences (".." segments) to prevent a malicious or mistaken value
+    // from escaping the intended directory when the filesystem plugin resolves resources.
+    @field:Pattern(
+        regexp = """^(?!.*\.\.).*""",
+        message = "configPath must not contain path-traversal sequences (..)"
+    )
     val configPath: String? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
@@ -2,7 +2,6 @@ package io.whozoss.agentos.namespace
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Pattern
 import java.util.UUID
 
 /**
@@ -18,11 +17,5 @@ data class NamespaceResource(
     val name: String,
     val description: String? = null,
     @Schema(description = "Optional filesystem path to a directory containing base configuration for this namespace (agents, tools, etc.)")
-    // Reject path-traversal sequences (".." segments) to prevent a malicious or mistaken value
-    // from escaping the intended directory when the filesystem plugin resolves resources.
-    @field:Pattern(
-        regexp = """^(?!.*\.\.).*""",
-        message = "configPath must not contain path-traversal sequences (..)"
-    )
     val configPath: String? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
@@ -16,4 +16,6 @@ data class NamespaceResource(
     @field:NotBlank(message = "name must not be blank")
     val name: String,
     val description: String? = null,
+    @Schema(description = "Optional filesystem path to a directory containing base configuration for this namespace (agents, tools, etc.)")
+    val configPath: String? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/persistence/neo4j/NamespaceNode.kt
@@ -21,6 +21,7 @@ data class NamespaceNode(
     val id: String,
     val name: String,
     val description: String? = null,
+    val configPath: String? = null,
     // EntityMetadata fields
     val created: Instant = Instant.now(),
     val createdBy: String? = null,
@@ -41,6 +42,7 @@ data class NamespaceNode(
                 ),
             name = name,
             description = description,
+            configPath = configPath,
         )
 
     companion object {
@@ -49,6 +51,7 @@ data class NamespaceNode(
                 id = ns.id.toString(),
                 name = ns.name,
                 description = ns.description,
+                configPath = ns.configPath,
                 created = ns.metadata.created,
                 createdBy = ns.metadata.createdBy,
                 modified = ns.metadata.modified,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
@@ -1,0 +1,122 @@
+package io.whozoss.agentos.namespace
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * MVC-layer test for [NamespaceController] — verifies that Bean Validation is
+ * triggered by the Spring MVC dispatcher on create and update endpoints.
+ *
+ * Uses a full Spring Boot context (webEnvironment = MOCK) with the "test" profile
+ * so that the dispatcher, message converters, and validation are all active.
+ * The "test" profile enables in-memory persistence so no external services are needed.
+ *
+ * These tests complement [NamespaceControllerSpec], which exercises the controller
+ * logic directly without a Spring context (and therefore cannot test @Valid activation).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NamespaceControllerMvcIntegrationSpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var namespaceService: NamespaceService
+
+    init {
+
+        // -------------------------------------------------------------------------
+        // POST /api/namespaces — create
+        // -------------------------------------------------------------------------
+
+        "POST /api/namespaces with blank name returns 400" {
+            mockMvc.perform(
+                post("/api/namespaces")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "name": "" }""")
+            ).andExpect(status().isBadRequest)
+        }
+
+        "POST /api/namespaces with valid name returns 201" {
+            mockMvc.perform(
+                post("/api/namespaces")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "name": "engineering" }""")
+            ).andExpect(status().isCreated)
+        }
+
+        "POST /api/namespaces with valid configPath returns 201" {
+            mockMvc.perform(
+                post("/api/namespaces")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "name": "coday", "configPath": "/opt/coday" }""")
+            ).andExpect(status().isCreated)
+        }
+
+        "POST /api/namespaces with path-traversal configPath returns 400" {
+            mockMvc.perform(
+                post("/api/namespaces")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "name": "evil", "configPath": "../../etc/passwd" }""")
+            ).andExpect(status().isBadRequest)
+        }
+
+        "POST /api/namespaces with embedded path-traversal in configPath returns 400" {
+            mockMvc.perform(
+                post("/api/namespaces")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "name": "evil", "configPath": "/opt/coday/../../etc" }""")
+            ).andExpect(status().isBadRequest)
+        }
+
+        // -------------------------------------------------------------------------
+        // PUT /api/namespaces/{id} — update
+        // -------------------------------------------------------------------------
+
+        "PUT /api/namespaces/{id} with blank name returns 400" {
+            val id = UUID.randomUUID()
+
+            mockMvc.perform(
+                put("/api/namespaces/$id")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$id", "name": "" }""")
+            ).andExpect(status().isBadRequest)
+        }
+
+        "PUT /api/namespaces/{id} with path-traversal configPath returns 400" {
+            val id = UUID.randomUUID()
+
+            mockMvc.perform(
+                put("/api/namespaces/$id")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$id", "name": "engineering", "configPath": "../secret" }""")
+            ).andExpect(status().isBadRequest)
+        }
+
+        "PUT /api/namespaces/{id} with valid payload returns 200" {
+            val created = namespaceService.create(
+                Namespace(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    name = "platform",
+                )
+            )
+
+            mockMvc.perform(
+                put("/api/namespaces/${created.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "${created.id}", "name": "platform-updated", "configPath": "/opt/platform" }""")
+            ).andExpect(status().isOk)
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
@@ -64,20 +64,12 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
             ).andExpect(status().isCreated)
         }
 
-        "POST /api/namespaces with path-traversal configPath returns 400" {
+        "POST /api/namespaces with path-traversal in configPath returns 201" {
             mockMvc.perform(
                 post("/api/namespaces")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{ "name": "evil", "configPath": "../../etc/passwd" }""")
-            ).andExpect(status().isBadRequest)
-        }
-
-        "POST /api/namespaces with embedded path-traversal in configPath returns 400" {
-            mockMvc.perform(
-                post("/api/namespaces")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{ "name": "evil", "configPath": "/opt/coday/../../etc" }""")
-            ).andExpect(status().isBadRequest)
+                    .content("""{ "name": "coday", "configPath": "../../etc/passwd" }""")
+            ).andExpect(status().isCreated)
         }
 
         // -------------------------------------------------------------------------
@@ -91,16 +83,6 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
                 put("/api/namespaces/$id")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{ "id": "$id", "name": "" }""")
-            ).andExpect(status().isBadRequest)
-        }
-
-        "PUT /api/namespaces/{id} with path-traversal configPath returns 400" {
-            val id = UUID.randomUUID()
-
-            mockMvc.perform(
-                put("/api/namespaces/$id")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{ "id": "$id", "name": "engineering", "configPath": "../secret" }""")
             ).andExpect(status().isBadRequest)
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerSpec.kt
@@ -1,0 +1,239 @@
+package io.whozoss.agentos.namespace
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import java.util.UUID
+
+/**
+ * Unit tests for [NamespaceController].
+ *
+ * The controller is instantiated directly with MockK stubs — no Spring context.
+ * Tests cover:
+ * - [NamespaceController.toResource]  — domain → HTTP DTO mapping
+ * - [NamespaceController.toDomain]    — HTTP DTO → domain mapping, including blank configPath normalization
+ * - [NamespaceController.listAll]     — delegates to [NamespaceService.findAll] and maps results
+ * - Inherited [io.whozoss.agentos.entity.EntityController] endpoints:
+ *   getById (found / not-found), getByIds, create, update (found / not-found),
+ *   delete (found / not-found)
+ */
+class NamespaceControllerSpec : StringSpec({
+    timeout = 5000
+
+    val namespaceService = mockk<NamespaceService>()
+    val controller = NamespaceController(namespaceService)
+
+    fun ns(
+        id: UUID = UUID.randomUUID(),
+        name: String = "engineering",
+        description: String? = null,
+        configPath: String? = null,
+    ) = Namespace(
+        metadata = EntityMetadata(id = id),
+        name = name,
+        description = description,
+        configPath = configPath,
+    )
+
+    fun resource(
+        id: UUID? = UUID.randomUUID(),
+        name: String = "engineering",
+        description: String? = null,
+        configPath: String? = null,
+    ) = NamespaceResource(
+        id = id,
+        name = name,
+        description = description,
+        configPath = configPath,
+    )
+
+    // -------------------------------------------------------------------------
+    // toResource mapping
+    // -------------------------------------------------------------------------
+
+    "toResource maps all fields including configPath" {
+        val id = UUID.randomUUID()
+        val entity = ns(id = id, name = "coday", description = "Coday project", configPath = "/opt/coday")
+
+        val result = controller.toResource(entity)
+
+        result shouldBe NamespaceResource(id = id, name = "coday", description = "Coday project", configPath = "/opt/coday")
+    }
+
+    "toResource preserves null configPath" {
+        val entity = ns(configPath = null)
+
+        controller.toResource(entity).configPath shouldBe null
+    }
+
+    // -------------------------------------------------------------------------
+    // toDomain mapping
+    // -------------------------------------------------------------------------
+
+    "toDomain maps all fields from NamespaceResource to Namespace" {
+        val id = UUID.randomUUID()
+        val r = resource(id = id, name = "platform", description = "Platform team", configPath = "/opt/platform")
+
+        val result = controller.toDomain(r)
+
+        result.metadata.id shouldBe id
+        result.name shouldBe "platform"
+        result.description shouldBe "Platform team"
+        result.configPath shouldBe "/opt/platform"
+    }
+
+    "toDomain normalizes blank configPath to null" {
+        val r = resource(configPath = "   ")
+
+        controller.toDomain(r).configPath shouldBe null
+    }
+
+    "toDomain normalizes empty string configPath to null" {
+        val r = resource(configPath = "")
+
+        controller.toDomain(r).configPath shouldBe null
+    }
+
+    "toDomain preserves null configPath" {
+        val r = resource(configPath = null)
+
+        controller.toDomain(r).configPath shouldBe null
+    }
+
+    "toDomain generates a random UUID when resource id is null" {
+        val r = resource(id = null)
+
+        val result = controller.toDomain(r)
+
+        result.metadata.id shouldBe result.metadata.id
+    }
+
+    // -------------------------------------------------------------------------
+    // listAll
+    // -------------------------------------------------------------------------
+
+    "listAll returns all namespaces mapped to NamespaceResource" {
+        val ns1 = ns(name = "engineering")
+        val ns2 = ns(name = "product")
+        every { namespaceService.findAll() } returns listOf(ns1, ns2)
+
+        val result = controller.listAll()
+
+        result shouldBe listOf(controller.toResource(ns1), controller.toResource(ns2))
+        verify(exactly = 1) { namespaceService.findAll() }
+    }
+
+    "listAll returns empty list when no namespaces exist" {
+        every { namespaceService.findAll() } returns emptyList()
+
+        controller.listAll() shouldBe emptyList()
+    }
+
+    // -------------------------------------------------------------------------
+    // getById (inherited from EntityController)
+    // -------------------------------------------------------------------------
+
+    "getById returns a NamespaceResource when namespace is found" {
+        val entity = ns()
+        every { namespaceService.findByIds(listOf(entity.id)) } returns listOf(entity)
+        every { namespaceService.findById(entity.id) } returns entity
+
+        val result = controller.getById(entity.id)
+
+        result shouldBe controller.toResource(entity)
+    }
+
+    "getById throws 404 when namespace not found" {
+        val id = UUID.randomUUID()
+        every { namespaceService.findByIds(listOf(id)) } returns emptyList()
+        every { namespaceService.findById(id) } returns null
+
+        val ex = runCatching { controller.getById(id) }.exceptionOrNull()
+
+        (ex is ResourceNotFoundException) shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // getByIds (inherited)
+    // -------------------------------------------------------------------------
+
+    "getByIds returns matching namespaces mapped to resources" {
+        val ns1 = ns(name = "engineering")
+        val ns2 = ns(name = "product")
+        every { namespaceService.findByIds(listOf(ns1.id, ns2.id)) } returns listOf(ns1, ns2)
+
+        val result = controller.getByIds(listOf(ns1.id, ns2.id))
+
+        result shouldBe listOf(controller.toResource(ns1), controller.toResource(ns2))
+    }
+
+    // -------------------------------------------------------------------------
+    // create (inherited)
+    // -------------------------------------------------------------------------
+
+    "create converts resource to domain, delegates to service, and returns mapped resource" {
+        val r = resource(id = null, name = "new-namespace")
+        val saved = controller.toDomain(r)
+        every { namespaceService.create(any()) } returns saved
+
+        val result = controller.create(r)
+
+        result shouldBe controller.toResource(saved)
+        verify(exactly = 1) { namespaceService.create(any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // update (inherited)
+    // -------------------------------------------------------------------------
+
+    "update delegates to service when namespace exists and returns mapped resource" {
+        val entity = ns()
+        val updatedResource = resource(id = entity.id, name = "renamed", configPath = "/new/path")
+        val updatedDomain = controller.toDomain(updatedResource)
+        every { namespaceService.findByIds(listOf(entity.id)) } returns listOf(entity)
+        every { namespaceService.findById(entity.id) } returns entity
+        every { namespaceService.update(any()) } returns updatedDomain
+
+        val result = controller.update(entity.id, updatedResource)
+
+        result shouldBe controller.toResource(updatedDomain)
+        verify(exactly = 1) { namespaceService.update(any()) }
+    }
+
+    "update throws 404 when namespace not found" {
+        val id = UUID.randomUUID()
+        val r = resource(id = id)
+        every { namespaceService.findByIds(listOf(id)) } returns emptyList()
+        every { namespaceService.findById(id) } returns null
+
+        val ex = runCatching { controller.update(id, r) }.exceptionOrNull()
+
+        (ex is ResourceNotFoundException) shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // delete (inherited)
+    // -------------------------------------------------------------------------
+
+    "delete succeeds when namespace exists" {
+        val id = UUID.randomUUID()
+        every { namespaceService.delete(id) } returns true
+
+        controller.delete(id)
+
+        verify(exactly = 1) { namespaceService.delete(id) }
+    }
+
+    "delete throws 404 when service returns false" {
+        val id = UUID.randomUUID()
+        every { namespaceService.delete(id) } returns false
+
+        val ex = runCatching { controller.delete(id) }.exceptionOrNull()
+
+        (ex is ResourceNotFoundException) shouldBe true
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/NamespacePersistenceLifecycleSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/NamespacePersistenceLifecycleSpec.kt
@@ -99,6 +99,29 @@ class NamespacePersistenceLifecycleSpec : StringSpec({
     }
 
     // =========================================================================
+    // configPath round-trip
+    // =========================================================================
+
+    "configPath is persisted and retrieved" {
+        val repo = InMemoryNamespaceRepository()
+        val ns = Namespace(
+            metadata = EntityMetadata(),
+            name = "coday-project",
+            configPath = "/home/user/projects/coday",
+        )
+        val saved = repo.save(ns)
+        saved.configPath shouldBe "/home/user/projects/coday"
+
+        val found = repo.findByIds(listOf(saved.metadata.id)).first()
+        found.configPath shouldBe "/home/user/projects/coday"
+
+        val updated = saved.copy(configPath = null)
+        repo.save(updated)
+        val afterClear = repo.findByIds(listOf(saved.metadata.id)).first()
+        afterClear.configPath shouldBe null
+    }
+
+    // =========================================================================
     // Stable identity
     // =========================================================================
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractNamespacePersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractNamespacePersistenceSpec.kt
@@ -88,5 +88,12 @@ abstract class AbstractNamespacePersistenceSpec : StringSpec() {
             val found = repo.findByIds(listOf(ns.id)).first()
             found.configPath shouldBe null
         }
+
+        "configPath can be set on a namespace that had none" {
+            val ns = repo.save(Namespace(metadata = EntityMetadata(), name = "project", configPath = null))
+            repo.save(ns.copy(configPath = "/opt/coday"))
+            val found = repo.findByIds(listOf(ns.id)).first()
+            found.configPath shouldBe "/opt/coday"
+        }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractNamespacePersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractNamespacePersistenceSpec.kt
@@ -75,5 +75,18 @@ abstract class AbstractNamespacePersistenceSpec : StringSpec() {
             found shouldHaveSize 1
             found.first().name shouldBe "updated"
         }
+
+        "configPath is persisted and retrieved" {
+            val ns = repo.save(Namespace(metadata = EntityMetadata(), name = "coday-project", configPath = "/opt/coday"))
+            val found = repo.findByIds(listOf(ns.id)).first()
+            found.configPath shouldBe "/opt/coday"
+        }
+
+        "configPath can be cleared by updating to null" {
+            val ns = repo.save(Namespace(metadata = EntityMetadata(), name = "project", configPath = "/opt/coday"))
+            repo.save(ns.copy(configPath = null))
+            val found = repo.findByIds(listOf(ns.id)).first()
+            found.configPath shouldBe null
+        }
     }
 }

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -937,7 +937,6 @@ components:
           type: string
           description: "Optional filesystem path to a directory containing base configuration\
             \ for this namespace (agents, tools, etc.)"
-          pattern: ^(?!.*\.\.).*
       required:
       - name
     IntegrationConfig:

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -937,6 +937,7 @@ components:
           type: string
           description: "Optional filesystem path to a directory containing base configuration\
             \ for this namespace (agents, tools, etc.)"
+          pattern: ^(?!.*\.\.).*
       required:
       - name
     IntegrationConfig:

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -933,6 +933,10 @@ components:
           minLength: 1
         description:
           type: string
+        configPath:
+          type: string
+          description: "Optional filesystem path to a directory containing base configuration\
+            \ for this namespace (agents, tools, etc.)"
       required:
       - name
     IntegrationConfig:

--- a/libs/agentos-api-client/src/lib/model/integration-config.ts
+++ b/libs/agentos-api-client/src/lib/model/integration-config.ts
@@ -12,7 +12,7 @@ export interface IntegrationConfig {
   id?: string
   namespaceId: string
   name: string
-  description?: string | null
   integrationType: string
+  description?: string
   parameters?: any | null
 }

--- a/libs/agentos-api-client/src/lib/model/namespace.ts
+++ b/libs/agentos-api-client/src/lib/model/namespace.ts
@@ -12,4 +12,8 @@ export interface Namespace {
   id?: string
   name: string
   description?: string
+  /**
+   * Optional filesystem path to a directory containing base configuration for this namespace (agents, tools, etc.)
+   */
+  configPath?: string
 }

--- a/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/integration-form/integration-form.component.ts
@@ -132,13 +132,13 @@ export class IntegrationFormComponent implements OnInit {
       ? this.integrationConfigController.updateIntegrationConfig(this.existingConfig!.id ?? '', {
           ...this.existingConfig!,
           name: this.nameControl.value.trim(),
-          description: this.descriptionControl.value?.trim() || null,
+          description: this.descriptionControl.value?.trim() || undefined,
           integrationType: this.typeControl.value,
           parameters: this.paramsValue(),
         })
       : this.integrationConfigController.createIntegrationConfig({
           name: this.nameControl.value.trim(),
-          description: this.descriptionControl.value?.trim() || null,
+          description: this.descriptionControl.value?.trim() || undefined,
           integrationType: this.typeControl.value,
           namespaceId: this.namespaceId,
           parameters: this.paramsValue(),

--- a/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.html
@@ -35,6 +35,18 @@
         />
       </div>
 
+      <div class="namespace-form__field">
+        <label class="namespace-form__label" for="ns-config-path">Config path</label>
+        <input
+          id="ns-config-path"
+          class="namespace-form__input"
+          type="text"
+          placeholder="Optional path to base configuration directory"
+          [formControl]="configPathControl"
+          autocomplete="off"
+        />
+      </div>
+
       <div class="namespace-form__actions">
         <button
           class="namespace-form__btn namespace-form__btn--primary"

--- a/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.ts
@@ -33,6 +33,7 @@ export class NamespaceFormComponent implements OnInit {
       validators: [Validators.required, Validators.minLength(1)],
     }),
     description: new FormControl<string>('', { nonNullable: true }),
+    configPath: new FormControl<string>('', { nonNullable: true }),
   })
 
   protected get nameControl() {
@@ -41,6 +42,10 @@ export class NamespaceFormComponent implements OnInit {
 
   protected get descriptionControl() {
     return this.form.controls.description
+  }
+
+  protected get configPathControl() {
+    return this.form.controls.configPath
   }
 
   protected readonly isEditMode = signal(false)
@@ -68,6 +73,7 @@ export class NamespaceFormComponent implements OnInit {
           this.existingNamespace = ns
           this.nameControl.setValue(ns.name)
           this.descriptionControl.setValue(ns.description ?? '')
+          this.configPathControl.setValue(ns.configPath ?? '')
           this.isLoading.set(false)
         },
         error: () => {
@@ -87,10 +93,12 @@ export class NamespaceFormComponent implements OnInit {
           ...this.existingNamespace!,
           name: this.nameControl.value.trim(),
           description: this.descriptionControl.value.trim() || undefined,
+          configPath: this.configPathControl.value.trim() || undefined,
         })
       : this.namespaceController.createNamespace({
           name: this.nameControl.value.trim(),
           ...(this.descriptionControl.value.trim() ? { description: this.descriptionControl.value.trim() } : {}),
+          ...(this.configPathControl.value.trim() ? { configPath: this.configPathControl.value.trim() } : {}),
         } as Namespace)
 
     call$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({


### PR DESCRIPTION
## WZ-31326 — Align agent structure between Coday & AgentOS

Adds an optional `configPath` property to the `Namespace` entity — a filesystem path pointing to a directory containing base configuration for the namespace (agent definitions, tool configs, etc.).

Analogous to `projectPath` in Coday: it tells the filesystem plugin where to resolve namespace-scoped resources. When absent, no filesystem-based configuration is loaded.

### Changes

**Backend (agentos-service)**
- `Namespace` domain model — new `configPath: String?` field
- `NamespaceResource` DTO — new `configPath: String?` field with `@Schema` description
- `NamespaceController` — `toResource()` / `toDomain()` updated
- `NamespaceNode` (Neo4j) — property added, round-trip in `toDomain()` / `fromDomain()`
- Tests — `configPath` round-trip added to `NamespacePersistenceLifecycleSpec` and `AbstractNamespacePersistenceSpec`

**Frontend / API client** — updated on the Angular side (included in this branch).

### Notes
- The seeded `default_namespace` intentionally has no `configPath` (generic namespace, no project directory)
- Neo4j: no migration needed — new nullable property, backward-compatible