### PR TITLE
feat: #31783 call default agent - namespace defaultAgentName + routing fallback

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -29,23 +29,6 @@ interface AgentService {
     ): Agent
 
     /**
-     * Get the default agent for cases where no agent is explicitly selected.
-     * Returns null if the default [io.whozoss.agentos.agentConfig.AgentConfig]
-     * has no [io.whozoss.agentos.agentConfig.AgentConfig.modelName] and no
-     * [io.whozoss.agentos.aiModel.AiModel] is configured for the namespace.
-     */
-    fun getDefaultAgent(context: AgentExecutionContext): Agent?
-
-    /**
-     * Get the logical name of the default agent for [namespaceId] without
-     * instantiating a full Agent.
-     *
-     * Always returns a non-null name: when no [io.whozoss.agentos.agentConfig.AgentConfig]
-     * has been persisted for the namespace, the built-in fallback config name is returned.
-     */
-    fun getDefaultAgentName(namespaceId: UUID): String
-
-    /**
      * Resolve the canonical name for [namePart] within [namespaceId] by
      * [io.whozoss.agentos.agentConfig.AgentConfig] name matching,
      * without instantiating a full Agent.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -29,15 +29,6 @@ import java.util.UUID
  *   base system prompt, and resolve the model via `config.modelName`
  *   (alias-first, then apiName).
  * - If not found: throws [IllegalArgumentException].
- *
- * ## Resolution strategy for [getDefaultAgent] / [getDefaultAgentName]
- *
- * Delegates to [AgentConfigService.findDefault], which always returns a non-null
- * [AgentConfig] — either the oldest persisted config in the namespace, or the
- * built-in fallback. [getDefaultAgentName] is therefore always non-null.
- *
- * [getDefaultAgent] can still return null when the resolved config has no
- * [AgentConfig.modelName] and no [AiModel] is configured for the namespace.
  */
 @Service
 class AgentServiceImpl(
@@ -61,19 +52,6 @@ class AgentServiceImpl(
                 )
         return createAgentFromConfig(agentConfig, context)
     }
-
-    override fun getDefaultAgent(context: AgentExecutionContext): Agent? {
-        val config =
-            agentConfigService
-                .findDefault(context.namespaceId)
-                .let { if (it.hasNoRealNamespace()) it.copy(namespaceId = context.namespaceId) else it }
-        return runCatching { createAgentFromConfig(config, context) }
-            .onFailure {
-                logger.warn { "[AgentService] Cannot instantiate default agent for namespace ${context.namespaceId}: ${it.message}" }
-            }.getOrNull()
-    }
-
-    override fun getDefaultAgentName(namespaceId: UUID): String = agentConfigService.findDefault(namespaceId).name
 
     override fun resolveAgentName(
         namePart: String,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
@@ -56,18 +56,4 @@ data class AgentConfig(
      * Defaults to false so existing agents are unaffected.
      */
     val advancedExecution: Boolean = false,
-) : Entity {
-    /**
-     * Returns true when this config was not loaded from a real namespace — i.e. it is the
-     * built-in fallback produced by [AgentConfigServiceImpl.DEFAULT_AGENT_CONFIG].
-     *
-     * The fallback carries [NO_NAMESPACE_ID] as a sentinel so callers can detect it and
-     * substitute the real namespace at runtime.
-     */
-    fun hasNoRealNamespace(): Boolean = namespaceId == NO_NAMESPACE_ID
-
-    companion object {
-        /** Sentinel UUID used by the built-in fallback [AgentConfig] when no real namespace is known yet. */
-        val NO_NAMESPACE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
-    }
-}
+) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -18,13 +18,4 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
         name: String,
     ): AgentConfig?
 
-    /**
-     * Return the default [AgentConfig] for [namespaceId].
-     *
-     * The default is the [AgentConfig] with the lowest [EntityMetadata.created] timestamp
-     * (i.e. the first one ever created in the namespace). When no agent config has been
-     * persisted yet, a built-in fallback config is returned so callers can always rely
-     * on a non-null result.
-     */
-    fun findDefault(namespaceId: UUID): AgentConfig
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -1,6 +1,5 @@
 package io.whozoss.agentos.agentConfig
 
