### PR TITLE
fix: #WZ-31209 maxTokens for OpenAI/Gemini and relax AiModel uniqueness to alias-only

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/aiModel/AiModelServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/aiModel/AiModelServiceImpl.kt
@@ -24,12 +24,9 @@ class AiModelServiceImpl(
     private val aiProviderService: AiProviderService,
 ) : AiModelService {
     override fun create(entity: AiModel): AiModel {
-        findByAiProviderAndApiName(entity.aiProviderId, entity.apiModelName)?.let {
-            throw ResponseStatusException(
-                HttpStatus.CONFLICT,
-                "A model config for apiName '${entity.apiModelName}' already exists in AiProvider ${entity.aiProviderId}",
-            )
-        }
+        // Uniqueness is enforced on alias only — two configs may share the same
+        // apiModelName under the same provider (e.g. same model with different
+        // temperature or maxTokens), as long as their aliases are distinct.
         entity.alias?.let { alias ->
             findByAiProviderAndAlias(entity.aiProviderId, alias)?.let {
                 throw ResponseStatusException(
@@ -48,14 +45,7 @@ class AiModelServiceImpl(
     }
 
     override fun update(entity: AiModel): AiModel {
-        findByAiProviderAndApiName(entity.aiProviderId, entity.apiModelName)
-            ?.takeIf { it.id != entity.id }
-            ?.let {
-                throw ResponseStatusException(
-                    HttpStatus.CONFLICT,
-                    "A model config for apiName '${entity.apiModelName}' already exists in AiProvider ${entity.aiProviderId}",
-                )
-            }
+        // Same uniqueness rule as create: only alias must be unique per provider.
         entity.alias?.let { alias ->
             findByAiProviderAndAlias(entity.aiProviderId, alias)
                 ?.takeIf { it.id != entity.id }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/aiModel/AiModelServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/aiModel/AiModelServiceImpl.kt
@@ -14,9 +14,13 @@ import java.util.UUID
  * [AiProviderService] and denormalises them onto the entity before saving, so that
  * namespace-scoped queries can be served without joining through [AiProvider].
  *
- * [create] also enforces two uniqueness constraints:
- * - (aiProviderId, apiName): a model can only be registered once per provider config
- * - (aiProviderId, alias): aliases must be unambiguous within a provider config
+ * [create] enforces one uniqueness constraint:
+ * - (aiProviderId, alias): aliases must be unambiguous within a provider config.
+ *   Two configs may share the same [AiModel.apiModelName] under the same provider
+ *   (e.g. same model at different temperatures) as long as their aliases differ.
+ *   When [AiModel.alias] is null the check is skipped — null aliases are intentionally
+ *   unconstrained so that provider-level "anonymous" configs (resolved only by apiName
+ *   fallback) can coexist without conflicting with each other.
  */
 @Service
 class AiModelServiceImpl(
@@ -24,9 +28,11 @@ class AiModelServiceImpl(
     private val aiProviderService: AiProviderService,
 ) : AiModelService {
     override fun create(entity: AiModel): AiModel {
-        // Uniqueness is enforced on alias only — two configs may share the same
-        // apiModelName under the same provider (e.g. same model with different
-        // temperature or maxTokens), as long as their aliases are distinct.
+        // Uniqueness is enforced on alias only. Two configs may share the same
+        // apiModelName under the same provider (e.g. same model at different
+        // temperatures). When alias is null the check is intentionally skipped:
+        // null-alias configs are anonymous and resolved only via apiName fallback;
+        // they are allowed to accumulate and the highest-priority one wins.
         entity.alias?.let { alias ->
             findByAiProviderAndAlias(entity.aiProviderId, alias)?.let {
                 throw ResponseStatusException(
@@ -46,6 +52,7 @@ class AiModelServiceImpl(
 
     override fun update(entity: AiModel): AiModel {
         // Same uniqueness rule as create: only alias must be unique per provider.
+        // Null alias skips the check for the same reason as in create.
         entity.alias?.let { alias ->
             findByAiProviderAndAlias(entity.aiProviderId, alias)
                 ?.takeIf { it.id != entity.id }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
@@ -68,7 +68,7 @@ class ChatModelFactory {
         apiKey: String,
         model: String,
         temp: Double,
-        maxTokens: Int? = null,
+        maxTokens: Int?,
     ): ChatModel {
         val api =
             OpenAiApi
@@ -134,7 +134,7 @@ class ChatModelFactory {
         apiKey: String,
         model: String,
         temp: Double,
-        maxTokens: Int? = null,
+        maxTokens: Int?,
     ): ChatModel {
         val api = Client.builder().apiKey(apiKey).build()
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
@@ -38,6 +38,7 @@ class ChatModelFactory {
                     apiKey = resolvedApiKey,
                     model = modelName,
                     temp = temperature ?: DEFAULT_TEMPERATURE,
+                    maxTokens = maxTokens,
                 )
             }
 
@@ -56,6 +57,7 @@ class ChatModelFactory {
                     apiKey = resolvedApiKey,
                     model = modelName,
                     temp = temperature ?: DEFAULT_TEMPERATURE,
+                    maxTokens = maxTokens,
                 )
             }
         }
@@ -66,6 +68,7 @@ class ChatModelFactory {
         apiKey: String,
         model: String,
         temp: Double,
+        maxTokens: Int? = null,
     ): ChatModel {
         val api =
             OpenAiApi
@@ -74,12 +77,15 @@ class ChatModelFactory {
                 .apiKey(apiKey)
                 .build()
 
-        val options =
+        val optionsBuilder =
             OpenAiChatOptions
                 .builder()
                 .temperature(temp)
                 .model(model)
-                .build()
+        if (maxTokens != null) {
+            optionsBuilder.maxTokens(maxTokens)
+        }
+        val options = optionsBuilder.build()
 
         return OpenAiChatModel(
             api,
@@ -128,15 +134,19 @@ class ChatModelFactory {
         apiKey: String,
         model: String,
         temp: Double,
+        maxTokens: Int? = null,
     ): ChatModel {
         val api = Client.builder().apiKey(apiKey).build()
 
-        val options =
+        val optionsBuilder =
             GoogleGenAiChatOptions
                 .builder()
                 .model(model)
                 .temperature(temp)
-                .build()
+        if (maxTokens != null) {
+            optionsBuilder.maxOutputTokens(maxTokens)
+        }
+        val options = optionsBuilder.build()
 
         return GoogleGenAiChatModel(
             api,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiModelConfig/AiModelServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiModelConfig/AiModelServiceImplSpec.kt
@@ -348,11 +348,11 @@ class AiModelServiceImplSpec : StringSpec() {
             service.findById(original.metadata.id)?.alias shouldBe "SMALL"
         }
 
-        "update does not conflict with itself on apiName" {
+        "update does not conflict with itself when changing inference parameters" {
             val (service, aiProviderId) = newService()
             val original = service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-haiku-4-5"))
 
-            // updating temperature on same entity must not trigger a self-conflict
+            // updating temperature on the same entity must not trigger a self-conflict on alias
             val updated = service.update(original.copy(temperature = 0.7))
             updated.temperature shouldBe 0.7
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiModelConfig/AiModelServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiModelConfig/AiModelServiceImplSpec.kt
@@ -169,13 +169,14 @@ class AiModelServiceImplSpec : StringSpec() {
         // Uniqueness constraints
         // -------------------------------------------------------------------------
 
-        "create throws 409 when (aiProviderId, apiName) already exists" {
+        "create allows two models with the same apiName under the same provider when aliases differ" {
+            // Uniqueness is on alias only — same apiName with different params (e.g. temperature)
+            // is a valid use-case (e.g. 'haiku-fast' vs 'haiku-careful' using the same model).
             val (service, aiProviderId) = newService()
-            service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-haiku-4-5"))
+            service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-haiku-4-5", alias = "haiku-fast", temperature = 1.0))
+            service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-haiku-4-5", alias = "haiku-careful", temperature = 0.2))
 
-            shouldThrow<ResponseStatusException> {
-                service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-haiku-4-5"))
-            }.statusCode.value() shouldBe 409
+            service.findByParent(aiProviderId) shouldHaveSize 2
         }
 
         "create throws 409 when (aiProviderId, alias) already exists" {
@@ -364,14 +365,14 @@ class AiModelServiceImplSpec : StringSpec() {
             updated.alias shouldBe "small"
         }
 
-        "update throws 409 when new apiName conflicts with a sibling" {
+        "update allows changing apiName to one already used by a sibling" {
+            // apiName uniqueness is no longer enforced — only alias uniqueness is.
             val (service, aiProviderId) = newService()
-            service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-opus-4-6"))
-            val toUpdate = service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-haiku-4-5"))
+            service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-opus-4-6", alias = "big"))
+            val toUpdate = service.create(modelConfig(aiProviderId = aiProviderId, apiName = "claude-haiku-4-5", alias = "small"))
 
-            shouldThrow<ResponseStatusException> {
-                service.update(toUpdate.copy(apiModelName = "claude-opus-4-6"))
-            }.statusCode.value() shouldBe 409
+            val updated = service.update(toUpdate.copy(apiModelName = "claude-opus-4-6"))
+            updated.apiModelName shouldBe "claude-opus-4-6"
         }
 
         "update throws 409 when new alias conflicts with a sibling" {


### PR DESCRIPTION
## Context

WZ-31209 — two bugs identified during local review of the namespace LLM config feature.

## Changes

### `maxTokens` was silently ignored for OpenAI and Gemini

`ChatModelFactory` received `maxTokens` but never passed it to the OpenAI or Gemini options builders. For Gemini the builder method is `maxOutputTokens()` (not `maxTokens()`), which also caused a compilation error. Anthropic was already correct.

### AiModel uniqueness constraint relaxed to alias-only

The `(aiProviderId, apiName)` uniqueness constraint on `AiModelServiceImpl` has been removed. Only `(aiProviderId, alias)` is now enforced. This allows two `AiModel` entries with the same `apiModelName` under the same provider but with different inference parameters (e.g. different temperature or maxTokens) as long as their aliases differ — which is the intended use case.

Tests updated accordingly.