### PR TITLE
fix: #801 replay ChoiceEvent on thread reconnection

### DIFF
--- a/apps/server/src/lib/thread-coday-manager.ts
+++ b/apps/server/src/lib/thread-coday-manager.ts
@@ -128,7 +128,7 @@ class ThreadCodayInstance {
         // the registry already knows about this invite, we're just re-sending it to the new SSE client.
         this.isReplaying = true
         try {
-          this.coday.interactor.replayLastInvite()
+          this.coday.interactor.replayLastQuestion()
         } finally {
           this.isReplaying = false
         }
@@ -497,7 +497,7 @@ export class ThreadCodayManager {
     this.projectEventManager.onNewGlobalConnection = (res) => {
       for (const instance of this.instances.values()) {
         if (!this.pendingInvites.has(instance.threadId)) continue
-        const lastInvite = instance.coday?.interactor?.getLastInviteEvent()
+        const lastInvite = instance.coday?.interactor?.getLastQuestionEvent()
         if (lastInvite) {
           const enriched = { ...lastInvite, threadId: instance.threadId, projectName: instance.projectName }
           const data = `data: ${JSON.stringify(enriched)}\n\n`
@@ -535,7 +535,7 @@ export class ThreadCodayManager {
       if (instance.projectName !== projectName) continue
       // Only replay if the registry confirms a pending invite (source of truth)
       if (!this.pendingInvites.has(instance.threadId)) continue
-      const lastInvite = instance.coday?.interactor?.getLastInviteEvent()
+      const lastInvite = instance.coday?.interactor?.getLastQuestionEvent()
       if (lastInvite) {
         const enriched = { ...lastInvite, threadId: instance.threadId }
         const data = `data: ${JSON.stringify(enriched)}\n\n`

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -134,7 +134,7 @@ export class Coday {
 
     // After replay, if not oneshot and thread is not running, re-emit last invite
     if (!this.options.oneshot && thread.runStatus !== RunStatus.RUNNING) {
-      this.interactor.replayLastInvite()
+      this.interactor.replayLastQuestion()
     }
   }
 

--- a/libs/model/src/lib/interactor.ts
+++ b/libs/model/src/lib/interactor.ts
@@ -4,6 +4,7 @@ import {
   CodayEvent,
   ErrorEvent,
   InviteEvent,
+  QuestionEvent,
   TextEvent,
   ThinkingEvent,
   WarnEvent,
@@ -14,7 +15,7 @@ export abstract class Interactor {
   events = new Subject<CodayEvent>()
   private thinking$ = new Subject<null>()
   private subs: Subscription[] = []
-  private lastInviteEvent?: InviteEvent
+  private lastQuestionEvent?: QuestionEvent
 
   debugLevelEnabled: boolean = false
 
@@ -28,7 +29,7 @@ export abstract class Interactor {
 
   async promptText(invite: string, defaultText?: string): Promise<string> {
     const inviteEvent = new InviteEvent({ invite, defaultValue: defaultText })
-    this.lastInviteEvent = inviteEvent
+    this.lastQuestionEvent = inviteEvent
     const answer: Observable<AnswerEvent> = this.events.pipe(
       filter((e) => e.parentKey === inviteEvent.timestamp),
       filter((e) => e instanceof AnswerEvent),
@@ -39,8 +40,8 @@ export abstract class Interactor {
     try {
       const answerEvent = await firstValueFrom(answer)
       this.lastAnswerName = answerEvent.name
-      // Clear lastInviteEvent so reconnecting clients don't see a stale invite
-      this.lastInviteEvent = undefined
+      // Clear lastQuestionEvent so reconnecting clients don't see a stale invite
+      this.lastQuestionEvent = undefined
       return answerEvent.answer
     } catch (error: any) {
       throw new Error(`No answer received over invite ${inviteEvent.timestamp} : ${error.message}`)
@@ -81,6 +82,7 @@ export abstract class Interactor {
       optionalQuestion: invite,
       allowFreeText: allowFreeText ?? false,
     })
+    this.lastQuestionEvent = choiceEvent
     const answer: Observable<string> = this.events.pipe(
       filter((e) => e.parentKey === choiceEvent.timestamp),
       filter((e) => e instanceof AnswerEvent),
@@ -90,8 +92,8 @@ export abstract class Interactor {
     this.sendEvent(choiceEvent)
     try {
       const result = await firstValueFrom(answer)
-      // Clear lastInviteEvent so reconnecting clients don't see a stale invite
-      this.lastInviteEvent = undefined
+      // Clear lastQuestionEvent so reconnecting clients don't see a stale choice
+      this.lastQuestionEvent = undefined
       return result
     } catch (error: any) {
       throw new Error(`No answer received over choice ${choiceEvent.timestamp} : ${error.message}`)
@@ -128,21 +130,21 @@ export abstract class Interactor {
   }
 
   /**
-   * Re-emit the last invite event if any.
+   * Re-emit the last question event (InviteEvent or ChoiceEvent) if any.
    * Used during reconnection to restore the input state.
    */
-  replayLastInvite(): void {
-    if (this.lastInviteEvent) {
-      this.sendEvent(this.lastInviteEvent)
+  replayLastQuestion(): void {
+    if (this.lastQuestionEvent) {
+      this.sendEvent(this.lastQuestionEvent)
     }
   }
 
   /**
-   * Return the last pending invite event without re-emitting it.
+   * Return the last pending question event (InviteEvent or ChoiceEvent) without re-emitting it.
    * Used by project-level SSE to replay active status to new clients.
    */
-  getLastInviteEvent(): InviteEvent | undefined {
-    return this.lastInviteEvent
+  getLastQuestionEvent(): QuestionEvent | undefined {
+    return this.lastQuestionEvent
   }
 
   kill() {


### PR DESCRIPTION
## Problem

When a client reconnected to an active thread, `replayLastInvite()` on the `Interactor` would replay nothing if the agent was blocked waiting on a `ChoiceEvent`. Only `InviteEvent` was being stored in the `lastInviteEvent` field — `chooseOption()` never stored its `ChoiceEvent`.

## Changes

All changes are in 3 files:

**`libs/model/src/lib/interactor.ts`**
- Renamed field `lastInviteEvent` → `lastQuestionEvent`, widened type from `InviteEvent | undefined` to `QuestionEvent | undefined`
- `chooseOption()` now stores `choiceEvent` in `lastQuestionEvent` before emitting (same pattern as `promptText()`), and clears it after receiving the answer
- Renamed `replayLastInvite()` → `replayLastQuestion()` — emits `lastQuestionEvent` if set (works for both `InviteEvent` and `ChoiceEvent`)
- Renamed `getLastInviteEvent()` → `getLastQuestionEvent()`, return type `QuestionEvent | undefined`

**`libs/core/src/lib/core.ts`**
- Updated call site: `replayLastInvite()` → `replayLastQuestion()`

**`apps/server/src/lib/thread-coday-manager.ts`**
- Updated two call sites: `replayLastInvite()` → `replayLastQuestion()`, `getLastInviteEvent()` → `getLastQuestionEvent()`

## Verification

Full build passed: `pnpm nx run-many -t build` — all 38 projects compiled successfully, no errors.

Closes #801