### PR TITLE
feat: #562 add Zendesk tools to browse categories, sections and articles

### DIFF
--- a/libs/integrations/zendesk-articles/src/lib/list-zendesk-articles-in-category.ts
+++ b/libs/integrations/zendesk-articles/src/lib/list-zendesk-articles-in-category.ts
@@ -1,0 +1,47 @@
+import axios from 'axios'
+import { Interactor } from '@coday/model'
+
+export async function listZendeskArticlesInCategory(
+  categoryId: string,
+  zendeskSubdomain: string,
+  zendeskEmail: string,
+  zendeskApiToken: string,
+  interactor: Interactor,
+  locale?: string
+): Promise<any> {
+  if (!zendeskSubdomain || !zendeskEmail || !zendeskApiToken) {
+    throw new Error('Zendesk integration incorrectly set')
+  }
+
+  try {
+    interactor.displayText(`Listing Zendesk articles in category ${categoryId}...`)
+
+    const localeSegment = locale ? `/${locale}` : ''
+    const url = `https://${zendeskSubdomain}.zendesk.com/api/v2/help_center${localeSegment}/categories/${categoryId}/articles.json`
+
+    const response = await axios.get(url, {
+      auth: {
+        username: `${zendeskEmail}/token`,
+        password: zendeskApiToken,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    const articles = response.data.articles
+    interactor.displayText(`... received ${articles?.length || 0} articles from Zendesk.`)
+
+    return articles.map((article: any) => ({
+      id: article.id,
+      title: article.title,
+      locale: article.locale,
+      url: article.html_url,
+      section_id: article.section_id,
+      updated_at: article.updated_at,
+    }))
+  } catch (error: any) {
+    interactor.warn(`Failed to list Zendesk articles in category ${categoryId}`)
+    return `Failed to list articles in category ${categoryId}: ${error.message}`
+  }
+}

--- a/libs/integrations/zendesk-articles/src/lib/list-zendesk-articles-in-section.ts
+++ b/libs/integrations/zendesk-articles/src/lib/list-zendesk-articles-in-section.ts
@@ -1,0 +1,47 @@
+import axios from 'axios'
+import { Interactor } from '@coday/model'
+
+export async function listZendeskArticlesInSection(
+  sectionId: string,
+  zendeskSubdomain: string,
+  zendeskEmail: string,
+  zendeskApiToken: string,
+  interactor: Interactor,
+  locale?: string
+): Promise<any> {
+  if (!zendeskSubdomain || !zendeskEmail || !zendeskApiToken) {
+    throw new Error('Zendesk integration incorrectly set')
+  }
+
+  try {
+    interactor.displayText(`Listing Zendesk articles in section ${sectionId}...`)
+
+    const localeSegment = locale ? `/${locale}` : ''
+    const url = `https://${zendeskSubdomain}.zendesk.com/api/v2/help_center${localeSegment}/sections/${sectionId}/articles.json`
+
+    const response = await axios.get(url, {
+      auth: {
+        username: `${zendeskEmail}/token`,
+        password: zendeskApiToken,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    const articles = response.data.articles
+    interactor.displayText(`... received ${articles?.length || 0} articles from Zendesk.`)
+
+    return articles.map((article: any) => ({
+      id: article.id,
+      title: article.title,
+      locale: article.locale,
+      url: article.html_url,
+      section_id: article.section_id,
+      updated_at: article.updated_at,
+    }))
+  } catch (error: any) {
+    interactor.warn(`Failed to list Zendesk articles in section ${sectionId}`)
+    return `Failed to list articles in section ${sectionId}: ${error.message}`
+  }
+}

--- a/libs/integrations/zendesk-articles/src/lib/list-zendesk-categories.ts
+++ b/libs/integrations/zendesk-articles/src/lib/list-zendesk-categories.ts
@@ -1,0 +1,46 @@
+import axios from 'axios'
+import { Interactor } from '@coday/model'
+
+export async function listZendeskCategories(
+  zendeskSubdomain: string,
+  zendeskEmail: string,
+  zendeskApiToken: string,
+  interactor: Interactor,
+  locale?: string
+): Promise<any> {
+  if (!zendeskSubdomain || !zendeskEmail || !zendeskApiToken) {
+    throw new Error('Zendesk integration incorrectly set')
+  }
+
+  try {
+    interactor.displayText('Listing Zendesk categories...')
+
+    const localeSegment = locale ? `/${locale}` : ''
+    const url = `https://${zendeskSubdomain}.zendesk.com/api/v2/help_center${localeSegment}/categories.json`
+
+    const response = await axios.get(url, {
+      auth: {
+        username: `${zendeskEmail}/token`,
+        password: zendeskApiToken,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    const categories = response.data.categories
+    interactor.displayText(`... received ${categories?.length || 0} categories from Zendesk.`)
+
+    return categories.map((category: any) => ({
+      id: category.id,
+      name: category.name,
+      description: category.description,
+      locale: category.locale,
+      url: category.html_url,
+      position: category.position,
+    }))
+  } catch (error: any) {
+    interactor.warn('Failed to list Zendesk categories')
+    return `Failed to list categories: ${error.message}`
+  }
+}

--- a/libs/integrations/zendesk-articles/src/lib/list-zendesk-sections.ts
+++ b/libs/integrations/zendesk-articles/src/lib/list-zendesk-sections.ts
@@ -1,0 +1,48 @@
+import axios from 'axios'
+import { Interactor } from '@coday/model'
+
+export async function listZendeskSections(
+  categoryId: string,
+  zendeskSubdomain: string,
+  zendeskEmail: string,
+  zendeskApiToken: string,
+  interactor: Interactor,
+  locale?: string
+): Promise<any> {
+  if (!zendeskSubdomain || !zendeskEmail || !zendeskApiToken) {
+    throw new Error('Zendesk integration incorrectly set')
+  }
+
+  try {
+    interactor.displayText(`Listing Zendesk sections for category ${categoryId}...`)
+
+    const localeSegment = locale ? `/${locale}` : ''
+    const url = `https://${zendeskSubdomain}.zendesk.com/api/v2/help_center${localeSegment}/categories/${categoryId}/sections.json`
+
+    const response = await axios.get(url, {
+      auth: {
+        username: `${zendeskEmail}/token`,
+        password: zendeskApiToken,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    const sections = response.data.sections
+    interactor.displayText(`... received ${sections?.length || 0} sections from Zendesk.`)
+
+    return sections.map((section: any) => ({
+      id: section.id,
+      name: section.name,
+      description: section.description,
+      locale: section.locale,
+      url: section.html_url,
+      category_id: section.category_id,
+      position: section.position,
+    }))
+  } catch (error: any) {
+    interactor.warn(`Failed to list Zendesk sections for category ${categoryId}`)
+    return `Failed to list sections for category ${categoryId}: ${error.message}`
+  }
+}

--- a/libs/integrations/zendesk-articles/src/lib/zendesk.tools.ts
+++ b/libs/integrations/zendesk-articles/src/lib/zendesk.tools.ts
@@ -1,5 +1,9 @@
 import { retrieveZendeskArticle } from './retrieve-zendesk-article'
 import { searchZendeskArticles } from './search-zendesk-articles'
+import { listZendeskCategories } from './list-zendesk-categories'
+import { listZendeskSections } from './list-zendesk-sections'
+import { listZendeskArticlesInSection } from './list-zendesk-articles-in-section'
+import { listZendeskArticlesInCategory } from './list-zendesk-articles-in-category'
 import { IntegrationService } from '@coday/service'
 import { Interactor } from '@coday/model'
 import { AssistantToolFactory } from '@coday/model'
@@ -99,7 +103,135 @@ export class ZendeskTools extends AssistantToolFactory {
       },
     }
 
-    result.push(articleRetrievalFunction, searchFunction)
+    const listCategoriesFunction: FunctionTool<{ locale?: string }> = {
+      type: 'function',
+      function: {
+        name: `${this.name}__listCategories`,
+        description:
+          'List all Zendesk Help Center categories. Use this as the entry point to navigate the knowledge base structure. Returns id, name, description, locale, url, and position for each category.',
+        parameters: {
+          type: 'object',
+          properties: {
+            locale: {
+              type: 'string',
+              description:
+                'Optional locale code (e.g., "en-us", "fr"). If not provided, returns categories in default locale.',
+            },
+          },
+        },
+        parse: JSON.parse,
+        function: (params: { locale?: string }) =>
+          listZendeskCategories(zendeskSubdomain, zendeskEmail, zendeskApiToken, this.interactor, params.locale),
+      },
+    }
+
+    const listSectionsFunction: FunctionTool<{ categoryId: string; locale?: string }> = {
+      type: 'function',
+      function: {
+        name: `${this.name}__listSections`,
+        description:
+          'List all sections within a Zendesk Help Center category. Returns id, name, description, locale, url, category_id, and position for each section.',
+        parameters: {
+          type: 'object',
+          properties: {
+            categoryId: {
+              type: 'string',
+              description: 'Zendesk category ID (numeric)',
+            },
+            locale: {
+              type: 'string',
+              description:
+                'Optional locale code (e.g., "en-us", "fr"). If not provided, returns sections in default locale.',
+            },
+          },
+        },
+        parse: JSON.parse,
+        function: (params: { categoryId: string; locale?: string }) =>
+          listZendeskSections(
+            params.categoryId,
+            zendeskSubdomain,
+            zendeskEmail,
+            zendeskApiToken,
+            this.interactor,
+            params.locale
+          ),
+      },
+    }
+
+    const listArticlesInSectionFunction: FunctionTool<{ sectionId: string; locale?: string }> = {
+      type: 'function',
+      function: {
+        name: `${this.name}__listArticlesInSection`,
+        description:
+          'List all articles within a Zendesk Help Center section. Returns id, title, locale, url, section_id, and updated_at for each article. Use getArticle to retrieve the full content of a specific article.',
+        parameters: {
+          type: 'object',
+          properties: {
+            sectionId: {
+              type: 'string',
+              description: 'Zendesk section ID (numeric)',
+            },
+            locale: {
+              type: 'string',
+              description:
+                'Optional locale code (e.g., "en-us", "fr"). If not provided, returns articles in default locale.',
+            },
+          },
+        },
+        parse: JSON.parse,
+        function: (params: { sectionId: string; locale?: string }) =>
+          listZendeskArticlesInSection(
+            params.sectionId,
+            zendeskSubdomain,
+            zendeskEmail,
+            zendeskApiToken,
+            this.interactor,
+            params.locale
+          ),
+      },
+    }
+
+    const listArticlesInCategoryFunction: FunctionTool<{ categoryId: string; locale?: string }> = {
+      type: 'function',
+      function: {
+        name: `${this.name}__listArticlesInCategory`,
+        description:
+          'List all articles within a Zendesk Help Center category (across all its sections). Returns id, title, locale, url, section_id, and updated_at for each article. Use getArticle to retrieve the full content of a specific article.',
+        parameters: {
+          type: 'object',
+          properties: {
+            categoryId: {
+              type: 'string',
+              description: 'Zendesk category ID (numeric)',
+            },
+            locale: {
+              type: 'string',
+              description:
+                'Optional locale code (e.g., "en-us", "fr"). If not provided, returns articles in default locale.',
+            },
+          },
+        },
+        parse: JSON.parse,
+        function: (params: { categoryId: string; locale?: string }) =>
+          listZendeskArticlesInCategory(
+            params.categoryId,
+            zendeskSubdomain,
+            zendeskEmail,
+            zendeskApiToken,
+            this.interactor,
+            params.locale
+          ),
+      },
+    }
+
+    result.push(
+      articleRetrievalFunction,
+      searchFunction,
+      listCategoriesFunction,
+      listSectionsFunction,
+      listArticlesInSectionFunction,
+      listArticlesInCategoryFunction
+    )
 
     return result
   }


### PR DESCRIPTION
## Summary

Extends the Zendesk integration with 4 new tools for structural navigation of the Help Center, as requested in #562.

## New Tools

- **`listCategories`** — `GET /api/v2/help_center/{locale}/categories` — entry point to discover the knowledge base hierarchy
- **`listSections`** — `GET /api/v2/help_center/{locale}/categories/{category_id}/sections` — list sections within a category
- **`listArticlesInSection`** — `GET /api/v2/help_center/{locale}/sections/{section_id}/articles` — list articles within a section
- **`listArticlesInCategory`** — `GET /api/v2/help_center/{locale}/categories/{category_id}/articles` — list all articles across a category

All tools return simplified, agent-friendly payloads (id, name/title, url, locale, etc.) and support an optional `locale` parameter consistent with existing tools.

## Changes

- 4 new function files in `libs/integrations/zendesk-articles/src/lib/`
- Updated `zendesk.tools.ts` to register all 4 new tools in `buildTools()`

Closes #562