### PR TITLE
fix: #788 case-chat vertical scroll with magnetic auto-scroll and floating button

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
@@ -1,5 +1,5 @@
 <div class="case-chat">
-  <div class="case-chat__messages">
+  <div #messagesContainer class="case-chat__messages">
     @if (timeline().length === 0) {
       <div class="case-chat__empty">
         <p>No messages yet.</p>
@@ -84,6 +84,18 @@
       </div>
     }
   </div>
+
+  <!-- Floating scroll-to-bottom button — visible when not at the bottom -->
+  @if (!isAtBottom()) {
+    <div class="case-chat__scroll-anchor">
+      <ds-icon-button
+        icon="keyboard_arrow_down"
+        variant="default"
+        title="Scroll to bottom"
+        (action)="onScrollToBottomClick()"
+      />
+    </div>
+  }
 
   <div class="case-chat__composer">
     <textarea

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -61,6 +61,9 @@
   }
 
   &__tool-call {
+    // flex-shrink: 0 prevents the flex container from compressing tool call cards
+    // to zero height when the messages area has min-height: 0.
+    flex-shrink: 0;
     border-radius: 8px;
     border: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
     background: var(--glass-bg, rgba(255, 255, 255, 0.72));
@@ -174,7 +177,14 @@
   }
 
   // Thinking indicator (three bouncing dots)
