### PR TITLE
feat(agentos): #WZ-29564 namespace management (Epic 2)

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
@@ -1,20 +1,37 @@
 package io.whozoss.agentos.namespace
 
-import io.whozoss.agentos.entity.EntityController
+import io.whozoss.agentos.entity.SecuredEntityController
+import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.PermissionRelation
+import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.UserService
+import jakarta.validation.Valid
 import mu.KLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
 /**
  * REST API for managing Namespaces.
  *
- * Extends [EntityController] with [NamespaceResource] as the HTTP DTO.
+ * Extends [SecuredEntityController] so that read/list/update flows are guarded by
+ * permission checks (404 for unauthorized READ, 403 for unauthorized WRITE on update).
+ *
+ * Namespace-specific rules (Story 2.1):
+ * - CREATE is restricted to SUPER-ADMIN users (isAdmin = true). The creator is
+ *   automatically granted an ADMIN relationship on the new namespace.
+ * - DELETE is restricted to SUPER-ADMIN users. All permission relationships
+ *   (ADMIN, MEMBER) pointing to the deleted namespace are cascade-revoked.
+ * - UPDATE is allowed for namespace ADMINs (via the inherited WRITE permission check).
  *
  * Standard CRUD endpoints (inherited):
  *   GET    /api/namespaces/{id}
@@ -25,7 +42,7 @@ import java.util.UUID
  *   DELETE /api/namespaces/{id}
  *
  * Additional endpoints:
- *   GET    /api/namespaces — list all namespaces (no parent filter needed)
+ *   GET    /api/namespaces — list all namespaces (filtering is scope of Story 2.4)
  */
 @RestController
 @RequestMapping(
@@ -34,7 +51,15 @@ import java.util.UUID
 )
 class NamespaceController(
     private val namespaceService: NamespaceService,
-) : EntityController<Namespace, String, NamespaceResource>(namespaceService) {
+    userService: UserService,
+    permissionService: PermissionService,
+) : SecuredEntityController<Namespace, String, NamespaceResource>(
+    namespaceService,
+    userService,
+    permissionService,
+) {
+
+    override fun getEntityType(): String = ENTITY_TYPE
 
     // -------------------------------------------------------------------------
     // Mapping between domain entity and HTTP resource
@@ -58,18 +83,200 @@ class NamespaceController(
         )
 
     // -------------------------------------------------------------------------
+    // Security overrides (Story 2.1)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Only SUPER-ADMIN users may create namespaces (FR1).
+     * A namespace ADMIN is not enough — this is a system-level operation.
+     *
+     * Uses the [userId] passed by the parent [SecuredEntityController.create]
+     * rather than refetching the current user, keeping the authorization decision
+     * consistent with the caller identity resolved upstream.
+     */
+    override fun checkCreatePermission(userId: String, entity: Namespace) {
+        val user = userService.findById(UUID.fromString(userId))
+            ?: throw ResponseStatusException(HttpStatus.FORBIDDEN, SUPER_ADMIN_REQUIRED)
+        if (!user.isAdmin) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, SUPER_ADMIN_REQUIRED)
+        }
+    }
+
+    /**
+     * POST /api/namespaces — delegates creation to the parent (which invokes
+     * [checkCreatePermission]), then auto-grants an ADMIN relationship to the
+     * creator. If the grant fails, we log a warning but do not roll back the
+     * creation — the user keeps the super-admin bypass anyway.
+     */
+    override fun create(@Valid @RequestBody resource: NamespaceResource): NamespaceResource {
+        val created = super.create(resource)
+        val namespaceId = created.id
+            ?: error("Created namespace must have an id")
+
+        val userId = userService.getCurrentUser().id.toString()
+        runCatching {
+            permissionService.grantPermission(
+                userId,
+                ENTITY_TYPE,
+                namespaceId.toString(),
+                PermissionRelation.ADMIN,
+            )
+            logger.info { "Super-admin $userId created namespace $namespaceId with auto-ADMIN grant" }
+        }.onFailure { e ->
+            logger.warn(e) {
+                "Auto-ADMIN grant failed for namespace $namespaceId — super-admin bypass still applies"
+            }
+        }
+
+        return created
+    }
+
+    /**
+     * DELETE /api/namespaces/{id} — SUPER-ADMIN only (FR2). Not overridable by a
+     * namespace ADMIN: deleting a namespace is a system-level operation.
+     *
+     * Order of checks:
+     *   1. Existence check (`findById`) — 404 if the entity does not exist.
+     *   2. READ permission check — 404 on failure to hide the namespace's existence
+     *      from callers without any access (aligns with the "always 404 if no READ"
+     *      rule in the architecture doc).
+     *   3. Super-admin gate — 403 for callers who have READ but are not super-admin.
+     *
+     * On success, cascade BEFORE the delete so that a failure to list/revoke
+     * permissions does not leave the system with orphan relationships pointing at a
+     * deleted namespace. Individual revoke failures are still best-effort (logged,
+     * not propagated) — only the bulk listing failure surfaces as a 500.
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun delete(@PathVariable id: UUID) {
+        service.findById(id) ?: throw ResourceNotFoundException("Entity not found: $id")
+
+        val currentUser = userService.getCurrentUser()
+        val currentUserId = currentUser.id.toString()
+        if (!permissionService.hasPermission(currentUserId, ENTITY_TYPE, id.toString(), Action.READ)) {
+            // Hide the namespace's existence from users without READ access.
+            throw ResourceNotFoundException("Entity not found: $id")
+        }
+        if (!currentUser.isAdmin) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, SUPER_ADMIN_REQUIRED)
+        }
+
+        val cascadedCount = cascadeRevokeNamespacePermissions(id)
+
+        if (!service.delete(id)) {
+            throw ResourceNotFoundException("Entity not found: $id")
+        }
+
+        logger.info {
+            "Super-admin ${currentUser.id} deleted namespace $id " +
+                "($cascadedCount permission relations cascade-removed)"
+        }
+    }
+
+    private fun cascadeRevokeNamespacePermissions(namespaceId: UUID): Int {
+        val namespaceIdString = namespaceId.toString()
+        // Let listing failures surface as 500: if we cannot enumerate the users with
+        // permissions, we must not proceed with deletion (would leave orphan relations).
+        val affectedUserIds = permissionService
+            .listUsersWithPermission(ENTITY_TYPE, namespaceIdString, null)
+            .distinct()
+
+        var revoked = 0
+        affectedUserIds.forEach { affectedUserId ->
+            listOf(PermissionRelation.ADMIN, PermissionRelation.MEMBER).forEach { relation ->
+                runCatching {
+                    permissionService.revokePermission(
+                        affectedUserId,
+                        ENTITY_TYPE,
+                        namespaceIdString,
+                        relation,
+                    )
+                    revoked++
+                }.onFailure { e ->
+                    logger.warn(e) {
+                        "Failed to revoke $relation on namespace $namespaceId for user $affectedUserId"
+                    }
+                }
+            }
+        }
+        return revoked
+    }
+
+    // -------------------------------------------------------------------------
     // Additional endpoints
     // -------------------------------------------------------------------------
 
     /**
-     * GET /api/namespaces — list all namespaces.
+     * GET /api/namespaces — list namespaces filtered by the caller's permissions (Story 2.4).
+     *
+     * - SUPER-ADMIN: returns every namespace with `role = "SUPER-ADMIN"`.
+     * - Regular user: returns only the namespaces the caller has at least READ on,
+     *   with `role = "ADMIN"` or `"MEMBER"` depending on the highest direct permission.
+     * - User without any permission: returns an empty list.
+     *
+     * Performance: uses `listEntitiesForUser` (one Neo4j query) to avoid an N+1
+     * `hasPermission` call per namespace. Per-namespace ADMIN detection is done
+     * with a set lookup against the WRITE entity list.
      */
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    fun listAll(): List<NamespaceResource> {
-        logger.info { "listing all namespaces" }
-        return namespaceService.findAll().map { toResource(it) }
+    fun listAll(): List<NamespaceListItem> {
+        logger.info { "listing all namespaces (permission-filtered)" }
+        val currentUser = userService.getCurrentUser()
+
+        if (currentUser.isAdmin) {
+            // Defensive soft-delete filter: the repository is expected to exclude
+            // removed entries, but we guard here explicitly to keep AC2 ("all namespaces
+            // except the soft-deleted ones") robust to any future repo change.
+            return namespaceService.findAll()
+                .filter { it.metadata.removed != true }
+                .map { toListItem(it, SUPER_ADMIN) }
+        }
+
+        val userId = currentUser.id.toString()
+        val readableIds = permissionService.listEntitiesForUser(userId, ENTITY_TYPE, Action.READ)
+        if (readableIds.isEmpty()) return emptyList()
+
+        // Defensive: filter out any malformed UUID strings (should never happen
+        // in practice since IDs come from Neo4j, but UUID.fromString throws).
+        // Log each malformed id as WARN so data corruption surfaces in ops instead
+        // of being silently swallowed.
+        val uuids = readableIds.mapNotNull { raw ->
+            runCatching { UUID.fromString(raw) }.getOrNull()
+                ?: run {
+                    logger.warn { "Dropping malformed namespace id from permission listing: '$raw'" }
+                    null
+                }
+        }
+        // findByIds already excludes soft-deleted namespaces (Neo4jNamespaceRepository filter).
+        val namespaces = namespaceService.findByIds(uuids)
+
+        val adminIdsSet = permissionService
+            .listEntitiesForUser(userId, ENTITY_TYPE, Action.WRITE)
+            .toSet()
+
+        return namespaces.map { ns ->
+            val role = if (ns.metadata.id.toString() in adminIdsSet) ADMIN else MEMBER
+            toListItem(ns, role)
+        }
     }
 
-    companion object : KLogging()
+    private fun toListItem(entity: Namespace, role: String): NamespaceListItem =
+        NamespaceListItem(
+            id = entity.metadata.id,
+            name = entity.name,
+            description = entity.description,
+            // Match toResource() semantics: never leak an empty string through the wire —
+            // callers rely on null to mean "unset".
+            configPath = entity.configPath?.takeIf { it.isNotBlank() },
+            role = role,
+        )
+
+    companion object : KLogging() {
+        private const val ENTITY_TYPE = "Namespace"
+        private const val SUPER_ADMIN_REQUIRED = "SUPER-ADMIN role required"
+        private const val SUPER_ADMIN = "SUPER-ADMIN"
+        private const val ADMIN = "ADMIN"
+        private const val MEMBER = "MEMBER"
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceListItem.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceListItem.kt
@@ -1,0 +1,28 @@
+package io.whozoss.agentos.namespace
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+/**
+ * HTTP resource returned by `GET /api/namespaces` (Story 2.4).
+ *
+ * Represents a namespace from the caller's perspective, carrying the caller's
+ * effective [role] on that namespace. Distinct from [NamespaceResource] (used for
+ * POST/PUT and `GET /{id}`) because the list endpoint is the only place where a
+ * computed per-caller role is meaningful.
+ *
+ * Possible [role] values:
+ * - `"SUPER-ADMIN"` — the caller has `isAdmin = true`; visible for every namespace
+ * - `"ADMIN"`       — the caller holds a direct `[:ADMIN]` relation on the namespace
+ * - `"MEMBER"`      — the caller holds a direct `[:MEMBER]` relation but no ADMIN
+ */
+@Schema(name = "NamespaceListItem")
+data class NamespaceListItem(
+    val id: UUID,
+    val name: String,
+    val description: String? = null,
+    @Schema(description = "Optional filesystem path to a directory containing base configuration for this namespace")
+    val configPath: String? = null,
+    @Schema(description = "The caller's effective role on this namespace", allowableValues = ["SUPER-ADMIN", "ADMIN", "MEMBER"])
+    val role: String,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpoints.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpoints.kt
@@ -1,0 +1,271 @@
+package io.whozoss.agentos.namespace
+
+import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.PermissionRelation
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.user.UserService
+import mu.KLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+/**
+ * Dedicated endpoints for managing namespace ADMIN permissions (Story 2.2).
+ *
+ * Kept separate from [NamespaceController] so CRUD and permission-management
+ * concerns do not mix. Both controllers share the `/api/namespaces` prefix.
+ *
+ * Endpoints:
+ *   PUT    /api/namespaces/{namespaceId}/admins/{targetUserId}
+ *   DELETE /api/namespaces/{namespaceId}/admins/{targetUserId}
+ *
+ * Authorization: the caller must hold the ADMIN relationship on the namespace
+ * (either directly or via the super-admin bypass handled by [PermissionService]).
+ *
+ * Idempotency: the Neo4j MERGE + DELETE primitives are naturally idempotent,
+ * so repeated PUTs/DELETEs are safe and return the same status code.
+ *
+ * Note: MEMBER management belongs to Story 2.3. Audit-trail properties
+ * (grantedBy / grantedAt) on the relationship are intentionally deferred.
+ */
+@RestController
+@RequestMapping(
+    "/api/namespaces",
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+class NamespacePermissionEndpoints(
+    private val namespaceService: NamespaceService,
+    private val userService: UserService,
+    private val permissionService: PermissionService,
+) {
+
+    /**
+     * PUT — grant ADMIN on the namespace to [targetUserId].
+     */
+    @PutMapping("/{namespaceId}/admins/{targetUserId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun grantAdmin(
+        @PathVariable namespaceId: UUID,
+        @PathVariable targetUserId: UUID,
+    ) {
+        val currentUserId = requireNamespaceAdmin(namespaceId, targetUserId)
+
+        permissionService.grantPermission(
+            targetUserId.toString(),
+            ENTITY_TYPE,
+            namespaceId.toString(),
+            PermissionRelation.ADMIN,
+        )
+        logger.info {
+            "User $currentUserId granted ADMIN on namespace $namespaceId to user $targetUserId"
+        }
+    }
+
+    /**
+     * DELETE — revoke the ADMIN relationship between [targetUserId] and the namespace.
+     */
+    @DeleteMapping("/{namespaceId}/admins/{targetUserId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun revokeAdmin(
+        @PathVariable namespaceId: UUID,
+        @PathVariable targetUserId: UUID,
+    ) {
+        val currentUserId = requireNamespaceAdmin(namespaceId, targetUserId)
+
+        permissionService.revokePermission(
+            targetUserId.toString(),
+            ENTITY_TYPE,
+            namespaceId.toString(),
+            PermissionRelation.ADMIN,
+        )
+        logger.info {
+            "User $currentUserId revoked ADMIN on namespace $namespaceId from user $targetUserId"
+        }
+    }
+
+    /**
+     * PUT — grant MEMBER on the namespace to [targetUserId] (Story 2.3).
+     *
+     * Authorization is identical to [grantAdmin]: the caller must hold the ADMIN
+     * relationship on the namespace (directly or via super-admin bypass). MEMBER
+     * gives the target user READ access to the namespace and transitive READ on
+     * its child entities.
+     */
+    @PutMapping("/{namespaceId}/members/{targetUserId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun grantMember(
+        @PathVariable namespaceId: UUID,
+        @PathVariable targetUserId: UUID,
+    ) {
+        val currentUserId = requireNamespaceAdmin(namespaceId, targetUserId)
+
+        permissionService.grantPermission(
+            targetUserId.toString(),
+            ENTITY_TYPE,
+            namespaceId.toString(),
+            PermissionRelation.MEMBER,
+        )
+        logger.info {
+            "User $currentUserId granted MEMBER on namespace $namespaceId to user $targetUserId"
+        }
+    }
+
+    /**
+     * DELETE — revoke the MEMBER relationship between [targetUserId] and the namespace (Story 2.3).
+     *
+     * Only removes the [:MEMBER] relationship. Any [:ADMIN] relationship the same
+     * user holds on the same namespace is left untouched — users who are both ADMIN
+     * and MEMBER keep their higher privilege after this call.
+     */
+    @DeleteMapping("/{namespaceId}/members/{targetUserId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun revokeMember(
+        @PathVariable namespaceId: UUID,
+        @PathVariable targetUserId: UUID,
+    ) {
+        val currentUserId = requireNamespaceAdmin(namespaceId, targetUserId)
+
+        permissionService.revokePermission(
+            targetUserId.toString(),
+            ENTITY_TYPE,
+            namespaceId.toString(),
+            PermissionRelation.MEMBER,
+        )
+        logger.info {
+            "User $currentUserId revoked MEMBER on namespace $namespaceId from user $targetUserId"
+        }
+    }
+
+    /**
+     * GET — list all users with a direct `[:ADMIN]` or `[:MEMBER]` relation on the
+     * namespace (Story 2.5).
+     *
+     * Authorization: caller must have READ on the namespace (MEMBER or ADMIN, or
+     * super-admin via bypass). Callers without access receive 404 to hide the
+     * namespace's existence.
+     *
+     * Response: each user appears at most once. Users with both ADMIN and MEMBER
+     * relations are returned with the higher role ("ADMIN"). Super-admins without
+     * a direct relation are NOT listed — this endpoint reflects namespace-level
+     * grants, not system-level roles.
+     *
+     * Permission relations pointing to users that no longer exist (orphans from a
+     * user deletion) are silently filtered out; a WARN log records the count.
+     */
+    @GetMapping("/{namespaceId}/users")
+    @ResponseStatus(HttpStatus.OK)
+    fun listNamespaceUsers(@PathVariable namespaceId: UUID): List<NamespaceUserListItem> {
+        requireNamespaceRead(namespaceId)
+
+        val namespaceIdString = namespaceId.toString()
+        val adminUserIds = permissionService
+            .listUsersWithPermission(ENTITY_TYPE, namespaceIdString, PermissionRelation.ADMIN)
+            .toSet()
+        val memberUserIds = permissionService
+            .listUsersWithPermission(ENTITY_TYPE, namespaceIdString, PermissionRelation.MEMBER)
+            .toSet()
+        val allUserIds = adminUserIds + memberUserIds
+        if (allUserIds.isEmpty()) return emptyList()
+
+        // Defensive: filter malformed UUID strings (should never happen in practice
+        // since IDs come from Neo4j; UUID.fromString throws otherwise).
+        // Log each malformed id as WARN so data corruption surfaces in ops.
+        val uuids = allUserIds.mapNotNull { raw ->
+            runCatching { UUID.fromString(raw) }.getOrNull()
+                ?: run {
+                    logger.warn {
+                        "Dropping malformed user id from permission listing on namespace $namespaceId: '$raw'"
+                    }
+                    null
+                }
+        }
+        val users = userService.findByIds(uuids)
+
+        val missingCount = uuids.size - users.size
+        if (missingCount > 0) {
+            logger.warn {
+                "Namespace $namespaceId has $missingCount permission relation(s) pointing to " +
+                    "non-existent users — filtered from response"
+            }
+        }
+
+        return users.map { user ->
+            val userIdString = user.metadata.id.toString()
+            val role = if (userIdString in adminUserIds) ADMIN else MEMBER
+            NamespaceUserListItem(
+                id = user.metadata.id,
+                externalId = user.externalId,
+                email = user.email,
+                firstname = user.firstname,
+                lastname = user.lastname,
+                role = role,
+            )
+        }
+    }
+
+    /**
+     * Validate that the namespace exists and the caller has READ on it.
+     *
+     * 404 is returned both when the namespace does not exist and when the caller
+     * lacks READ — callers without access should not be able to distinguish the
+     * two cases.
+     */
+    private fun requireNamespaceRead(namespaceId: UUID): String {
+        namespaceService.findById(namespaceId)
+            ?: throw ResourceNotFoundException("Namespace not found: $namespaceId")
+
+        val currentUserId = userService.getCurrentUser().id.toString()
+        if (!permissionService.hasPermission(currentUserId, ENTITY_TYPE, namespaceId.toString(), Action.READ)) {
+            throw ResourceNotFoundException("Namespace not found: $namespaceId")
+        }
+        return currentUserId
+    }
+
+    /**
+     * Validate that the namespace and target user exist, and that the caller has
+     * ADMIN rights on the namespace. Returns the caller's userId for logging.
+     *
+     * Order of checks (aligned with the "always 404 if no READ" rule in the
+     * architecture doc to avoid leaking namespace existence to non-members):
+     *   1. Namespace existence → 404 if missing.
+     *   2. Caller's READ permission on the namespace → 404 if denied
+     *      (hides the existence from callers with no access at all).
+     *   3. Target user existence → 404 if missing (caller has READ so disclosure is fine).
+     *   4. Caller's WRITE permission on the namespace → 403 if denied
+     *      (caller has READ and knows the namespace exists).
+     */
+    private fun requireNamespaceAdmin(namespaceId: UUID, targetUserId: UUID): String {
+        namespaceService.findById(namespaceId)
+            ?: throw ResourceNotFoundException("Namespace not found: $namespaceId")
+
+        val currentUserId = userService.getCurrentUser().id.toString()
+        val namespaceIdString = namespaceId.toString()
+
+        if (!permissionService.hasPermission(currentUserId, ENTITY_TYPE, namespaceIdString, Action.READ)) {
+            throw ResourceNotFoundException("Namespace not found: $namespaceId")
+        }
+
+        userService.findById(targetUserId)
+            ?: throw ResourceNotFoundException("User not found: $targetUserId")
+
+        if (!permissionService.hasPermission(currentUserId, ENTITY_TYPE, namespaceIdString, Action.WRITE)) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Namespace ADMIN role required")
+        }
+        return currentUserId
+    }
+
+    companion object : KLogging() {
+        private const val ENTITY_TYPE = "Namespace"
+        private const val ADMIN = "ADMIN"
+        private const val MEMBER = "MEMBER"
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceUserListItem.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceUserListItem.kt
@@ -1,0 +1,24 @@
+package io.whozoss.agentos.namespace
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+/**
+ * HTTP resource returned by `GET /api/namespaces/{id}/users` (Story 2.5).
+ *
+ * Represents a user holding a direct `[:ADMIN]` or `[:MEMBER]` relation on the
+ * namespace. Super-admins are not listed here unless they also hold a direct
+ * relation — this endpoint surfaces namespace-level grants, not system-level roles.
+ *
+ * Users with both ADMIN and MEMBER relations appear once with `role = "ADMIN"`.
+ */
+@Schema(name = "NamespaceUserListItem")
+data class NamespaceUserListItem(
+    val id: UUID,
+    val externalId: String,
+    val email: String,
+    val firstname: String? = null,
+    val lastname: String? = null,
+    @Schema(description = "The user's direct role on this namespace", allowableValues = ["ADMIN", "MEMBER"])
+    val role: String,
+)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
@@ -9,21 +9,24 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.UUID
 
 /**
- * MVC-layer test for [NamespaceController] — verifies that Bean Validation is
- * triggered by the Spring MVC dispatcher on create and update endpoints.
+ * MVC-layer test for [NamespaceController] — verifies Bean Validation and Story 2.1
+ * security flows through the full Spring MVC dispatcher.
  *
  * Uses a full Spring Boot context (webEnvironment = MOCK) with the "test" profile
- * so that the dispatcher, message converters, and validation are all active.
- * The "test" profile enables in-memory persistence so no external services are needed.
+ * (in-memory persistence). The OS user is auto-promoted to super-admin on first
+ * access (first-user bootstrap), so positive CRUD paths succeed without extra setup.
  *
- * These tests complement [NamespaceControllerSpec], which exercises the controller
- * logic directly without a Spring context (and therefore cannot test @Valid activation).
+ * These tests complement [NamespaceControllerSpec], which covers negative paths
+ * (403 for non-super-admin) at the unit level.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
@@ -37,7 +40,7 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
     init {
 
         // -------------------------------------------------------------------------
-        // POST /api/namespaces — create
+        // POST /api/namespaces — create (Bean Validation + super-admin gate)
         // -------------------------------------------------------------------------
 
         "POST /api/namespaces with blank name returns 400" {
@@ -48,7 +51,7 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
             ).andExpect(status().isBadRequest)
         }
 
-        "POST /api/namespaces with valid name returns 201" {
+        "POST /api/namespaces with valid name returns 201 (OS user is super-admin)" {
             mockMvc.perform(
                 post("/api/namespaces")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -72,6 +75,13 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
             ).andExpect(status().isCreated)
         }
 
+        // NOTE: Verifying the auto-ADMIN grant via [PermissionService.listEntitiesForUser]
+        // is not possible in this test class because the "test" profile uses
+        // [InMemoryPermissionServiceImpl], a permissive no-op stub. The auto-grant
+        // behaviour is covered exhaustively by the mocked unit tests in
+        // [NamespaceControllerSpec] and by the real Neo4j test
+        // [Neo4jSecuredEntityControllerSpec].
+
         // -------------------------------------------------------------------------
         // PUT /api/namespaces/{id} — update
         // -------------------------------------------------------------------------
@@ -86,7 +96,7 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
             ).andExpect(status().isBadRequest)
         }
 
-        "PUT /api/namespaces/{id} with valid payload returns 200" {
+        "PUT /api/namespaces/{id} with valid payload returns 200 (super-admin bypass)" {
             val created = namespaceService.create(
                 Namespace(
                     metadata = EntityMetadata(id = UUID.randomUUID()),
@@ -99,6 +109,45 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{ "id": "${created.id}", "name": "platform-updated", "configPath": "/opt/platform" }""")
             ).andExpect(status().isOk)
+        }
+
+        // -------------------------------------------------------------------------
+        // DELETE /api/namespaces/{id} — super-admin only + cascade (Story 2.1)
+        // -------------------------------------------------------------------------
+
+        "DELETE /api/namespaces/{id} returns 204 for super-admin" {
+            val created = namespaceService.create(
+                Namespace(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    name = "to-delete",
+                )
+            )
+
+            mockMvc.perform(delete("/api/namespaces/${created.id}"))
+                .andExpect(status().isNoContent)
+        }
+
+        "DELETE /api/namespaces/{id} returns 404 when namespace does not exist" {
+            val missingId = UUID.randomUUID()
+            mockMvc.perform(delete("/api/namespaces/$missingId"))
+                .andExpect(status().isNotFound)
+        }
+
+        // -------------------------------------------------------------------------
+        // GET /api/namespaces — listAll (Story 2.4)
+        // -------------------------------------------------------------------------
+
+        "GET /api/namespaces returns items with role=SUPER-ADMIN for the super-admin caller" {
+            namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "list-probe-${UUID.randomUUID()}"),
+            )
+
+            mockMvc.perform(get("/api/namespaces"))
+                .andExpect(status().isOk)
+                // At least one item must be present (we just created one)
+                .andExpect(jsonPath("$[0].role").value("SUPER-ADMIN"))
+                // Every item returned must carry role = "SUPER-ADMIN"
+                .andExpect(jsonPath("$[*].role", org.hamcrest.Matchers.everyItem(org.hamcrest.Matchers.equalTo("SUPER-ADMIN"))))
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerSpec.kt
@@ -1,31 +1,60 @@
 package io.whozoss.agentos.namespace
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.Runs
+import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.PermissionRelation
+import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
 /**
  * Unit tests for [NamespaceController].
  *
- * The controller is instantiated directly with MockK stubs — no Spring context.
- * Tests cover:
- * - [NamespaceController.toResource]  — domain → HTTP DTO mapping
- * - [NamespaceController.toDomain]    — HTTP DTO → domain mapping, including blank configPath normalization
- * - [NamespaceController.listAll]     — delegates to [NamespaceService.findAll] and maps results
- * - Inherited [io.whozoss.agentos.entity.EntityController] endpoints:
- *   getById (found / not-found), getByIds, create, update (found / not-found),
- *   delete (found / not-found)
+ * Covers:
+ * - Mapping (toResource / toDomain, including blank configPath normalization)
+ * - listAll endpoint (no permission filtering — scope of Story 2.4)
+ * - Inherited secured CRUD endpoints (getById, getByIds, update, delete) via
+ *   [io.whozoss.agentos.entity.SecuredEntityController] — permission checks mocked
+ * - Story 2.1 security overrides:
+ *   * create: super-admin only (FR1) + auto-grant ADMIN to creator
+ *   * delete: super-admin only (FR2) + cascade revoke of ADMIN/MEMBER relations
  */
 class NamespaceControllerSpec : StringSpec({
-    timeout = 5000
-
     val namespaceService = mockk<NamespaceService>()
-    val controller = NamespaceController(namespaceService)
+    val userService = mockk<UserService>()
+    val permissionService = mockk<PermissionService>()
+    val controller = NamespaceController(namespaceService, userService, permissionService)
+
+    val superAdminId = UUID.randomUUID()
+    val superAdmin = User(
+        metadata = EntityMetadata(id = superAdminId),
+        externalId = "super@example.com",
+        email = "super@example.com",
+        isAdmin = true,
+    )
+    val regularUserId = UUID.randomUUID()
+    val regularUser = User(
+        metadata = EntityMetadata(id = regularUserId),
+        externalId = "user@example.com",
+        email = "user@example.com",
+        isAdmin = false,
+    )
 
     fun ns(
         id: UUID = UUID.randomUUID(),
@@ -51,6 +80,10 @@ class NamespaceControllerSpec : StringSpec({
         configPath = configPath,
     )
 
+    beforeTest {
+        clearAllMocks()
+    }
+
     // -------------------------------------------------------------------------
     // toResource mapping
     // -------------------------------------------------------------------------
@@ -59,15 +92,16 @@ class NamespaceControllerSpec : StringSpec({
         val id = UUID.randomUUID()
         val entity = ns(id = id, name = "coday", description = "Coday project", configPath = "/opt/coday")
 
-        val result = controller.toResource(entity)
-
-        result shouldBe NamespaceResource(id = id, name = "coday", description = "Coday project", configPath = "/opt/coday")
+        controller.toResource(entity) shouldBe NamespaceResource(
+            id = id,
+            name = "coday",
+            description = "Coday project",
+            configPath = "/opt/coday",
+        )
     }
 
     "toResource preserves null configPath" {
-        val entity = ns(configPath = null)
-
-        controller.toResource(entity).configPath shouldBe null
+        controller.toResource(ns(configPath = null)).configPath shouldBe null
     }
 
     // -------------------------------------------------------------------------
@@ -87,153 +121,492 @@ class NamespaceControllerSpec : StringSpec({
     }
 
     "toDomain normalizes blank configPath to null" {
-        val r = resource(configPath = "   ")
-
-        controller.toDomain(r).configPath shouldBe null
+        controller.toDomain(resource(configPath = "   ")).configPath shouldBe null
     }
 
     "toDomain normalizes empty string configPath to null" {
-        val r = resource(configPath = "")
-
-        controller.toDomain(r).configPath shouldBe null
+        controller.toDomain(resource(configPath = "")).configPath shouldBe null
     }
 
     "toDomain preserves null configPath" {
-        val r = resource(configPath = null)
-
-        controller.toDomain(r).configPath shouldBe null
+        controller.toDomain(resource(configPath = null)).configPath shouldBe null
     }
 
     "toDomain generates a random UUID when resource id is null" {
-        val r = resource(id = null)
+        val firstId = controller.toDomain(resource(id = null)).metadata.id
+        val secondId = controller.toDomain(resource(id = null)).metadata.id
 
-        val result = controller.toDomain(r)
-
-        result.metadata.id shouldBe result.metadata.id
+        // Two calls must produce distinct, non-null UUIDs — proving a fresh UUID is
+        // generated rather than a default/sentinel value being reused.
+        firstId shouldNotBe secondId
     }
 
     // -------------------------------------------------------------------------
-    // listAll
+    // getEntityType — must match the Neo4j label
     // -------------------------------------------------------------------------
 
-    "listAll returns all namespaces mapped to NamespaceResource" {
+    "getEntityType returns \"Namespace\" (must match Neo4j label)" {
+        controller.getEntityType() shouldBe "Namespace"
+    }
+
+    // -------------------------------------------------------------------------
+    // listAll (unchanged by Story 2.1 — filtering is Story 2.4 scope)
+    // -------------------------------------------------------------------------
+
+    "listAll returns all namespaces with role=SUPER-ADMIN for a super-admin caller" {
         val ns1 = ns(name = "engineering")
         val ns2 = ns(name = "product")
+        every { userService.getCurrentUser() } returns superAdmin
         every { namespaceService.findAll() } returns listOf(ns1, ns2)
 
         val result = controller.listAll()
 
-        result shouldBe listOf(controller.toResource(ns1), controller.toResource(ns2))
+        result.map { it.id } shouldContainExactlyInAnyOrder listOf(ns1.id, ns2.id)
+        result.forAll { it.role shouldBe "SUPER-ADMIN" }
         verify(exactly = 1) { namespaceService.findAll() }
+        // Super-admin short-circuits: listEntitiesForUser must NOT be called
+        verify(exactly = 0) { permissionService.listEntitiesForUser(any(), any(), any()) }
     }
 
-    "listAll returns empty list when no namespaces exist" {
-        every { namespaceService.findAll() } returns emptyList()
+    "listAll returns empty list for a regular user with no permissions" {
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.READ)
+        } returns emptyList()
 
-        controller.listAll() shouldBe emptyList()
+        val result = controller.listAll()
+
+        result shouldBe emptyList()
+        // No namespace fetch when READ list is empty
+        verify(exactly = 0) { namespaceService.findByIds(any()) }
+        // Should not even query WRITE list when READ is empty
+        verify(exactly = 0) {
+            permissionService.listEntitiesForUser(any(), any(), Action.WRITE)
+        }
+    }
+
+    "listAll returns accessible namespaces with role=MEMBER when user has only READ" {
+        val ns1 = ns(name = "engineering")
+        val ns2 = ns(name = "product")
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.READ)
+        } returns listOf(ns1.id.toString(), ns2.id.toString())
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.WRITE)
+        } returns emptyList()
+        every { namespaceService.findByIds(any()) } returns listOf(ns1, ns2)
+
+        val result = controller.listAll()
+
+        result.map { it.id } shouldContainExactlyInAnyOrder listOf(ns1.id, ns2.id)
+        result.forAll { it.role shouldBe "MEMBER" }
+    }
+
+    "listAll assigns role=ADMIN for namespaces in the WRITE set, role=MEMBER otherwise" {
+        val nsAdmin = ns(name = "admin-ns")
+        val nsMember = ns(name = "member-ns")
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.READ)
+        } returns listOf(nsAdmin.id.toString(), nsMember.id.toString())
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.WRITE)
+        } returns listOf(nsAdmin.id.toString())
+        every { namespaceService.findByIds(any()) } returns listOf(nsAdmin, nsMember)
+
+        val result = controller.listAll().associateBy { it.id }
+
+        result[nsAdmin.id]?.role shouldBe "ADMIN"
+        result[nsMember.id]?.role shouldBe "MEMBER"
+    }
+
+    "listAll filters out malformed UUID strings from listEntitiesForUser defensively" {
+        val goodNs = ns(name = "good")
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.READ)
+        } returns listOf("not-a-uuid", goodNs.id.toString())
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.WRITE)
+        } returns emptyList()
+        every { namespaceService.findByIds(listOf(goodNs.id)) } returns listOf(goodNs)
+
+        val result = controller.listAll()
+
+        result.map { it.id } shouldBe listOf(goodNs.id)
+        verify(exactly = 1) { namespaceService.findByIds(listOf(goodNs.id)) }
+    }
+
+    "listAll never calls hasPermission per namespace (no N+1)" {
+        val ns1 = ns(name = "a")
+        val ns2 = ns(name = "b")
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.READ)
+        } returns listOf(ns1.id.toString(), ns2.id.toString())
+        every {
+            permissionService.listEntitiesForUser(regularUserId.toString(), "Namespace", Action.WRITE)
+        } returns emptyList()
+        every { namespaceService.findByIds(any()) } returns listOf(ns1, ns2)
+
+        controller.listAll()
+
+        verify(exactly = 0) { permissionService.hasPermission(any(), any(), any(), any()) }
     }
 
     // -------------------------------------------------------------------------
