### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,16 +6,28 @@
   "targetDefaults": {
     "@nx/js:tsc": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^default"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^default"
+      ]
     },
     "@nx/esbuild:esbuild": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^default"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^default"
+      ]
     },
     "nx-release-publish": {
-      "dependsOn": ["build"]
+      "dependsOn": [
+        "build"
+      ]
     },
     "lint": {
       "cache": true
@@ -25,12 +37,21 @@
     },
     "@angular/build:application": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^default"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^default"
+      ]
     },
     "@nx/jest:jest": {
       "cache": true,
-      "inputs": ["default", "^default", "{workspaceRoot}/jest.preset.cjs"],
+      "inputs": [
+        "default",
+        "^default",
+        "{workspaceRoot}/jest.preset.cjs"
+      ],
       "options": {
         "passWithNoTests": true
       },
@@ -68,7 +89,10 @@
     }
   ],
   "release": {
-    "projects": ["tag:platform:npm", "tag:platform:jvm"],
+    "projects": [
+      "tag:platform:npm",
+      "tag:platform:jvm"
+    ],
     "releaseTagPattern": "release/{version}",
     "changelog": {
       "workspaceChangelog": {
@@ -82,7 +106,9 @@
     },
     "version": {
       "conventionalCommits": true,
-      "manifestRootsToUpdate": ["apps/{projectName}"],
+      "manifestRootsToUpdate": [
+        "apps/{projectName}"
+      ],
       "versionActionsOptions": {
         "skipLockFileUpdate": true
       },
@@ -104,8 +130,14 @@
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*"],
-    "production": ["default", "!{projectRoot}/src/test/**/*"]
+    "default": [
+      "{projectRoot}/**/*"
+    ],
+    "production": [
+      "default",
+      "!{projectRoot}/src/test/**/*"
+    ]
   },
-  "analytics": false
+  "analytics": false,
+  "nxCloudId": "69faead76f99323de41d00d3"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/69faead5fa220033121a61f8/workspaces/69faead76f99323de41d00d3

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.