### PR TITLE
fix: #792 case list does not scroll in its drawer

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
@@ -1,3 +1,9 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 // Scoped styles for the case item row rendered inside ds-entity-list
 .case-drawer-item {
   display: flex;

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
@@ -1,3 +1,10 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .entity-list {
   display: flex;
   flex-direction: column;

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
@@ -1,6 +1,8 @@
 .entity-list {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   box-sizing: border-box;
 }
@@ -70,6 +72,9 @@
 // ── Content (max-width constrained) ─────────────────────────────────────
 
 .entity-list__content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   width: 100%;
   max-width: 900px; // overridden at runtime via [style.max-width]
   margin: 0 auto;


### PR DESCRIPTION
## Problem

The case list inside the `ds-drawer` sidenav did not scroll vertically. Cases beyond the visible area were inaccessible.

## Root Cause

Three missing pieces in the CSS flex hierarchy:

```
case-shell__sidenav (flex column, height: 100%, overflow: hidden)  ← scroll boundary
  └─ agentos-case-drawer :host  ← inline by default, no height propagation
    └─ <ds-entity-list> :host   ← inline by default, no height propagation
      └─ .entity-list (flex column)
        ├─ .entity-list__toolbar (56px, fixed)
        └─ .entity-list__content  ← no flex: 1, no overflow-y: auto
```

1. `agentos-case-drawer` `:host` had no height or flex layout — it didn't propagate the sidenav's bounded height.
2. `ds-entity-list` `:host` was `display: inline` by default — same problem.
3. `.entity-list__content` had no `flex: 1` or `overflow-y: auto` — it never claimed the remaining space or enabled scrolling.

## Fix

**`libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss`**
- Added `:host { display: flex; flex-direction: column; height: 100% }` to propagate the drawer's bounded height into `ds-entity-list`

**`libs/design-system/src/lib/components/entity-list/entity-list.component.scss`**
- Added `:host { display: flex; flex-direction: column; flex: 1; min-height: 0 }` so the host participates in the flex chain
- Added `flex: 1; min-height: 0` to `.entity-list` 
- Added `flex: 1; min-height: 0; overflow-y: auto` to `.entity-list__content`

## Impact on other usages

All other `ds-entity-list` usages (project-list, agent-list, namespace-list, etc.) live inside page wrappers with `display: block` and `min-height: 100vh`. In those contexts:
- `flex: 1` on `:host` is ignored (no flex parent) → height grows naturally with content ✅
- `overflow-y: auto` on `.entity-list__content` only activates when height is constrained → no change ✅

No regression expected on existing pages.

Closes #792