-    // getById (inherited from EntityController)
+    // getById (inherited from SecuredEntityController)
     // -------------------------------------------------------------------------
 
-    "getById returns a NamespaceResource when namespace is found" {
+    "getById returns a NamespaceResource when namespace is found and READ permission granted" {
         val entity = ns()
-        every { namespaceService.findByIds(listOf(entity.id)) } returns listOf(entity)
         every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.hasPermission(
+                regularUserId.toString(), "Namespace", entity.id.toString(), Action.READ,
+            )
+        } returns true
 
-        val result = controller.getById(entity.id)
-
-        result shouldBe controller.toResource(entity)
+        controller.getById(entity.id) shouldBe controller.toResource(entity)
     }
 
     "getById throws 404 when namespace not found" {
         val id = UUID.randomUUID()
-        every { namespaceService.findByIds(listOf(id)) } returns emptyList()
         every { namespaceService.findById(id) } returns null
 
-        val ex = runCatching { controller.getById(id) }.exceptionOrNull()
+        shouldThrow<ResourceNotFoundException> { controller.getById(id) }
+    }
 
-        (ex is ResourceNotFoundException) shouldBe true
+    "getById throws 404 when user lacks READ permission (hides existence)" {
+        val entity = ns()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.hasPermission(
+                regularUserId.toString(), "Namespace", entity.id.toString(), Action.READ,
+            )
+        } returns false
+
+        shouldThrow<ResourceNotFoundException> { controller.getById(entity.id) }
     }
 
     // -------------------------------------------------------------------------
