### PR TITLE
fix: #760 basecamp oauth silent token refresh before full re-auth

### DIFF
--- a/libs/integrations/basecamp/src/lib/basecamp-oauth.ts
+++ b/libs/integrations/basecamp/src/lib/basecamp-oauth.ts
@@ -102,6 +102,19 @@ export class BasecampOAuth {
       return this.tokenData!
     }
 
+    // Token is expired or missing — try silent refresh first
+    if (this.tokenData?.refreshToken) {
+      try {
+        this.interactor.debug('Access token expired, attempting silent refresh...')
+        await this.refreshToken()
+        this.interactor.debug('Token refreshed successfully')
+        return this.tokenData!
+      } catch (error: any) {
+        // Refresh failed: tokenData and storage already cleared by refreshToken()
+        this.interactor.debug(`Silent refresh failed (${error.message}), starting full re-authentication`)
+      }
+    }
+
     // Generate PKCE challenge and state
     const state = oauth.generateRandomState()
     const codeVerifier = oauth.generateRandomCodeVerifier()


### PR DESCRIPTION
## Problem

When a stored Basecamp OAuth token is expired, `authenticate()` was launching the full OAuth flow (popup) immediately, without attempting a silent token refresh first. If the popup failed or was mishandled, the user would see "OAuth authentication cancelled by user" even though they hadn't cancelled anything.

Logs from the issue:
```
Token expires at: 4/2/2026, 11:56:07 AM (in -14d -24h)
Using stored Basecamp account: Whoz
Warning: "OAuth authentication cancelled by user"
```

## Root Cause

`authenticate()` checked `isAuthenticated()` (which returns `false` for expired tokens) and jumped straight to the full re-auth flow. The `refreshToken()` method existed and worked correctly but was only called from `getAccessToken()` — never from `authenticate()`.

## Fix

Added a silent refresh attempt inside `authenticate()` before launching the full OAuth flow:

1. Token still valid → return immediately ✅
2. Token expired + refresh token present → **silent refresh** → return if successful ✅  
3. Refresh failed (or no refresh token) → `refreshToken()` already clears expired token and storage → **full re-auth** with popup ✅

This fix is centralized in `BasecampOAuth.authenticate()`, so all Basecamp tools benefit automatically without any changes to individual tool implementations.

Fixes #760