### PR TITLE
feat(agentos): #WZ-29564 case lifecycle and permissions (Epic 3)

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -2,12 +2,14 @@ package io.whozoss.agentos.caseFlow
 
 import io.whozoss.agentos.entity.SecuredEntityController
 import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.PermissionRelation
 import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.UserService
+import jakarta.validation.Valid
 import mu.KLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -30,13 +32,99 @@ class CaseController(
     permissionService: PermissionService,
 ) : SecuredEntityController<Case, UUID, CaseResource>(caseService, userService, permissionService) {
 
-    override fun getEntityType(): String = "Case"
+    override fun getEntityType(): String = ENTITY_TYPE
 
+    /**
+     * To create a Case, the caller must have at least READ on the parent namespace
+     * (i.e. hold a MEMBER or ADMIN relation, or be super-admin via bypass). This
+     * matches Story 3.1 AC1, where a namespace MEMBER may create their own cases.
+     *
+     * Note: [Action.WRITE] would require a namespace ADMIN relation per
+     * [io.whozoss.agentos.permissions.PermissionServiceImpl.evaluatePermission] —
+     * too strict for this use case.
+     */
     override fun checkCreatePermission(userId: String, entity: Case) {
-        // To create a Case, the user must have WRITE permission on the parent namespace
-        if (!permissionService.hasPermission(userId, "Namespace", entity.namespaceId.toString(), Action.WRITE)) {
-            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied - no write permission on namespace")
+        if (!permissionService.hasPermission(userId, NAMESPACE_TYPE, entity.namespaceId.toString(), Action.READ)) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied - no access to namespace")
         }
+    }
+
+    /**
+     * GET /api/cases/by-parentId/{parentId} — list cases in a namespace.
+     *
+     * Two fast paths, both avoiding the N+1 `hasPermission` cost of
+     * [io.whozoss.agentos.entity.SecuredEntityController.listByParent]:
+     *
+     * 1. Namespace ADMIN short-circuit (Story 3.2): if the caller holds the ADMIN
+     *    relation on the parent namespace (or is super-admin via bypass), they
+     *    transitively ADMIN every case — return `findByParent` unfiltered in a
+     *    single query. The short-circuit uses `hasPermission(Action.WRITE)` which
+     *    maps to `PermissionRelation.ADMIN` in
+     *    [io.whozoss.agentos.permissions.PermissionServiceImpl.evaluatePermission];
+     *    if a future permission model adds a non-ADMIN WRITE grant (e.g. an
+     *    "editor" relation), revisit this check to avoid leaking every case.
+     * 2. Permission-filtered listing (Story 3.3): otherwise delegate to a
+     *    dedicated Cypher query that returns only cases with a direct
+     *    ADMIN/MEMBER relation on the case OR transitive ADMIN via namespace.
+     *    Namespace MEMBERs do NOT gain transitive READ on cases (FR15).
+     */
+    override fun listByParent(@PathVariable parentId: UUID): List<CaseResource> {
+        val user = userService.getCurrentUser()
+        val userId = user.id.toString()
+        val isNamespaceAdmin = permissionService.hasPermission(
+            userId,
+            NAMESPACE_TYPE,
+            parentId.toString(),
+            Action.WRITE,
+        )
+        if (isNamespaceAdmin) {
+            logger.debug {
+                "User $userId is namespace-ADMIN on $parentId — short-circuit list (no filtering)"
+            }
+            return caseService.findByParent(parentId).map { toResource(it) }
+        }
+        logger.debug {
+            "User $userId is not namespace-ADMIN on $parentId — using permission-filtered listing"
+        }
+        return caseService
+            .findAccessibleByUserInNamespace(user.id, parentId)
+            .map { toResource(it) }
+    }
+
+    /**
+     * POST /api/cases — delegates creation to the parent (which invokes
+     * [checkCreatePermission]), then auto-grants an ADMIN relationship on the new
+     * case to the creator (Story 3.1 AC1).
+     *
+     * The grant is best-effort (non-transactional) — same pattern as Story 2.1 on
+     * namespace creation. A grant failure is logged at WARN; the case stays
+     * persisted. Super-admins keep their bypass regardless.
+     */
+    override fun create(@Valid @RequestBody resource: CaseResource): CaseResource {
+        val created = super.create(resource)
+        val caseId = created.id ?: error("Created case must have an id")
+        val userId = userService.getCurrentUser().id.toString()
+        runCatching {
+            permissionService.grantPermission(
+                userId,
+                ENTITY_TYPE,
+                caseId.toString(),
+                PermissionRelation.ADMIN,
+            )
+            logger.info { "User $userId created case $caseId with auto-ADMIN grant" }
+        }.onFailure { e ->
+            // The case is persisted but the creator lost their direct ADMIN grant.
+            // For a super-admin or namespace ADMIN creator this is harmless (they
+            // retain access via bypass / transitivity). For a namespace MEMBER
+            // creator this is a LOCKOUT: after Story 3.3 (FR15) MEMBERs do not
+            // inherit transitive READ on cases, so only a super-admin or
+            // namespace ADMIN can recover access by manually granting the relation.
+            logger.warn(e) {
+                "Auto-ADMIN grant failed for case $caseId (user $userId) — case persisted. " +
+                    "Recovery: a super-admin or namespace ADMIN must grant ADMIN on the case manually."
+            }
+        }
+        return created
     }
 
     // -------------------------------------------------------------------------
@@ -51,13 +139,17 @@ class CaseController(
             title = entity.title,
         )
 
-    override fun toDomain(resource: CaseResource): Case =
-        Case(
-            metadata = EntityMetadata(id = resource.id ?: UUID.randomUUID()),
+    override fun toDomain(resource: CaseResource): Case {
+        val metadata = EntityMetadata(id = resource.id ?: UUID.randomUUID())
+        return Case(
+            metadata = metadata,
             namespaceId = resource.namespaceId,
             status = resource.status,
-            title = resource.title ?: "",
+            // Mirror the Case data-class default "Case $id" when the client omits
+            // a title, instead of persisting an empty string (Story 3.4 AC4).
+            title = resource.title ?: "Case ${metadata.id}",
         )
+    }
 
     // -------------------------------------------------------------------------
     // Additional endpoints
@@ -129,7 +221,10 @@ class CaseController(
         logger.info { "Case killed: $caseId" }
     }
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        private const val ENTITY_TYPE = "Case"
+        private const val NAMESPACE_TYPE = "Namespace"
+    }
 }
 
 data class AddMessageRequest(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNodeNeo4jRepository.kt
@@ -51,4 +51,33 @@ interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
         caseId: String,
         userId: String,
     )
