### PR TITLE
feat: tag-based project selection for release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,7 @@ jobs:
         id: resolve
         # --json --quiet mirrors validate.yml to avoid output pollution from the nx daemon/cache
         run: |
-          PROJECTS=$(npx nx show projects --projects="tag:platform:jvm" --json --quiet | jq -c '.')
+          PROJECTS=$(npx nx show projects --projects="tag:platform:jvm" --json --quiet | jq -c '.' || echo '[]')
           echo "projects=$PROJECTS" >> $GITHUB_OUTPUT
 
   publish-agentos-artifacts:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,10 +242,41 @@ jobs:
             echo "Warning: Coday Twin PKG not found"
           fi
 
-  publish-agentos-artifacts:
-    name: Publish ${{ matrix.project }} to GitHub Packages
+  # Job 4: Resolve the list of JVM projects to publish from the platform:jvm tag
+  compute-jvm-projects:
     runs-on: ubuntu-latest
     needs: release
+    if: needs.release.outputs.new_version != ''
+    outputs:
+      projects: ${{ steps.resolve.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.release_sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve JVM projects from tag
+        id: resolve
+        # --json --quiet mirrors validate.yml to avoid output pollution from the nx daemon/cache
+        run: |
+          PROJECTS=$(npx nx show projects --projects="tag:platform:jvm" --json --quiet | jq -c '.')
+          echo "projects=$PROJECTS" >> $GITHUB_OUTPUT
+
+  publish-agentos-artifacts:
+    name: publish ${{ matrix.project }} to github packages
+    runs-on: ubuntu-latest
+    needs: [release, compute-jvm-projects]
     if: needs.release.outputs.new_version != ''
 
     permissions:
@@ -254,13 +285,7 @@ jobs:
 
     strategy:
       matrix:
-        project:
-          - agentos-sdk
-          - agentos-service
-          - agentos-datetime-plugin
-          - agentos-file-plugin
-          - agentos-bash-plugin
-          - agentos-tmux-plugin
+        project: ${{ fromJson(needs.compute-jvm-projects.outputs.projects) }}
 
     steps:
       - name: Checkout repository

--- a/agentos/agentos-plugins-filesystem/project.json
+++ b/agentos/agentos-plugins-filesystem/project.json
@@ -90,7 +90,6 @@
   },
   "tags": [
     "type:app",
-    "platform:jvm",
     "scope:service"
   ]
 }

--- a/agents/Archay.yaml
+++ b/agents/Archay.yaml
@@ -52,3 +52,4 @@ mandatoryDocs:
   - ./docs/to-rework/ARCHITECTURE.md
   - ./docs/to-rework/DEV_WORKFLOW.md
   - ./docs/to-rework/HANDLER_DESIGN.md
+  - ./docs/to-rework/RELEASE_PIPELINE.md

--- a/apps/client/project.json
+++ b/apps/client/project.json
@@ -4,7 +4,7 @@
   "projectType": "application",
   "prefix": "app",
   "sourceRoot": "apps/client/src",
