### PR TITLE
feat(ci): split validate workflow into parallel ts/jvm jobs with merge gate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,30 @@ defaults:
     shell: bash
 
 jobs:
-  validate:
+  validate-ts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint and test TypeScript projects
+        run: npx nx affected --base=origin/${GITHUB_BASE_REF} --head=HEAD --target="lint,test" --exclude="tag:platform:jvm" --parallel=$NX_MAX_WORKERS --verbose
+
+  validate-jvm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,9 +63,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint and test TypeScript projects
-        run: npx nx affected --base=origin/${GITHUB_BASE_REF} --head=HEAD --target="lint,test" --exclude="tag:platform:jvm" --parallel=$NX_MAX_WORKERS --verbose
-
       # nx affected cannot be used directly with --projects="tag:platform:jvm" because the tag filter
       # gets forwarded to the underlying Gradle/Jest commands as an unknown flag, causing build failures.
       # Instead, we resolve the affected JVM project names first via nx show projects, then pass the
@@ -58,3 +78,18 @@ jobs:
 
       - name: Check OpenAPI spec is up to date
         run: npx nx affected --base=origin/${GITHUB_BASE_REF} --head=HEAD --target="check-openapi-spec" --verbose
+
+  merge-gate:
+    runs-on: ubuntu-latest
+    needs: [validate-ts, validate-jvm]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          results='${{ toJson(needs.*.result) }}'
+          echo "Job results: $results"
+          if echo "$results" | grep -qE '"failure"|"cancelled"'; then
+            echo "One or more validation jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "All validation jobs passed or were skipped"


### PR DESCRIPTION
Split the single sequential `validate` job into two parallel jobs (`validate-ts`, `validate-jvm`)
and add a `merge-gate` job as the single required status check for branch protection.

Closes #841