+
+    /**
+     * Find cases in a namespace that a specific user is allowed to see (Story 3.3).
+     *
+     * Access rule for Case (owner-private, FR15):
+     * - Direct relation on the case: ADMIN or MEMBER → user can see it
+     * - Transitive via namespace: only ADMIN on namespace → user can see all cases
+     *   (namespace MEMBER does NOT gain transitive READ on cases)
+     *
+     * Soft-deleted cases are filtered out. Returns cases in creation order.
+     *
+     * Super-admins do not use this query — the controller short-circuits them
+     * upstream via [io.whozoss.agentos.permissions.PermissionService.hasPermission]
+     * on the parent namespace.
+     */
+    @Query(
+        $$"""MATCH (c:Case)-[r:BELONGS_TO]->(ns:Namespace {id: $namespaceId})
+            WHERE (c.removed IS NULL OR c.removed = false)
+              AND (
+                EXISTS { MATCH (:User {id: $userId})-[:ADMIN|MEMBER]->(c) }
+                OR EXISTS { MATCH (:User {id: $userId})-[:ADMIN]->(ns) }
+              )
+            RETURN c, r, ns ORDER BY c.created ASC
+            """,
+    )
+    fun findAccessibleByUserInNamespace(
+        userId: String,
+        namespaceId: String,
+    ): List<CaseNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRepository.kt
@@ -8,4 +8,19 @@ import java.util.UUID
  *
  * Parent type is UUID representing the namespaceId.
  */