-  "tags": ["platform:node"],
+  "tags": ["platform:npm"],
   "targets": {
     "build": {
       "executor": "nx:run-commands",

--- a/apps/client/project.json
+++ b/apps/client/project.json
@@ -4,7 +4,7 @@
   "projectType": "application",
   "prefix": "app",
   "sourceRoot": "apps/client/src",
-  "tags": [],
+  "tags": ["platform:node"],
   "targets": {
     "build": {
       "executor": "nx:run-commands",

--- a/apps/desktop-twin/project.json
+++ b/apps/desktop-twin/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "{projectRoot}",
-  "tags": ["desktop-bundle", "platform:node"],
+  "tags": ["desktop-bundle", "platform:npm"],
   "targets": {
     "nx-release-publish": {
       "executor": "nx:run-commands",

--- a/apps/desktop-twin/project.json
+++ b/apps/desktop-twin/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "{projectRoot}",
-  "tags": ["desktop-bundle"],
+  "tags": ["desktop-bundle", "platform:node"],
   "targets": {
     "nx-release-publish": {
       "executor": "nx:run-commands",

--- a/apps/desktop/project.json
+++ b/apps/desktop/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "{projectRoot}",
-  "tags": ["desktop-bundle", "platform:node"],
+  "tags": ["desktop-bundle", "platform:npm"],
   "targets": {
     "nx-release-publish": {
       "executor": "nx:run-commands",

--- a/apps/desktop/project.json
+++ b/apps/desktop/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "{projectRoot}",
-  "tags": ["desktop-bundle"],
+  "tags": ["desktop-bundle", "platform:node"],
   "targets": {
     "nx-release-publish": {
       "executor": "nx:run-commands",

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "apps/server/src",
-  "tags": ["web-server", "platform:node"],
+  "tags": ["web-server", "platform:npm"],
   "targets": {
     "build": {
       "executor": "nx:run-commands",

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "apps/server/src",
-  "tags": ["web-server"],
+  "tags": ["web-server", "platform:node"],
   "targets": {
     "build": {
       "executor": "nx:run-commands",

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "{projectRoot}",
-  "tags": ["web-bundle"],
+  "tags": ["web-bundle", "platform:node"],
   "targets": {
     "serve": {
       "executor": "nx:run-commands",

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "{projectRoot}",
-  "tags": ["web-bundle", "platform:node"],
+  "tags": ["web-bundle", "platform:npm"],
   "targets": {
     "serve": {
       "executor": "nx:run-commands",

--- a/docs/nxpert/01-coday-nx-knowledge.md
+++ b/docs/nxpert/01-coday-nx-knowledge.md
@@ -26,8 +26,13 @@ like `check-openapi-spec`, `bootRun`, `generate-client` are explicitly declared 
 ## JVM Sub-workspace (`agentos/`)
 
 The `agentos/` directory is a separate Gradle multi-project build integrated into Nx via
-`nx:run-commands`. Projects: `agentos-service`, `agentos-sdk`, `agentos-plugins-filesystem`,
-`agentos-datetime-plugin`.
+`nx:run-commands`. Publishable projects carry the `platform:jvm` tag — use
+`nx show projects --projects="tag:platform:jvm"` to get the current list.
+`agentos-plugins-filesystem` is a legacy project — it has no `platform:jvm` tag and is not published.
+
+Nx integration is handled by a **local plugin** at `tools/plugins/agentos-gradle/src/agentos-gradle.ts`
+(not `@nx/gradle`). It globs `agentos/*/build.gradle.kts` and infers `build`, `test`, `clean`,
+`nx-release-publish`, `publish` targets only for projects that already have a `project.json`.
 
 Key patterns:
 - All Gradle targets set `"cwd": "agentos"` in options
@@ -62,14 +67,23 @@ Boundary rules enforced in root `eslint.config.js`:
 ## CI Architecture
 
 Two GitHub Actions workflows in `.github/workflows/`:
-- **`validate.yml`**: PR validation — runs `nx affected --target="lint,test"` + `check-openapi-spec`
-- **`release.yml`**: Push to master — `nx release`, Electron desktop packaging (macOS-signed .pkg),
-  Gradle SDK publish to GitHub Packages
+- **`validate.yml`**: PR validation — runs `nx affected --target="lint,test"` + `check-openapi-spec`.
+  JVM projects are handled separately: `nx show projects --affected --projects="tag:platform:jvm" --json --quiet`
+  resolves affected names first, then `nx run-many` is called with explicit names (tag filter can't
+  be forwarded to Gradle executors directly).
+- **`release.yml`**: Push to master — 4 jobs in sequence:
+  1. `check-release` — detects releasable commits since last tag
+  2. `release` — runs `nx release` (version bump, changelog, GitHub release, npm publish for Node projects)
+  3. `desktop-release` — macOS runner, signs and packages `.pkg` for `tag:platform:node` desktop apps, uploads to GitHub Release
+  4. `compute-jvm-projects` — resolves `tag:platform:jvm` projects via `nx show projects --json --quiet | jq -c '.'`
+  5. `publish-agentos-artifacts` — matrix job over the dynamic list, publishes each JVM project to GitHub Packages
 
 ## Release System
 
-Uses `nx release` with conventional commits. Projects released: `server`, `client`, `web`,
-`desktop`, `desktop-twin`. Tag pattern: `release/{version}`.
+Uses `nx release` with conventional commits. Tag pattern: `release/{version}`.
+- **Node projects** selected via `tag:platform:node` in `nx.json` release config
+- **JVM projects** selected via `tag:platform:jvm` — `agentos-plugins-filesystem` explicitly does NOT carry this tag (legacy, not published)
+- Adding a new publishable project only requires the right `platform:*` tag — no CI config changes needed
 
 ## Cache Debugging Checklist
 

--- a/docs/nxpert/01-coday-nx-knowledge.md
+++ b/docs/nxpert/01-coday-nx-knowledge.md
@@ -71,17 +71,17 @@ Two GitHub Actions workflows in `.github/workflows/`:
   JVM projects are handled separately: `nx show projects --affected --projects="tag:platform:jvm" --json --quiet`
   resolves affected names first, then `nx run-many` is called with explicit names (tag filter can't
   be forwarded to Gradle executors directly).
-- **`release.yml`**: Push to master — 4 jobs in sequence:
+- **`release.yml`**: Push to master — 5 jobs in sequence:
   1. `check-release` — detects releasable commits since last tag
   2. `release` — runs `nx release` (version bump, changelog, GitHub release, npm publish for Node projects)
-  3. `desktop-release` — macOS runner, signs and packages `.pkg` for `tag:platform:node` desktop apps, uploads to GitHub Release
+  3. `desktop-release` — macOS runner, signs and packages `.pkg` for `tag:platform:npm` desktop apps, uploads to GitHub Release
   4. `compute-jvm-projects` — resolves `tag:platform:jvm` projects via `nx show projects --json --quiet | jq -c '.'`
   5. `publish-agentos-artifacts` — matrix job over the dynamic list, publishes each JVM project to GitHub Packages
 
 ## Release System
 
 Uses `nx release` with conventional commits. Tag pattern: `release/{version}`.
-- **Node projects** selected via `tag:platform:node` in `nx.json` release config
+- **npm projects** selected via `tag:platform:npm` in `nx.json` release config
 - **JVM projects** selected via `tag:platform:jvm` — `agentos-plugins-filesystem` explicitly does NOT carry this tag (legacy, not published)
 - Adding a new publishable project only requires the right `platform:*` tag — no CI config changes needed
 

--- a/docs/to-rework/RELEASE_PIPELINE.md
+++ b/docs/to-rework/RELEASE_PIPELINE.md
@@ -6,8 +6,16 @@ Releases trigger automatically on push to `master` via `.github/workflows/releas
 
 Project inclusion is tag-driven — no CI or `nx.json` changes needed:
 
-- Add `platform:node` to a Node.js/Electron project → published to npm
+- Add `platform:npm` to a Node.js/Electron project → published to npm
 - Add `platform:jvm` to a Kotlin/Gradle project → published to GitHub Packages
+
+## Pipeline jobs
+
+1. `check-release` — detects releasable commits since the last `release/*` tag
+2. `release` — runs `nx release`: version bump, changelog, GitHub release, npm publish for `platform:npm` projects
+3. `desktop-release` — macOS runner, signs and packages `.pkg` installers for desktop apps, uploads to the GitHub release
+4. `compute-jvm-projects` — resolves `tag:platform:jvm` project names at runtime via `nx show projects --json --quiet | jq -c '.'`
+5. `publish-agentos-artifacts` — matrix job (one runner per JVM project) that publishes each artifact to GitHub Packages
 
 ## Adding a new JVM plugin
 

--- a/docs/to-rework/RELEASE_PIPELINE.md
+++ b/docs/to-rework/RELEASE_PIPELINE.md
@@ -1,0 +1,17 @@
+# Release Pipeline
+
+Releases trigger automatically on push to `master` via `.github/workflows/release.yml`, using `nx release` with conventional commits.
+
+## Adding a new project to the release pipeline
+
+Project inclusion is tag-driven — no CI or `nx.json` changes needed:
+
+- Add `platform:node` to a Node.js/Electron project → published to npm
+- Add `platform:jvm` to a Kotlin/Gradle project → published to GitHub Packages
+
+## Adding a new JVM plugin
+
+For a new agentos plugin, the local Nx plugin at `tools/plugins/agentos-gradle/` automatically
+infers `build`, `test`, `clean`, and `publish` targets for any project that has a `project.json`
+and a `build.gradle.kts`. Adding `platform:jvm` to its tags is the only step needed to have it
+built, tested (in CI via `validate.yml`) and published (in CI via `release.yml`).

--- a/nx.json
+++ b/nx.json
@@ -68,7 +68,7 @@
     }
   ],
   "release": {
-    "projects": ["tag:platform:node", "tag:platform:jvm"],
+    "projects": ["tag:platform:npm", "tag:platform:jvm"],
     "releaseTagPattern": "release/{version}",
     "changelog": {
       "workspaceChangelog": {

--- a/nx.json
+++ b/nx.json
@@ -68,15 +68,7 @@
     }
   ],
   "release": {
-    "projects": [
-      "server",
-      "client",
-      "web",
-      "desktop",
-      "desktop-twin",
-      "tag:platform:jvm",
-      "!agentos-plugins-filesystem"
-    ],
+    "projects": ["tag:platform:node", "tag:platform:jvm"],
     "releaseTagPattern": "release/{version}",
     "changelog": {
       "workspaceChangelog": {


### PR DESCRIPTION
Replaces all hardcoded project lists in `nx.json` and `release.yml` with tag-driven selection.

### Changes
- Add `platform:npm` tag to the 5 npm-published projects
- Remove `platform:jvm` from `agentos-plugins-filesystem` (legacy, not published)
- `nx.json` release projects: `["tag:platform:npm", "tag:platform:jvm"]`
- `release.yml`: new `compute-jvm-projects` job resolves the JVM matrix dynamically via `nx show projects --json --quiet`
- Added `|| echo '[]'` fallback on the JVM resolver to avoid opaque failures on nx errors

Adding a new publishable project now only requires the right `platform:*` tag — no CI changes needed.