-    // getByIds (inherited)
+    // getByIds (inherited) — filters out entities without READ permission
     // -------------------------------------------------------------------------
 
-    "getByIds returns matching namespaces mapped to resources" {
+    "getByIds returns only entities the user has READ permission on" {
         val ns1 = ns(name = "engineering")
         val ns2 = ns(name = "product")
         every { namespaceService.findByIds(listOf(ns1.id, ns2.id)) } returns listOf(ns1, ns2)
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.hasPermission(
+                regularUserId.toString(), "Namespace", ns1.id.toString(), Action.READ,
+            )
+        } returns true
+        every {
+            permissionService.hasPermission(
+                regularUserId.toString(), "Namespace", ns2.id.toString(), Action.READ,
+            )
+        } returns false
 
-        val result = controller.getByIds(listOf(ns1.id, ns2.id))
-
-        result shouldBe listOf(controller.toResource(ns1), controller.toResource(ns2))
+        controller.getByIds(listOf(ns1.id, ns2.id)) shouldBe listOf(controller.toResource(ns1))
     }
 
     // -------------------------------------------------------------------------
-    // create (inherited)
+    // create (Story 2.1)
     // -------------------------------------------------------------------------
 
-    "create converts resource to domain, delegates to service, and returns mapped resource" {
+    "create succeeds for super-admin and auto-grants ADMIN on the new namespace" {
         val r = resource(id = null, name = "new-namespace")
-        val saved = controller.toDomain(r)
-        every { namespaceService.create(any()) } returns saved
+        val savedEntity = ns(name = "new-namespace")
+        every { userService.getCurrentUser() } returns superAdmin
+        every { userService.findById(superAdminId) } returns superAdmin
+        every { namespaceService.create(any()) } returns savedEntity
+        every {
+            permissionService.grantPermission(
+                superAdminId.toString(), "Namespace", savedEntity.id.toString(), PermissionRelation.ADMIN,
+            )
+        } just Runs
 
         val result = controller.create(r)
 
-        result shouldBe controller.toResource(saved)
+        result.id shouldBe savedEntity.id
+        verify(exactly = 1) { namespaceService.create(any()) }
+        verify(exactly = 1) {
+            permissionService.grantPermission(
+                superAdminId.toString(), "Namespace", savedEntity.id.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    "create throws 403 \"SUPER-ADMIN role required\" for a non-super-admin user" {
+        val r = resource(id = null, name = "new-namespace")
+        every { userService.getCurrentUser() } returns regularUser
+        every { userService.findById(regularUserId) } returns regularUser
+
+        val ex = shouldThrow<ResponseStatusException> { controller.create(r) }
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        ex.reason shouldBe "SUPER-ADMIN role required"
+        verify(exactly = 0) { namespaceService.create(any()) }
+        verify(exactly = 0) {
+            permissionService.grantPermission(any(), any(), any(), any())
+        }
+    }
+
+    "create throws 403 when userService.findById returns null for the caller (edge)" {
+        val r = resource(id = null, name = "new-namespace")
+        every { userService.getCurrentUser() } returns superAdmin
+        every { userService.findById(superAdminId) } returns null
+
+        val ex = shouldThrow<ResponseStatusException> { controller.create(r) }
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        verify(exactly = 0) { namespaceService.create(any()) }
+    }
+
+    "create still succeeds when auto-grant ADMIN fails (logs warning, no rollback)" {
+        val r = resource(id = null, name = "new-namespace")
+        val savedEntity = ns(name = "new-namespace")
+        every { userService.getCurrentUser() } returns superAdmin
+        every { userService.findById(superAdminId) } returns superAdmin
+        every { namespaceService.create(any()) } returns savedEntity
+        every {
+            permissionService.grantPermission(
+                superAdminId.toString(), "Namespace", savedEntity.id.toString(), PermissionRelation.ADMIN,
+            )
+        } throws RuntimeException("grant failed")
+
+        val result = controller.create(r)
+
+        result.id shouldBe savedEntity.id
         verify(exactly = 1) { namespaceService.create(any()) }
     }
 
     // -------------------------------------------------------------------------
-    // update (inherited)
+    // update (inherited, checks WRITE permission)
     // -------------------------------------------------------------------------
 
-    "update delegates to service when namespace exists and returns mapped resource" {
+    "update succeeds when user has WRITE permission (namespace ADMIN)" {
         val entity = ns()
         val updatedResource = resource(id = entity.id, name = "renamed", configPath = "/new/path")
         val updatedDomain = controller.toDomain(updatedResource)
-        every { namespaceService.findByIds(listOf(entity.id)) } returns listOf(entity)
         every { namespaceService.findById(entity.id) } returns entity
         every { namespaceService.update(any()) } returns updatedDomain
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.hasPermission(
+                regularUserId.toString(), "Namespace", entity.id.toString(), Action.WRITE,
+            )
+        } returns true
 
-        val result = controller.update(entity.id, updatedResource)
+        controller.update(entity.id, updatedResource).name shouldBe "renamed"
+    }
 
-        result shouldBe controller.toResource(updatedDomain)
-        verify(exactly = 1) { namespaceService.update(any()) }
+    "update throws 403 when user lacks WRITE permission" {
+        val entity = ns()
+        val r = resource(id = entity.id)
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.hasPermission(
+                regularUserId.toString(), "Namespace", entity.id.toString(), Action.WRITE,
+            )
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> { controller.update(entity.id, r) }
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
     }
 
     "update throws 404 when namespace not found" {
         val id = UUID.randomUUID()
-        val r = resource(id = id)
-        every { namespaceService.findByIds(listOf(id)) } returns emptyList()
+        every { userService.getCurrentUser() } returns regularUser
         every { namespaceService.findById(id) } returns null
 
-        val ex = runCatching { controller.update(id, r) }.exceptionOrNull()
-
-        (ex is ResourceNotFoundException) shouldBe true
+        shouldThrow<ResourceNotFoundException> { controller.update(id, resource(id = id)) }
     }
 
     // -------------------------------------------------------------------------
-    // delete (inherited)
+    // delete (Story 2.1) — super-admin only, cascade permissions
     // -------------------------------------------------------------------------
 
-    "delete succeeds when namespace exists" {
-        val id = UUID.randomUUID()
-        every { namespaceService.delete(id) } returns true
+    "delete succeeds for super-admin and cascade-revokes ADMIN and MEMBER relations (cascade before delete)" {
+        val entity = ns()
+        val userA = UUID.randomUUID().toString()
+        val userB = UUID.randomUUID().toString()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(superAdminId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns true
+        every { namespaceService.delete(entity.id) } returns true
+        every {
+            permissionService.listUsersWithPermission("Namespace", entity.id.toString(), null)
+        } returns listOf(userA, userB)
+        every { permissionService.revokePermission(any(), any(), any(), any()) } just Runs
 
-        controller.delete(id)
+        controller.delete(entity.id)
 
-        verify(exactly = 1) { namespaceService.delete(id) }
+        verify(exactly = 1) { namespaceService.delete(entity.id) }
+        listOf(userA, userB).forEach { uid ->
+            verify(exactly = 1) {
+                permissionService.revokePermission(uid, "Namespace", entity.id.toString(), PermissionRelation.ADMIN)
+            }
+            verify(exactly = 1) {
+                permissionService.revokePermission(uid, "Namespace", entity.id.toString(), PermissionRelation.MEMBER)
+            }
+        }
     }
 
-    "delete throws 404 when service returns false" {
+    "delete dedups affected users (cascade loops each user only once)" {
+        val entity = ns()
+        val userA = UUID.randomUUID().toString()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(superAdminId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns true
+        every { namespaceService.delete(entity.id) } returns true
+        // User with both ADMIN and MEMBER relations appears twice in the raw listing
+        every {
+            permissionService.listUsersWithPermission("Namespace", entity.id.toString(), null)
+        } returns listOf(userA, userA)
+        every { permissionService.revokePermission(any(), any(), any(), any()) } just Runs
+
+        controller.delete(entity.id)
+
+        // dedup: revoke ADMIN called once, revoke MEMBER called once — not twice
+        verify(exactly = 1) {
+            permissionService.revokePermission(userA, "Namespace", entity.id.toString(), PermissionRelation.ADMIN)
+        }
+        verify(exactly = 1) {
+            permissionService.revokePermission(userA, "Namespace", entity.id.toString(), PermissionRelation.MEMBER)
+        }
+    }
+
+    "delete succeeds with no affected users (empty cascade)" {
+        val entity = ns()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(superAdminId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns true
+        every { namespaceService.delete(entity.id) } returns true
+        every {
+            permissionService.listUsersWithPermission("Namespace", entity.id.toString(), null)
+        } returns emptyList()
+
+        controller.delete(entity.id)
+
+        verify(exactly = 1) { namespaceService.delete(entity.id) }
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "delete throws 403 for non-super-admin who has READ (namespace ADMIN but not super-admin)" {
+        val entity = ns()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.hasPermission(regularUserId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns true
+
+        val ex = shouldThrow<ResponseStatusException> { controller.delete(entity.id) }
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        ex.reason shouldBe "SUPER-ADMIN role required"
+        verify(exactly = 0) { namespaceService.delete(any()) }
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "delete throws 404 when caller has no READ permission (hides namespace existence)" {
+        val entity = ns()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns regularUser
+        every {
+            permissionService.hasPermission(regularUserId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns false
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.delete(entity.id) }
+        ex.message shouldBe "Entity not found: ${entity.id}"
+        verify(exactly = 0) { namespaceService.delete(any()) }
+        verify(exactly = 0) { permissionService.listUsersWithPermission(any(), any(), any()) }
+    }
+
+    "delete throws 404 when namespace not found" {
         val id = UUID.randomUUID()
-        every { namespaceService.delete(id) } returns false
+        every { namespaceService.findById(id) } returns null
 
-        val ex = runCatching { controller.delete(id) }.exceptionOrNull()
+        shouldThrow<ResourceNotFoundException> { controller.delete(id) }
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
 
-        (ex is ResourceNotFoundException) shouldBe true
+    "delete throws 404 when service.delete returns false (concurrent delete race)" {
+        val entity = ns()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(superAdminId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns true
+        every {
+            permissionService.listUsersWithPermission("Namespace", entity.id.toString(), null)
+        } returns emptyList()
+        every { namespaceService.delete(entity.id) } returns false
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.delete(entity.id) }
+        ex.message shouldBe "Entity not found: ${entity.id}"
+    }
+
+    "delete re-raises when listUsersWithPermission fails (cascade before delete, no orphans)" {
+        val entity = ns()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(superAdminId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns true
+        every {
+            permissionService.listUsersWithPermission("Namespace", entity.id.toString(), null)
+        } throws RuntimeException("neo4j down")
+
+        shouldThrow<RuntimeException> { controller.delete(entity.id) }
+
+        // namespace MUST NOT be deleted if cascade cannot be attempted
+        verify(exactly = 0) { namespaceService.delete(any()) }
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "delete continues cascade when an individual revoke fails" {
+        val entity = ns()
+        val userA = UUID.randomUUID().toString()
+        val userB = UUID.randomUUID().toString()
+        every { namespaceService.findById(entity.id) } returns entity
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(superAdminId.toString(), "Namespace", entity.id.toString(), Action.READ)
+        } returns true
+        every { namespaceService.delete(entity.id) } returns true
+        every {
+            permissionService.listUsersWithPermission("Namespace", entity.id.toString(), null)
+        } returns listOf(userA, userB)
+        every {
+            permissionService.revokePermission(userA, "Namespace", entity.id.toString(), PermissionRelation.ADMIN)
+        } throws RuntimeException("transient")
+        every {
+            permissionService.revokePermission(userA, "Namespace", entity.id.toString(), PermissionRelation.MEMBER)
+        } just Runs
+        every {
+            permissionService.revokePermission(userB, "Namespace", entity.id.toString(), PermissionRelation.ADMIN)
+        } just Runs
+        every {
+            permissionService.revokePermission(userB, "Namespace", entity.id.toString(), PermissionRelation.MEMBER)
+        } just Runs
+
+        controller.delete(entity.id)
+
+        verify(exactly = 1) {
+            permissionService.revokePermission(userB, "Namespace", entity.id.toString(), PermissionRelation.ADMIN)
+        }
+        verify(exactly = 1) {
+            permissionService.revokePermission(userB, "Namespace", entity.id.toString(), PermissionRelation.MEMBER)
+        }
     }
 })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpointsMvcIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpointsMvcIntegrationSpec.kt
@@ -1,0 +1,191 @@
+package io.whozoss.agentos.namespace
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.UserService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * MVC-layer test for [NamespacePermissionEndpoints] (Story 2.2).
+ *
+ * In the "test" profile ([io.whozoss.agentos.permissions.InMemoryPermissionServiceImpl]
+ * is used), the permission service is a permissive no-op: every
+ * [io.whozoss.agentos.permissions.PermissionService.hasPermission] call returns true
+ * and grant/revoke are no-ops. This lets us exercise the full MVC wiring but means
+ * 403 flows cannot be validated here — they live in [NamespacePermissionEndpointsSpec].
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NamespacePermissionEndpointsMvcIntegrationSpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var namespaceService: NamespaceService
+    @Autowired lateinit var userService: UserService
+
+    init {
+
+        // -------------------------------------------------------------------------
+        // PUT /api/namespaces/{id}/admins/{userId}
+        // -------------------------------------------------------------------------
+
+        "PUT /api/namespaces/{id}/admins/{userId} returns 200 when namespace and user exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-put-ok"),
+            )
+            val target = userService.resolveOrCreateByExternalId("put-ok-${UUID.randomUUID()}@example.com")
+
+            mockMvc.perform(put("/api/namespaces/${namespace.id}/admins/${target.id}"))
+                .andExpect(status().isOk)
+        }
+
+        "PUT returns 404 when namespace does not exist" {
+            val target = userService.resolveOrCreateByExternalId("put-404ns-${UUID.randomUUID()}@example.com")
+            val missingNamespaceId = UUID.randomUUID()
+
+            mockMvc.perform(put("/api/namespaces/$missingNamespaceId/admins/${target.id}"))
+                .andExpect(status().isNotFound)
+        }
+
+        "PUT returns 404 when target user does not exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-put-404user"),
+            )
+            val missingUserId = UUID.randomUUID()
+
+            mockMvc.perform(put("/api/namespaces/${namespace.id}/admins/$missingUserId"))
+                .andExpect(status().isNotFound)
+        }
+
+        // -------------------------------------------------------------------------
+        // DELETE /api/namespaces/{id}/admins/{userId}
+        // -------------------------------------------------------------------------
+
+        "DELETE /api/namespaces/{id}/admins/{userId} returns 204 when namespace and user exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-delete-ok"),
+            )
+            val target = userService.resolveOrCreateByExternalId("delete-ok-${UUID.randomUUID()}@example.com")
+
+            mockMvc.perform(delete("/api/namespaces/${namespace.id}/admins/${target.id}"))
+                .andExpect(status().isNoContent)
+        }
+
+        "DELETE returns 404 when namespace does not exist" {
+            val target = userService.resolveOrCreateByExternalId("delete-404ns-${UUID.randomUUID()}@example.com")
+            val missingNamespaceId = UUID.randomUUID()
+
+            mockMvc.perform(delete("/api/namespaces/$missingNamespaceId/admins/${target.id}"))
+                .andExpect(status().isNotFound)
+        }
+
+        "DELETE returns 404 when target user does not exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-delete-404user"),
+            )
+            val missingUserId = UUID.randomUUID()
+
+            mockMvc.perform(delete("/api/namespaces/${namespace.id}/admins/$missingUserId"))
+                .andExpect(status().isNotFound)
+        }
+
+        // -------------------------------------------------------------------------
+        // PUT /api/namespaces/{id}/members/{userId} (Story 2.3)
+        // -------------------------------------------------------------------------
+
+        "PUT /api/namespaces/{id}/members/{userId} returns 200 when namespace and user exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-put-member-ok"),
+            )
+            val target = userService.resolveOrCreateByExternalId("put-member-ok-${UUID.randomUUID()}@example.com")
+
+            mockMvc.perform(put("/api/namespaces/${namespace.id}/members/${target.id}"))
+                .andExpect(status().isOk)
+        }
+
+        "PUT members returns 404 when namespace does not exist" {
+            val target = userService.resolveOrCreateByExternalId("put-member-404ns-${UUID.randomUUID()}@example.com")
+            val missingNamespaceId = UUID.randomUUID()
+
+            mockMvc.perform(put("/api/namespaces/$missingNamespaceId/members/${target.id}"))
+                .andExpect(status().isNotFound)
+        }
+
+        "PUT members returns 404 when target user does not exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-put-member-404user"),
+            )
+            val missingUserId = UUID.randomUUID()
+
+            mockMvc.perform(put("/api/namespaces/${namespace.id}/members/$missingUserId"))
+                .andExpect(status().isNotFound)
+        }
+
+        // -------------------------------------------------------------------------
+        // DELETE /api/namespaces/{id}/members/{userId} (Story 2.3)
+        // -------------------------------------------------------------------------
+
+        "DELETE /api/namespaces/{id}/members/{userId} returns 204 when namespace and user exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-delete-member-ok"),
+            )
+            val target = userService.resolveOrCreateByExternalId("delete-member-ok-${UUID.randomUUID()}@example.com")
+
+            mockMvc.perform(delete("/api/namespaces/${namespace.id}/members/${target.id}"))
+                .andExpect(status().isNoContent)
+        }
+
+        "DELETE members returns 404 when namespace does not exist" {
+            val target = userService.resolveOrCreateByExternalId("delete-member-404ns-${UUID.randomUUID()}@example.com")
+            val missingNamespaceId = UUID.randomUUID()
+
+            mockMvc.perform(delete("/api/namespaces/$missingNamespaceId/members/${target.id}"))
+                .andExpect(status().isNotFound)
+        }
+
+        "DELETE members returns 404 when target user does not exist" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-delete-member-404user"),
+            )
+            val missingUserId = UUID.randomUUID()
+
+            mockMvc.perform(delete("/api/namespaces/${namespace.id}/members/$missingUserId"))
+                .andExpect(status().isNotFound)
+        }
+
+        // -------------------------------------------------------------------------
+        // GET /api/namespaces/{id}/users (Story 2.5)
+        // -------------------------------------------------------------------------
+
+        "GET /api/namespaces/{id}/users returns 200 with empty list for newly-created namespace" {
+            val namespace = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-get-users-empty"),
+            )
+
+            // InMemoryPermissionServiceImpl.listUsersWithPermission returns emptyList always,
+            // so any newly-created namespace (regardless of Neo4j state) will surface as empty here.
+            mockMvc.perform(get("/api/namespaces/${namespace.id}/users"))
+                .andExpect(status().isOk)
+                .andExpect(content().json("[]"))
+        }
+
+        "GET /api/namespaces/{id}/users returns 404 when namespace does not exist" {
+            val missingNamespaceId = UUID.randomUUID()
+
+            mockMvc.perform(get("/api/namespaces/$missingNamespaceId/users"))
+                .andExpect(status().isNotFound)
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpointsSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpointsSpec.kt
@@ -1,0 +1,640 @@
+package io.whozoss.agentos.namespace
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.PermissionRelation
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+/**
+ * Unit tests for [NamespacePermissionEndpoints] (Story 2.2).
+ *
+ * Covers:
+ * - PUT grant: permission delegated to [PermissionService], 403 when caller lacks WRITE,
+ *   404 when namespace or target user does not exist, idempotence, super-admin bypass
+ * - DELETE revoke: symmetric to grant, idempotent when relationship does not exist
+ */
+class NamespacePermissionEndpointsSpec : StringSpec({
+
+    val namespaceService = mockk<NamespaceService>()
+    val userService = mockk<UserService>()
+    val permissionService = mockk<PermissionService>()
+    val controller = NamespacePermissionEndpoints(namespaceService, userService, permissionService)
+
+    val namespaceId = UUID.randomUUID()
+    val targetUserId = UUID.randomUUID()
+    val callerId = UUID.randomUUID()
+
+    val caller = User(
+        metadata = EntityMetadata(id = callerId),
+        externalId = "caller@example.com",
+        email = "caller@example.com",
+        isAdmin = false,
+    )
+    val target = User(
+        metadata = EntityMetadata(id = targetUserId),
+        externalId = "target@example.com",
+        email = "target@example.com",
+        isAdmin = false,
+    )
+    val namespace = Namespace(
+        metadata = EntityMetadata(id = namespaceId),
+        name = "engineering",
+    )
+
+    /**
+     * Stub the 3 existence/READ gates of [NamespacePermissionEndpoints.requireNamespaceAdmin]
+     * with allow-all defaults. Individual tests override specific gates to assert the
+     * 404/403 paths.
+     */
+    fun stubExistence(hasReadOnNamespace: Boolean = true) {
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.findById(targetUserId) } returns target
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns hasReadOnNamespace
+    }
+
+    beforeTest {
+        clearAllMocks()
+    }
+
+    // -------------------------------------------------------------------------
+    // PUT — grant ADMIN
+    // -------------------------------------------------------------------------
+
+    "PUT grants ADMIN to target user when caller has WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every {
+            permissionService.grantPermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.ADMIN,
+            )
+        } just Runs
+
+        controller.grantAdmin(namespaceId, targetUserId)
+
+        verify(exactly = 1) {
+            permissionService.grantPermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    "PUT succeeds for super-admin (hasPermission returns true via bypass)" {
+        val superAdmin = caller.copy(isAdmin = true)
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.findById(targetUserId) } returns target
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.grantPermission(any(), any(), any(), any()) } just Runs
+
+        controller.grantAdmin(namespaceId, targetUserId)
+
+        verify(exactly = 1) {
+            permissionService.grantPermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    "PUT returns 404 when caller has no READ on namespace (hides existence)" {
+        stubExistence(hasReadOnNamespace = false)
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.grantAdmin(namespaceId, targetUserId) }
+
+        ex.message shouldBe "Namespace not found: $namespaceId"
+        // READ check runs before target user check — target user lookup must NOT happen
+        verify(exactly = 0) { userService.findById(targetUserId) }
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT returns 403 when caller lacks WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> { controller.grantAdmin(namespaceId, targetUserId) }
+
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        ex.reason shouldBe "Namespace ADMIN role required"
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT returns 404 when namespace not found" {
+        every { namespaceService.findById(namespaceId) } returns null
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.grantAdmin(namespaceId, targetUserId) }
+
+        ex.message shouldBe "Namespace not found: $namespaceId"
+        verify(exactly = 0) { userService.findById(any<UUID>()) }
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT returns 404 when target user not found" {
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every { userService.findById(targetUserId) } returns null
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.grantAdmin(namespaceId, targetUserId) }
+
+        ex.message shouldBe "User not found: $targetUserId"
+        // WRITE check must not run when target user is missing
+        verify(exactly = 0) {
+            permissionService.hasPermission(any(), any(), any(), Action.WRITE)
+        }
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT is idempotent: calling twice delegates to grantPermission each time (MERGE is a no-op)" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.grantPermission(any(), any(), any(), any()) } just Runs
+
+        controller.grantAdmin(namespaceId, targetUserId)
+        controller.grantAdmin(namespaceId, targetUserId)
+
+        verify(exactly = 2) {
+            permissionService.grantPermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE — revoke ADMIN
+    // -------------------------------------------------------------------------
+
+    "DELETE revokes ADMIN when caller has WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every {
+            permissionService.revokePermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.ADMIN,
+            )
+        } just Runs
+
+        controller.revokeAdmin(namespaceId, targetUserId)
+
+        verify(exactly = 1) {
+            permissionService.revokePermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    "DELETE returns 403 when caller lacks WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> { controller.revokeAdmin(namespaceId, targetUserId) }
+
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE returns 404 when namespace not found" {
+        every { namespaceService.findById(namespaceId) } returns null
+
+        shouldThrow<ResourceNotFoundException> { controller.revokeAdmin(namespaceId, targetUserId) }
+
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE returns 404 when target user not found" {
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every { userService.findById(targetUserId) } returns null
+
+        shouldThrow<ResourceNotFoundException> { controller.revokeAdmin(namespaceId, targetUserId) }
+
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE returns 404 when caller has no READ on namespace (hides existence)" {
+        stubExistence(hasReadOnNamespace = false)
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.revokeAdmin(namespaceId, targetUserId) }
+
+        ex.message shouldBe "Namespace not found: $namespaceId"
+        verify(exactly = 0) { userService.findById(targetUserId) }
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE is idempotent: revoking a non-existent relation does not throw" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        // revokePermission is a no-op when the relationship does not exist (Neo4j DELETE on absent pattern)
+        every { permissionService.revokePermission(any(), any(), any(), any()) } just Runs
+
+        controller.revokeAdmin(namespaceId, targetUserId)
+        controller.revokeAdmin(namespaceId, targetUserId)
+
+        verify(exactly = 2) {
+            permissionService.revokePermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // PUT members — grant MEMBER (Story 2.3)
+    // -------------------------------------------------------------------------
+
+    "PUT members grants MEMBER to target user when caller has WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.grantPermission(any(), any(), any(), any()) } just Runs
+
+        controller.grantMember(namespaceId, targetUserId)
+
+        verify(exactly = 1) {
+            permissionService.grantPermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.MEMBER,
+            )
+        }
+    }
+
+    "PUT members succeeds for super-admin" {
+        val superAdmin = caller.copy(isAdmin = true)
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.findById(targetUserId) } returns target
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.grantPermission(any(), any(), any(), any()) } just Runs
+
+        controller.grantMember(namespaceId, targetUserId)
+
+        verify(exactly = 1) {
+            permissionService.grantPermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.MEMBER,
+            )
+        }
+    }
+
+    "PUT members returns 403 when caller lacks WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> { controller.grantMember(namespaceId, targetUserId) }
+
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        ex.reason shouldBe "Namespace ADMIN role required"
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT members returns 404 when caller has no READ on namespace (hides existence)" {
+        stubExistence(hasReadOnNamespace = false)
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.grantMember(namespaceId, targetUserId) }
+
+        ex.message shouldBe "Namespace not found: $namespaceId"
+        verify(exactly = 0) { userService.findById(targetUserId) }
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT members returns 404 when namespace not found" {
+        every { namespaceService.findById(namespaceId) } returns null
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.grantMember(namespaceId, targetUserId) }
+
+        ex.message shouldBe "Namespace not found: $namespaceId"
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT members returns 404 when target user not found" {
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every { userService.findById(targetUserId) } returns null
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.grantMember(namespaceId, targetUserId) }
+
+        ex.message shouldBe "User not found: $targetUserId"
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "PUT members is idempotent: repeated grants delegate to grantPermission each time" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.grantPermission(any(), any(), any(), any()) } just Runs
+
+        controller.grantMember(namespaceId, targetUserId)
+        controller.grantMember(namespaceId, targetUserId)
+
+        verify(exactly = 2) {
+            permissionService.grantPermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.MEMBER,
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE members — revoke MEMBER (Story 2.3)
+    // -------------------------------------------------------------------------
+
+    "DELETE members revokes MEMBER when caller has WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.revokePermission(any(), any(), any(), any()) } just Runs
+
+        controller.revokeMember(namespaceId, targetUserId)
+
+        verify(exactly = 1) {
+            permissionService.revokePermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.MEMBER,
+            )
+        }
+    }
+
+    "DELETE members does NOT revoke ADMIN relation (AC3: preserves higher privilege)" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.revokePermission(any(), any(), any(), any()) } just Runs
+
+        controller.revokeMember(namespaceId, targetUserId)
+
+        verify(exactly = 0) {
+            permissionService.revokePermission(
+                any(), any(), any(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    "DELETE members returns 403 when caller lacks WRITE on namespace" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> { controller.revokeMember(namespaceId, targetUserId) }
+
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE members returns 404 when caller has no READ on namespace (hides existence)" {
+        stubExistence(hasReadOnNamespace = false)
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.revokeMember(namespaceId, targetUserId) }
+
+        ex.message shouldBe "Namespace not found: $namespaceId"
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE members returns 404 when namespace not found" {
+        every { namespaceService.findById(namespaceId) } returns null
+
+        shouldThrow<ResourceNotFoundException> { controller.revokeMember(namespaceId, targetUserId) }
+
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE members returns 404 when target user not found" {
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every { userService.findById(targetUserId) } returns null
+
+        shouldThrow<ResourceNotFoundException> { controller.revokeMember(namespaceId, targetUserId) }
+
+        verify(exactly = 0) { permissionService.revokePermission(any(), any(), any(), any()) }
+    }
+
+    "DELETE members is idempotent: revoking a non-existent MEMBER relation does not throw" {
+        stubExistence()
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { permissionService.revokePermission(any(), any(), any(), any()) } just Runs
+
+        controller.revokeMember(namespaceId, targetUserId)
+        controller.revokeMember(namespaceId, targetUserId)
+
+        verify(exactly = 2) {
+            permissionService.revokePermission(
+                targetUserId.toString(), "Namespace", namespaceId.toString(), PermissionRelation.MEMBER,
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /{namespaceId}/users — list namespace users (Story 2.5)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Stub the namespace-existence + caller-READ gates for [listNamespaceUsers].
+     * Does NOT stub the target user (the endpoint has no target parameter).
+     */
+    fun stubReadOnNamespace(hasRead: Boolean = true) {
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns hasRead
+    }
+
+    "GET users returns list of namespace users with correct roles" {
+        stubReadOnNamespace()
+        val adminUser = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "admin@example.com",
+            email = "admin@example.com",
+            isAdmin = false,
+        )
+        val memberUser = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "member@example.com",
+            email = "member@example.com",
+            firstname = "Mem",
+            lastname = "Ber",
+            isAdmin = false,
+        )
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.ADMIN)
+        } returns listOf(adminUser.metadata.id.toString())
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.MEMBER)
+        } returns listOf(memberUser.metadata.id.toString())
+        every { userService.findByIds(any()) } returns listOf(adminUser, memberUser)
+
+        val result = controller.listNamespaceUsers(namespaceId).associateBy { it.id }
+
+        result.size shouldBe 2
+        result[adminUser.metadata.id]?.role shouldBe "ADMIN"
+        result[memberUser.metadata.id]?.role shouldBe "MEMBER"
+        result[memberUser.metadata.id]?.firstname shouldBe "Mem"
+    }
+
+    "GET users deduplicates users with both ADMIN and MEMBER relations (role=ADMIN)" {
+        stubReadOnNamespace()
+        val dualUser = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "dual@example.com",
+            email = "dual@example.com",
+            isAdmin = false,
+        )
+        val dualIdString = dualUser.metadata.id.toString()
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.ADMIN)
+        } returns listOf(dualIdString)
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.MEMBER)
+        } returns listOf(dualIdString)
+        every { userService.findByIds(any()) } returns listOf(dualUser)
+
+        val result = controller.listNamespaceUsers(namespaceId)
+
+        result.size shouldBe 1
+        result.first().role shouldBe "ADMIN"
+        result.first().id shouldBe dualUser.metadata.id
+    }
+
+    "GET users returns empty list when no user has a direct relation" {
+        stubReadOnNamespace()
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.ADMIN)
+        } returns emptyList()
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.MEMBER)
+        } returns emptyList()
+
+        controller.listNamespaceUsers(namespaceId) shouldBe emptyList()
+        verify(exactly = 0) { userService.findByIds(any()) }
+    }
+
+    "GET users returns 404 when namespace not found" {
+        every { namespaceService.findById(namespaceId) } returns null
+
+        shouldThrow<ResourceNotFoundException> { controller.listNamespaceUsers(namespaceId) }
+
+        verify(exactly = 0) { permissionService.listUsersWithPermission(any(), any(), any()) }
+    }
+
+    "GET users returns 404 when caller has no READ on namespace (hides existence)" {
+        stubReadOnNamespace(hasRead = false)
+
+        val ex = shouldThrow<ResourceNotFoundException> { controller.listNamespaceUsers(namespaceId) }
+
+        ex.message shouldBe "Namespace not found: $namespaceId"
+        verify(exactly = 0) { permissionService.listUsersWithPermission(any(), any(), any()) }
+    }
+
+    "GET users succeeds for super-admin via permission bypass" {
+        val superAdmin = caller.copy(isAdmin = true)
+        every { namespaceService.findById(namespaceId) } returns namespace
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.ADMIN)
+        } returns emptyList()
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.MEMBER)
+        } returns emptyList()
+
+        controller.listNamespaceUsers(namespaceId) shouldBe emptyList()
+    }
+
+    "GET users filters out orphan user ids silently" {
+        stubReadOnNamespace()
+        val existingUser = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "exists@example.com",
+            email = "exists@example.com",
+            isAdmin = false,
+        )
+        val ghostId = UUID.randomUUID().toString()
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.ADMIN)
+        } returns listOf(existingUser.metadata.id.toString(), ghostId)
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.MEMBER)
+        } returns emptyList()
+        // Ghost user is not returned by userService — simulates deleted user with lingering relation
+        every { userService.findByIds(any()) } returns listOf(existingUser)
+
+        val result = controller.listNamespaceUsers(namespaceId)
+
+        result.map { it.id } shouldBe listOf(existingUser.metadata.id)
+    }
+
+    "GET users is defensive against malformed UUID strings in permission relations" {
+        stubReadOnNamespace()
+        val validUser = User(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            externalId = "valid@example.com",
+            email = "valid@example.com",
+            isAdmin = false,
+        )
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.ADMIN)
+        } returns listOf("not-a-uuid", validUser.metadata.id.toString())
+        every {
+            permissionService.listUsersWithPermission("Namespace", namespaceId.toString(), PermissionRelation.MEMBER)
+        } returns emptyList()
+        every { userService.findByIds(listOf(validUser.metadata.id)) } returns listOf(validUser)
+
+        val result = controller.listNamespaceUsers(namespaceId)
+
+        result.map { it.id } shouldBe listOf(validUser.metadata.id)
+        verify(exactly = 1) { userService.findByIds(listOf(validUser.metadata.id)) }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRelationsSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRelationsSpec.kt
@@ -170,6 +170,50 @@ class Neo4jPermissionRelationsSpec : StringSpec() {
             ).shouldBeFalse()
         }
 
