### PR TITLE
fix: PR #832 review follow-ups (audit log, UX fallback, test pin, rename)

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
@@ -138,8 +138,12 @@ class UserController(
             externalId = existing.externalId,        // server-managed (IdP key)
             isAdmin = newIsAdmin,                    // self-rule applied above
         )
-        logger.info { "User profile $id updated" }
-        return toResource(userService.update(updated))
+        val persisted = userService.update(updated)
+        logger.info {
+            "User profile $id updated by caller=$callerName " +
+                "(isAdmin: ${existing.isAdmin} -> ${persisted.isAdmin}, selfEdit=$isSelfEdit)"
+        }
+        return toResource(persisted)
     }
 
     @DeleteMapping("/{id}")

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSelfRuleIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSelfRuleIntegrationSpec.kt
@@ -6,6 +6,7 @@ import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.slot
+import io.mockk.verify
 import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,7 +40,7 @@ import java.util.UUID
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class UserControllerSelfRuleMvcSpec : StringSpec() {
+class UserControllerSelfRuleIntegrationSpec : StringSpec() {
     override fun extensions() = listOf(SpringExtension)
 
     @Autowired lateinit var mockMvc: MockMvc
@@ -236,6 +237,11 @@ class UserControllerSelfRuleMvcSpec : StringSpec() {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{ "id": "$targetUserId", "email": "target@example.com", "isAdmin": true }""")
             ).andExpect(status().isForbidden)
+
+            // Pin: the 403 must come from @PreAuthorize, not from a relaxed-mock
+            // findById returning null (which would yield 404). If the annotation
+            // were ever removed, this assertion would fail.
+            verify(exactly = 0) { userService.findById(targetUserId) }
         }
     }
 }

--- a/libs/agentos-ui/src/lib/components/user-form/user-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/user-form/user-form.component.ts
@@ -69,6 +69,9 @@ export class UserFormComponent implements OnInit {
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe({
           next: () => applySelfEditDisable(),
+          // If we can't resolve the current user, disable the checkbox unconditionally
+          // so the UI never falsely advertises a permission the backend will reject.
+          error: () => this.form.controls.isAdmin.disable(),
         })
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #832 (already merged). Addresses 4 of the 5 review comments from @vincent-audibert-whoz that did not block the original merge but are worth landing for hygiene.

- **Backend audit log** — `UserController.update` now logs caller identity, both `isAdmin` values (before/after) and the `selfEdit` flag. Privilege changes are now traceable from the standard log stream without a dedicated audit logger.
- **Frontend UX fallback** — `user-form.component.ts`: `loadMe()` subscription now has an `error` callback that disables the `isAdmin` checkbox unconditionally, so the UI never advertises a permission the backend will reject (e.g. on network error / 401).
- **Test pin** — `UserControllerSelfRuleIntegrationSpec`: the "non-admin → 403" test now asserts `verify(exactly = 0) { userService.findById(targetUserId) }`, pinning the intent that the 403 must come from `@PreAuthorize`, not from a relaxed-mock returning `null` (which would yield 404).
- **Rename** — `UserControllerSelfRuleMvcSpec.kt` → `UserControllerSelfRuleIntegrationSpec.kt` per project convention (`*IntegrationSpec.kt`).

## Not addressed

The 5th comment (inject `Authentication` as a method parameter instead of reading `SecurityContextHolder`) is **not implementable** without a refactor of `EntityController`: keeping `override` forbids extending the signature, and dropping `override` registers two competing `@PutMapping("/{id}")` handlers (this is exactly the regression we hit during the original implementation, documented in the tech-spec frontmatter under `implementation_deviation`). The silent-failure scenario is closed in practice by the `@PreAuthorize` SpEL on the same method (which evaluates `authentication.name` and throws NPE if `authentication` is null, blocking entry into the body via the MVC stack). Discussion thread: https://github.com/whoz-oss/coday/pull/832#discussion_r3189010869.

## Test plan

- [x] `:agentos-service:test --tests UserControllerSpec --tests UserControllerSelfRuleIntegrationSpec` — green
- [ ] CI validate workflow
- [ ] Smoke check log output on `PUT /api/users/{id}` (super-admin promote/demote on another user, and self-edit)
- [ ] Smoke check UX: `loadMe()` fail (offline) → checkbox disabled in self-edit