-interface CaseRepository : EntityRepository<Case, UUID>
+interface CaseRepository : EntityRepository<Case, UUID> {
+    /**
+     * Find cases in a namespace that [userId] is allowed to see (Story 3.3).
+     *
+     * Permission rule for Case (owner-private, FR15):
+     * - User has a direct `[:ADMIN]` or `[:MEMBER]` relation on the case, or
+     * - User has a direct `[:ADMIN]` relation on the parent namespace (transitive
+     *   ADMIN). Namespace MEMBER does NOT grant transitive READ on cases.
+     *
+     * Super-admin callers must be handled upstream (controller short-circuits
+     * and uses [findByParent] directly to avoid going through this filter).
+     *
+     * Implementations must exclude soft-deleted cases.
+     */
+    fun findAccessibleByUserInNamespace(userId: UUID, namespaceId: UUID): List<Case>
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseService.kt
@@ -24,6 +24,20 @@ import java.util.UUID
  */
 interface CaseService : EntityService<Case, UUID> {
     // ========================================
+    // Permission-filtered listing (Story 3.3)
+    // ========================================
+
+    /**
+     * List cases in [namespaceId] that [userId] is permitted to see.
+     *
+     * Delegates to [CaseRepository.findAccessibleByUserInNamespace]. Callers that
+     * already know the user holds namespace ADMIN (or super-admin) should prefer
+     * [findByParent] to skip the permission filter — the controller does this in
+     * [io.whozoss.agentos.caseFlow.CaseController.listByParent].
+     */
+    fun findAccessibleByUserInNamespace(userId: UUID, namespaceId: UUID): List<Case>
+
+    // ========================================
     // Runtime Instance Management
     // ========================================
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -47,7 +47,9 @@ class CaseServiceImpl(
 
     override fun create(entity: Case): Case {
         require(findById(entity.id) == null) { "Duplicate entity id: ${entity.id}" }
-        val saved = caseRepository.save(Case(metadata = entity.metadata, namespaceId = entity.namespaceId))
+        // Persist the full entity so client-supplied title and status are preserved
+        // (Story 3.4 AC4 — previous implementation silently dropped both fields).
+        val saved = caseRepository.save(entity)
         activeRuntimes[saved.id] = buildRuntime(saved)
         logger.info { "[CaseService] Case created: ${saved.id} for namespace ${entity.namespaceId}" }
         return saved
@@ -71,6 +73,9 @@ class CaseServiceImpl(
     override fun findByIds(ids: Collection<UUID>): List<Case> = caseRepository.findByIds(ids)
 
     override fun findByParent(parentId: UUID): List<Case> = caseRepository.findByParent(parentId)
+
+    override fun findAccessibleByUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
+        caseRepository.findAccessibleByUserInNamespace(userId, namespaceId)
 
     override fun delete(id: UUID): Boolean {
         if (activeRuntimes.containsKey(id)) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/InMemoryCaseRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/InMemoryCaseRepository.kt
@@ -18,9 +18,20 @@ import java.util.UUID
     "'\${agentos.persistence.mode:in-memory}' != 'neo4j' " +
         "and '\${agentos.persistence.mode:in-memory}' != 'embedded-neo4j'",
 )
-class InMemoryCaseRepository :
-    CaseRepository,
-    EntityRepository<Case, UUID> by InMemoryEntityRepository(
+class InMemoryCaseRepository(
+    private val delegate: EntityRepository<Case, UUID> = InMemoryEntityRepository(
         parentIdExtractor = { it.namespaceId },
         comparator = compareBy { it.metadata.id },
-    )
+    ),
+) : CaseRepository,
+    EntityRepository<Case, UUID> by delegate {
+
+    /**
+     * Permissive implementation: returns every case in the namespace. Consistent
+     * with [io.whozoss.agentos.permissions.InMemoryPermissionServiceImpl] which
+     * always grants access in in-memory mode. Production filtering happens in
+     * [Neo4jCaseRepository.findAccessibleByUserInNamespace].
+     */
+    override fun findAccessibleByUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
+        delegate.findByParent(namespaceId)
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Neo4jCaseRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Neo4jCaseRepository.kt
@@ -35,6 +35,14 @@ open class Neo4jCaseRepository(
             .findActiveByNamespaceId(parentId.toString())
             .map { it.toDomain() }
 
+    override fun findAccessibleByUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
+        caseNodeNeo4jRepository
+            .findAccessibleByUserInNamespace(
+                userId = userId.toString(),
+                namespaceId = namespaceId.toString(),
+            )
+            .map { it.toDomain() }
+
     override fun delete(id: UUID): Boolean =
         caseNodeNeo4jRepository
             .findByIdOrNull(id.toString())

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRepository.kt
@@ -15,7 +15,19 @@ class Neo4jPermissionRepository(
     private val permissionNodeRepository: PermissionNodeNeo4jRepository
 ) : PermissionRepository {
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        /**
+         * Entity types where a namespace MEMBER does NOT gain transitive READ
+         * through the parent namespace — only via a direct relation on the
+         * entity itself, or through namespace ADMIN transitivity.
+         *
+         * Rationale (Story 3.3, FR15): these entities are "owner-private" — each
+         * one has a creator who is auto-granted ADMIN on creation (Story 3.1).
+         * Letting every namespace MEMBER see every owner-private entity would
+         * break content isolation.
+         */
+        private val OWNER_PRIVATE_ENTITY_TYPES: Set<String> = setOf("Case")
+    }
 
     override fun hasDirectPermission(
         userId: String,
@@ -67,12 +79,26 @@ class Neo4jPermissionRepository(
                     )
                 }
                 PermissionRelation.MEMBER -> {
-                    // MEMBER relation allows READ access transitively
-                    permissionNodeRepository.hasReadAccessViaNamespace(
-                        userId = userId,
-                        entityId = entityId,
-                        entityLabel = entityType
-                    )
+                    if (entityType in OWNER_PRIVATE_ENTITY_TYPES) {
+                        // Owner-private entities (e.g. Case, FR15): a namespace MEMBER
+                        // does NOT get transitive READ on children — only a namespace
+                        // ADMIN does, or the user with a direct relation on the entity
+                        // (handled in hasDirectPermission upstream).
+                        permissionNodeRepository.hasAdminAccessViaNamespace(
+                            userId = userId,
+                            entityId = entityId,
+                            entityLabel = entityType
+                        )
+                    } else {
+                        // Shared entities (AgentConfig, IntegrationConfig, AiProvider,
+                        // AiModel): namespace MEMBERs legitimately inherit READ through
+                        // the namespace (FR21, FR27, FR32, FR35).
+                        permissionNodeRepository.hasReadAccessViaNamespace(
+                            userId = userId,
+                            entityId = entityId,
+                            entityLabel = entityType
+                        )
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -181,7 +207,16 @@ class Neo4jPermissionRepository(
                     }
                 }
                 PermissionRelation.MEMBER -> {
-                    if (isNamespaceChildEntity(entityType)) {
+                    if (entityType in OWNER_PRIVATE_ENTITY_TYPES) {
+                        // Owner-private entities: MEMBER transitivity via namespace-MEMBER
+                        // is forbidden (FR15). Use the admin-transitive query which gives
+                        // direct ADMIN on entity + transitive via namespace ADMIN — the
+                        // exact set a user is allowed to "see".
+                        permissionNodeRepository.findEntitiesWhereUserIsAdminTransitive(
+                            userId = userId,
+                            entityLabel = entityType
+                        )
+                    } else if (isNamespaceChildEntity(entityType)) {
                         permissionNodeRepository.findEntitiesWhereUserHasAccessTransitive(
                             userId = userId,
                             entityLabel = entityType

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerMvcIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerMvcIntegrationSpec.kt
@@ -1,0 +1,204 @@
+package io.whozoss.agentos.caseFlow
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceService
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * MVC-layer test for [CaseController] (Story 3.1).
+ *
+ * The "test" profile uses [io.whozoss.agentos.permissions.InMemoryPermissionServiceImpl],
+ * a permissive no-op stub: every `hasPermission` returns true. Negative paths
+ * (403 without namespace access) are therefore covered in [CaseControllerSpec]
+ * at the unit level, not here.
+ *
+ * This suite focuses on:
+ * - Bean Validation (`namespaceId` required)
+ * - Successful POST /api/cases returns 201 with correct body shape
+ * - The JSON response includes the case metadata
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CaseControllerMvcIntegrationSpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var namespaceService: NamespaceService
+
+    init {
+
+        "POST /api/cases with missing namespaceId returns 400" {
+            mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "title": "no namespace" }""")
+            ).andExpect(status().isBadRequest)
+        }
+
+        "POST /api/cases with a valid namespaceId returns 201 (super-admin path)" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-create"),
+            )
+
+            mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}", "title": "hello" }""")
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.namespaceId").value(ns.id.toString()))
+                .andExpect(jsonPath("$.id").exists())
+                // Story 3.4 AC4: title is now preserved after the CaseServiceImpl fix.
+                .andExpect(jsonPath("$.title").value("hello"))
+        }
+
+        "POST /api/cases without title still returns 201 (title optional)" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-no-title"),
+            )
+
+            mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}" }""")
+            ).andExpect(status().isCreated)
+        }
+
+        // -------------------------------------------------------------------------
+        // GET /api/cases/by-parentId/{namespaceId} (Story 3.2)
+        // -------------------------------------------------------------------------
+
+        "GET /api/cases/by-parentId/{namespaceId} returns cases for a super-admin caller" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-list-cases"),
+            )
+            // Create 2 cases in the namespace via the REST API (super-admin path)
+            mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}" }""")
+            ).andExpect(status().isCreated)
+            mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}" }""")
+            ).andExpect(status().isCreated)
+
+            mockMvc.perform(get("/api/cases/by-parentId/${ns.id}"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize<Any>(2)))
+        }
+
+        // -------------------------------------------------------------------------
+        // PUT /api/cases/{id} (Story 3.4)
+        // -------------------------------------------------------------------------
+
+        "PUT /api/cases/{id} updates title when caller has WRITE permission (super-admin)" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-update"),
+            )
+            val createResponse = mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}", "title": "initial" }""")
+            ).andExpect(status().isCreated).andReturn().response.contentAsString
+            val caseId = Regex("\"id\"\\s*:\\s*\"([0-9a-f-]+)\"").find(createResponse)!!.groupValues[1]
+
+            mockMvc.perform(
+                put("/api/cases/$caseId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$caseId", "namespaceId": "${ns.id}", "title": "updated" }""")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.id").value(caseId))
+                .andExpect(jsonPath("$.title").value("updated"))
+                .andExpect(jsonPath("$.namespaceId").value(ns.id.toString()))
+        }
+
+        "PUT /api/cases/{id} returns 404 when case does not exist" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-put-404"),
+            )
+            val missing = UUID.randomUUID()
+
+            mockMvc.perform(
+                put("/api/cases/$missing")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$missing", "namespaceId": "${ns.id}", "title": "nope" }""")
+            ).andExpect(status().isNotFound)
+        }
+
+        "PUT /api/cases/{id} with missing namespaceId returns 400 (Bean Validation)" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-put-400"),
+            )
+            val createResponse = mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}" }""")
+            ).andExpect(status().isCreated).andReturn().response.contentAsString
+            val caseId = Regex("\"id\"\\s*:\\s*\"([0-9a-f-]+)\"").find(createResponse)!!.groupValues[1]
+
+            mockMvc.perform(
+                put("/api/cases/$caseId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$caseId", "title": "no namespace" }""")
+            ).andExpect(status().isBadRequest)
+        }
+
+        // -------------------------------------------------------------------------
+        // DELETE /api/cases/{id} (Story 3.4)
+        // -------------------------------------------------------------------------
+
+        "DELETE /api/cases/{id} returns 204 and makes the case invisible in subsequent listings" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-delete"),
+            )
+            val createResponse = mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}", "title": "to-delete" }""")
+            ).andExpect(status().isCreated).andReturn().response.contentAsString
+            val caseId = Regex("\"id\"\\s*:\\s*\"([0-9a-f-]+)\"").find(createResponse)!!.groupValues[1]
+
+            mockMvc.perform(delete("/api/cases/$caseId"))
+                .andExpect(status().isNoContent)
+
+            // The deleted case should no longer appear in listings
+            mockMvc.perform(get("/api/cases/by-parentId/${ns.id}"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$[?(@.id == '$caseId')]", org.hamcrest.Matchers.hasSize<Any>(0)))
+        }
+
+        "DELETE /api/cases/{id} returns 404 on a second attempt (already soft-deleted)" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-delete-twice"),
+            )
+            val createResponse = mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}" }""")
+            ).andExpect(status().isCreated).andReturn().response.contentAsString
+            val caseId = Regex("\"id\"\\s*:\\s*\"([0-9a-f-]+)\"").find(createResponse)!!.groupValues[1]
+
+            mockMvc.perform(delete("/api/cases/$caseId")).andExpect(status().isNoContent)
+            mockMvc.perform(delete("/api/cases/$caseId")).andExpect(status().isNotFound)
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
@@ -1,0 +1,314 @@
+package io.whozoss.agentos.caseFlow
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.PermissionRelation
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+/**
+ * Unit tests for [CaseController] (Story 3.1).
+ *
+ * Covers:
+ * - `checkCreatePermission` gate: at least READ on the parent namespace is
+ *   required (MEMBER and ADMIN accepted; no relation → 403)
+ * - `create` override: auto-grants `[:ADMIN]` on the new case to the creator,
+ *   best-effort (grant failure logs WARN but does not roll back creation)
+ * - Mapping helpers (`toResource`, `toDomain`)
+ *
+ * Inherited endpoints (`getById`, `listByParent`, etc.) are covered at the
+ * framework level by `SecuredEntityControllerSpec`.
+ */
+class CaseControllerSpec : StringSpec({
+
+    val caseService = mockk<CaseService>()
+    val userService = mockk<UserService>()
+    val permissionService = mockk<PermissionService>()
+    val controller = CaseController(caseService, userService, permissionService)
+
+    val callerId = UUID.randomUUID()
+    val caller = User(
+        metadata = EntityMetadata(id = callerId),
+        externalId = "member@example.com",
+        email = "member@example.com",
+        isAdmin = false,
+    )
+
+    val namespaceId = UUID.randomUUID()
+
+    fun caseEntity(id: UUID = UUID.randomUUID(), title: String = "my case") = Case(
+        metadata = EntityMetadata(id = id),
+        namespaceId = namespaceId,
+        status = CaseStatus.PENDING,
+        title = title,
+    )
+
+    fun caseResource(id: UUID? = null, title: String? = "my case") = CaseResource(
+        id = id,
+        namespaceId = namespaceId,
+        status = CaseStatus.PENDING,
+        title = title,
+    )
+
+    beforeTest { clearAllMocks() }
+
+    // -------------------------------------------------------------------------
+    // getEntityType
+    // -------------------------------------------------------------------------
+
+    "getEntityType returns \"Case\" (must match Neo4j label)" {
+        controller.getEntityType() shouldBe "Case"
+    }
+
+    // -------------------------------------------------------------------------
+    // Mapping
+    // -------------------------------------------------------------------------
+
+    "toResource maps all case fields including namespaceId and status" {
+        val entity = caseEntity(title = "engineering case")
+
+        val result = controller.toResource(entity)
+
+        result.id shouldBe entity.metadata.id
+        result.namespaceId shouldBe namespaceId
+        result.status shouldBe CaseStatus.PENDING
+        result.title shouldBe "engineering case"
+    }
+
+    "toDomain generates a random UUID when resource id is null" {
+        val first = controller.toDomain(caseResource(id = null)).metadata.id
+        val second = controller.toDomain(caseResource(id = null)).metadata.id
+
+        // Two consecutive calls must yield distinct ids — proving a fresh UUID
+        // is generated rather than a default/sentinel value being reused.
+        first shouldNotBe second
+    }
+
+    "toDomain preserves a provided id" {
+        val id = UUID.randomUUID()
+        controller.toDomain(caseResource(id = id)).metadata.id shouldBe id
+    }
+
+    "toDomain fills null title with the default 'Case <id>' (Story 3.4 AC4)" {
+        val id = UUID.randomUUID()
+        val result = controller.toDomain(caseResource(id = id, title = null))
+
+        result.title shouldBe "Case $id"
+    }
+
+    // -------------------------------------------------------------------------
+    // create (Story 3.1) — happy path + auto-grant
+    // -------------------------------------------------------------------------
+
+    "create succeeds when caller has READ on the parent namespace and auto-grants ADMIN on the new case" {
+        val r = caseResource(id = null)
+        val saved = caseEntity()
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every { caseService.create(any()) } returns saved
+        every {
+            permissionService.grantPermission(
+                callerId.toString(), "Case", saved.metadata.id.toString(), PermissionRelation.ADMIN,
+            )
+        } just Runs
+
+        val result = controller.create(r)
+
+        result.id shouldBe saved.metadata.id
+        result.namespaceId shouldBe namespaceId
+        verify(exactly = 1) { caseService.create(any()) }
+        verify(exactly = 1) {
+            permissionService.grantPermission(
+                callerId.toString(), "Case", saved.metadata.id.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    "create throws 403 when caller has no READ on the parent namespace" {
+        val r = caseResource(id = null)
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> { controller.create(r) }
+
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        ex.reason shouldBe "Access denied - no access to namespace"
+        // Neither persistence nor grant should happen when permission is denied
+        verify(exactly = 0) { caseService.create(any()) }
+        verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
+    }
+
+    "create still succeeds when the auto-ADMIN grant fails (logs warning, no rollback)" {
+        val r = caseResource(id = null)
+        val saved = caseEntity()
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every { caseService.create(any()) } returns saved
+        every {
+            permissionService.grantPermission(
+                callerId.toString(), "Case", saved.metadata.id.toString(), PermissionRelation.ADMIN,
+            )
+        } throws RuntimeException("transient Neo4j failure")
+
+        val result = controller.create(r)
+
+        result.id shouldBe saved.metadata.id
+        verify(exactly = 1) { caseService.create(any()) }
+    }
+
+    "create succeeds for super-admin via hasPermission bypass (READ returns true)" {
+        val superAdmin = caller.copy(isAdmin = true)
+        val r = caseResource(id = null)
+        val saved = caseEntity()
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.READ)
+        } returns true
+        every { caseService.create(any()) } returns saved
+        every { permissionService.grantPermission(any(), any(), any(), any()) } just Runs
+
+        controller.create(r).id shouldBe saved.metadata.id
+
+        verify(exactly = 1) {
+            permissionService.grantPermission(
+                callerId.toString(), "Case", saved.metadata.id.toString(), PermissionRelation.ADMIN,
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // listByParent (Story 3.2) — short-circuit for namespace ADMIN
+    // -------------------------------------------------------------------------
+
+    "listByParent short-circuits and returns all cases unfiltered when caller has ADMIN on the parent namespace" {
+        val case1 = caseEntity(title = "a")
+        val case2 = caseEntity(title = "b")
+        val case3 = caseEntity(title = "c")
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { caseService.findByParent(namespaceId) } returns listOf(case1, case2, case3)
+
+        val result = controller.listByParent(namespaceId)
+
+        result.map { it.id } shouldBe listOf(case1.metadata.id, case2.metadata.id, case3.metadata.id)
+        verify(exactly = 1) { caseService.findByParent(namespaceId) }
+        // No per-case hasPermission call when caller is namespace ADMIN (avoids N+1)
+        verify(exactly = 0) {
+            permissionService.hasPermission(any(), "Case", any(), any())
+        }
+    }
+
+    "listByParent uses findAccessibleByUserInNamespace when caller is not namespace ADMIN (Story 3.3)" {
+        val ownCase = caseEntity(title = "mine")
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns false
+        // The permission-filtered repo method returns only cases the user has
+        // access to — the repo applies the FR15 rule, controller just maps.
+        every {
+            caseService.findAccessibleByUserInNamespace(callerId, namespaceId)
+        } returns listOf(ownCase)
+
+        val result = controller.listByParent(namespaceId)
+
+        result.map { it.id } shouldBe listOf(ownCase.metadata.id)
+        // Assert we do NOT fall back to the per-case super.listByParent path
+        verify(exactly = 0) {
+            permissionService.hasPermission(any(), "Case", any(), any())
+        }
+        verify(exactly = 0) { caseService.findByParent(namespaceId) }
+        verify(exactly = 1) { caseService.findAccessibleByUserInNamespace(callerId, namespaceId) }
+    }
+
+    "listByParent non-admin path returns empty list when the user has no accessible case" {
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns false
+        every {
+            caseService.findAccessibleByUserInNamespace(callerId, namespaceId)
+        } returns emptyList()
+
+        controller.listByParent(namespaceId) shouldBe emptyList()
+    }
+
+    "listByParent short-circuits for super-admin (hasPermission WRITE returns true via bypass)" {
+        val superAdmin = caller.copy(isAdmin = true)
+        val case1 = caseEntity()
+        every { userService.getCurrentUser() } returns superAdmin
+        every {
+            permissionService.hasPermission(callerId.toString(), "Namespace", namespaceId.toString(), Action.WRITE)
+        } returns true
+        every { caseService.findByParent(namespaceId) } returns listOf(case1)
+
+        controller.listByParent(namespaceId).size shouldBe 1
+        verify(exactly = 0) {
+            permissionService.hasPermission(any(), "Case", any(), any())
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // update / delete — AC3 403 for MEMBER without direct ADMIN (Story 3.4)
+    // -------------------------------------------------------------------------
+
+    "update returns 403 when caller has only namespace MEMBER and no direct ADMIN on case" {
+        val entity = caseEntity()
+        val updateResource = caseResource(id = entity.metadata.id, title = "updated")
+        every { caseService.findById(entity.metadata.id) } returns entity
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(
+                callerId.toString(), "Case", entity.metadata.id.toString(), Action.WRITE,
+            )
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> {
+            controller.update(entity.metadata.id, updateResource)
+        }
+
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        verify(exactly = 0) { caseService.update(any()) }
+    }
+
+    "delete returns 403 when caller has only namespace MEMBER and no direct ADMIN on case" {
+        val entity = caseEntity()
+        every { caseService.findById(entity.metadata.id) } returns entity
+        every { userService.getCurrentUser() } returns caller
+        every {
+            permissionService.hasPermission(
+                callerId.toString(), "Case", entity.metadata.id.toString(), Action.DELETE,
+            )
+        } returns false
+
+        val ex = shouldThrow<ResponseStatusException> {
+            controller.delete(entity.metadata.id)
+        }
+
+        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+        verify(exactly = 0) { caseService.delete(any()) }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
@@ -4,6 +4,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
 import io.whozoss.agentos.caseFlow.Case
 import io.whozoss.agentos.caseFlow.CaseRepository
 import io.whozoss.agentos.namespace.Namespace
@@ -108,21 +110,127 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             ).shouldBeTrue()
         }
 
-        "MEMBER on namespace grants READ on child Case" {
+        /**
+         * Story 3.3 FR15: a namespace MEMBER must NOT gain transitive READ on
+         * child Cases. Each case is owner-private — only the creator (direct
+         * ADMIN via Story 3.1 auto-grant) or the namespace ADMIN can access it.
+         * Test previously asserted the opposite when the bug was present.
+         */
+        "MEMBER on namespace does NOT grant READ on child Case (Story 3.3 FR15)" {
             val user = createUser()
             val namespace = createNamespace()
             val case = createCase(namespace.id)
 
-            // Grant MEMBER on namespace
+            // Grant MEMBER on namespace only
             permissionNodeRepository.createMemberPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
                 entityLabel = "Namespace"
             )
 
-            // MEMBER should grant READ
+            // Before Story 3.3 this returned true (bug). It must now be false.
             permissionService.hasPermission(
                 user.id.toString(), "Case", case.id.toString(), Action.READ
+            ).shouldBeFalse()
+        }
+
+        "MEMBER with direct ADMIN on a case retains full access (Story 3.3 AC3)" {
+            val user = createUser()
+            val namespace = createNamespace()
+            val case = createCase(namespace.id)
+
+            // Only namespace MEMBER — triggers the FR15 block on transitivity
+            permissionNodeRepository.createMemberPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            )
+            // Plus direct ADMIN on the case (simulates Story 3.1 auto-grant)
+            permissionNodeRepository.createAdminPermission(
+                userId = user.id.toString(),
+                entityId = case.id.toString(),
+                entityLabel = "Case"
+            )
+
+            // Direct relation grants full access regardless of the transitive rule
+            permissionService.hasPermission(
+                user.id.toString(), "Case", case.id.toString(), Action.READ
+            ).shouldBeTrue()
+            permissionService.hasPermission(
+                user.id.toString(), "Case", case.id.toString(), Action.WRITE
+            ).shouldBeTrue()
+            permissionService.hasPermission(
+                user.id.toString(), "Case", case.id.toString(), Action.DELETE
+            ).shouldBeTrue()
+        }
+
+        /**
+         * AC6 anti-regression: the FR15 rule must apply ONLY to Case. Shared
+         * child entities (AgentConfig, IntegrationConfig, AiProvider, AiModel)
+         * keep the MEMBER → transitive READ behaviour required by FR21/FR27/
+         * FR32/FR35. We simulate an "AgentConfig" node by creating a
+         * non-Case entity with a BELONGS_TO edge to the namespace.
+         */
+        /**
+         * Story 3.4 AC2: soft-deleting a case must NOT remove its [:ADMIN]
+         * relations — they survive for audit purposes. The repository's delete
+         * implementation merely sets `removed = true` on the CaseNode and must
+         * leave every permission edge intact.
+         */
+        "soft-deleting a case preserves direct ADMIN relation for audit (Story 3.4 AC2)" {
+            val user = createUser("owner@example.com")
+            val namespace = createNamespace()
+            val case = createCase(namespace.id)
+
+            permissionNodeRepository.createAdminPermission(
+                userId = user.id.toString(),
+                entityId = case.id.toString(),
+                entityLabel = "Case"
+            )
+            // Sanity check: ADMIN relation exists before the delete
+            permissionNodeRepository.hasAdminPermission(
+                userId = user.id.toString(),
+                entityId = case.id.toString(),
+                entityLabel = "Case"
+            ).shouldBeTrue()
+
+            // Soft-delete the case via the repository
+            val deleted = caseRepository.delete(case.id)
+            deleted.shouldBeTrue()
+
+            // The case is no longer findable (filtered by `removed != true`)
+            caseRepository.findByIds(listOf(case.id)).shouldBeEmpty()
+
+            // But the direct [:ADMIN] relation in Neo4j is preserved for audit
+            permissionNodeRepository.hasAdminPermission(
+                userId = user.id.toString(),
+                entityId = case.id.toString(),
+                entityLabel = "Case"
+            ).shouldBeTrue()
+        }
+
+        "namespace MEMBER still grants transitive READ on non-Case shared entities (Story 3.3 AC6 anti-regression)" {
+            val user = createUser()
+            val namespace = createNamespace()
+            // Create an AgentConfig-like node directly in Neo4j with a BELONGS_TO edge
+            val agentConfigId = java.util.UUID.randomUUID().toString()
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, removed: false})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to agentConfigId, "nsId" to namespace.id.toString()),
+                )
+            }
+
+            permissionNodeRepository.createMemberPermission(
+                userId = user.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace"
+            )
+
+            // MEMBER transitivity DOES apply to AgentConfig (FR21 legitimate)
+            permissionService.hasPermission(
+                user.id.toString(), "AgentConfig", agentConfigId, Action.READ
             ).shouldBeTrue()
         }
 
@@ -233,6 +341,58 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionService.hasPermission(
                 user.id.toString(), "Namespace", namespace.id.toString(), Action.READ
             ).shouldBeFalse()
+        }
+
+        /**
+         * Story 3.2 AC1: a namespace ADMIN transitively has ADMIN on cases that
+         * were created — and auto-granted — to a different user. Proves end-to-end
+         * that `findByParent` + transitive `hasPermission` surfaces all cases in the
+         * namespace to a namespace admin, not just those they created themselves.
+         */
+        "namespace ADMIN has transitive ADMIN on cases created by other users (Story 3.2 AC1)" {
+            val adminUser = createUser("admin@example.com")
+            val creatorUser = createUser("creator@example.com")
+            val namespace = createNamespace()
+            val case1 = createCase(namespace.id)
+            val case2 = createCase(namespace.id)
+
+            // adminUser holds [:ADMIN] on the namespace
+            permissionNodeRepository.createAdminPermission(
+                userId = adminUser.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace",
+            )
+            // creatorUser holds direct [:ADMIN] on their two cases
+            // (mirrors Story 3.1 auto-grant flow)
+            permissionNodeRepository.createAdminPermission(
+                userId = creatorUser.id.toString(),
+                entityId = case1.id.toString(),
+                entityLabel = "Case",
+            )
+            permissionNodeRepository.createAdminPermission(
+                userId = creatorUser.id.toString(),
+                entityId = case2.id.toString(),
+                entityLabel = "Case",
+            )
+
+            // adminUser has NO direct relation on either case, yet should have
+            // full ADMIN privileges via transitive namespace ADMIN.
+            listOf(case1, case2).forEach { case ->
+                permissionService.hasPermission(
+                    adminUser.id.toString(), "Case", case.id.toString(), Action.READ,
+                ).shouldBeTrue()
+                permissionService.hasPermission(
+                    adminUser.id.toString(), "Case", case.id.toString(), Action.WRITE,
+                ).shouldBeTrue()
+                permissionService.hasPermission(
+                    adminUser.id.toString(), "Case", case.id.toString(), Action.DELETE,
+                ).shouldBeTrue()
+            }
+
+            // Service layer: findByParent returns every case in the namespace,
+            // letting the controller's short-circuit (Story 3.2 T1) skip per-case
+            // filtering for a namespace admin.
+            caseRepository.findByParent(namespace.id) shouldHaveSize 2
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements Epic 3 of the AgentOS permissions system: case creation, per-case access control, and owner-private visibility rules. **Stacked on top of #805 (Epic 2 PR)** — merge Epic 1 then Epic 2 first, then this retargets to master.

## Stories covered

- **3.1 Case creation with auto-admin** — `CaseController.checkCreatePermission` is relaxed from `Action.WRITE` to `Action.READ` so namespace MEMBERs can create cases (FR11). `create()` auto-grants `[:ADMIN]` on the new case to the creator (best-effort, non-transactional — same pattern as Story 2.1).
- **3.2 Namespace ADMIN access to cases** — `listByParent` short-circuits when the caller holds ADMIN on the parent namespace: one query instead of N+1 `hasPermission` calls per case. A new Neo4j integration test exercises the full transitive-admin path end-to-end.
- **3.3 Member limited to own cases (FR15)** — Case is declared owner-private in `Neo4jPermissionRepository.OWNER_PRIVATE_ENTITY_TYPES`. Case+MEMBER is dispatched to `hasAdminAccessViaNamespace` so a namespace MEMBER no longer gains transitive READ on cases they did not create. A dedicated Cypher `CaseNodeNeo4jRepository.findAccessibleByUserInNamespace` returns the MEMBER-visible case set in a single query (no N+1). Other child entity types (AgentConfig, IntegrationConfig, AiProvider, AiModel) keep the permissive MEMBER → transitive READ path required by FR21/FR27/FR32/FR35 — verified by an anti-regression test.
- **3.4 CRUD operations on cases** — fix `CaseServiceImpl.create` which silently dropped `title` and `status`; align `CaseController.toDomain` to use the `Case` data-class default `\"Case <id>\"` when the client omits a title. A new Neo4j integration test proves that soft-deleting a case leaves its `[:ADMIN]` relation intact for audit.

## Security model (unchanged)

- Super-admin bypass via `isAdmin`, handled centrally in `PermissionService.hasPermission`.
- 404 (not 403) to hide resource existence from callers with no READ.
- 403 is returned only once READ is established (explicit denial).

## Intentionally out of scope

- **PUT/PATCH semantics & merge-on-update** — the framework `SecuredEntityController.update` uses `toDomain` for both CREATE and UPDATE paths. Any field the client omits is silently reset to the DTO default (title becomes `\"Case <id>\"`, description becomes `null`, etc.). This pre-existing framework behaviour surfaces in Epic 3 only because we added content assertions on updated entities. Fixing it requires a cross-cutting decision (PUT = replace / PUT = merge + explicit clear / PATCH endpoint / JsonNullable) that should apply to every controller and will land in a dedicated story.
- **Entity metadata auto-population** — `createdBy` / `created` / `modifiedBy` / `modified` on `EntityMetadata` are not populated by this work. Covered by Epic 7 Story 7.2 (FR50/FR51).
- **Soft-delete + ID collision MERGE** — an edge case where creating a case with the id of a soft-deleted case would resurrect it. Marginal probability (UUID collision), pre-existing, to be addressed in a later cleanup story.

## Tests

- **Unit** (Kotest + MockK): new `CaseControllerSpec` covering mapping, create (MEMBER allowed, 403 on no-access, best-effort grant failure), listByParent (short-circuit and filtered paths, no-N+1 assertion), update/delete 403 for non-ADMIN (Story 3.4 AC3).
- **MVC** (`@SpringBootTest` + `@AutoConfigureMockMvc`, `test` profile): new `CaseControllerMvcIntegrationSpec` covers Bean Validation, POST 201 with title preserved, GET list (super-admin path), PUT update (success, 404, 400), DELETE 204 + invisible-in-listing + 404 on second attempt.
- **Neo4j integration** (`Neo4jTransitivePermissionsSpec`): two new tests — (1) namespace ADMIN has transitive ADMIN on cases created by other users (Story 3.2 AC1/AC2), (2) MEMBER on namespace does NOT grant READ on child Case (Story 3.3 FR15 — inverts the pre-existing test that documented the bug), plus MEMBER-with-direct-ADMIN keeps access, AC6 anti-regression on AgentConfig, and soft-delete preserves `[:ADMIN]` (Story 3.4 AC2).

## Test plan

- [ ] \`cd agentos && ./gradlew :agentos-service:test\` passes (full regression)
- [ ] Manual smoke:
  - [ ] Super-admin creates a namespace, creates a case → receives direct ADMIN; updates + deletes OK
  - [ ] Namespace ADMIN sees every case in the namespace (transitive); can update/delete any of them
  - [ ] Namespace MEMBER creates their own case → direct ADMIN; cannot see or update another member's case (404)
  - [ ] Deleting a case removes it from listings; the `[:ADMIN]` relation persists in Neo4j for audit
- [ ] Verify the PR auto-retargets to \`master\` after Epic 2 (#805) is merged (or retarget manually)