-import io.whozoss.agentos.sdk.entity.EntityMetadata
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -30,29 +29,4 @@ class AgentConfigServiceImpl(
         agentConfigRepository
             .findByParent(namespaceId)
             .firstOrNull { it.name.equals(name, ignoreCase = true) }
-
-    override fun findDefault(namespaceId: UUID): AgentConfig =
-        agentConfigRepository
-            .findByParent(namespaceId)
-            // TODO: add a dedicated findOldestByParent repository method to avoid full scan
-            .minByOrNull { it.metadata.created }
-            ?: DEFAULT_AGENT_CONFIG
-
-    companion object {
-        /**
-         * Built-in fallback agent returned when a namespace has no persisted [AgentConfig].
-         *
-         * Uses a stable UUID derived from the name so the identity is consistent across
-         * restarts. [modelName] is null: the namespace's default [AiModel] will be used.
-         */
-        val DEFAULT_AGENT_CONFIG =
-            AgentConfig(
-                metadata = EntityMetadata(id = UUID.nameUUIDFromBytes("default-agent".toByteArray())),
-                namespaceId = AgentConfig.NO_NAMESPACE_ID,
-                name = "Default Agent",
-                description = "General-purpose agent. Delegates to specialised agents when appropriate.",
-                instructions = null,
-                modelName = null,
-            )
-    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -4,6 +4,7 @@ import io.whozoss.agentos.agent.AgentExecutionContext
 import io.whozoss.agentos.agent.AgentService
 import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.exception.ResourceNotFoundException
+import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
@@ -33,6 +34,7 @@ class CaseServiceImpl(
     private val caseRepository: CaseRepository,
     private val caseEventService: CaseEventService,
     private val userService: UserService,
+    private val namespaceService: NamespaceService,
 ) : CaseService {
     /**
      * Coroutine scope used to run case execution loops in the background.
@@ -153,16 +155,18 @@ class CaseServiceImpl(
      * events to store+emit on the runtime.
      *
      * Resolution order:
-     * 1. Explicit `@mention` in the message content.
-     * 2. Last agent selected in this case (from [pastEvents]) — preserves continuity
-     *    across turns when the user does not re-mention an agent.
-     * 3. Namespace default agent — fallback when no prior selection exists.
+     * 1. Explicit `@mention` in the message content — resolved by name; on miss, falls
+     *    back to the namespace default with a [WarnEvent].
+     * 2. Last selected agent in this case (from [pastEvents]) — preserves continuity
+     *    across turns. If the agent is no longer available (deleted, disabled), falls
+     *    back to the namespace default with a [WarnEvent].
+     * 3. Namespace default agent — [Namespace.defaultAgentName] resolved by name.
      *
-     * Returns an empty list when no agent is configured (signals the runtime to stop).
+     * Returns a single [WarnEvent] (no [AgentSelectedEvent]) when no default agent
+     * is configured on the namespace, signalling the runtime to stop cleanly.
      *
      * @param content the message content to inspect for @mention syntax.
-     * @param pastEvents the full event history of the case at the time of this call,
-     *   used to recover the last [AgentSelectedEvent] for sticky-agent behaviour.
+     * @param pastEvents the full event history of the case at the time of this call.
      */
     private fun selectAgent(
         content: List<MessageContent>,
@@ -184,13 +188,10 @@ class CaseServiceImpl(
             if (resolvedName != null) {
                 logger.info { "[CaseService] Agent mention resolved: @$mentionedName -> $resolvedName" }
                 return listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
-            } else {
-                logger.warn { "[CaseService] Agent '@$mentionedName' not found, falling back to default" }
-                val warn =
-                    WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$mentionedName' not found")
-                val defaultName = agentService.getDefaultAgentName(namespaceId)
-                return listOf(warn, agentSelectedEvent(defaultName, namespaceId, caseId))
             }
+            logger.warn { "[CaseService] Agent '@$mentionedName' not found, falling back to default" }
+            val warn = WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$mentionedName' not found")
+            return listOf(warn) + selectDefaultAgent(namespaceId, caseId)
         }
 
         // No explicit mention: re-use the last selected agent so the conversation
@@ -205,13 +206,58 @@ class CaseServiceImpl(
                 ?.agentName
 
         if (lastSelectedName != null) {
-            logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
-            return listOf(agentSelectedEvent(lastSelectedName, namespaceId, caseId))
+            val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId) != null
+            if (stillAvailable) {
+                logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
+                return listOf(agentSelectedEvent(lastSelectedName, namespaceId, caseId))
+            }
+            logger.warn { "[CaseService] Last selected agent '$lastSelectedName' is no longer available, falling back to default" }
+            val warn = WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$lastSelectedName' is no longer available")
+            return listOf(warn) + selectDefaultAgent(namespaceId, caseId)
         }
 
-        val defaultName = agentService.getDefaultAgentName(namespaceId)
-        logger.info { "[CaseService] Selecting default agent: $defaultName" }
-        return listOf(agentSelectedEvent(defaultName, namespaceId, caseId))
+        return selectDefaultAgent(namespaceId, caseId)
+    }
+
+    /**
+     * Resolves the namespace default agent by name from [Namespace.defaultAgentName].
+     *
+     * Returns a single [AgentSelectedEvent] when the default is configured and resolvable.
+     * Returns a single [WarnEvent] (no [AgentSelectedEvent]) when:
+     * - [Namespace.defaultAgentName] is null (no default configured)
+     * - the configured name no longer matches any [AgentConfig] in the namespace
+     *
+     * In both error cases the runtime will stop cleanly on the [WarnEvent] with no
+     * [AgentSelectedEvent] following it.
+     */
+    private fun selectDefaultAgent(
+        namespaceId: UUID,
+        caseId: UUID,
+    ): List<CaseEvent> {
+        val defaultAgentName = namespaceService.findById(namespaceId)?.defaultAgentName
+        if (defaultAgentName == null) {
+            logger.warn { "[CaseService] No default agent configured for namespace $namespaceId" }
+            return listOf(
+                WarnEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    message = "No default agent configured for this namespace. Use @agentName to address an agent explicitly.",
+                ),
+            )
+        }
+        val resolvedName = agentService.resolveAgentName(defaultAgentName, namespaceId)
+        if (resolvedName == null) {
+            logger.warn { "[CaseService] Default agent '$defaultAgentName' is not available in namespace $namespaceId" }
+            return listOf(
+                WarnEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    message = "Default agent '$defaultAgentName' is not available. Use @agentName to address an agent explicitly.",
+                ),
+            )
+        }
+        logger.info { "[CaseService] Selecting default agent: $resolvedName" }
+        return listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
     }
 
     private fun agentSelectedEvent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -174,29 +174,14 @@ class CaseServiceImpl(
         namespaceId: UUID,
         caseId: UUID,
     ): List<CaseEvent> {
-        val firstText =
+        val mentionedName =
             content
                 .filterIsInstance<MessageContent.Text>()
                 .firstOrNull()
                 ?.content
                 ?.trim()
+                ?.let { """^@(\S+)""".toRegex().find(it)?.groupValues?.get(1) }
 
-        val mentionedName = firstText?.let { """^@(\S+)""".toRegex().find(it)?.groupValues?.get(1) }
-
-        if (mentionedName != null) {
-            val resolvedName = agentService.resolveAgentName(mentionedName, namespaceId)
-            if (resolvedName != null) {
-                logger.info { "[CaseService] Agent mention resolved: @$mentionedName -> $resolvedName" }
-                return listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
-            }
-            logger.warn { "[CaseService] Agent '@$mentionedName' not found, falling back to default" }
-            val warn = WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$mentionedName' not found")
-            return listOf(warn) + selectDefaultAgent(namespaceId, caseId)
-        }
-
-        // No explicit mention: re-use the last selected agent so the conversation
-        // stays with the same agent across turns without requiring the user to
-        // repeat the @mention on every message.
         val lastUserMessageIndex = pastEvents.indexOfLast { it is MessageEvent }
         val lastSelectedName =
             pastEvents
@@ -205,18 +190,37 @@ class CaseServiceImpl(
                 .lastOrNull()
                 ?.agentName
 
-        if (lastSelectedName != null) {
-            val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId) != null
-            if (stillAvailable) {
-                logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
-                return listOf(agentSelectedEvent(lastSelectedName, namespaceId, caseId))
+        return when {
+            mentionedName != null -> {
+                val resolvedName = agentService.resolveAgentName(mentionedName, namespaceId)
+                when {
+                    resolvedName != null -> {
+                        logger.info { "[CaseService] Agent mention resolved: @$mentionedName -> $resolvedName" }
+                        listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
+                    }
+                    else -> {
+                        logger.warn { "[CaseService] Agent '@$mentionedName' not found, falling back to default" }
+                        listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$mentionedName' not found")) +
+                            selectDefaultAgent(namespaceId, caseId)
+                    }
+                }
             }
-            logger.warn { "[CaseService] Last selected agent '$lastSelectedName' is no longer available, falling back to default" }
-            val warn = WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$lastSelectedName' is no longer available")
-            return listOf(warn) + selectDefaultAgent(namespaceId, caseId)
+            lastSelectedName != null -> {
+                val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId) != null
+                when {
+                    stillAvailable -> {
+                        logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
+                        listOf(agentSelectedEvent(lastSelectedName, namespaceId, caseId))
+                    }
+                    else -> {
+                        logger.warn { "[CaseService] Last selected agent '$lastSelectedName' is no longer available, falling back to default" }
+                        listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$lastSelectedName' is no longer available")) +
+                            selectDefaultAgent(namespaceId, caseId)
+                    }
+                }
+            }
+            else -> selectDefaultAgent(namespaceId, caseId)
         }
-
-        return selectDefaultAgent(namespaceId, caseId)
     }
 
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/Namespace.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/Namespace.kt
@@ -14,6 +14,12 @@ import io.whozoss.agentos.sdk.entity.EntityMetadata
  * Analogous to `projectPath` in Coday: it tells the filesystem plugin where to resolve
  * namespace-scoped resources. When absent, no filesystem-based configuration is loaded.
  *
+ * [defaultAgentName] is the logical name of the agent to invoke when no explicit
+ * `@mention` is present in a user message. Resolved at runtime by [AgentService]
+ * via name matching against [AgentConfig] entries in this namespace. When null,
+ * sending a message without an `@mention` produces an explicit error rather than
+ * silently routing to an arbitrary agent.
+ *
  * Implements Entity for standard CRUD operations.
  * No parent entity — namespaces are root-level.
  */
@@ -24,4 +30,5 @@ data class Namespace(
     val description: String? = null,
     val configPath: String? = null,
     val externalId: String? = null,
+    val defaultAgentName: String? = null,
 ) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceController.kt
@@ -58,6 +58,7 @@ class NamespaceController(
             description = entity.description,
             configPath = entity.configPath,
             externalId = entity.externalId,
+            defaultAgentName = entity.defaultAgentName,
         )
 
     override fun toDomain(resource: NamespaceResource): Namespace =
@@ -67,6 +68,7 @@ class NamespaceController(
             description = resource.description,
             configPath = resource.configPath?.takeIf { it.isNotBlank() },
             externalId = resource.externalId?.takeIf { it.isNotBlank() },
+            defaultAgentName = resource.defaultAgentName?.takeIf { it.isNotBlank() },
         )
 
     @GetMapping("/{id}")
@@ -185,6 +187,7 @@ class NamespaceController(
             description = entity.description,
             configPath = entity.configPath?.takeIf { it.isNotBlank() },
             externalId = entity.externalId,
+            defaultAgentName = entity.defaultAgentName,
             role = role,
         )
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceListItem.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceListItem.kt
@@ -25,6 +25,8 @@ data class NamespaceListItem(
     val configPath: String? = null,
     @Schema(description = "Optional external identifier for this namespace, e.g. a federation id from an external system")
     val externalId: String? = null,
+    @Schema(description = "Logical name of the default agent for this namespace. Null means no default is configured.")
+    val defaultAgentName: String? = null,
     @Schema(description = "The caller's effective role on this namespace", allowableValues = ["SUPER-ADMIN", "ADMIN", "MEMBER"])
     val role: String,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceNode.kt
@@ -22,6 +22,7 @@ data class NamespaceNode(
     val description: String? = null,
     val configPath: String? = null,
     val externalId: String? = null,
+    val defaultAgentName: String? = null,
     // EntityMetadata fields
     val created: Instant = Instant.now(),
     val createdBy: String? = null,
@@ -44,6 +45,7 @@ data class NamespaceNode(
             description = description,
             configPath = configPath,
             externalId = externalId,
+            defaultAgentName = defaultAgentName,
         )
 
     companion object {
@@ -54,6 +56,7 @@ data class NamespaceNode(
                 description = ns.description,
                 configPath = ns.configPath,
                 externalId = ns.externalId,
+                defaultAgentName = ns.defaultAgentName,
                 created = ns.metadata.created,
                 createdBy = ns.metadata.createdBy,
                 modified = ns.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/namespace/NamespaceResource.kt
@@ -20,4 +20,6 @@ data class NamespaceResource(
     val configPath: String? = null,
     @Schema(description = "Optional external identifier for this namespace, e.g. a federation id from an external system")
     val externalId: String? = null,
+    @Schema(description = "Logical name of the default agent for this namespace. Resolved at runtime against AgentConfig entries. When null, messages without an @mention will produce an explicit error.")
+    val defaultAgentName: String? = null,
 )

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
-import io.whozoss.agentos.agentConfig.AgentConfigServiceImpl
 import io.whozoss.agentos.aiModel.AiModelService
 import io.whozoss.agentos.aiProvider.AiProviderService
 import io.whozoss.agentos.chat.ChatClientProvider
@@ -489,29 +488,6 @@ class AgentServiceImplUnitSpec : StringSpec() {
             agentService.findAgentByName("my-agent", context)
 
             verify(exactly = 1) { toolRegistryService.resolveToolsForNamespace(namespaceId, integrations) }
-        }
-
-        // -------------------------------------------------------------------------
-        // getDefaultAgentName
-        // -------------------------------------------------------------------------
-
-        "getDefaultAgentName returns AgentConfig name when one exists" {
-            val config = agentConfig(name = "my-agent")
-            every { agentConfigService.findDefault(namespaceId) } returns config
-
-            agentService.getDefaultAgentName(namespaceId) shouldBe "my-agent"
-
-            verify(exactly = 0) { aiModelService.findAiModel(any()) }
-            verify(exactly = 0) { chatClientProvider.getChatClient(any(), any()) }
-        }
-
-        "getDefaultAgentName returns built-in fallback name when no AgentConfig is persisted" {
-            every { agentConfigService.findDefault(namespaceId) } returns AgentConfigServiceImpl.DEFAULT_AGENT_CONFIG
-
-            agentService.getDefaultAgentName(namespaceId) shouldBe "Default Agent"
-
-            verify(exactly = 0) { aiModelService.findAiModel(any()) }
-            verify(exactly = 0) { chatClientProvider.getChatClient(any(), any()) }
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -2,11 +2,9 @@ package io.whozoss.agentos.agentConfig
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.whozoss.agentos.entity.InMemoryEntityRepository
 import io.whozoss.agentos.sdk.entity.EntityMetadata
-import java.time.Instant
 import java.util.UUID
 
 class AgentConfigServiceImplUnitSpec : StringSpec({
@@ -28,9 +26,8 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
         name: String,
         nsId: UUID = namespaceId,
         modelName: String? = "BIG",
-        createdAt: Instant = Instant.ofEpochSecond(1_000_000),
     ) = AgentConfig(
-        metadata = EntityMetadata(id = UUID.randomUUID(), created = createdAt),
+        metadata = EntityMetadata(id = UUID.randomUUID()),
         namespaceId = nsId,
         name = name,
         modelName = modelName,
@@ -72,42 +69,4 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
         svc.findByName(namespaceId, "Dev").shouldBeNull()
     }
 
-    // -------------------------------------------------------------------------
-    // findDefault
-    // -------------------------------------------------------------------------
-
-    "findDefault returns built-in fallback when namespace has no configs" {
-        val svc = service()
-
-        val result = svc.findDefault(namespaceId)
-
-        result shouldBe AgentConfigServiceImpl.DEFAULT_AGENT_CONFIG
-    }
-
-    "findDefault returns the oldest config when multiple exist" {
-        val repo = repository()
-        val svc = service(repo)
-        val older = repo.save(config("Alpha", nsId = namespaceId, createdAt = Instant.ofEpochSecond(1000)))
-        repo.save(config("Beta", nsId = namespaceId, createdAt = Instant.ofEpochSecond(2000)))
-
-        svc.findDefault(namespaceId) shouldBe older
-    }
-
-    "findDefault returns the single config when only one exists" {
-        val repo = repository()
-        val svc = service(repo)
-        val saved = repo.save(config("Solo", nsId = namespaceId))
-
-        svc.findDefault(namespaceId).shouldNotBeNull() shouldBe saved
-    }
-
-    "findDefault is scoped to the given namespace" {
-        val repo = repository()
-        val svc = service(repo)
-        val otherNamespaceId = UUID.randomUUID()
-        repo.save(config("Alpha", nsId = otherNamespaceId))
-
-        // own namespace is empty -> fallback
-        svc.findDefault(namespaceId) shouldBe AgentConfigServiceImpl.DEFAULT_AGENT_CONFIG
-    }
 })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -554,7 +554,24 @@ class CaseServiceImplSpec :
         }
 
         "first message without @mention produces WarnEvent and stops when namespace has no default agent" {
-            val service = buildService(defaultAgentName = null)
+            // Wire the service manually to keep a reference to the event store.
+            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = null,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            // resolveAgentName is never reached because selectDefaultAgent short-circuits on null
+            val agentService = mockk<AgentService>(relaxed = true)
+            val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val service = CaseServiceImpl(
+                agentService,
+                InMemoryCaseRepository(),
+                caseEventService,
+                userService,
+                namespaceService,
+            )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -567,20 +584,13 @@ class CaseServiceImplSpec :
             )
             awaiter.join()
 
-            // Case must be IDLE (not ERROR): no default is a clean stop, not a crash
+            // Case must be IDLE (not ERROR): no default is a configuration issue, not a crash
             service.getById(case.id).status shouldBe CaseStatus.IDLE
-            // A WarnEvent must be in the persisted store
-            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val events = runtime.let {
-                // read from the service's event store via findByParent
-                service.let { svc ->
-                    // We can't access caseEventService directly, so verify via SSE events
-                    // collected before the status change.
-                    Unit
-                }
-            }
-            // The key assertion: case reached IDLE cleanly (no ERROR), confirming the
-            // WarnEvent path was taken and the runtime stopped without crashing.
+            // A WarnEvent must have been persisted — it is the only event besides the MessageEvent
+            val persistedEvents = caseEventService.findByParent(case.id)
+            persistedEvents.filterIsInstance<WarnEvent>() shouldHaveAtLeastSize 1
+            // No AgentSelectedEvent: routing stopped at the WarnEvent
+            persistedEvents.filterIsInstance<AgentSelectedEvent>() shouldBe emptyList()
         }
 
         "last active agent unavailable falls back to namespace default" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -595,18 +595,25 @@ class CaseServiceImplSpec :
 
         "last active agent unavailable falls back to namespace default" {
             val unavailableAgentName = "old-agent"
+            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val namespace = Namespace(
                 metadata = EntityMetadata(id = namespaceId),
                 name = "test-namespace",
                 defaultAgentName = agentName,
             )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            // resolveAgentName call sequence:
+            //   turn 1, @mention path: resolveAgentName(unavailableAgentName) -> unavailableAgentName (found)
+            //   turn 2, sticky-agent availability check: resolveAgentName(unavailableAgentName) -> null (gone)
+            //   turn 2, default resolution: resolveAgentName(agentName) -> agentName (found)
+            val resolveCallCount = java.util.concurrent.atomic.AtomicInteger(0)
             val agentService = mockk<AgentService> {
-                // First call: @mention resolves the old agent
-                every { resolveAgentName(unavailableAgentName, namespaceId) } returns unavailableAgentName
-                // Second call (sticky-agent check): old agent no longer available
-                every { resolveAgentName(unavailableAgentName, namespaceId) } returns unavailableAgentName andThen null
-                // Default agent resolution
+                every { resolveAgentName(unavailableAgentName, namespaceId) } answers {
+                    when (resolveCallCount.incrementAndGet()) {
+                        1 -> unavailableAgentName  // turn 1: @mention resolves
+                        else -> null              // turn 2: sticky-agent check fails
+                    }
+                }
                 every { resolveAgentName(agentName, namespaceId) } returns agentName
                 every { findAgentByName(any(), any()) } returns finishingAgent()
             }
@@ -614,7 +621,7 @@ class CaseServiceImplSpec :
             val service = CaseServiceImpl(
                 agentService,
                 InMemoryCaseRepository(),
-                CaseEventServiceImpl(InMemoryCaseEventRepository()),
+                caseEventService,
                 userServiceMock,
                 namespaceService,
             )
@@ -622,7 +629,7 @@ class CaseServiceImplSpec :
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
 
-            // First turn: explicit @mention of the old agent
+            // First turn: explicit @mention of the old agent — resolves and runs normally
             val firstIdle = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
             service.addMessage(
                 caseId = case.id,
@@ -632,7 +639,7 @@ class CaseServiceImplSpec :
             firstIdle.join()
             awaitNotRunning(runtime)
 
-            // Second turn: no @mention, old agent is gone -> should fall back to default
+            // Second turn: no @mention, old agent is gone -> WarnEvent + fallback to default
             val secondIdle = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
             service.addMessage(
                 caseId = case.id,
@@ -642,6 +649,11 @@ class CaseServiceImplSpec :
             secondIdle.join()
 
             service.getById(case.id).status shouldBe CaseStatus.IDLE
+            // WarnEvent must have been persisted during the second turn
+            val persistedEvents = caseEventService.findByParent(case.id)
+            persistedEvents.filterIsInstance<WarnEvent>() shouldHaveAtLeastSize 1
+            // Default agent was ultimately selected after the warn
+            persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe agentName
         }
 
         "second message without @mention uses the same agent as the first" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -9,6 +9,8 @@ import io.mockk.mockk
 import io.whozoss.agentos.agent.AgentService
 import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
 import io.whozoss.agentos.caseEvent.InMemoryCaseEventRepository
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
@@ -21,6 +23,7 @@ import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
+import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.User
@@ -134,16 +137,22 @@ class CaseServiceImplSpec :
         fun buildService(
             agent: Agent = finishingAgent(),
             userService: UserService = mockk { every { findById(userId) } returns activeUser },
+            defaultAgentName: String? = agentName,
         ): CaseServiceImpl {
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = defaultAgentName,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { getDefaultAgentName(any()) } returns agentName
                     every { resolveAgentName(any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns agent
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            return CaseServiceImpl(agentService, caseRepository, caseEventService, userService)
+            return CaseServiceImpl(agentService, caseRepository, caseEventService, userService, namespaceService)
         }
 
         // -------------------------------------------------------------------------
@@ -247,14 +256,19 @@ class CaseServiceImplSpec :
 
         "persisted events contain the full agent lifecycle sequence" {
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = agentName,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { getDefaultAgentName(any()) } returns agentName
                     every { resolveAgentName(any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns finishingAgent()
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService)
+            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -446,13 +460,19 @@ class CaseServiceImplSpec :
                     }
                 }
 
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = agentName,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { getDefaultAgentName(namespaceId) } returns agentName
+                    every { resolveAgentName(agentName, namespaceId) } returns agentName
                     every { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService)
+            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
 
@@ -512,6 +532,108 @@ class CaseServiceImplSpec :
         // Sticky-agent behaviour: second message without @mention reuses last agent
         // -------------------------------------------------------------------------
 
+        // -------------------------------------------------------------------------
+        // Default agent routing
+        // -------------------------------------------------------------------------
+
+        "first message without @mention routes to namespace default agent" {
+            val service = buildService()
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE, CaseStatus.ERROR)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+        }
+
+        "first message without @mention produces WarnEvent and stops when namespace has no default agent" {
+            val service = buildService(defaultAgentName = null)
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE, CaseStatus.ERROR)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+
+            // Case must be IDLE (not ERROR): no default is a clean stop, not a crash
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+            // A WarnEvent must be in the persisted store
+            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+            val events = runtime.let {
+                // read from the service's event store via findByParent
+                service.let { svc ->
+                    // We can't access caseEventService directly, so verify via SSE events
+                    // collected before the status change.
+                    Unit
+                }
+            }
+            // The key assertion: case reached IDLE cleanly (no ERROR), confirming the
+            // WarnEvent path was taken and the runtime stopped without crashing.
+        }
+
+        "last active agent unavailable falls back to namespace default" {
+            val unavailableAgentName = "old-agent"
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = agentName,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            val agentService = mockk<AgentService> {
+                // First call: @mention resolves the old agent
+                every { resolveAgentName(unavailableAgentName, namespaceId) } returns unavailableAgentName
+                // Second call (sticky-agent check): old agent no longer available
+                every { resolveAgentName(unavailableAgentName, namespaceId) } returns unavailableAgentName andThen null
+                // Default agent resolution
+                every { resolveAgentName(agentName, namespaceId) } returns agentName
+                every { findAgentByName(any(), any()) } returns finishingAgent()
+            }
+            val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val service = CaseServiceImpl(
+                agentService,
+                InMemoryCaseRepository(),
+                CaseEventServiceImpl(InMemoryCaseEventRepository()),
+                userServiceMock,
+                namespaceService,
+            )
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            // First turn: explicit @mention of the old agent
+            val firstIdle = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("@$unavailableAgentName hello")),
+            )
+            firstIdle.join()
+            awaitNotRunning(runtime)
+
+            // Second turn: no @mention, old agent is gone -> should fall back to default
+            val secondIdle = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("follow-up")),
+            )
+            secondIdle.join()
+
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+        }
+
         "second message without @mention uses the same agent as the first" {
             // Regression test for the sticky-agent feature.
             //
@@ -547,9 +669,14 @@ class CaseServiceImplSpec :
                     }
                 }
 
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = defaultAgentName,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { getDefaultAgentName(any()) } returns defaultAgentName
                     // @selected-agent resolves to selectedAgentName
                     every { resolveAgentName(selectedAgentName, any()) } returns selectedAgentName
                     // no other mention resolution needed
@@ -558,7 +685,7 @@ class CaseServiceImplSpec :
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, caseRepository, caseEventService, userService)
+            val service = CaseServiceImpl(agentService, caseRepository, caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -1565,6 +1565,11 @@ components:
           type: string
           description: "Optional external identifier for this namespace, e.g. a federation\
             \ id from an external system"
+        defaultAgentName:
+          type: string
+          description: "Logical name of the default agent for this namespace. Resolved\
+            \ at runtime against AgentConfig entries. When null, messages without\
+            \ an @mention will produce an explicit error."
       required:
       - name
     IntegrationConfig:
@@ -2279,6 +2284,10 @@ components:
           type: string
           description: "Optional external identifier for this namespace, e.g. a federation\
             \ id from an external system"
+        defaultAgentName:
+          type: string
+          description: Logical name of the default agent for this namespace. Null
+            means no default is configured.
         role:
           type: string
           description: The caller's effective role on this namespace

--- a/libs/agentos-api-client/src/lib/model/namespace-list-item.ts
+++ b/libs/agentos-api-client/src/lib/model/namespace-list-item.ts
@@ -21,10 +21,15 @@ export interface NamespaceListItem {
    */
   externalId?: string
   /**
+   * Logical name of the default agent for this namespace. Null means no default is configured.
+   */
+  defaultAgentName?: string
+  /**
    * The caller\'s effective role on this namespace
    */
   role: NamespaceListItemRoleEnum
 }
+
 export enum NamespaceListItemRoleEnum {
   SUPER_ADMIN = 'SUPER-ADMIN',
   ADMIN = 'ADMIN',

--- a/libs/agentos-api-client/src/lib/model/namespace.ts
+++ b/libs/agentos-api-client/src/lib/model/namespace.ts
@@ -20,4 +20,8 @@ export interface Namespace {
    * Optional external identifier for this namespace, e.g. a federation id from an external system
    */
   externalId?: string
+  /**
+   * Logical name of the default agent for this namespace. Resolved at runtime against AgentConfig entries. When null, messages without an @mention will produce an explicit error.
+   */
+  defaultAgentName?: string
 }

--- a/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.html
@@ -8,7 +8,7 @@
   </header>
 
   @if (isLoading()) {
-    <p class="namespace-form__loading">Loading…</p>
+    <p class="namespace-form__loading">Loading&hellip;</p>
   } @else {
     <form class="namespace-form__form" [formGroup]="form" (ngSubmit)="submit()">
       <div class="namespace-form__field">
@@ -31,6 +31,30 @@
           type="text"
           placeholder="Optional description"
           [formControl]="descriptionControl"
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="namespace-form__field">
+        <label class="namespace-form__label" for="ns-external-id">External ID</label>
+        <input
+          id="ns-external-id"
+          class="namespace-form__input"
+          type="text"
+          placeholder="Optional federation ID from an external system"
+          [formControl]="externalIdControl"
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="namespace-form__field">
+        <label class="namespace-form__label" for="ns-default-agent">Default agent</label>
+        <input
+          id="ns-default-agent"
+          class="namespace-form__input"
+          type="text"
+          placeholder="Logical name of the default agent (e.g. coday)"
+          [formControl]="defaultAgentNameControl"
           autocomplete="off"
         />
       </div>

--- a/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.ts
@@ -34,6 +34,8 @@ export class NamespaceFormComponent implements OnInit {
     }),
     description: new FormControl<string>('', { nonNullable: true }),
     configPath: new FormControl<string>('', { nonNullable: true }),
+    externalId: new FormControl<string>('', { nonNullable: true }),
+    defaultAgentName: new FormControl<string>('', { nonNullable: true }),
   })
 
   protected get nameControl() {
@@ -46,6 +48,14 @@ export class NamespaceFormComponent implements OnInit {
 
   protected get configPathControl() {
     return this.form.controls.configPath
+  }
+
+  protected get externalIdControl() {
+    return this.form.controls.externalId
+  }
+
+  protected get defaultAgentNameControl() {
+    return this.form.controls.defaultAgentName
   }
 
   protected readonly isEditMode = signal(false)
@@ -74,6 +84,8 @@ export class NamespaceFormComponent implements OnInit {
           this.nameControl.setValue(ns.name)
           this.descriptionControl.setValue(ns.description ?? '')
           this.configPathControl.setValue(ns.configPath ?? '')
+          this.externalIdControl.setValue(ns.externalId ?? '')
+          this.defaultAgentNameControl.setValue(ns.defaultAgentName ?? '')
           this.isLoading.set(false)
         },
         error: () => {
@@ -88,18 +100,18 @@ export class NamespaceFormComponent implements OnInit {
 
     this.isSubmitting.set(true)
 
+    const payload: Namespace = {
+      ...this.existingNamespace,
+      name: this.nameControl.value.trim(),
+      description: this.descriptionControl.value.trim() || undefined,
+      configPath: this.configPathControl.value.trim() || undefined,
+      externalId: this.externalIdControl.value.trim() || undefined,
+      defaultAgentName: this.defaultAgentNameControl.value.trim() || undefined,
+    }
+
     const call$ = this.isEditMode()
-      ? this.namespaceController.updateNamespace(this.existingNamespace!.id ?? '', {
-          ...this.existingNamespace!,
-          name: this.nameControl.value.trim(),
-          description: this.descriptionControl.value.trim() || undefined,
-          configPath: this.configPathControl.value.trim() || undefined,
-        })
-      : this.namespaceController.createNamespace({
-          name: this.nameControl.value.trim(),
-          ...(this.descriptionControl.value.trim() ? { description: this.descriptionControl.value.trim() } : {}),
-          ...(this.configPathControl.value.trim() ? { configPath: this.configPathControl.value.trim() } : {}),
-        } as Namespace)
+      ? this.namespaceController.updateNamespace(this.existingNamespace!.id ?? '', payload)
+      : this.namespaceController.createNamespace(payload)
 
     call$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => this.navigateBack(),

--- a/libs/agentos-ui/src/lib/components/namespace-list/namespace-list.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-list/namespace-list.component.ts
@@ -43,6 +43,7 @@ export class NamespaceListComponent {
           id: ns.id ?? '',
           name: ns.name,
           description: ns.description,
+          badges: ns.defaultAgentName ? [{ label: ns.defaultAgentName, variant: 'info' }] : undefined,
         })
       )
     )


### PR DESCRIPTION
## WZ-31783 — [AgentOS] BE - Call Default Agent

### What

Implements automatic default agent routing in AgentOS: when a user sends a message without an `@mention`, the namespace's configured default agent is called automatically. When the last active agent becomes unavailable, the runtime falls back to the default rather than crashing.

### Changes

**`Namespace` model** — new `defaultAgentName: String?` field, propagated through `NamespaceNode`, `NamespaceResource`, `NamespaceListItem`, and `NamespaceController`. Nullable by design: a namespace without a default configured is a valid explicit state that produces a clear error message rather than a silent failure.

**`CaseServiceImpl.selectAgent`** — rewritten as a `when` expression covering three cases:
1. Explicit `@mention` → resolve by name; on miss, `WarnEvent` + fallback to default
2. Sticky agent (last selected) → verify still available via `resolveAgentName`; if gone, `WarnEvent` + fallback to default
3. No mention, no history → delegate to `selectDefaultAgent`

**`selectDefaultAgent`** (new private method) — reads `namespace.defaultAgentName`, resolves it, returns `AgentSelectedEvent` on success or a `WarnEvent` + clean IDLE stop on null/unresolvable. No ERROR status: a missing default is a configuration issue, not a runtime crash.

**Cleanup** — removed `AgentConfigService.findDefault()`, `AgentConfigServiceImpl.DEFAULT_AGENT_CONFIG`, `AgentService.getDefaultAgent()`, `AgentService.getDefaultAgentName()`, `AgentConfig.hasNoRealNamespace()`, `AgentConfig.NO_NAMESPACE_ID`. The "default agent" concept now lives entirely on the namespace, not scattered across multiple service layers.

**OpenAPI** — regenerated `agentos-openapi.yaml` with `defaultAgentName` on both `Namespace` and `NamespaceListItem` schemas.

### Acceptance criteria coverage

| Criterion | Status |
|---|---|
| First message with no `@mention` → default agent called | ✅ |
| First message with `@mention` → named agent called (unchanged) | ✅ |
| Last active agent still available → routed to it | ✅ |
| Last active agent unavailable → silent fallback to default | ✅ |
| Clear error if no default configured in namespace | ✅ `WarnEvent` + IDLE |

### Design note

`defaultAgentName` is a soft reference by name, not a FK to an `AgentConfig` UUID. This is intentional: namespace admins may not control which `AgentConfig` versions are deployed on their namespace (platform-level concern). The name indirection decouples namespace configuration from `AgentConfig` versioning.