+  // Messages and thinking indicator are also direct flex items of __messages:
+  // flex-shrink: 0 prevents them from being crushed in the scroll container.
+  &__message {
+    flex-shrink: 0;
+  }
+
   &__thinking {
+    flex-shrink: 0;
     display: flex;
     gap: 0.3rem;
     padding: 0.75rem 1rem;

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -1,19 +1,42 @@
+:host {
+  // Ensure the component fills the router-outlet container and participates
+  // in the flex column chain that constrains height to the viewport.
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .case-chat {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  // Fill the :host — which is already sized by the parent flex container.
+  flex: 1;
+  min-height: 0;
   max-width: 800px;
+  width: 100%;
   margin: 0 auto;
   padding: 1.5rem;
   gap: 1rem;
+  // Needed so the floating scroll button is positioned relative to this container.
+  position: relative;
 
   &__messages {
+    // Flex-grow to fill available height, flex-shrink + min-height so it
+    // actually shrinks when the composer is present (avoids overflow on :host).
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
     padding-bottom: 0.5rem;
+    // Smooth momentum scrolling on iOS.
+    -webkit-overflow-scrolling: touch;
+    // Thin scrollbar on supporting browsers.
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border, rgba(0, 0, 0, 0.15)) transparent;
   }
 
   &__empty {
@@ -163,7 +186,29 @@
     opacity: 0.95;
   }
 
+  // Floating "scroll to bottom" button — sits just above the composer.
+  &__scroll-anchor {
+    position: absolute;
+    // Sit just above the composer. The composer has ~80px height + 1rem gap.
+    // We use bottom so it stays anchored regardless of composer size.
+    bottom: calc(1.5rem + 80px + 0.5rem);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    background: var(--glass-bg, rgba(255, 255, 255, 0.88));
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.3));
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-radius: 50%;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+    // Fade in/out animation handled by @if in the template.
+    animation: scroll-anchor-in 0.15s ease;
+  }
+
   &__composer {
+    // flex-shrink: 0 ensures the composer is never compressed — it always
+    // stays fully visible at the bottom while the messages area shrinks.
+    flex-shrink: 0;
     display: flex;
     align-items: flex-end;
     gap: 0.5rem;
@@ -231,5 +276,16 @@
   40% {
     transform: translateY(-6px);
     opacity: 1;
+  }
+}
+
+@keyframes scroll-anchor-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
   }
 }

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http'
 import {
+  afterNextRender,
   Component,
   computed,
   DestroyRef,
@@ -36,12 +37,22 @@ export type TimelineItem =
   | { kind: 'tool'; call: ToolCall }
   | { kind: 'streaming'; text: string }
 
+/** Threshold (px) from the bottom of the scroll container below which we consider "at bottom". */
+const SCROLL_BOTTOM_THRESHOLD = 64
+
 /**
  * CaseChatComponent — real-time chat view for an active case.
  *
  * Connexion SSE directe sur /api/agentos/api/cases/:caseId/events.
  * Accumule tous les CaseEvent reçus, affiche les MessageEvent
  * et les ToolRequestEvent/ToolResponseEvent intercalés chronologiquement.
+ *
+ * Scroll behaviour:
+ * - The messages area fills available height and scrolls independently.
+ * - The composer (input + actions) is always visible at the bottom.
+ * - "Magnetic" auto-scroll: while the user is at the bottom, new content
+ *   automatically scrolls the view down. Scrolling up breaks the magnet.
+ * - A floating "scroll to bottom" button appears when not at the bottom.
  */
 @Component({
   selector: 'agentos-case-chat',
@@ -87,6 +98,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   private eventSource: EventSource | null = null
 
   @ViewChild('composerInput') private composerInput?: ElementRef<HTMLTextAreaElement>
+  @ViewChild('messagesContainer') private messagesContainer?: ElementRef<HTMLDivElement>
 
   protected readonly events = signal<CaseEvent[]>([])
   protected inputValue = signal('')
@@ -99,12 +111,39 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   /** Collapsed state per toolRequestId */
   protected readonly collapsedTools = signal<Set<string>>(new Set())
 
+  /**
+   * Whether the user is currently scrolled to (or near) the bottom of the messages area.
+   * When true, new content triggers automatic scroll-to-bottom (magnetic behaviour).
+   * Flips to false as soon as the user scrolls up past the threshold.
+   */
+  protected readonly isAtBottom = signal(true)
+
+  /** Listener cleanup function registered on the messages container. */
+  private scrollListenerCleanup: (() => void) | null = null
+
   constructor() {
     // Restore focus to the composer whenever we return to an interactive state.
-    // (Agent turn finished → AgentFinishedEvent, or status becomes IDLE.)
     effect(() => {
       if (this.isRunning() || this.isTerminal()) return
       queueMicrotask(() => this.composerInput?.nativeElement.focus())
+    })
+
+    // Auto-scroll to bottom whenever the timeline or streaming text changes,
+    // but only when the user is already at the bottom (magnetic behaviour).
+    effect(() => {
+      // Depend on timeline and streamingText so the effect re-runs on content changes.
+      this.timeline()
+      this.streamingText()
+
+      if (this.isAtBottom()) {
+        // Defer to next microtask so the DOM has updated before we measure.
+        queueMicrotask(() => this.scrollToBottom())
+      }
+    })
+
+    // Register scroll listener after the first render so the ViewChild is available.
+    afterNextRender(() => {
+      this.attachScrollListener()
     })
   }
 
@@ -194,7 +233,48 @@ export class CaseChatComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.eventSource?.close()
+    this.scrollListenerCleanup?.()
   }
+
+  // ---------------------------------------------------------------------------
+  // Scroll management
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Attach a scroll listener to the messages container.
+   * Updates `isAtBottom` as the user scrolls.
+   * Called once after the first render.
+   */
+  private attachScrollListener(): void {
+    const el = this.messagesContainer?.nativeElement
+    if (!el) return
+
+    const onScroll = () => {
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+      this.isAtBottom.set(distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD)
+    }
+
+    el.addEventListener('scroll', onScroll, { passive: true })
+    this.scrollListenerCleanup = () => el.removeEventListener('scroll', onScroll)
+  }
+
+  /** Programmatically scroll the messages container to the very bottom. */
+  protected scrollToBottom(): void {
+    const el = this.messagesContainer?.nativeElement
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }
+
+  /**
+   * Called by the floating "scroll to bottom" button.
+   * Re-enables the magnetic behaviour and scrolls down.
+   */
+  protected onScrollToBottomClick(): void {
+    this.isAtBottom.set(true)
+    this.scrollToBottom()
+  }
+
+  // ---------------------------------------------------------------------------
 
   private connectSse(): void {
     const url = `${this.config.basePath}/api/cases/${this.caseId}/events`
@@ -364,6 +444,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     this.isTerminal.set(false)
     this.streamingText.set('')
     this.collapsedTools.set(new Set())
+    this.isAtBottom.set(true)
     this.connectSse()
   }
 


### PR DESCRIPTION
## Problem

The `CaseChatComponent` did not scroll vertically as the conversation grew. The composer (input + actions) was not guaranteed to stay visible either.

## Root cause

The `router-outlet` inserts the component's host element into the DOM without inheriting flex constraints from the parent. Without `:host` styles, `.case-chat` grew unboundedly instead of being constrained by the viewport chain.

## Changes

### Phase 1 — Scroll layout fix

- **`:host`** gets `display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: hidden` — plugs the component into the `case-shell__content` flex chain
- **`.case-chat`** gains `flex: 1; min-height: 0`
- **`.case-chat__messages`** gains `min-height: 0` (critical: without it, flex prevents the element from shrinking below its content height)
- **`.case-chat__composer`** gets `flex-shrink: 0` — always fully visible, never compressed

### Phase 2 — Magnetic auto-scroll + floating button

- **`isAtBottom` signal** (default `true`): updated by a passive `scroll` listener on the messages container. Threshold: 64px from the bottom.
- **Auto-scroll effect**: reacts to `timeline()` and `streamingText()` changes. Scrolls to bottom via `queueMicrotask` (after DOM update) only when `isAtBottom()` is true.
- **Magnet break**: scrolling up past the threshold sets `isAtBottom` to `false` — auto-scroll stops.
- **Floating button**: `ds-icon-button` with `keyboard_arrow_down`, absolutely positioned above the composer, visible only when `!isAtBottom()`. Clicking it re-enables the magnet and scrolls to bottom. Appears with a subtle fade + slide animation.