+        "delete MEMBER relation preserves a pre-existing ADMIN relation for the same user (Story 2.3 AC3)" {
+            val user = createUser()
+            val namespace = createNamespace()
+
+            // Grant both roles to the same user on the same namespace
+            permissionNodeRepository.createAdminPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            )
+            permissionNodeRepository.createMemberPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            )
+
+            // Revoke only MEMBER
+            permissionNodeRepository.deleteMemberPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            )
+
+            // ADMIN must remain — higher privilege retained
+            permissionNodeRepository.hasAdminPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            ).shouldBeTrue()
+
+            // Proof that MEMBER was actually removed (not a no-op):
+            // after deleting ADMIN, no permission relation of any kind should remain.
+            permissionNodeRepository.deleteAdminPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            )
+            permissionNodeRepository.hasMemberOrAdminPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            ).shouldBeFalse()
+        }
+
         "hasAdminPermission returns false when no relation exists" {
             val user = createUser()
             val namespace = createNamespace()


### PR DESCRIPTION
## Summary

Implements Epic 2 of the AgentOS permissions system: full namespace management on top of the foundation laid by Epic 1. **Stacked on top of #803 (Epic 1 PR)** — merge Epic 1 first, then this retargets to master.

## Stories covered

- **2.1 Super-admin namespace CRUD** — `NamespaceController` migrates to `SecuredEntityController`. CREATE/DELETE are restricted to super-admin callers. The creator automatically receives an ADMIN relation on the new namespace. DELETE cascade-revokes all namespace permission relations (ADMIN + MEMBER) before the soft delete; a failure to enumerate affected users aborts the whole operation so no orphan relations remain.
- **2.2 Admin management** — `PUT/DELETE /api/namespaces/{id}/admins/{userId}` in a dedicated `NamespacePermissionEndpoints` controller. Caller must hold ADMIN on the namespace (or be super-admin). Idempotent via Neo4j `MERGE` / `DELETE` on absent pattern.
- **2.3 Member management** — `PUT/DELETE /api/namespaces/{id}/members/{userId}` with the same authorization model. Revoking MEMBER leaves any concurrent ADMIN relation intact — verified end-to-end by a dedicated Neo4j integration test that also proves the MEMBER relation is actually removed (not a no-op).
- **2.4 Permission-filtered namespace listing** — `GET /api/namespaces` now returns only the namespaces the caller has at least READ on, each carrying the caller's effective `role` (`SUPER-ADMIN` / `ADMIN` / `MEMBER`). Implementation uses `listEntitiesForUser(READ)` + `listEntitiesForUser(WRITE)` + `findByIds` → constant number of permission-service calls regardless of result size (no N+1 on `hasPermission`).
- **2.5 Namespace user listing** — `GET /api/namespaces/{id}/users` lists users with a direct `ADMIN` / `MEMBER` relation on the namespace. Users holding both relations appear once with `role = \"ADMIN\"`. Orphan relations (pointing to deleted users) are filtered silently with a WARN log; malformed UUIDs from Neo4j are logged and skipped defensively.

## Security model

- All namespace-scoped endpoints follow the architectural rule *\"always 404 if no READ\"*: a caller with no READ on a namespace sees 404 regardless of whether the namespace exists, hiding its existence from non-members.
- 403 \`Namespace ADMIN role required\` is emitted only **after** the caller has been confirmed as having READ — so 403 vs 404 only distinguishes cases for callers who legitimately know the resource exists.
- Super-admin bypass is handled centrally inside \`PermissionService.hasPermission\`; controllers do not re-check \`isAdmin\` except where a system-level privilege is required (CREATE / DELETE namespace).

## New files

- \`NamespacePermissionEndpoints.kt\` — dedicated controller for grant/revoke/list endpoints under \`/api/namespaces/{id}\`
- \`NamespaceListItem.kt\` — list-endpoint DTO with computed \`role\` (kept separate from \`NamespaceResource\` which stays write-only)
- \`NamespaceUserListItem.kt\` — DTO for the namespace-user listing endpoint

## Intentionally out of scope

- \`grantedBy\` / \`grantedAt\` audit metadata on permission relations — deferred project-wide.
- Pagination on list endpoints — cross-cutting NFR, separate story.
- Last-admin / self-revoke protection — explicit \"hors scope\" in stories 2.2 / 2.5.

## Tests

- **Unit** (Kotest + MockK): full 404 / 403 matrix per endpoint, super-admin bypass paths, idempotency of grant/revoke, deduplication in listings, defensive UUID handling, no-N+1 assertions.
- **MVC** (\`@SpringBootTest\` + \`@AutoConfigureMockMvc\`, \`test\` profile with \`in-memory\` persistence): dispatcher wiring, Bean Validation, JSON serialization of the new \`role\` field.
- **Neo4j integration** (\`Neo4jPermissionRelationsSpec\`): new test proving \`deleteMemberPermission\` preserves a concurrent ADMIN relation **and** that the MEMBER relation is actually removed.

## Test plan

- [ ] \`cd agentos && ./gradlew :agentos-service:test\` passes (full regression)
- [ ] Manual smoke: create namespace (super-admin) → grant ADMIN/MEMBER to another user → list namespaces (each role) → list namespace users → revoke MEMBER preserves ADMIN → delete namespace removes all relations
- [ ] Verify the PR auto-retargets to \`master\` after Epic 1 (#803) is merged, or retarget manually