### PR TITLE
chore: update PR github tools on Sway, Archay, Dev, Frontay agents

### DIFF
--- a/agents/Archay.yaml
+++ b/agents/Archay.yaml
@@ -11,10 +11,9 @@ integrations:
     - add_issue_comment
     - issue_read
     - issue_write
-    - create_pull_request
-    - get_pull_request
-    - get_pull_request_reviews
-    - get_pull_request_comments
+    - pull_request_read
+    - pull_request_review_write
+    - update_pull_request
   GIT:
   DELEGATE:
     - Sway

--- a/agents/Archay.yaml
+++ b/agents/Archay.yaml
@@ -11,6 +11,7 @@ integrations:
     - add_issue_comment
     - issue_read
     - issue_write
+    - create_pull_request
     - pull_request_read
     - pull_request_review_write
     - update_pull_request

--- a/agents/Dev.yaml
+++ b/agents/Dev.yaml
@@ -11,10 +11,9 @@ integrations:
     - add_issue_comment
     - issue_read
     - issue_write
-    - create_pull_request
-    - get_pull_request
-    - get_pull_request_reviews
-    - get_pull_request_comments
+    - pull_request_read
+    - pull_request_review_write
+    - update_pull_request
   GIT:
   JIRA:
   DELEGATE:

--- a/agents/Dev.yaml
+++ b/agents/Dev.yaml
@@ -11,6 +11,7 @@ integrations:
     - add_issue_comment
     - issue_read
     - issue_write
+    - create_pull_request
     - pull_request_read
     - pull_request_review_write
     - update_pull_request

--- a/agents/Frontay.yaml
+++ b/agents/Frontay.yaml
@@ -10,6 +10,7 @@ integrations:
     - create_issue
     - get_issue
     - get_issue_comments
+    - create_pull_request
     - pull_request_read
     - pull_request_review_write
     - update_pull_request

--- a/agents/Frontay.yaml
+++ b/agents/Frontay.yaml
@@ -10,11 +10,9 @@ integrations:
     - create_issue
     - get_issue
     - get_issue_comments
-    - create_pull_request
-    - get_pull_request
-    - get_pull_request_comments
-    - get_pull_request_reviews
-    - get_pull_request_status
+    - pull_request_read
+    - pull_request_review_write
+    - update_pull_request
   GIT:
   CHROME:
   DELEGATE:

--- a/agents/Sway.yaml
+++ b/agents/Sway.yaml
@@ -11,10 +11,9 @@ integrations:
     - add_issue_comment
     - issue_read
     - issue_write
-    - create_pull_request
-    - get_pull_request
-    - get_pull_request_reviews
-    - get_pull_request_comments
+    - pull_request_read
+    - pull_request_review_write
+    - update_pull_request
   GIT:
   DELEGATE:
     - Nxay

--- a/agents/Sway.yaml
+++ b/agents/Sway.yaml
@@ -11,6 +11,7 @@ integrations:
     - add_issue_comment
     - issue_read
     - issue_write
+    - create_pull_request
     - pull_request_read
     - pull_request_review_write
     - update_pull_request


### PR DESCRIPTION
Replace the previous pull request tools (`create_pull_request`, `get_pull_request`, `get_pull_request_reviews`, `get_pull_request_comments`, `get_pull_request_status`) with the new unified tools on all four agents:

- `pull_request_read`
- `pull_request_review_write`
- `update_pull_request`

Agents affected: Sway, Archay, Dev, Frontay.