### PR TITLE
fix: restore lockstep versioning and fix releasePublish for JVM projects

### DIFF
--- a/agentos/agentos-sdk/project.json
+++ b/agentos/agentos-sdk/project.json
@@ -2,6 +2,11 @@
   "name": "agentos-sdk",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": []
+    }
+  },
   "sourceRoot": "agentos/agentos-sdk/src",
   "targets": {
     "build": {
@@ -35,6 +40,12 @@
         "passWithNoTests": null
       },
       "dependsOn": ["build"]
+    },
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo 'agentos-sdk published via Gradle in CI'"
+      }
     },
     "publish": {
       "executor": "nx:run-commands",

--- a/nx.json
+++ b/nx.json
@@ -71,6 +71,7 @@
     }
   ],
   "release": {
+    "projects": ["server", "client", "web", "desktop", "desktop-twin", "agentos-sdk"],
     "releaseTagPattern": "release/{version}",
     "changelog": {
       "workspaceChangelog": {
@@ -84,26 +85,13 @@
     },
     "version": {
       "conventionalCommits": true,
+      "manifestRootsToUpdate": ["apps/{projectName}"],
       "versionActionsOptions": {
         "skipLockFileUpdate": true
       },
       "git": {
         "commit": false,
         "tag": false
-      }
-    },
-    "groups": {
-      "npm": {
-        "projects": ["server", "client", "web", "desktop", "desktop-twin"],
-        "version": {
-          "manifestRootsToUpdate": ["apps/{projectName}"]
-        }
-      },
-      "jvm": {
-        "projects": ["tag:platform:jvm"],
-        "version": {
-          "manifestRootsToUpdate": []
-        }
       }
     }
   },

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -8,8 +8,11 @@ import { updateTomlVersion } from './utils/update-toml-version'
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run')
+  if (dryRun) console.log('Dry run mode — no files will be written, no git operations performed')
+
   // Step 1: Determine new version and update package.json files
-  const { projectsVersionData, releaseGraph } = await releaseVersion({ dryRun: false, verbose: false })
+  const { projectsVersionData, releaseGraph } = await releaseVersion({ dryRun, verbose: false })
 
   // workspaceVersion (from releaseVersion) is undefined when there are multiple release groups — derive from projectsVersionData instead
   const newVersion = Object.values(projectsVersionData).find((v) => v.newVersion)?.newVersion
@@ -25,34 +28,43 @@ async function main(): Promise<void> {
   // This must happen AFTER releaseVersion (which determines the new version)
   // but BEFORE releaseChangelog (which commits, tags, and pushes).
   const tomlRelativePath = 'agentos/gradle/libs.versions.toml'
-  const tomlPath = join(__dirname, '..', tomlRelativePath)
-  const tomlContent = readFileSync(tomlPath, 'utf-8')
-  const updatedToml = updateTomlVersion(tomlContent, 'agentosSdk', newVersion)
-  writeFileSync(tomlPath, updatedToml, 'utf-8')
-  console.log(`Updated libs.versions.toml agentosSdk to ${newVersion}`)
+  if (dryRun) {
+    console.log(`[dry-run] Would update libs.versions.toml agentosSdk to ${newVersion}`)
+  } else {
+    const tomlPath = join(__dirname, '..', tomlRelativePath)
+    const tomlContent = readFileSync(tomlPath, 'utf-8')
+    const updatedToml = updateTomlVersion(tomlContent, 'agentosSdk', newVersion)
+    writeFileSync(tomlPath, updatedToml, 'utf-8')
+    console.log(`Updated libs.versions.toml agentosSdk to ${newVersion}`)
 
-  // Explicitly stage the toml file so it's included in the release commit.
-  // Nx's releaseChangelog only stages files it knows about (package.json, CHANGELOG.md),
-  // so we must stage our additional file manually.
-  execSync(`git add ${tomlRelativePath}`, { stdio: 'inherit' })
+    // Explicitly stage the toml file so it's included in the release commit.
+    // Nx's releaseChangelog only stages files it knows about (package.json, CHANGELOG.md),
+    // so we must stage our additional file manually.
+    execSync(`git add ${tomlRelativePath}`, { stdio: 'inherit' })
+  }
 
   // Step 3: Generate changelog, commit all staged changes (including toml), tag, and push
   await releaseChangelog({
     releaseGraph,
     versionData: projectsVersionData,
     version: newVersion,
-    dryRun: false,
+    dryRun,
     verbose: false,
   })
 
-  // Step 4: Publish npm packages
+  // Step 4: Publish packages — JVM projects are skipped via no-op nx-release-publish targets (published via Gradle in CI)
   const publishResults = await releasePublish({
     releaseGraph,
-    dryRun: false,
+    dryRun,
     verbose: false,
   })
 
   process.exit(Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1)
 }
 
-void main()
+try {
+  await main()
+} catch (err) {
+  console.error('Release failed:', err)
+  process.exit(1)
+}


### PR DESCRIPTION
## Problem

Two regressions were introduced when the `jvm` release group was added to `nx.json`:

1. **Lockstep broken** — the `npm` and `jvm` groups computed version bumps independently from their own commit history, causing them to diverge (e.g. `0.126.0` vs `0.125.5`).
2. **`releasePublish` failing** — JVM projects have no `nx-release-publish` target (they publish via Gradle), causing the release script to error.

## Solution

- **Remove release groups entirely** — replace with a flat `release.projects` list including `agentos-sdk`. A single fixed group restores lockstep: one version for all projects, driven by the most significant commit across all of them.
- **Add `agentos-sdk` to `release.projects`** — ensures commits to `agentos/` can drive a version bump and trigger the `publish-sdk` CI job.
- **No-op `nx-release-publish` target on `agentos-sdk`** — satisfies `releasePublish` without publishing anything; the real Gradle publish continues to happen in the dedicated `publish-sdk` CI job.
- **`manifestRootsToUpdate: []` on `agentos-sdk`** — prevents `releaseVersion` from trying to resolve `apps/agentos-sdk/package.json`.
- **`--dry-run` flag on `scripts/release.ts`** — allows safe local testing with zero side effects.

## Future JVM projects

When additional JVM projects (e.g. `agentos-service`, plugins) need to drive version bumps, the pattern is:
1. Add them to `release.projects` in `nx.json`
2. Add `release.version.manifestRootsToUpdate: []` and a no-op `nx-release-publish` target to their `project.json`
3. Add a corresponding publish job in `release.yml` — `release.ts` needs no changes