### PR TITLE
fix: remove 'push' from git danger keywords

### DIFF
--- a/libs/integrations/git/src/lib/git.ts
+++ b/libs/integrations/git/src/lib/git.ts
@@ -1,7 +1,7 @@
 import { Interactor } from '@coday/model'
 import { runBash } from '@coday/function'
 
-const dangerKeywords = ['push', 'push -f', 'push --force', 'push --tags', 'reset', '&&', 'clean']
+const dangerKeywords = ['push -f', 'push --force', 'push --tags', 'reset', '&&', 'clean']
 
 /**
  * All worktree subcommands are blocked except 'list'.


### PR DESCRIPTION
Remove `'push'` from the `dangerKeywords` list in `git.ts`.

The force-push variants (`push -f`, `push --force`, `push --tags`) are kept as dangerous and still require confirmation. A plain `git push` no longer triggers the confirmation prompt.