### PR TITLE
feat: #799 add Whisper audio transcription as alternative voice input

### DIFF
--- a/apps/client/src/app/components/chat-message/chat-message.component.ts
+++ b/apps/client/src/app/components/chat-message/chat-message.component.ts
@@ -191,6 +191,22 @@ export class ChatMessageComponent implements OnInit, OnDestroy {
           </div>
         `
         htmlParts.push(imgHtml)
+      } else if (item.type === 'audio') {
+        // Create audio player element
+        const audioSrc = `data:${item.mimeType};base64,${item.content}`
+        const transcriptionHtml = item.transcription
+          ? `<div class="audio-transcription" style="margin-top: 4px; font-style: italic; color: var(--text-secondary, #666); font-size: 0.9em;">“${item.transcription}”</div>`
+          : ''
+        const audioHtml = `
+          <div class="audio-content" style="margin: 8px 0;">
+            <audio controls preload="metadata" style="width: 100%; max-width: 400px; display: block;">
+              <source src="${audioSrc}" type="${item.mimeType}">
+              Your browser does not support the audio element.
+            </audio>
+            ${transcriptionHtml}
+          </div>
+        `
+        htmlParts.push(audioHtml)
       }
     }
 
@@ -227,8 +243,10 @@ export class ChatMessageComponent implements OnInit, OnDestroy {
    */
   private extractTextContent(): string {
     return this.message.content
-      .filter((content) => content.type === 'text')
-      .map((content) => content.content)
+      .filter((content) => content.type === 'text' || (content.type === 'audio' && (content as any).transcription))
+      .map((content) =>
+        content.type === 'text' ? content.content : `[Voice message]: ${(content as any).transcription}`
+      )
       .join('\n\n')
   }
 }

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -90,8 +90,7 @@
           <ds-icon-button
             class="voice-btn"
             icon="mic"
-            variant="default"
-            [class.recording]="isRecording || isTranscribing"
+            [variant]="isRecording || isTranscribing ? 'danger' : 'default'"
             [class.hidden]="message.trim() && !isRecording && !isTranscribing"
             [disabled]="isTranscribing"
             [title]="

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -1,10 +1,4 @@
 <div class="chat-input-container">
-  @if (isRecording) {
-    <div class="recording-indicator">
-      <span class="recording-dot"></span>
-      Recording... Click mic to stop
-    </div>
-  }
   @if (isTranscribing) {
     <div class="recording-indicator transcribing-indicator">
       <span class="transcribing-dot"></span>
@@ -69,7 +63,7 @@
             (action)="onStopClick()"
           />
         }
-        @if (!isThinking || message.trim()) {
+        @if ((!isThinking || message.trim()) && !isRecording) {
           <ds-icon-button
             class="send-btn"
             icon="send"
@@ -82,7 +76,7 @@
           />
         }
         @if (!isThinking) {
-          @if (!showWelcome) {
+          @if (!showWelcome && !isRecording) {
             <ds-icon-button
               class="upload-btn"
               icon="attach_file"
@@ -102,10 +96,10 @@
           }
           <ds-icon-button
             class="voice-btn"
-            [icon]="isRecording ? 'fiber_manual_record' : 'mic'"
+            icon="mic"
             variant="default"
             [class.recording]="isRecording"
-            [class.hidden]="message.trim()"
+            [class.hidden]="message.trim() && !isRecording"
             [disabled]="isTranscribing"
             [title]="
               isRecording ? 'Click to stop recording' : isTranscribing ? 'Transcribing...' : 'Click to start recording'

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -45,6 +45,7 @@
     [class.focused]="isFocused"
     [class.welcome-mode]="showWelcome"
     [class.is-thinking]="isThinking"
+    [class.is-listening]="isRecording"
   >
     <textarea
       #messageInput
@@ -53,7 +54,7 @@
       [placeholder]="getPlaceholder()"
       (keydown)="onKeyDown($event)"
       (input)="onInput()"
-      [disabled]="isDisabled"
+      [disabled]="isDisabled || isRecording"
       (focus)="isFocused = true; textareaFocused.emit()"
       (blur)="isFocused = false"
     ></textarea>

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -5,6 +5,12 @@
       Recording... Click mic to stop
     </div>
   }
+  @if (isTranscribing) {
+    <div class="recording-indicator transcribing-indicator">
+      <span class="transcribing-dot"></span>
+      Transcribing...
+    </div>
+  }
 
   <!-- Autocomplete popup - appears above textarea -->
   @if (autocompleteVisible) {
@@ -99,7 +105,10 @@
             variant="default"
             [class.recording]="isRecording"
             [class.hidden]="message.trim()"
-            [title]="isRecording ? 'Click to stop recording' : 'Click to start recording'"
+            [disabled]="isTranscribing"
+            [title]="
+              isRecording ? 'Click to stop recording' : isTranscribing ? 'Transcribing...' : 'Click to start recording'
+            "
             (action)="toggleRecording()"
           />
         }

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -56,7 +56,7 @@
             (action)="onStopClick()"
           />
         }
-        @if ((!isThinking || message.trim()) && !isRecording) {
+        @if ((!isThinking || message.trim()) && !isRecording && !isTranscribing) {
           <ds-icon-button
             class="send-btn"
             icon="send"
@@ -69,7 +69,7 @@
           />
         }
         @if (!isThinking) {
-          @if (!showWelcome && !isRecording) {
+          @if (!showWelcome && !isRecording && !isTranscribing) {
             <ds-icon-button
               class="upload-btn"
               icon="attach_file"

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -1,4 +1,16 @@
 <div class="chat-input-container">
+  @if (!isVoiceMessageMode && isRecording) {
+    <div class="recording-indicator">
+      <span class="recording-dot"></span>
+      Recording... Click mic to stop
+    </div>
+  }
+  @if (!isVoiceMessageMode && isTranscribing) {
+    <div class="recording-indicator">
+      <span class="transcribing-dot"></span>
+      Transcribing...
+    </div>
+  }
   <!-- Autocomplete popup - appears above textarea -->
   @if (autocompleteVisible) {
     <div class="autocomplete-popup">

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -1,11 +1,4 @@
 <div class="chat-input-container">
-  @if (isTranscribing) {
-    <div class="recording-indicator transcribing-indicator">
-      <span class="transcribing-dot"></span>
-      Transcribing...
-    </div>
-  }
-
   <!-- Autocomplete popup - appears above textarea -->
   @if (autocompleteVisible) {
     <div class="autocomplete-popup">
@@ -39,7 +32,7 @@
     [class.focused]="isFocused"
     [class.welcome-mode]="showWelcome"
     [class.is-thinking]="isThinking"
-    [class.is-listening]="isRecording"
+    [class.is-listening]="isRecording || isTranscribing"
   >
     <textarea
       #messageInput
@@ -48,7 +41,7 @@
       [placeholder]="getPlaceholder()"
       (keydown)="onKeyDown($event)"
       (input)="onInput()"
-      [disabled]="isDisabled || isRecording"
+      [disabled]="isDisabled || isRecording || isTranscribing"
       (focus)="isFocused = true; textareaFocused.emit()"
       (blur)="isFocused = false"
     ></textarea>
@@ -98,11 +91,11 @@
             class="voice-btn"
             icon="mic"
             variant="default"
-            [class.recording]="isRecording"
-            [class.hidden]="message.trim() && !isRecording"
+            [class.recording]="isRecording || isTranscribing"
+            [class.hidden]="message.trim() && !isRecording && !isTranscribing"
             [disabled]="isTranscribing"
             [title]="
-              isRecording ? 'Click to stop recording' : isTranscribing ? 'Transcribing...' : 'Click to start recording'
+              isRecording ? 'Click to stop recording' : isTranscribing ? 'Uploading...' : 'Click to start recording'
             "
             (action)="toggleRecording()"
           />

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.html
@@ -32,7 +32,7 @@
     [class.focused]="isFocused"
     [class.welcome-mode]="showWelcome"
     [class.is-thinking]="isThinking"
-    [class.is-listening]="isRecording || isTranscribing"
+    [class.is-listening]="isVoiceMessageMode && (isRecording || isTranscribing)"
   >
     <textarea
       #messageInput
@@ -41,7 +41,7 @@
       [placeholder]="getPlaceholder()"
       (keydown)="onKeyDown($event)"
       (input)="onInput()"
-      [disabled]="isDisabled || isRecording || isTranscribing"
+      [disabled]="isDisabled || (isVoiceMessageMode && (isRecording || isTranscribing))"
       (focus)="isFocused = true; textareaFocused.emit()"
       (blur)="isFocused = false"
     ></textarea>
@@ -56,7 +56,7 @@
             (action)="onStopClick()"
           />
         }
-        @if ((!isThinking || message.trim()) && !isRecording && !isTranscribing) {
+        @if ((!isThinking || message.trim()) && !(isVoiceMessageMode && (isRecording || isTranscribing))) {
           <ds-icon-button
             class="send-btn"
             icon="send"
@@ -69,7 +69,7 @@
           />
         }
         @if (!isThinking) {
-          @if (!showWelcome && !isRecording && !isTranscribing) {
+          @if (!showWelcome && !(isVoiceMessageMode && (isRecording || isTranscribing))) {
             <ds-icon-button
               class="upload-btn"
               icon="attach_file"
@@ -90,9 +90,9 @@
           <ds-icon-button
             class="voice-btn"
             icon="mic"
-            [variant]="isRecording || isTranscribing ? 'danger' : 'default'"
+            [variant]="isVoiceMessageMode && (isRecording || isTranscribing) ? 'danger' : 'default'"
             [class.hidden]="message.trim() && !isRecording && !isTranscribing"
-            [disabled]="isTranscribing"
+            [disabled]="isVoiceMessageMode && isTranscribing"
             [title]="
               isRecording ? 'Click to stop recording' : isTranscribing ? 'Uploading...' : 'Click to start recording'
             "

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.scss
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.scss
@@ -182,11 +182,6 @@
   justify-content: center;
 }
 
-// Recording/uploading state: solid red mic, no pulse
-.voice-btn.recording button {
-  color: var(--color-error);
-}
-
 // Send button: slide-in/out animation + gradient hover
 // These are contextual behaviors that stay in chat-textarea, not in the design system
 .send-btn {

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.scss
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.scss
@@ -37,6 +37,31 @@
 .input-row {
   @include animated-gradient-border.animated-gradient-border;
 
+  /* When listening (recording), apply same animated gradient as thinking */
+  &.is-listening {
+    &::before {
+      inset: 0;
+      mask: none;
+      padding: 0;
+      opacity: 0.15;
+      z-index: 0;
+      background: linear-gradient(
+        90deg,
+        var(--color-error, #ef4444) 0%,
+        var(--color-accent, #8b5cf6) 50%,
+        var(--color-error, #ef4444) 100%
+      );
+      background-size: 200% 100%;
+      animation: gradientBorderShift 2s ease-in-out infinite;
+    }
+
+    .message-input,
+    .action-btn {
+      position: relative;
+      z-index: 1;
+    }
+  }
+
   /* When thinking, apply animated gradient to full box background */
   &.is-thinking {
     &::before {

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.scss
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.scss
@@ -182,10 +182,9 @@
   justify-content: center;
 }
 
-// Recording state: pulse animation on the inner button
+// Recording/uploading state: solid red mic, no pulse
 .voice-btn.recording button {
   color: var(--color-error);
-  animation: pulse 1.5s infinite;
 }
 
 // Send button: slide-in/out animation + gradient hover

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -23,6 +23,7 @@ import { PromptApiService, PromptAutocomplete } from '../../core/services/prompt
 import { ProjectStateService } from '../../core/services/project-state.service'
 import { HighlightPipe } from '../../pipes/highlight.pipe'
 import { AudioApiService } from '../../core/services/audio-api.service'
+import { ThreadStateService } from '../../core/services/thread-state.service'
 
 @Component({
   selector: 'app-chat-textarea',
@@ -96,6 +97,7 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
   private readonly promptApiService = inject(PromptApiService)
   private readonly projectStateService = inject(ProjectStateService)
   private readonly audioApiService = inject(AudioApiService)
+  private readonly threadStateService = inject(ThreadStateService)
 
   ngOnInit(): void {
     this.initializeVoiceInput()
@@ -456,7 +458,26 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
       const language = voiceLang.split('-')[0]
 
       if (this.voiceInputMode === 'voice-message') {
-        // Voice message mode: send audio as a message to the thread
+        if (!this.threadStateService.getSelectedThreadId()) {
+          // No thread yet: transcribe and emit as a regular message submission so the
+          // parent component (main-app) can create a thread and send it as an instruction.
+          console.log('[WHISPER] No thread selected — transcribing and submitting as text message')
+          this.audioApiService.transcribeAudio(base64, mimeType, language).subscribe({
+            next: (response) => {
+              this.isTranscribing = false
+              if (response.text) {
+                this.messageSubmitted.emit(response.text.trim())
+              }
+            },
+            error: (error) => {
+              console.error('[WHISPER] Transcription error (no-thread fallback):', error)
+              this.isTranscribing = false
+            },
+          })
+          return
+        }
+        // Voice message mode: send audio to the active thread; the backend will
+        // transcribe it, store the audio content, and trigger the agent.
         this.audioApiService.sendVoiceMessage(base64, mimeType, language).subscribe({
           next: (response) => {
             this.isTranscribing = false

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -24,6 +24,7 @@ import { ProjectStateService } from '../../core/services/project-state.service'
 import { HighlightPipe } from '../../pipes/highlight.pipe'
 import { AudioApiService } from '../../core/services/audio-api.service'
 import { ThreadStateService } from '../../core/services/thread-state.service'
+import { PendingVoiceMessage } from '../../core/services/first-message-state.service'
 
 @Component({
   selector: 'app-chat-textarea',
@@ -43,6 +44,7 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
   isStopping: boolean = false
   @Output() filesPasted = new EventEmitter<File[]>()
   @Output() messageSubmitted = new EventEmitter<string>()
+  @Output() voiceMessageReady = new EventEmitter<PendingVoiceMessage>()
   @Output() voiceRecordingToggled = new EventEmitter<boolean>()
   @Output() heightChanged = new EventEmitter<number>()
   @Output() stopRequested = new EventEmitter<void>()
@@ -459,21 +461,11 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
 
       if (this.voiceInputMode === 'voice-message') {
         if (!this.threadStateService.getSelectedThreadId()) {
-          // No thread yet: transcribe and emit as a regular message submission so the
-          // parent component (main-app) can create a thread and send it as an instruction.
-          console.log('[WHISPER] No thread selected — transcribing and submitting as text message')
-          this.audioApiService.transcribeAudio(base64, mimeType, language).subscribe({
-            next: (response) => {
-              this.isTranscribing = false
-              if (response.text) {
-                this.messageSubmitted.emit(response.text.trim())
-              }
-            },
-            error: (error) => {
-              console.error('[WHISPER] Transcription error (no-thread fallback):', error)
-              this.isTranscribing = false
-            },
-          })
+          // No thread yet: emit the raw audio so the parent (main-app) can create a
+          // thread and send it as a voice message, preserving the audio content.
+          console.log('[WHISPER] No thread selected — emitting voiceMessageReady for thread creation')
+          this.isTranscribing = false
+          this.voiceMessageReady.emit({ base64, mimeType, language })
           return
         }
         // Voice message mode: send audio to the active thread; the backend will

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -22,6 +22,7 @@ import { AgentApiService, AgentAutocomplete } from '../../core/services/agent-ap
 import { PromptApiService, PromptAutocomplete } from '../../core/services/prompt-api.service'
 import { ProjectStateService } from '../../core/services/project-state.service'
 import { HighlightPipe } from '../../pipes/highlight.pipe'
+import { AudioApiService } from '../../core/services/audio-api.service'
 
 @Component({
   selector: 'app-chat-textarea',
@@ -52,10 +53,16 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
 
   message: string = ''
   isRecording: boolean = false
+  isTranscribing: boolean = false
   isFocused: boolean = false
 
   // Voice recognition properties
   private recognition: any = null
+
+  // Whisper / MediaRecorder state
+  private mediaRecorder: MediaRecorder | null = null
+  private audioChunks: Blob[] = []
+  private voiceInputMode: 'browser' | 'whisper' | 'voice-message' = 'browser'
   private sessionHadTranscript: boolean = false
   private pendingLineBreaksTimeout: number | null = null
   // Index of the last processed final result — guards against Chrome mobile replaying all results
@@ -88,6 +95,7 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
   private readonly agentApiService = inject(AgentApiService)
   private readonly promptApiService = inject(PromptApiService)
   private readonly projectStateService = inject(ProjectStateService)
+  private readonly audioApiService = inject(AudioApiService)
 
   ngOnInit(): void {
     this.initializeVoiceInput()
@@ -97,6 +105,13 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
 
     // Listen to voice language changes
     this.subscriptions.push(this.preferencesService.voiceLanguage$.subscribe(() => this.updateRecognitionLanguage()))
+
+    // Listen to voice input mode changes
+    this.subscriptions.push(
+      this.preferencesService.voiceInputMode$.subscribe((mode) => {
+        this.voiceInputMode = mode as 'browser' | 'whisper' | 'voice-message'
+      })
+    )
 
     // Listen to Enter key behavior changes
     this.subscriptions.push(
@@ -352,10 +367,140 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
 
   toggleRecording(): void {
     if (this.isRecording) {
-      this.stopRecording()
+      if (this.voiceInputMode === 'whisper' || this.voiceInputMode === 'voice-message') {
+        this.stopWhisperRecording()
+      } else {
+        this.stopRecording()
+      }
     } else {
-      this.startRecording()
+      if (this.voiceInputMode === 'whisper' || this.voiceInputMode === 'voice-message') {
+        void this.startWhisperRecording()
+      } else {
+        void this.startRecording()
+      }
     }
+  }
+
+  private async startWhisperRecording(): Promise<void> {
+    if (this.isRecording) return
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      this.audioChunks = []
+      this.mediaRecorder = new MediaRecorder(stream)
+
+      this.mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          this.audioChunks.push(event.data)
+        }
+      }
+
+      this.mediaRecorder.onstop = () => {
+        stream.getTracks().forEach((track) => track.stop())
+        this.processWhisperAudio()
+      }
+
+      this.mediaRecorder.onerror = (event: Event) => {
+        console.error('[WHISPER] MediaRecorder error:', event)
+        stream.getTracks().forEach((track) => track.stop())
+        this.isRecording = false
+        this.voiceRecordingToggled.emit(false)
+      }
+
+      this.mediaRecorder.start()
+      this.isRecording = true
+      this.voiceRecordingToggled.emit(true)
+      console.log('[WHISPER] Started recording')
+    } catch (error) {
+      console.error('[WHISPER] Failed to start recording:', error)
+      this.isRecording = false
+      this.voiceRecordingToggled.emit(false)
+    }
+  }
+
+  private stopWhisperRecording(): void {
+    if (!this.mediaRecorder || !this.isRecording) return
+
+    try {
+      this.mediaRecorder.stop()
+      this.isRecording = false
+      this.voiceRecordingToggled.emit(false)
+      console.log('[WHISPER] Stopped recording')
+    } catch (error) {
+      console.error('[WHISPER] Failed to stop recording:', error)
+      this.isRecording = false
+      this.voiceRecordingToggled.emit(false)
+    }
+  }
+
+  private processWhisperAudio(): void {
+    if (this.audioChunks.length === 0) return
+
+    const blob = new Blob(this.audioChunks, { type: this.mediaRecorder?.mimeType || 'audio/webm' })
+    const mimeType = blob.type.split(';')[0] || 'audio/webm' // Strip codec info like ";codecs=opus"
+    this.audioChunks = []
+
+    this.isTranscribing = true
+
+    const reader = new FileReader()
+    reader.onloadend = () => {
+      const base64 = (reader.result as string).split(',')[1] // Remove data URL prefix
+      if (!base64) {
+        console.error('[WHISPER] Failed to read audio as base64')
+        this.isTranscribing = false
+        return
+      }
+
+      // Map voiceLanguage (e.g. 'en-US') to ISO 639-1 (e.g. 'en')
+      const voiceLang = this.preferencesService.getVoiceLanguage()
+      const language = voiceLang.split('-')[0]
+
+      if (this.voiceInputMode === 'voice-message') {
+        // Voice message mode: send audio as a message to the thread
+        this.audioApiService.sendVoiceMessage(base64, mimeType, language).subscribe({
+          next: (response) => {
+            this.isTranscribing = false
+            console.log('[WHISPER] Voice message sent, transcription:', response.transcription?.substring(0, 50))
+          },
+          error: (error) => {
+            console.error('[WHISPER] Voice message error:', error)
+            this.isTranscribing = false
+            // Fallback: transcribe to textarea instead
+            this.fallbackToTranscription(base64, mimeType, language)
+          },
+        })
+      } else {
+        // Whisper mode: transcribe and put text in textarea
+        this.audioApiService.transcribeAudio(base64, mimeType, language).subscribe({
+          next: (response) => {
+            this.isTranscribing = false
+            if (response.text) {
+              this.appendToTextarea(response.text + ' ')
+            }
+          },
+          error: (error) => {
+            console.error('[WHISPER] Transcription error:', error)
+            this.isTranscribing = false
+          },
+        })
+      }
+    }
+    reader.readAsDataURL(blob)
+  }
+
+  private fallbackToTranscription(base64: string, mimeType: string, language?: string): void {
+    this.audioApiService.transcribeAudio(base64, mimeType, language).subscribe({
+      next: (response) => {
+        this.isTranscribing = false
+        if (response.text) {
+          this.appendToTextarea(response.text + ' ')
+        }
+      },
+      error: (error) => {
+        console.error('[WHISPER] Fallback transcription also failed:', error)
+        this.isTranscribing = false
+      },
+    })
   }
 
   private initializeVoiceInput(): void {

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -66,6 +66,10 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
   private mediaRecorder: MediaRecorder | null = null
   private audioChunks: Blob[] = []
   private voiceInputMode: 'browser' | 'whisper' | 'voice-message' = 'browser'
+
+  get isVoiceMessageMode(): boolean {
+    return this.voiceInputMode === 'voice-message'
+  }
   private sessionHadTranscript: boolean = false
   private pendingLineBreaksTimeout: number | null = null
   // Index of the last processed final result — guards against Chrome mobile replaying all results
@@ -755,9 +759,9 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
       }
       // Show "Starting..." for first message, then rotate phrases
       return this.isStarting ? 'Processing request...' : this.currentThinkingPhrase
-    } else if (this.isTranscribing) {
+    } else if (this.isVoiceMessageMode && this.isTranscribing) {
       return 'Uploading...'
-    } else if (this.isRecording) {
+    } else if (this.isVoiceMessageMode && this.isRecording) {
       return 'Listening...'
     } else if (this.showWelcome) {
       return 'How can I help you today?'

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -755,6 +755,8 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
       }
       // Show "Starting..." for first message, then rotate phrases
       return this.isStarting ? 'Processing request...' : this.currentThinkingPhrase
+    } else if (this.isTranscribing) {
+      return 'Uploading...'
     } else if (this.isRecording) {
       return 'Listening...'
     } else if (this.showWelcome) {

--- a/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
+++ b/apps/client/src/app/components/chat-textarea/chat-textarea.component.ts
@@ -755,6 +755,8 @@ export class ChatTextareaComponent implements OnInit, OnDestroy, AfterViewInit, 
       }
       // Show "Starting..." for first message, then rotate phrases
       return this.isStarting ? 'Processing request...' : this.currentThinkingPhrase
+    } else if (this.isRecording) {
+      return 'Listening...'
     } else if (this.showWelcome) {
       return 'How can I help you today?'
     } else {

--- a/apps/client/src/app/components/main-app/main-app.component.html
+++ b/apps/client/src/app/components/main-app/main-app.component.html
@@ -27,6 +27,7 @@
               [isThinking]="false"
               [isStarting]="isStartingFirstMessage"
               (messageSubmitted)="onMessageSubmitted($event)"
+              (voiceMessageReady)="onVoiceMessageReady($event)"
               (voiceRecordingToggled)="onVoiceToggled($event)"
               (heightChanged)="onInputHeightChanged($event)"
               (textareaFocused)="onChatFocusedOnMobile()"

--- a/apps/client/src/app/components/main-app/main-app.component.ts
+++ b/apps/client/src/app/components/main-app/main-app.component.ts
@@ -14,7 +14,7 @@ import { TabTitleService } from '../../services/tab-title.service'
 import { PreferencesService } from '../../services/preferences.service'
 import { ThreadApiService } from '../../core/services/thread-api.service'
 import { AgentNotificationService } from '../../services/agent-notification.service'
-import { FirstMessageStateService } from '../../core/services/first-message-state.service'
+import { FirstMessageStateService, PendingVoiceMessage } from '../../core/services/first-message-state.service'
 
 @Component({
   selector: 'app-main',
@@ -155,7 +155,30 @@ export class MainAppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   onVoiceToggled(isRecording: boolean): void {
     console.log('[VOICE] Recording in welcome view:', isRecording)
-    // TODO: Implement speech-to-text for welcome view
+  }
+
+  /**
+   * Handle voice message from welcome view (implicit thread creation with audio)
+   */
+  onVoiceMessageReady(payload: PendingVoiceMessage): void {
+    console.log('[MAIN-APP] Voice message ready from welcome view')
+
+    this.isSessionInitializing = true
+    this.isStartingFirstMessage = true
+
+    this.threadApiService.createThread().subscribe({
+      next: (response) => {
+        console.log('[MAIN-APP] Thread created for voice message:', response.thread.id)
+        this.firstMessageState.setPendingVoiceMessage(payload)
+        this.router.navigate(['project', this.projectName, 'thread', response.thread.id])
+      },
+      error: (error) => {
+        console.error('[MAIN-APP] Failed to create thread for voice message:', error)
+        this.isSessionInitializing = false
+        this.isStartingFirstMessage = false
+        alert('Failed to create conversation: ' + (error.message || 'Unknown error'))
+      },
+    })
   }
 
   /**

--- a/apps/client/src/app/components/options-panel/options-panel.component.html
+++ b/apps/client/src/app/components/options-panel/options-panel.component.html
@@ -155,6 +155,20 @@
     </div>
 
     <div class="option-group">
+      <label for="voice-input-mode-select" class="option-label">Voice input method:</label>
+      <select
+        id="voice-input-mode-select"
+        class="option-select"
+        [value]="voiceInputMode"
+        (change)="onVoiceInputModeChange($event)"
+      >
+        <option value="browser">Browser (real-time)</option>
+        <option value="whisper">Whisper (higher accuracy)</option>
+        <option value="voice-message">Voice message (send audio)</option>
+      </select>
+    </div>
+
+    <div class="option-group">
       <label for="voice-language-select" class="option-label">Voice recognition language:</label>
       <select
         id="voice-language-select"

--- a/apps/client/src/app/components/options-panel/options-panel.component.ts
+++ b/apps/client/src/app/components/options-panel/options-panel.component.ts
@@ -31,6 +31,7 @@ export class OptionsPanelComponent implements OnInit, OnDestroy {
   showTechnicalMessages = true
   showWarningMessages = true
 
+  voiceInputMode: 'browser' | 'whisper' | 'voice-message' = 'browser'
   voiceAnnounceEnabled = false
   voiceMode: 'speech' | 'notification' = 'speech'
   voiceReadFullText = false
@@ -73,6 +74,7 @@ export class OptionsPanelComponent implements OnInit, OnDestroy {
     this.printTechnicalMessages = this.preferencesService.getPrintTechnicalMessages()
     this.showTechnicalMessages = !this.preferencesService.getHideTechnicalMessages()
     this.showWarningMessages = !this.preferencesService.getHideWarningMessages()
+    this.voiceInputMode = this.preferencesService.getVoiceInputMode()
     this.voiceAnnounceEnabled = this.preferencesService.getVoiceAnnounceEnabled()
     this.voiceMode = this.preferencesService.getVoiceMode()
     this.voiceReadFullText = this.preferencesService.getVoiceReadFullText()
@@ -109,6 +111,10 @@ export class OptionsPanelComponent implements OnInit, OnDestroy {
 
     this.preferencesService.hideWarningMessages$.pipe(takeUntil(this.destroy$)).subscribe((hideWarningMessages) => {
       this.showWarningMessages = !hideWarningMessages
+    })
+
+    this.preferencesService.voiceInputMode$.pipe(takeUntil(this.destroy$)).subscribe((mode) => {
+      this.voiceInputMode = mode as 'browser' | 'whisper' | 'voice-message'
     })
 
     this.preferencesService.voiceAnnounceEnabled$.pipe(takeUntil(this.destroy$)).subscribe((enabled) => {
@@ -189,6 +195,12 @@ export class OptionsPanelComponent implements OnInit, OnDestroy {
     const hideValue = !this.showWarningMessages
     console.log('[OPTIONS] Show warning messages changed to:', this.showWarningMessages, '(hide:', hideValue, ')')
     this.preferencesService.setHideWarningMessages(hideValue)
+  }
+
+  onVoiceInputModeChange(event: Event): void {
+    const mode = (event.target as HTMLSelectElement).value as 'browser' | 'whisper' | 'voice-message'
+    console.log('[OPTIONS] Voice input mode changed to:', mode)
+    this.preferencesService.setVoiceInputMode(mode)
   }
 
   onVoiceAnnounceEnabledChange(): void {

--- a/apps/client/src/app/components/thread/thread.component.ts
+++ b/apps/client/src/app/components/thread/thread.component.ts
@@ -39,6 +39,7 @@ import { ThreadApiService, ThreadDetails } from '../../core/services/thread-api.
 import { ImageUploadService } from '../../services/image-upload.service'
 import { FileExchangeStateService } from '../../core/services/file-exchange-state.service'
 import { FirstMessageStateService } from '../../core/services/first-message-state.service'
+import { AudioApiService } from '../../core/services/audio-api.service'
 import { UserService } from '../../core/services/user.service'
 import { Router } from '@angular/router'
 
@@ -150,6 +151,7 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
   private readonly imageUploadService = inject(ImageUploadService)
   private readonly fileExchangeState = inject(FileExchangeStateService)
   private readonly firstMessageState = inject(FirstMessageStateService)
+  private readonly audioApiService = inject(AudioApiService)
 
   ngOnInit(): void {
     console.log('[THREAD] Initializing with project:', this.projectName, 'thread:', this.threadId)
@@ -297,7 +299,25 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
         error: (err) => console.warn('[THREAD] Could not load REST history:', err),
       })
 
-    // Check if we have a first message from the state service (implicit thread creation)
+    // Check if we have a pending voice message from the state service (implicit thread creation)
+    const pendingVoice = this.firstMessageState.consumePendingVoiceMessage()
+    if (pendingVoice) {
+      console.log('[THREAD] Pending voice message found, sending as voice message')
+      this.codayService.setThinkingForPendingMessage()
+      this.audioApiService
+        .sendVoiceMessage(pendingVoice.base64, pendingVoice.mimeType, pendingVoice.language)
+        .subscribe({
+          next: (response) => {
+            console.log('[THREAD] First voice message sent, transcription:', response.transcription?.substring(0, 50))
+          },
+          error: (error) => {
+            console.error('[THREAD] Failed to send first voice message:', error)
+          },
+        })
+      return
+    }
+
+    // Check if we have a first text message from the state service (implicit thread creation)
     const firstMessage = this.firstMessageState.consumePendingFirstMessage()
 
     // If we have a first message, wait for the first InviteEvent before sending it

--- a/apps/client/src/app/components/thread/thread.component.ts
+++ b/apps/client/src/app/components/thread/thread.component.ts
@@ -302,18 +302,30 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
     // Check if we have a pending voice message from the state service (implicit thread creation)
     const pendingVoice = this.firstMessageState.consumePendingVoiceMessage()
     if (pendingVoice) {
-      console.log('[THREAD] Pending voice message found, sending as voice message')
+      console.log('[THREAD] Pending voice message found, waiting for InviteEvent before sending')
       this.codayService.setThinkingForPendingMessage()
-      this.audioApiService
-        .sendVoiceMessage(pendingVoice.base64, pendingVoice.mimeType, pendingVoice.language)
-        .subscribe({
-          next: (response) => {
-            console.log('[THREAD] First voice message sent, transcription:', response.transcription?.substring(0, 50))
-          },
-          error: (error) => {
-            console.error('[THREAD] Failed to send first voice message:', error)
-          },
+      // Wait for the backend Coday instance to be ready (signalled by the first InviteEvent)
+      // before sending the voice message — same pattern as text first messages.
+      this.subscriptions.push(
+        this.codayService.currentInviteEvent$.subscribe((inviteEvent) => {
+          if (inviteEvent) {
+            console.log('[THREAD] InviteEvent received, sending pending voice message')
+            this.audioApiService
+              .sendVoiceMessage(pendingVoice.base64, pendingVoice.mimeType, pendingVoice.language)
+              .subscribe({
+                next: (response) => {
+                  console.log(
+                    '[THREAD] First voice message sent, transcription:',
+                    response.transcription?.substring(0, 50)
+                  )
+                },
+                error: (error) => {
+                  console.error('[THREAD] Failed to send first voice message:', error)
+                },
+              })
+          }
         })
+      )
       return
     }
 

--- a/apps/client/src/app/components/thread/thread.component.ts
+++ b/apps/client/src/app/components/thread/thread.component.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/core'
 
 import { Subject } from 'rxjs'
-import { takeUntil } from 'rxjs/operators'
+import { filter, take, takeUntil } from 'rxjs/operators'
 
 import { ChatHistoryComponent } from '../chat-history/chat-history.component'
 import { ChatMessage } from '../chat-message/chat-message.component'
@@ -306,9 +306,14 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
       this.codayService.setThinkingForPendingMessage()
       // Wait for the backend Coday instance to be ready (signalled by the first InviteEvent)
       // before sending the voice message — same pattern as text first messages.
+      // Use filter+take(1) to fire exactly once and auto-unsubscribe.
       this.subscriptions.push(
-        this.codayService.currentInviteEvent$.subscribe((inviteEvent) => {
-          if (inviteEvent) {
+        this.codayService.currentInviteEvent$
+          .pipe(
+            filter((inviteEvent) => !!inviteEvent),
+            take(1)
+          )
+          .subscribe(() => {
             console.log('[THREAD] InviteEvent received, sending pending voice message')
             this.audioApiService
               .sendVoiceMessage(pendingVoice.base64, pendingVoice.mimeType, pendingVoice.language)
@@ -323,8 +328,7 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
                   console.error('[THREAD] Failed to send first voice message:', error)
                 },
               })
-          }
-        })
+          })
       )
       return
     }

--- a/apps/client/src/app/core/services/audio-api.service.ts
+++ b/apps/client/src/app/core/services/audio-api.service.ts
@@ -1,0 +1,58 @@
+import { inject, Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { ProjectStateService } from './project-state.service'
+import { ThreadStateService } from './thread-state.service'
+
+/**
+ * Service for audio transcription and voice message API calls.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AudioApiService {
+  private readonly http = inject(HttpClient)
+  private readonly projectState = inject(ProjectStateService)
+  private readonly threadState = inject(ThreadStateService)
+
+  /**
+   * Transcribe audio using OpenAI Whisper via the project-level endpoint.
+   * No thread required — only an OpenAI API key configured server-side.
+   *
+   * @param audio Base64-encoded audio data
+   * @param mimeType Audio MIME type (e.g. 'audio/webm')
+   * @param language Optional ISO 639-1 language code (e.g. 'en')
+   */
+  transcribeAudio(audio: string, mimeType: string, language?: string): Observable<{ success: boolean; text: string }> {
+    const projectName = this.projectState.getSelectedProjectIdOrThrow()
+
+    return this.http.post<{ success: boolean; text: string }>(`/api/projects/${projectName}/transcribe`, {
+      audio,
+      mimeType,
+      ...(language ? { language } : {}),
+    })
+  }
+
+  /**
+   * Send a voice message to the active thread.
+   * The audio is transcribed with Whisper server-side and stored as an AudioContent message.
+   * Requires an active thread and a running Coday instance.
+   *
+   * @param audio Base64-encoded audio data
+   * @param mimeType Audio MIME type (e.g. 'audio/webm')
+   * @param language Optional ISO 639-1 language code (e.g. 'en')
+   */
+  sendVoiceMessage(
+    audio: string,
+    mimeType: string,
+    language?: string
+  ): Observable<{ success: boolean; transcription: string }> {
+    const projectName = this.projectState.getSelectedProjectIdOrThrow()
+    const threadId = this.threadState.getSelectedThreadIdOrThrow()
+
+    return this.http.post<{ success: boolean; transcription: string }>(
+      `/api/projects/${projectName}/threads/${threadId}/voice-message`,
+      { audio, mimeType, ...(language ? { language } : {}) }
+    )
+  }
+}

--- a/apps/client/src/app/core/services/coday.service.ts
+++ b/apps/client/src/app/core/services/coday.service.ts
@@ -434,6 +434,12 @@ export class CodayService implements OnDestroy {
       }
     }
 
+    // Silent answers (e.g. voice message triggers) are already displayed via another
+    // message (audio upload) — skip rendering to avoid duplicates.
+    if ((event as any).silent) {
+      return
+    }
+
     // Display AnswerEvent as a user message
     const message: ChatMessage = {
       id: event.timestamp,

--- a/apps/client/src/app/core/services/first-message-state.service.ts
+++ b/apps/client/src/app/core/services/first-message-state.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@angular/core'
 
+export interface PendingVoiceMessage {
+  base64: string
+  mimeType: string
+  language?: string
+}
+
 /**
  * Service to manage the first message state during implicit thread creation.
  *
@@ -15,6 +21,7 @@ import { Injectable } from '@angular/core'
 })
 export class FirstMessageStateService {
   private pendingFirstMessage: string | null = null
+  private pendingVoiceMessage: PendingVoiceMessage | null = null
 
   /**
    * Store a first message to be sent after thread navigation
@@ -41,11 +48,31 @@ export class FirstMessageStateService {
   }
 
   /**
+   * Store a voice message payload to be sent after thread navigation.
+   */
+  setPendingVoiceMessage(payload: PendingVoiceMessage): void {
+    console.log('[FIRST-MESSAGE-STATE] Storing pending voice message')
+    this.pendingVoiceMessage = payload
+  }
+
+  /**
+   * Retrieve and clear the pending voice message (consume pattern).
+   */
+  consumePendingVoiceMessage(): PendingVoiceMessage | null {
+    const payload = this.pendingVoiceMessage
+    if (payload) {
+      console.log('[FIRST-MESSAGE-STATE] Consuming pending voice message')
+      this.pendingVoiceMessage = null
+    }
+    return payload
+  }
+
+  /**
    * Check if there's a pending first message without consuming it
    * @returns True if there's a pending first message
    */
   hasPendingFirstMessage(): boolean {
-    return this.pendingFirstMessage !== null
+    return this.pendingFirstMessage !== null || this.pendingVoiceMessage !== null
   }
 
   /**
@@ -56,5 +83,6 @@ export class FirstMessageStateService {
       console.log('[FIRST-MESSAGE-STATE] Clearing pending first message')
       this.pendingFirstMessage = null
     }
+    this.pendingVoiceMessage = null
   }
 }

--- a/apps/client/src/app/services/preferences.service.ts
+++ b/apps/client/src/app/services/preferences.service.ts
@@ -20,6 +20,9 @@ export class PreferencesService {
   private voiceLanguageSubject = new BehaviorSubject<string>('en-US')
   public voiceLanguage$ = this.voiceLanguageSubject.asObservable()
 
+  private voiceInputModeSubject = new BehaviorSubject<'browser' | 'whisper' | 'voice-message'>('browser')
+  public voiceInputMode$ = this.voiceInputModeSubject.asObservable()
+
   private enterToSendSubject = new BehaviorSubject<boolean>(true)
   public enterToSend$ = this.enterToSendSubject.asObservable()
 
@@ -133,6 +136,10 @@ export class PreferencesService {
     const storedTheme = this.getPreferenceSync<string>('theme', 'light') ?? 'light'
     this.themeSubject.next(storedTheme)
 
+    const storedVoiceInputMode =
+      this.getPreferenceSync<'browser' | 'whisper' | 'voice-message'>('voiceInputMode', 'browser') ?? 'browser'
+    this.voiceInputModeSubject.next(storedVoiceInputMode)
+
     console.log('[PREFERENCES] All preferences initialized successfully')
   }
 
@@ -188,6 +195,10 @@ export class PreferencesService {
 
     const storedTheme = (await this.getPreferenceAsync<string>('theme', 'light')) ?? 'light'
     this.themeSubject.next(storedTheme)
+
+    const storedVoiceInputMode =
+      (await this.getPreferenceAsync<'browser' | 'whisper' | 'voice-message'>('voiceInputMode', 'browser')) ?? 'browser'
+    this.voiceInputModeSubject.next(storedVoiceInputMode)
 
     console.log('[PREFERENCES] All preferences initialized successfully (async)')
   }
@@ -313,6 +324,9 @@ export class PreferencesService {
     if (key === 'theme') {
       this.themeSubject.next(value as string)
     }
+    if (key === 'voiceInputMode') {
+      this.voiceInputModeSubject.next(value as 'browser' | 'whisper' | 'voice-message')
+    }
   }
 
   setVoiceLanguage(language: string): void {
@@ -322,6 +336,15 @@ export class PreferencesService {
 
   getVoiceLanguage(): string {
     return this.getPreference<string>('voiceLanguage', 'en-US') ?? 'en-US'
+  }
+
+  setVoiceInputMode(mode: 'browser' | 'whisper' | 'voice-message'): void {
+    console.log('[PREFERENCES] Setting voice input mode to:', mode)
+    this.setPreference('voiceInputMode', mode)
+  }
+
+  getVoiceInputMode(): 'browser' | 'whisper' | 'voice-message' {
+    return this.getPreference<'browser' | 'whisper' | 'voice-message'>('voiceInputMode', 'browser') ?? 'browser'
   }
 
   setEnterToSend(useEnterToSend: boolean): void {

--- a/apps/server/src/lib/thread.routes.ts
+++ b/apps/server/src/lib/thread.routes.ts
@@ -993,12 +993,10 @@ export function registerThreadRoutes(
           transcription,
         }
 
-        // Upload the audio content so it appears in the thread history
+        // Upload the audio content so it appears in the thread history with the player + transcription.
+        // Then trigger the agent silently with the transcription — no duplicate UI message.
         instance.coday.upload([audioContent])
-
-        // Trigger the agent with the transcription as a user instruction,
-        // exactly as if the user had typed and submitted the text.
-        instance.coday.addUserMessage(username, transcription)
+        instance.coday.triggerWithMessage(username, transcription)
 
         res.status(200).json({ success: true, type: 'voice-message', transcription })
       } catch (error) {

--- a/apps/server/src/lib/thread.routes.ts
+++ b/apps/server/src/lib/thread.routes.ts
@@ -9,7 +9,9 @@ import { CodayOptions } from '@coday/model'
 import { MAX_FILE_SIZE, isFileExtensionAllowed, getAllowedExtensionsString } from '@coday/model'
 import { ThreadService } from '@coday/service'
 import { ThreadFileService } from '@coday/service'
+import { ConfigServiceRegistry } from '@coday/service'
 import { hasAccess, ThreadUpdateEvent } from '@coday/model'
+import { transcribeWithWhisper } from './whisper'
 
 /**
  * Thread Management REST API Routes
@@ -50,7 +52,8 @@ export function registerThreadRoutes(
   threadFileService: ThreadFileService,
   threadCodayManager: ThreadCodayManager,
   getUsernameFn: (req: express.Request) => string,
-  codayOptions: CodayOptions
+  codayOptions: CodayOptions,
+  configRegistry: ConfigServiceRegistry
 ): void {
   /**
    * GET /api/projects/:projectName/threads
@@ -905,6 +908,102 @@ export function registerThreadRoutes(
         console.error('Error deleting file:', error)
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
         res.status(500).json({ error: `Failed to delete file: ${errorMessage}` })
+      }
+    }
+  )
+
+  /**
+   * POST /api/projects/:projectName/threads/:threadId/voice-message
+   * Send a voice message to a thread.
+   * The audio is transcribed with Whisper and sent as an AudioContent message.
+   *
+   * Body: {
+   *   audio: string (base64-encoded audio),
+   *   mimeType: string,
+   *   language?: string (ISO 639-1, e.g. 'en')
+   * }
+   */
+  app.post(
+    '/api/projects/:projectName/threads/:threadId/voice-message',
+    async (req: express.Request, res: express.Response) => {
+      try {
+        const projectName = getParamAsString(req.params.projectName)
+        const threadId = getParamAsString(req.params.threadId)
+        const { audio, mimeType, language } = req.body
+
+        if (!projectName || !threadId) {
+          res.status(400).json({ error: 'Project name and thread ID are required' })
+          return
+        }
+
+        if (!audio || !mimeType) {
+          res.status(400).json({ error: 'Missing required fields: audio, mimeType' })
+          return
+        }
+
+        const username = getUsernameFn(req)
+        if (!username) {
+          res.status(401).json({ error: 'Authentication required' })
+          return
+        }
+
+        const thread = await threadService.getThread(projectName, threadId)
+        if (!thread || !hasAccess(thread, username)) {
+          res.status(403).json({ error: 'Access denied: thread belongs to another user' })
+          return
+        }
+
+        const instance = threadCodayManager.get(threadId)
+        if (!instance?.coday) {
+          res.status(404).json({ error: 'Thread not found or not active' })
+          return
+        }
+
+        const buffer = Buffer.from(audio, 'base64')
+
+        if (buffer.length > MAX_FILE_SIZE) {
+          res.status(400).json({
+            error: `Audio too large: ${(buffer.length / 1024 / 1024).toFixed(2)} MB exceeds maximum of ${MAX_FILE_SIZE / 1024 / 1024} MB`,
+          })
+          return
+        }
+
+        const allowedAudioTypes = [
+          'audio/webm',
+          'audio/mp4',
+          'audio/mpeg',
+          'audio/mp3',
+          'audio/wav',
+          'audio/m4a',
+          'audio/ogg',
+        ]
+        if (!allowedAudioTypes.includes(mimeType)) {
+          res.status(400).json({ error: `Unsupported audio type: ${mimeType}` })
+          return
+        }
+
+        debugLog('VOICE_MESSAGE', `threadId: ${threadId}, project: ${projectName}, mimeType: ${mimeType}`)
+
+        const transcription = await transcribeWithWhisper(buffer, mimeType, username, configRegistry, language)
+
+        const audioContent = {
+          type: 'audio' as const,
+          content: audio,
+          mimeType,
+          transcription,
+        }
+
+        instance.coday.upload([audioContent])
+
+        res.status(200).json({ success: true, type: 'voice-message', transcription })
+      } catch (error) {
+        console.error('Error sending voice message:', error)
+        const errorMessage = error instanceof Error ? error.message : 'Voice message failed'
+        if (errorMessage.includes('OpenAI provider not configured')) {
+          res.status(400).json({ error: errorMessage })
+        } else {
+          res.status(500).json({ error: errorMessage })
+        }
       }
     }
   )

--- a/apps/server/src/lib/thread.routes.ts
+++ b/apps/server/src/lib/thread.routes.ts
@@ -993,7 +993,12 @@ export function registerThreadRoutes(
           transcription,
         }
 
+        // Upload the audio content so it appears in the thread history
         instance.coday.upload([audioContent])
+
+        // Trigger the agent with the transcription as a user instruction,
+        // exactly as if the user had typed and submitted the text.
+        instance.coday.addUserMessage(username, transcription)
 
         res.status(200).json({ success: true, type: 'voice-message', transcription })
       } catch (error) {

--- a/apps/server/src/lib/transcribe.routes.ts
+++ b/apps/server/src/lib/transcribe.routes.ts
@@ -1,0 +1,83 @@
+import express from 'express'
+import { debugLog } from './log'
+import { getParamAsString } from './route-helpers'
+import { MAX_FILE_SIZE } from '@coday/model'
+import { ConfigServiceRegistry } from '@coday/service'
+import { transcribeWithWhisper } from './whisper'
+
+const ALLOWED_AUDIO_TYPES = [
+  'audio/webm',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/m4a',
+  'audio/ogg',
+]
+
+/**
+ * Register the project-level audio transcription route.
+ * This endpoint does NOT require an active thread — it only needs an OpenAI API key
+ * from the user's configuration or the OPENAI_API_KEY environment variable.
+ *
+ * POST /api/projects/:projectName/transcribe
+ */
+export function registerTranscribeRoutes(
+  app: express.Application,
+  configRegistry: ConfigServiceRegistry,
+  getUsernameFn: (req: express.Request) => string
+): void {
+  app.post('/api/projects/:projectName/transcribe', async (req: express.Request, res: express.Response) => {
+    try {
+      const projectName = getParamAsString(req.params.projectName)
+      const { audio, mimeType, language } = req.body
+
+      if (!projectName) {
+        res.status(400).json({ error: 'Project name is required' })
+        return
+      }
+
+      if (!audio || !mimeType) {
+        res.status(400).json({ error: 'Missing required fields: audio, mimeType' })
+        return
+      }
+
+      const username = getUsernameFn(req)
+      if (!username) {
+        res.status(401).json({ error: 'Authentication required' })
+        return
+      }
+
+      const buffer = Buffer.from(audio, 'base64')
+
+      if (buffer.length > MAX_FILE_SIZE) {
+        res.status(400).json({
+          error: `Audio too large: ${(buffer.length / 1024 / 1024).toFixed(2)} MB exceeds maximum of ${MAX_FILE_SIZE / 1024 / 1024} MB`,
+        })
+        return
+      }
+
+      if (!ALLOWED_AUDIO_TYPES.includes(mimeType)) {
+        res.status(400).json({ error: `Unsupported audio type: ${mimeType}` })
+        return
+      }
+
+      debugLog(
+        'TRANSCRIBE',
+        `project: ${projectName}, user: ${username}, mimeType: ${mimeType}, language: ${language || 'auto'}`
+      )
+
+      const text = await transcribeWithWhisper(buffer, mimeType, username, configRegistry, language)
+
+      res.status(200).json({ success: true, text })
+    } catch (error) {
+      console.error('Error transcribing audio:', error)
+      const errorMessage = error instanceof Error ? error.message : 'Transcription failed'
+      if (errorMessage.includes('OpenAI provider not configured')) {
+        res.status(400).json({ error: errorMessage })
+      } else {
+        res.status(500).json({ error: errorMessage })
+      }
+    }
+  })
+}

--- a/apps/server/src/lib/whisper.ts
+++ b/apps/server/src/lib/whisper.ts
@@ -1,0 +1,46 @@
+import { ConfigServiceRegistry } from '@coday/service'
+
+/**
+ * Transcribe audio using OpenAI Whisper.
+ * Resolves the OpenAI API key from the OPENAI_API_KEY environment variable first,
+ * then falls back to the user's configured OpenAI provider.
+ *
+ * @param audioBuffer Raw audio data
+ * @param mimeType MIME type of the audio (e.g. 'audio/webm')
+ * @param username Username for config lookup
+ * @param configRegistry Registry to resolve user config
+ * @param language Optional ISO 639-1 language code (e.g. 'en')
+ * @returns Transcribed text
+ */
+export async function transcribeWithWhisper(
+  audioBuffer: Buffer,
+  mimeType: string,
+  username: string,
+  configRegistry: ConfigServiceRegistry,
+  language?: string
+): Promise<string> {
+  const userService = configRegistry.getUserService(username)
+  const aiConfigs = userService.config.ai || []
+  const openaiConfig = aiConfigs.find((c) => c.name.toLowerCase() === 'openai')
+  const apiKey = process.env['OPENAI_API_KEY'] || openaiConfig?.apiKey
+  const baseURL = openaiConfig?.url
+
+  if (!apiKey) {
+    throw new Error('OpenAI provider not configured. Whisper transcription requires an OpenAI API key.')
+  }
+
+  const OpenAI = (await import('openai')).default
+  const openai = new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) })
+
+  const { toFile } = await import('openai')
+  const ext = mimeType.split('/')[1]?.replace('x-', '') || 'webm'
+  const file = await toFile(audioBuffer, `recording.${ext}`, { type: mimeType })
+
+  const transcription = await openai.audio.transcriptions.create({
+    model: 'whisper-1',
+    file,
+    ...(language ? { language } : {}),
+  })
+
+  return transcription.text
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -29,6 +29,7 @@ import { registerSchedulerRoutes } from './lib/scheduler.routes'
 import { registerPromptExecutionRoutes } from './lib/prompt-execution.routes'
 import { registerTokenUsageRoutes } from './lib/token-usage.routes'
 import { registerProjectPreviewRoutes } from './lib/project-preview.routes'
+import { registerTranscribeRoutes } from './lib/transcribe.routes'
 import { parseCodayOptions } from './lib/coday-options-utils'
 import { ProjectFileRepository } from '@coday/repository'
 import { McpInstancePool } from '@coday/mcp'
@@ -292,6 +293,9 @@ registerUserRoutes(app, getUsername, codayOptions.configDir, !!codayOptions.auth
 // Register configuration management routes
 registerConfigRoutes(app, configRegistry, getUsername)
 
+// Register audio transcription routes (project-level, no thread required)
+registerTranscribeRoutes(app, configRegistry, getUsername)
+
 // Note: Legacy webhook routes removed - use prompt routes instead
 // Webhook execution is now handled by prompt-execution.routes.ts
 
@@ -316,7 +320,15 @@ registerProjectRoutes(
 registerProjectPreviewRoutes(app, projectService)
 
 // Register thread management routes
-registerThreadRoutes(app, threadService, threadFileService, threadCodayManager, getUsername, codayOptions)
+registerThreadRoutes(
+  app,
+  threadService,
+  threadFileService,
+  threadCodayManager,
+  getUsername,
+  codayOptions,
+  configRegistry
+)
 
 // Register message management routes
 registerMessageRoutes(app, threadCodayManager, getUsername)

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -129,6 +129,7 @@ export class Coday {
     if (this.pendingQuestionEvent) {
       const answerEvent = this.pendingQuestionEvent.buildAnswer(message)
       answerEvent.name = username
+      answerEvent.silent = true
       this.interactor.sendEvent(answerEvent)
     } else {
       this.messageQueue.push({ username, message })

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -121,6 +121,21 @@ export class Coday {
   }
 
   /**
+   * Trigger agent processing with a message without emitting a UI MessageEvent.
+   * Use this when the message is already displayed via another mechanism (e.g. audio upload)
+   * and only the agent trigger is needed.
+   */
+  triggerWithMessage(username: string, message: string): void {
+    if (this.pendingQuestionEvent) {
+      const answerEvent = this.pendingQuestionEvent.buildAnswer(message)
+      answerEvent.name = username
+      this.interactor.sendEvent(answerEvent)
+    } else {
+      this.messageQueue.push({ username, message })
+    }
+  }
+
+  /**
    * Replay the current thread's messages.
    * Useful for reconnection scenarios.
    */

--- a/libs/handler/src/lib/anthropic.client.ts
+++ b/libs/handler/src/lib/anthropic.client.ts
@@ -341,6 +341,13 @@ export class AnthropicClient extends AiClient {
                   },
                 }
               }
+              if (c.type === 'audio') {
+                // Audio is not sent to AI — use transcription as text context instead
+                const text = c.transcription
+                  ? `[Voice message]: ${c.transcription}`
+                  : '[Voice message: no transcription available]'
+                result = { type: 'text', text }
+              }
               if (!result) {
                 // Fallback for unknown content types
                 this.interactor.warn(`Unknown content type: ${(c as any).type}`)

--- a/libs/handler/src/lib/openai.client.ts
+++ b/libs/handler/src/lib/openai.client.ts
@@ -463,6 +463,13 @@ export class OpenaiClient extends AiClient {
             console.log(`got an image in message event`)
             return image
           }
+          if (c.type === 'audio') {
+            // Audio is not sent to AI — use transcription as text context instead
+            const text = c.transcription
+              ? `[Voice message]: ${c.transcription}`
+              : '[Voice message: no transcription available]'
+            return { type: 'text' as const, text }
+          }
           throw new Error(`Unknown content type: ${(c as any).type}`)
         })
 

--- a/libs/model/src/lib/coday-events.ts
+++ b/libs/model/src/lib/coday-events.ts
@@ -14,7 +14,15 @@ export type ImageContent = {
   height?: number
 }
 
-export type MessageContent = TextContent | ImageContent
+export type AudioContent = {
+  type: 'audio'
+  content: string // base64-encoded audio data
+  mimeType: string // e.g., 'audio/webm'
+  duration?: number // duration in seconds (for UI display)
+  transcription?: string // Whisper transcription text (for AI context)
+}
+
+export type MessageContent = TextContent | ImageContent | AudioContent
 
 /**
  * Helper function to truncate text for display
@@ -330,6 +338,10 @@ export class MessageEvent extends CodayEvent {
         if (content.type === 'image') {
           const tokens = ((content.width || 0) * (content.height || 0)) / 750
           return tokens ? tokens * 3.5 : content.content.length
+        }
+        if (content.type === 'audio') {
+          // Use transcription length for token estimation, or a reasonable default
+          return content.transcription?.length ?? 100
         }
         return 0
       })

--- a/libs/model/src/lib/coday-events.ts
+++ b/libs/model/src/lib/coday-events.ts
@@ -136,6 +136,11 @@ export class AnswerEvent extends CodayEvent {
   invite: string | undefined
   /** Name of the human who sent this answer */
   name: string | undefined
+  /**
+   * When true, the frontend should not render this answer as a chat message.
+   * Used when the answer is already represented by another message (e.g. audio upload).
+   */
+  silent: boolean | undefined
   static override type = 'answer'
 
   constructor(event: Partial<AnswerEvent>) {
@@ -143,6 +148,7 @@ export class AnswerEvent extends CodayEvent {
     this.answer = event.answer ?? 'No answer'
     this.invite = event.invite
     this.name = event.name
+    this.silent = event.silent
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #799

Adds OpenAI Whisper-powered voice input with three modes:
- **Browser (real-time)**: Existing `SpeechRecognition` API — real-time, client-side
- **Whisper (transcription)**: Server-side Whisper transcription — text returned to textarea for review/edit
- **Voice message (send audio)**: Audio sent as a message with Whisper transcription — playable in thread with `<audio>` player

## Architecture

### Three-layer design

1. **Project-level transcription** (`POST /api/projects/:projectName/transcribe`) — no thread needed, resolves OpenAI key from user config or `OPENAI_API_KEY` env var. Works from welcome view.
2. **Thread-level voice messages** (`POST /api/projects/:projectName/threads/:threadId/voice-message`) — transcribes + sends audio as an `AudioContent` message to the thread via `coday.upload()`.
3. **Shared Whisper helper** (`apps/server/src/lib/whisper.ts`) — `transcribeWithWhisper()` used by both endpoints.

### New `AudioContent` type

Added alongside `TextContent` and `ImageContent` in the model:
```typescript
type AudioContent = {
  type: 'audio'
  content: string        // base64 audio
  mimeType: string
  duration?: number
  transcription?: string // Whisper text for AI context
}
```

AI providers (Anthropic, OpenAI) convert `AudioContent` to `[Voice message]: <transcription>` — audio binary is never sent to the AI.

## Changes

### Backend (5 files, 1 new)
- `whisper.ts` (new) — shared transcription helper
- `transcribe.routes.ts` (new) — project-level transcription endpoint
- `thread.routes.ts` — voice-message endpoint
- `server.ts` — route registration

### Model (1 file)
- `coday-events.ts` — `AudioContent` type, `MessageContent` union update

### AI Providers (2 files)
- `anthropic.client.ts` — handle `AudioContent` as text
- `openai.client.ts` — handle `AudioContent` as text

### Frontend (6 files, 1 new)
- `audio-api.service.ts` (new) — `transcribeAudio()` + `sendVoiceMessage()`
- `preferences.service.ts` — `voiceInputMode` preference (`browser | whisper | voice-message`)
- `chat-textarea.component.ts` — MediaRecorder recording, mode dispatch, fallback logic
- `chat-textarea.component.html` — transcribing indicator
- `chat-message.component.ts` — `<audio>` player + transcription rendering
- `options-panel` — voice input mode selector with 3 options

## Key Decisions

- Audio is stored **inline as base64** in `MessageEvent` (same pattern as images)
- Transcription endpoint is **project-scoped** (no thread needed) — works from welcome view
- Voice message endpoint is **thread-scoped** (messages need a thread)
- On voice-message error, falls back to transcribe-to-textarea
- `voiceInputMode` is a user preference, not a per-recording choice