### PR TITLE
fix: skip publish jobs when no version bump was produced and include agentos projects in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         run: |
           npx tsx scripts/release.ts
-          # Capture the new version for desktop build from client package.json
-          NEW_VERSION=$(node -p "require('./apps/client/package.json').version")
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          # Capture new version only if a release commit was just made
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match="release/*" 2>/dev/null || echo "")
+          LATEST_TAG_COMMIT=$(git rev-list -n 1 "$LATEST_TAG" 2>/dev/null || echo "")
+          HEAD_COMMIT=$(git rev-parse HEAD)
+          if [ "$LATEST_TAG_COMMIT" = "$HEAD_COMMIT" ]; then
+            NEW_VERSION=${LATEST_TAG#release/}
+            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "new_version=" >> $GITHUB_OUTPUT
+          fi
 
       - name: Capture release commit SHA
         id: release_sha

--- a/nx.json
+++ b/nx.json
@@ -71,7 +71,6 @@
     }
   ],
   "release": {
-    "projects": ["server", "client", "web", "desktop", "desktop-twin"],
     "releaseTagPattern": "release/{version}",
     "changelog": {
       "workspaceChangelog": {
@@ -85,13 +84,26 @@
     },
     "version": {
       "conventionalCommits": true,
-      "manifestRootsToUpdate": ["apps/{projectName}"],
       "versionActionsOptions": {
         "skipLockFileUpdate": true
       },
       "git": {
         "commit": false,
         "tag": false
+      }
+    },
+    "groups": {
+      "npm": {
+        "projects": ["server", "client", "web", "desktop", "desktop-twin"],
+        "version": {
+          "manifestRootsToUpdate": ["apps/{projectName}"]
+        }
+      },
+      "jvm": {
+        "projects": ["tag:platform:jvm"],
+        "version": {
+          "manifestRootsToUpdate": []
+        }
       }
     }
   },


### PR DESCRIPTION
Two fixes to the release pipeline:

**Skip downstream jobs when no release happened**
When a commit only touches `agentos/` files, Nx detects no version bump is needed
and exits early — but `publish-sdk` and `desktop-release` were still running,
causing a 409 conflict when trying to republish an already existing SDK version.
The release job now only outputs `new_version` when a release tag was actually
created (git tag check against HEAD), so downstream jobs skip automatically.

**Include JVM projects in release versioning**
Added `tag:platform:jvm` to a dedicated `jvm` release group in `nx.json` so that
changes to any JVM project (`agentos-sdk`, `agentos-service`, plugins, etc.)
correctly trigger a version bump alongside the npm release. New JVM projects are
automatically included as long as they carry the `platform:jvm` tag.