### PR TITLE
fix: relax super-admin creation/update via API with self-rule

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
@@ -75,7 +75,7 @@ class UserController(
             firstname = resource.firstname,
             lastname = resource.lastname,
             bio = resource.bio,
-            isAdmin = resource.isAdmin ?: false,  // null in request body → default non-admin
+            isAdmin = resource.isAdmin,
         )
 
     @GetMapping("/{id}")
@@ -127,15 +127,12 @@ class UserController(
         // needs ANOTHER super-admin to be demoted). auth.name is the User's UUID
         // as a String (cf. AgentOsAuthentication.getName()).
         //
-        // Body-omitted isAdmin (resource.isAdmin == null) preserves existing.isAdmin too:
-        // protects against silent demotes when a client PUTs a partial body without isAdmin.
+        // PUT is replace-semantic: clients are expected to send the full state.
+        // A partial body that omits isAdmin will reset it to `false` (Kotlin default
+        // on the DTO) — same convention as other resource DTOs in this API.
         val callerName = SecurityContextHolder.getContext().authentication?.name
         val isSelfEdit = callerName != null && id.toString() == callerName
-        val newIsAdmin = when {
-            isSelfEdit -> existing.isAdmin
-            resource.isAdmin != null -> resource.isAdmin
-            else -> existing.isAdmin
-        }
+        val newIsAdmin = if (isSelfEdit) existing.isAdmin else resource.isAdmin
         val updated = toDomain(resource).copy(
             metadata = existing.metadata,
             externalId = existing.externalId,        // server-managed (IdP key)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
@@ -11,6 +11,7 @@ import mu.KLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -33,8 +34,10 @@ import java.util.UUID
  * - Super-admin only (list, create, delete, batch fetch): `hasRole('SUPER_ADMIN')`
  * - `/me`: any authenticated user — resolves their own record
  *
- * The `update` override preserves [User.externalId] and [User.isAdmin] from the persisted
- * entity (mass-assignment guard — these are server-managed fields).
+ * The `update` method preserves [User.externalId] always (server-managed IdP key).
+ * [User.isAdmin] is preserved only in self-edit mode (caller == target). When a
+ * super-admin updates another user, [User.isAdmin] from the request body is honored.
+ * Self-rule guarantees no API call can ever leave the DB with zero super-admins.
  */
 @RestController
 @RequestMapping(
@@ -72,7 +75,7 @@ class UserController(
             firstname = resource.firstname,
             lastname = resource.lastname,
             bio = resource.bio,
-            isAdmin = resource.isAdmin,
+            isAdmin = resource.isAdmin ?: false,  // null in request body → default non-admin
         )
 
     @GetMapping("/{id}")
@@ -106,10 +109,8 @@ class UserController(
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     override fun create(@Valid @RequestBody resource: UserResource): UserResource {
-        // Never allow isAdmin promotion from request body — only system/bootstrap can grant super-admin.
-        val newUser = toDomain(resource).copy(isAdmin = false)
-        val created = service.create(newUser)
-        logger.info { "Super-admin created user ${created.id}" }
+        val created = service.create(toDomain(resource))
+        logger.info { "Super-admin created user ${created.id} (isAdmin=${created.isAdmin})" }
         return toResource(created)
     }
 
@@ -121,10 +122,24 @@ class UserController(
     ): UserResource {
         val existing = userService.findById(id)
             ?: throw ResourceNotFoundException("Entity not found: $id")
+        // Self-rule: a user can never change their own isAdmin via the API.
+        // Guarantees the DB never reaches 0 super-admins via API (a super-admin
+        // needs ANOTHER super-admin to be demoted). auth.name is the User's UUID
+        // as a String (cf. AgentOsAuthentication.getName()).
+        //
+        // Body-omitted isAdmin (resource.isAdmin == null) preserves existing.isAdmin too:
+        // protects against silent demotes when a client PUTs a partial body without isAdmin.
+        val callerName = SecurityContextHolder.getContext().authentication?.name
+        val isSelfEdit = callerName != null && id.toString() == callerName
+        val newIsAdmin = when {
+            isSelfEdit -> existing.isAdmin
+            resource.isAdmin != null -> resource.isAdmin
+            else -> existing.isAdmin
+        }
         val updated = toDomain(resource).copy(
             metadata = existing.metadata,
             externalId = existing.externalId,        // server-managed (IdP key)
-            isAdmin = existing.isAdmin,              // server-managed (only system/bootstrap can set)
+            isAdmin = newIsAdmin,                    // self-rule applied above
         )
         logger.info { "User profile $id updated" }
         return toResource(userService.update(updated))

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserResource.kt
@@ -19,6 +19,10 @@ import java.util.UUID
  * [externalId] is a read-only server-managed field (IdP key). HTTP clients may receive
  * it in responses but it is never written from the request body.
  *
+ * [isAdmin] is nullable on the request body so PATCH-like PUT (omitting the field)
+ * preserves the persisted value instead of silently demoting. On responses, the
+ * server always sets a non-null value derived from [User.isAdmin].
+ *
  * Annotated with @Schema(name = "User") so that the generated OpenAPI spec
  * keeps the schema name "User" instead of "UserResource".
  */
@@ -31,5 +35,5 @@ data class UserResource(
     val firstname: String? = null,
     val lastname: String? = null,
     val bio: String? = null,
-    val isAdmin: Boolean = false,
+    val isAdmin: Boolean? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserResource.kt
@@ -19,9 +19,10 @@ import java.util.UUID
  * [externalId] is a read-only server-managed field (IdP key). HTTP clients may receive
  * it in responses but it is never written from the request body.
  *
- * [isAdmin] is nullable on the request body so PATCH-like PUT (omitting the field)
- * preserves the persisted value instead of silently demoting. On responses, the
- * server always sets a non-null value derived from [User.isAdmin].
+ * [isAdmin] follows PUT replace-semantic: clients are expected to send the full
+ * state on update. Omitting the field on PUT will reset it to `false` (Kotlin
+ * default). The self-rule in the controller still protects against changing
+ * one's own [isAdmin], independently of body content.
  *
  * Annotated with @Schema(name = "User") so that the generated OpenAPI spec
  * keeps the schema name "User" instead of "UserResource".
@@ -35,5 +36,5 @@ data class UserResource(
     val firstname: String? = null,
     val lastname: String? = null,
     val bio: String? = null,
-    val isAdmin: Boolean? = null,
+    val isAdmin: Boolean = false,
 )

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSelfRuleMvcSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSelfRuleMvcSpec.kt
@@ -194,30 +194,33 @@ class UserControllerSelfRuleMvcSpec : StringSpec() {
         }
 
         // -----------------------------------------------------------------
-        // PUT — partial body without isAdmin field preserves existing
-        // (regression cover for adversarial finding F12)
+        // PUT — replace semantic : a body omitting isAdmin resets it to false.
+        // Documents the API contract and aligns with the rest of the API
+        // (e.g. AiModelResource.priority defaulting to 0). Clients on PUT must
+        // send the full state.
         // -----------------------------------------------------------------
 
-        "PUT partial body (no isAdmin field) on OTHER super-admin preserves existing.isAdmin=true" {
+        "PUT partial body (no isAdmin field) on OTHER super-admin resets isAdmin to false (replace-semantic)" {
             val target = User(
                 metadata = EntityMetadata(id = targetUserId),
                 externalId = "other-admin@example.com",
                 email = "other-admin@example.com",
-                isAdmin = true,    // existing target IS a super-admin
+                isAdmin = true,
             )
             val captured = slot<User>()
             every { userService.getCurrentUser() } returns superAdmin
             every { userService.findById(targetUserId) } returns target
             every { userService.update(capture(captured)) } answers { firstArg() }
 
-            // Body intentionally omits isAdmin — must not silently demote the target.
             mockMvc.perform(
                 put("/api/users/$targetUserId")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{ "id": "$targetUserId", "email": "other-admin@example.com", "firstname": "Renamed" }""")
             ).andExpect(status().isOk)
 
-            captured.captured.isAdmin shouldBe true  // PRESERVED — no silent demote
+            // PUT is replace, not patch — omitted isAdmin field deserialises to default false.
+            // The self-rule does NOT apply here because caller != target.
+            captured.captured.isAdmin shouldBe false
         }
 
         // -----------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSelfRuleMvcSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSelfRuleMvcSpec.kt
@@ -1,0 +1,238 @@
+package io.whozoss.agentos.user
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.slot
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+/**
+ * MVC integration tests for the `isAdmin` self-rule introduced in the
+ * "relax super-admin creation/update via API" hotfix.
+ *
+ * **What is tested at HTTP level:**
+ *  - `POST /api/users` honors `isAdmin` from the body when the caller is a super-admin.
+ *  - `PUT /api/users/{id}` honors `isAdmin` from the body when the caller is a super-admin
+ *     AND the target is NOT the caller (promote/demote on another user).
+ *  - `PUT /api/users/{id}` PRESERVES `existing.isAdmin` when the caller IS the target
+ *     (self-rule — applies to both super-admins and non-admins).
+ *
+ * **Auth mechanism**: [UserService] is mocked, so `getCurrentUser()` controls the
+ * identity that [io.whozoss.agentos.security.declarative.AgentOsAuthentication] carries
+ * into Spring Security. `auth.name` ends up being `mockedUser.id.toString()`.
+ *
+ * Bean Validation and the basic happy-path stay covered by [UserControllerMvcIntegrationSpec].
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UserControllerSelfRuleMvcSpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var mockMvc: MockMvc
+
+    @MockkBean(relaxed = true) lateinit var userService: UserService
+
+    @Suppress("unused")
+    @MockkBean(relaxed = true) lateinit var permissionService: PermissionService
+
+    private val superAdminId = UUID.randomUUID()
+    private val regularUserId = UUID.randomUUID()
+    private val targetUserId = UUID.randomUUID()
+
+    private val superAdmin = User(
+        metadata = EntityMetadata(id = superAdminId),
+        externalId = "root@example.com",
+        email = "root@example.com",
+        isAdmin = true,
+    )
+
+    private val regularUser = User(
+        metadata = EntityMetadata(id = regularUserId),
+        externalId = "alice@example.com",
+        email = "alice@example.com",
+        isAdmin = false,
+    )
+
+    init {
+
+        // -----------------------------------------------------------------
+        // POST /api/users — super-admin can create a super-admin (AC1)
+        // -----------------------------------------------------------------
+
+        "POST with isAdmin=true (caller=super-admin) persists isAdmin=true" {
+            val captured = slot<User>()
+            every { userService.getCurrentUser() } returns superAdmin
+            every { userService.create(capture(captured)) } answers { firstArg() }
+
+            mockMvc.perform(
+                post("/api/users")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "email": "promoted@example.com", "isAdmin": true }""")
+            ).andExpect(status().isCreated)
+
+            captured.captured.isAdmin shouldBe true
+        }
+
+        // -----------------------------------------------------------------
+        // POST /api/users — default isAdmin=false stays false (AC2)
+        // -----------------------------------------------------------------
+
+        "POST without isAdmin (caller=super-admin) persists isAdmin=false" {
+            val captured = slot<User>()
+            every { userService.getCurrentUser() } returns superAdmin
+            every { userService.create(capture(captured)) } answers { firstArg() }
+
+            mockMvc.perform(
+                post("/api/users")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "email": "regular@example.com" }""")
+            ).andExpect(status().isCreated)
+
+            captured.captured.isAdmin shouldBe false
+        }
+
+        // -----------------------------------------------------------------
+        // PUT — super-admin promotes another user (AC4)
+        // -----------------------------------------------------------------
+
+        "PUT with isAdmin=true on OTHER user (caller=super-admin) persists isAdmin=true" {
+            val target = User(
+                metadata = EntityMetadata(id = targetUserId),
+                externalId = "target@example.com",
+                email = "target@example.com",
+                isAdmin = false,
+            )
+            val captured = slot<User>()
+            every { userService.getCurrentUser() } returns superAdmin
+            every { userService.findById(targetUserId) } returns target
+            every { userService.update(capture(captured)) } answers { firstArg() }
+
+            mockMvc.perform(
+                put("/api/users/$targetUserId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$targetUserId", "email": "target@example.com", "isAdmin": true }""")
+            ).andExpect(status().isOk)
+
+            captured.captured.isAdmin shouldBe true
+        }
+
+        // -----------------------------------------------------------------
+        // PUT — super-admin demotes another user (AC5)
+        // -----------------------------------------------------------------
+
+        "PUT with isAdmin=false on OTHER user (caller=super-admin) persists isAdmin=false" {
+            val target = User(
+                metadata = EntityMetadata(id = targetUserId),
+                externalId = "target@example.com",
+                email = "target@example.com",
+                isAdmin = true,
+            )
+            val captured = slot<User>()
+            every { userService.getCurrentUser() } returns superAdmin
+            every { userService.findById(targetUserId) } returns target
+            every { userService.update(capture(captured)) } answers { firstArg() }
+
+            mockMvc.perform(
+                put("/api/users/$targetUserId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$targetUserId", "email": "target@example.com", "isAdmin": false }""")
+            ).andExpect(status().isOk)
+
+            captured.captured.isAdmin shouldBe false
+        }
+
+        // -----------------------------------------------------------------
+        // PUT — self-rule blocks self-demote for a super-admin (AC6)
+        // -----------------------------------------------------------------
+
+        "PUT with isAdmin=false on SELF (caller=super-admin, existing isAdmin=true) preserves isAdmin=true" {
+            val captured = slot<User>()
+            every { userService.getCurrentUser() } returns superAdmin
+            every { userService.findById(superAdminId) } returns superAdmin
+            every { userService.update(capture(captured)) } answers { firstArg() }
+
+            mockMvc.perform(
+                put("/api/users/$superAdminId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$superAdminId", "email": "root@example.com", "isAdmin": false }""")
+            ).andExpect(status().isOk)
+
+            captured.captured.isAdmin shouldBe true   // PRESERVED
+        }
+
+        // -----------------------------------------------------------------
+        // PUT — self-rule blocks self-promote for a regular user (AC7)
+        // -----------------------------------------------------------------
+
+        "PUT with isAdmin=true on SELF (caller=non-admin, existing isAdmin=false) preserves isAdmin=false" {
+            val captured = slot<User>()
+            every { userService.getCurrentUser() } returns regularUser
+            every { userService.findById(regularUserId) } returns regularUser
+            every { userService.update(capture(captured)) } answers { firstArg() }
+
+            mockMvc.perform(
+                put("/api/users/$regularUserId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$regularUserId", "email": "alice@example.com", "isAdmin": true }""")
+            ).andExpect(status().isOk)
+
+            captured.captured.isAdmin shouldBe false  // PRESERVED
+        }
+
+        // -----------------------------------------------------------------
+        // PUT — partial body without isAdmin field preserves existing
+        // (regression cover for adversarial finding F12)
+        // -----------------------------------------------------------------
+
+        "PUT partial body (no isAdmin field) on OTHER super-admin preserves existing.isAdmin=true" {
+            val target = User(
+                metadata = EntityMetadata(id = targetUserId),
+                externalId = "other-admin@example.com",
+                email = "other-admin@example.com",
+                isAdmin = true,    // existing target IS a super-admin
+            )
+            val captured = slot<User>()
+            every { userService.getCurrentUser() } returns superAdmin
+            every { userService.findById(targetUserId) } returns target
+            every { userService.update(capture(captured)) } answers { firstArg() }
+
+            // Body intentionally omits isAdmin — must not silently demote the target.
+            mockMvc.perform(
+                put("/api/users/$targetUserId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$targetUserId", "email": "other-admin@example.com", "firstname": "Renamed" }""")
+            ).andExpect(status().isOk)
+
+            captured.captured.isAdmin shouldBe true  // PRESERVED — no silent demote
+        }
+
+        // -----------------------------------------------------------------
+        // PUT — non-admin on OTHER user → 403
+        // (regression cover for adversarial finding F7a / F19)
+        // -----------------------------------------------------------------
+
+        "PUT on OTHER user when caller is non-admin returns 403" {
+            every { userService.getCurrentUser() } returns regularUser
+
+            mockMvc.perform(
+                put("/api/users/$targetUserId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "id": "$targetUserId", "email": "target@example.com", "isAdmin": true }""")
+            ).andExpect(status().isForbidden)
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSpec.kt
@@ -4,11 +4,29 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
 import java.util.UUID
+
+/**
+ * Run [block] with [auth] installed in the SecurityContextHolder, then clear.
+ * Mirrors what AgentOsAuthenticationFilter does at runtime so unit tests of
+ * UserController.update can exercise the self-rule branch.
+ */
+private inline fun <T> withAuthContext(auth: Authentication, block: () -> T): T {
+    val previous = SecurityContextHolder.getContext().authentication
+    SecurityContextHolder.getContext().authentication = auth
+    try {
+        return block()
+    } finally {
+        SecurityContextHolder.getContext().authentication = previous
+    }
+}
 
 /**
  * Unit tests for [UserController].
@@ -73,7 +91,7 @@ class UserControllerSpec : StringSpec({
 
         val result = controller.toResource(u)
 
-        result shouldBe UserResource(id = id, email = "bob@example.com", externalId = "ext-key", firstname = "Bob", lastname = "Jones", bio = "dev")
+        result shouldBe UserResource(id = id, email = "bob@example.com", externalId = "ext-key", firstname = "Bob", lastname = "Jones", bio = "dev", isAdmin = false)
     }
 
     "toResource returns null email when user has no email (local mode)" {
@@ -213,23 +231,23 @@ class UserControllerSpec : StringSpec({
     // update (inherited from EntityController)
     // -------------------------------------------------------------------------
 
-    "update delegates to service when user exists and returns mapped resource" {
-        val u = user()
-        val updatedResource = resource(id = u.id, email = u.email, firstname = "Updated")
-        // toDomain produces externalId=""; update() replaces it with the existing entity's externalId
-        val updatedDomain = controller.toDomain(updatedResource).copy(
-            metadata = u.metadata,
-            externalId = u.externalId,
-            isAdmin = u.isAdmin,
-        )
+    "update delegates to service and preserves isAdmin via self-rule" {
+        // u.isAdmin = true and the body sends isAdmin = false (attempt self-demote).
+        // The self-rule MUST keep isAdmin = true on the persisted entity.
+        val u = user(isAdmin = true)
+        val updatedResource = resource(id = u.id, email = u.email, firstname = "Updated", isAdmin = false)
+        val captured = slot<User>()
+        val auth = mockk<Authentication> { every { name } returns u.id.toString() }
         every { userService.getCurrentUser() } returns u
         every { userService.findByIds(listOf(u.id)) } returns listOf(u)
         every { userService.findById(u.id) } returns u
-        every { userService.update(any()) } returns updatedDomain
+        every { userService.update(capture(captured)) } answers { firstArg() }
 
-        val result = controller.update(u.id, updatedResource)
+        val result = withAuthContext(auth) { controller.update(u.id, updatedResource) }
 
-        result shouldBe controller.toResource(updatedDomain)
+        captured.captured.isAdmin shouldBe true        // PRESERVED — self-rule active
+        captured.captured.externalId shouldBe u.externalId  // server-managed, never from body
+        result.isAdmin shouldBe true
         verify(exactly = 1) { userService.update(any()) }
     }
 
@@ -237,13 +255,108 @@ class UserControllerSpec : StringSpec({
         val id = UUID.randomUUID()
         val currentUser = user(id = id)  // Current user is updating their own profile
         val r = resource(id = id)
+        val auth = mockk<Authentication> { every { name } returns id.toString() }
         every { userService.getCurrentUser() } returns currentUser
         every { userService.findByIds(listOf(id)) } returns emptyList()
         every { userService.findById(id) } returns null
 
-        val ex = runCatching { controller.update(id, r) }.exceptionOrNull()
+        val ex = runCatching { withAuthContext(auth) { controller.update(id, r) } }.exceptionOrNull()
 
         (ex is ResourceNotFoundException) shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // create — isAdmin promotion (relaxed in this story)
+    // -------------------------------------------------------------------------
+
+    "create with isAdmin=true persists isAdmin=true (super-admin can promote)" {
+        val adminUser = user(isAdmin = true)
+        val r = resource(id = null, email = "promoted@example.com", isAdmin = true)
+        val captured = slot<User>()
+        every { userService.getCurrentUser() } returns adminUser
+        every { userService.create(capture(captured)) } answers { firstArg() }
+
+        val result = controller.create(r)
+
+        captured.captured.isAdmin shouldBe true
+        result.isAdmin shouldBe true
+    }
+
+    "create with isAdmin=false persists isAdmin=false (default)" {
+        val adminUser = user(isAdmin = true)
+        val r = resource(id = null, email = "regular@example.com", isAdmin = false)
+        val captured = slot<User>()
+        every { userService.getCurrentUser() } returns adminUser
+        every { userService.create(capture(captured)) } answers { firstArg() }
+
+        controller.create(r)
+
+        captured.captured.isAdmin shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // update — self-rule (isAdmin preservation when caller == target)
+    // -------------------------------------------------------------------------
+
+    "update super-admin on OTHER user with isAdmin=true persists isAdmin=true (promote)" {
+        val adminId = UUID.randomUUID()
+        val targetId = UUID.randomUUID()
+        val target = user(id = targetId, isAdmin = false)
+        val r = resource(id = targetId, email = target.email, isAdmin = true)
+        val auth = mockk<Authentication> { every { name } returns adminId.toString() }
+        val captured = slot<User>()
+        every { userService.findById(targetId) } returns target
+        every { userService.update(capture(captured)) } answers { firstArg() }
+
+        val result = withAuthContext(auth) { controller.update(targetId, r) }
+
+        captured.captured.isAdmin shouldBe true
+        result.isAdmin shouldBe true
+    }
+
+    "update super-admin on OTHER user with isAdmin=false persists isAdmin=false (demote)" {
+        val adminId = UUID.randomUUID()
+        val targetId = UUID.randomUUID()
+        val target = user(id = targetId, isAdmin = true)
+        val r = resource(id = targetId, email = target.email, isAdmin = false)
+        val auth = mockk<Authentication> { every { name } returns adminId.toString() }
+        val captured = slot<User>()
+        every { userService.findById(targetId) } returns target
+        every { userService.update(capture(captured)) } answers { firstArg() }
+
+        withAuthContext(auth) { controller.update(targetId, r) }
+
+        captured.captured.isAdmin shouldBe false
+    }
+
+    "update self with isAdmin=false on existing super-admin preserves isAdmin=true (self-rule blocks demote)" {
+        val selfId = UUID.randomUUID()
+        val self = user(id = selfId, isAdmin = true)
+        val r = resource(id = selfId, email = self.email, isAdmin = false)  // attempt self-demote
+        val auth = mockk<Authentication> { every { name } returns selfId.toString() }
+        val captured = slot<User>()
+        every { userService.findById(selfId) } returns self
+        every { userService.update(capture(captured)) } answers { firstArg() }
+
+        val result = withAuthContext(auth) { controller.update(selfId, r) }
+
+        captured.captured.isAdmin shouldBe true   // PRESERVED
+        result.isAdmin shouldBe true
+    }
+
+    "update self with isAdmin=true on existing non-admin preserves isAdmin=false (self-rule blocks promote)" {
+        val selfId = UUID.randomUUID()
+        val self = user(id = selfId, isAdmin = false)
+        val r = resource(id = selfId, email = self.email, isAdmin = true)  // attempt self-promote
+        val auth = mockk<Authentication> { every { name } returns selfId.toString() }
+        val captured = slot<User>()
+        every { userService.findById(selfId) } returns self
+        every { userService.update(capture(captured)) } answers { firstArg() }
+
+        val result = withAuthContext(auth) { controller.update(selfId, r) }
+
+        captured.captured.isAdmin shouldBe false  // PRESERVED
+        result.isAdmin shouldBe false
     }
 
     // -------------------------------------------------------------------------

--- a/libs/agentos-ui/src/lib/components/user-form/user-form.component.html
+++ b/libs/agentos-ui/src/lib/components/user-form/user-form.component.html
@@ -86,7 +86,9 @@
 
         <div class="user-form__field user-form__field--checkbox">
           <input id="uf-isAdmin" class="user-form__checkbox" type="checkbox" formControlName="isAdmin" />
-          <label class="user-form__label user-form__label--checkbox" for="uf-isAdmin">Administrator</label>
+          <label class="user-form__label user-form__label--checkbox" for="uf-isAdmin">
+            Super admin (full access to AgentOS)
+          </label>
         </div>
       </div>
 

--- a/libs/agentos-ui/src/lib/components/user-form/user-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/user-form/user-form.component.ts
@@ -3,6 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms'
 import { ActivatedRoute, Router } from '@angular/router'
 import { UserAdminStateService } from '../../services/user-admin-state.service'
+import { UserStateService } from '../../services/user-state.service'
 
 /**
  * UserFormComponent — create and edit form for a user (admin view).
@@ -31,6 +32,7 @@ export class UserFormComponent implements OnInit {
   private readonly router = inject(Router)
   private readonly destroyRef = inject(DestroyRef)
   private readonly userAdminState = inject(UserAdminStateService)
+  private readonly userState = inject(UserStateService)
 
   private readonly userId = this.route.snapshot.params['userId'] as string | undefined
 
@@ -49,6 +51,26 @@ export class UserFormComponent implements OnInit {
 
   ngOnInit(): void {
     if (!this.isEditMode) return
+
+    // Self-rule: the backend ignores isAdmin changes from the caller on their own
+    // record. Disable the checkbox in self-edit mode so the UX matches the contract.
+    // Fallback: if currentUser hasn't been loaded yet (e.g. direct landing), fetch it
+    // before deciding — without this, a self-edit could leave the checkbox enabled.
+    const applySelfEditDisable = () => {
+      if (this.userState.currentUser()?.id === this.userId) {
+        this.form.controls.isAdmin.disable()
+      }
+    }
+    if (this.userState.currentUser()) {
+      applySelfEditDisable()
+    } else {
+      this.userState
+        .loadMe()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: () => applySelfEditDisable(),
+        })
+    }
 
     // Try to resolve from already-loaded state first (avoids extra HTTP call).
     const existing = this.userAdminState.users().find((u) => u.id === this.userId)


### PR DESCRIPTION
## Summary

- **Backend** — `POST /api/users` honors body `isAdmin` (gated `SUPER_ADMIN`) ; `PUT /api/users/{id}` honors body `isAdmin` only when caller ≠ target.
- **Self-rule** — a user can NEVER change their own `isAdmin` via the API. Combined with `@PreAuthorize`, this guarantees the DB cannot reach zero super-admins via API calls (proof in code comments).
- **Front** — admin user-form now includes an `isAdmin` checkbox, disabled in self-edit mode. Resolves the TS compile error from #811.

## Why

1. **Compile fix** — Since PR #811 (`WZ-29564 permissions v2`), the generated TS client requires `User.isAdmin` (boolean), breaking `user-form.component.ts:95` with `TS2345 — Property 'isAdmin' is missing`. The form was never updated.
2. **Operational** — bootstrap was the only path to create a super-admin. If the bootstrap admin leaves, no one can promote a replacement without direct DB manipulation.
3. **Contract honesty** — the OpenAPI schema declared `isAdmin: required` but the backend force-set `false`. Lying contract.

## Key design decisions

- **PUT replace-semantic** — `isAdmin: Boolean = false` (non-null, with default) is consistent with the rest of the API (e.g. `AiModelResource.priority: Int = 0`). Clients on PUT are expected to send the full state; an omitted field deserialises to the Kotlin default. A pinned regression test documents this behavior.
- **Self-rule subsumes "last super-admin" guard** — explicit decision documented in spec. Proof: only another super-admin can demote (non-admins are blocked by `@PreAuthorize`), so if there is ONE super-admin, no one can demote them. No counter needed.
- **No dedicated audit logger** — relies on the existing `userService.create/.update` info logs. Can be revisited in a follow-up if compliance requires.
- **`override` + `SecurityContextHolder`** — kept the parent's `update` signature to avoid Spring registering two competing `@PutMapping` handlers. `Authentication` is read from `SecurityContextHolder` inside the method.

## Test plan

Backend unit (`UserControllerSpec`) :
- [x] POST `isAdmin: true` (caller = super-admin) → persists `true`
- [x] POST `isAdmin: false` → persists `false`
- [x] PUT super-admin on OTHER user `isAdmin: true` → promote
- [x] PUT super-admin on OTHER user `isAdmin: false` → demote
- [x] PUT self with `isAdmin: false` (existing `true`) → **preserved** (self-rule)
- [x] PUT self with `isAdmin: true` (existing `false`) → **preserved** (self-rule)
- [x] PUT delegates and preserves isAdmin via self-rule (regression on existing test)

Backend MVC integration (`UserControllerSelfRuleMvcSpec` — new) :
- [x] All of the above through full Spring MVC stack
- [x] PUT partial body on OTHER super-admin (no `isAdmin` field) → **resets to false** (replace-semantic, pinning test)
- [x] PUT on OTHER user when caller is non-admin → 403

