### PR TITLE
fix: move release git config to version and changelog subcommands

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -73,14 +73,14 @@
   "release": {
     "projects": ["server", "client", "web", "desktop", "desktop-twin"],
     "releaseTagPattern": "release/{version}",
-    "git": {
-      "commitMessage": "chore(release): {version}",
-      "tag": true
-    },
     "changelog": {
       "workspaceChangelog": {
         "file": "CHANGELOG.md",
         "createRelease": "github"
+      },
+      "git": {
+        "commitMessage": "chore(release): {version}",
+        "tag": true
       }
     },
     "version": {
@@ -88,6 +88,10 @@
       "manifestRootsToUpdate": ["apps/{projectName}"],
       "versionActionsOptions": {
         "skipLockFileUpdate": true
+      },
+      "git": {
+        "commit": false,
+        "tag": false
       }
     }
   },


### PR DESCRIPTION
The release pipeline was failing because `release.git` is not allowed when using the programmatic API.
Moved git configuration to the correct subcommand level:

- `release.version.git` — no commit/tag during versioning
- `release.changelog.git` — commit and tag during changelog step