### PR TITLE
fix: remove duplicate addAnswerEvent calls — persistence handled by agent.run()

### DIFF
--- a/apps/server/src/lib/message.routes.ts
+++ b/apps/server/src/lib/message.routes.ts
@@ -159,10 +159,7 @@ export function registerMessageRoutes(
         // Handle legacy AnswerEvent flow (has type === 'answer')
         if (payload.type === 'answer') {
           const answerEvent = new AnswerEvent({ ...payload, name: username })
-          // Persist the answer in the thread so it survives reconnection.
-          // Without this, loadHistoryFromRest sees the InviteEvent without a matching
-          // AnswerEvent and treats the invite as still pending.
-          aiThread.addAnswerEvent(answerEvent)
+          // Persistence is handled by agent.run() via Agent.run() — do NOT call addAnswerEvent here.
           instance.coday.interactor.sendEvent(answerEvent)
           // Clear pendingInvite flag now that the user has answered (synchronous, in-memory)
           const tid = <string>threadId

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -105,14 +105,7 @@ export class Coday {
       const answerEvent = this.pendingQuestionEvent.buildAnswer(message)
       answerEvent.name = username
 
-      // Persist the answer in the thread with its parentKey so it survives reconnection.
-      // The InviteEvent was already persisted when it was emitted (see subscriber above).
-      // InviteEventDefault is the main loop prompt — not a real question, skip it.
-      const thread = this.context?.aiThread
-      if (thread && this.pendingQuestionEvent.invite !== InviteEventDefault) {
-        thread.addAnswerEvent(answerEvent)
-      }
-
+      // Persistence is handled by agent.run() via Agent.run() — do NOT call addAnswerEvent here.
       this.interactor.sendEvent(answerEvent)
     } else {
       // Agent is running — queue the message for the next initCommand() iteration.


### PR DESCRIPTION
## Summary

Removes duplicate `addAnswerEvent` calls that were causing user messages to be saved twice. Persistence is already handled by `agent.run()`, so the extra calls were redundant.

## Changes

- Removed duplicate `addAnswerEvent` calls — persistence is now solely handled by `agent.run()`