### PR TITLE
feat: #31893 environment-level default agent fallback

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos
 
+import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.config.PersistenceConfigProperties
 import io.whozoss.agentos.service.config.AgentOsPluginsConfigProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -14,7 +15,7 @@ import org.springframework.boot.runApplication
         org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration::class,
     ],
 )
-@EnableConfigurationProperties(AgentOsPluginsConfigProperties::class, PersistenceConfigProperties::class)
+@EnableConfigurationProperties(AgentConfigProperties::class, AgentOsPluginsConfigProperties::class, PersistenceConfigProperties::class)
 class AgentOSApplication
 
 fun main(args: Array<String>) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentConfigProperties.kt
@@ -1,0 +1,34 @@
+package io.whozoss.agentos.agent
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Platform-level agent configuration properties.
+ *
+ * Bound from the `agentos.agent` prefix in application.yml.
+ *
+ * [defaultAgentName] is the environment-level fallback agent name. It is consulted
+ * when a namespace has no [io.whozoss.agentos.namespace.Namespace.defaultAgentName]
+ * configured, and is resolved in the same way — by name against the [AgentConfig]
+ * entries of the case's namespace. This means the named agent must exist in each
+ * namespace that wants to benefit from the fallback.
+ *
+ * Fallback resolution order when routing a conversation:
+ * 1. Namespace default agent ([Namespace.defaultAgentName]), if configured
+ * 2. Environment default agent ([defaultAgentName]), if configured
+ * 3. Silent fail (WarnEvent emitted, no agent selected)
+ *
+ * Override with environment variable (Spring Boot relaxed binding):
+ * - AGENTOS_DEFAULTS_AGENT_NAME
+ *
+ * Example (application.yml):
+ * ```yaml
+ * agentos:
+ *   defaults:
+ *     agent-name: copilot
+ * ```
+ */
+@ConfigurationProperties(prefix = "agentos.defaults")
+data class AgentConfigProperties(
+    val agentName: String? = null,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.caseFlow
 
+import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentExecutionContext
 import io.whozoss.agentos.agent.AgentService
 import io.whozoss.agentos.caseEvent.CaseEventService
@@ -31,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Service
 class CaseServiceImpl(
     private val agentService: AgentService,
+    private val agentConfigProperties: AgentConfigProperties,
     private val caseRepository: CaseRepository,
     private val caseEventService: CaseEventService,
     private val userService: UserService,
@@ -238,30 +240,39 @@ class CaseServiceImpl(
         namespaceId: UUID,
         caseId: UUID,
     ): List<CaseEvent> {
-        val defaultAgentName = namespaceService.findById(namespaceId)?.defaultAgentName
-        return if (defaultAgentName == null) {
-            logger.warn { "[CaseService] No default agent configured for namespace $namespaceId" }
-            listOf(
-                WarnEvent(
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    message = "No default agent configured for this namespace. Use @agentName to address an agent explicitly.",
-                ),
-            )
-        } else {
-            val resolvedName = agentService.resolveAgentName(defaultAgentName, namespaceId)
-            if (resolvedName == null) {
-                logger.warn { "[CaseService] Default agent '$defaultAgentName' is not available in namespace $namespaceId" }
+        val namespaceLevelDefault = namespaceService.findById(namespaceId)?.defaultAgentName
+        val effectiveDefaultName = namespaceLevelDefault ?: agentConfigProperties.agentName
+
+        return when {
+            effectiveDefaultName == null -> {
+                logger.warn { "[CaseService] No default agent configured for namespace $namespaceId" }
                 listOf(
                     WarnEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
-                        message = "Default agent '$defaultAgentName' is not available. Use @agentName to address an agent explicitly.",
+                        message = "No default agent configured for this namespace. Use @agentName to address an agent explicitly.",
                     ),
                 )
-            } else {
-                logger.info { "[CaseService] Selecting default agent: $resolvedName" }
-                listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
+            }
+            else -> {
+                val resolvedName = agentService.resolveAgentName(effectiveDefaultName, namespaceId)
+                when {
+                    resolvedName != null -> {
+                        val source = if (namespaceLevelDefault != null) "namespace" else "environment"
+                        logger.info { "[CaseService] Selecting $source default agent: $resolvedName" }
+                        listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
+                    }
+                    else -> {
+                        logger.warn { "[CaseService] Default agent '$effectiveDefaultName' is not available in namespace $namespaceId" }
+                        listOf(
+                            WarnEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                message = "Default agent '$effectiveDefaultName' is not available. Use @agentName to address an agent explicitly.",
+                            ),
+                        )
+                    }
+                }
             }
         }
     }

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -69,6 +69,11 @@ management:
       show-details: always
 
 agentos:
+  defaults:
+    # Environment-level fallback agent name. Consulted when a namespace has no
+    # defaultAgentName configured. The named agent must exist in the case's namespace.
+    # Override with env var: AGENTOS_DEFAULTS_AGENT_NAME
+    # agent-name: copilot
   plugins:
     dir: ${PLUGINS_DIR:plugins/}
   security:

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
+import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentService
 import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
 import io.whozoss.agentos.caseEvent.InMemoryCaseEventRepository
@@ -138,6 +139,7 @@ class CaseServiceImplSpec :
             agent: Agent = finishingAgent(),
             userService: UserService = mockk { every { findById(userId) } returns activeUser },
             defaultAgentName: String? = agentName,
+            environmentAgentName: String? = null,
         ): CaseServiceImpl {
             val namespace = Namespace(
                 metadata = EntityMetadata(id = namespaceId),
@@ -152,7 +154,14 @@ class CaseServiceImplSpec :
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            return CaseServiceImpl(agentService, caseRepository, caseEventService, userService, namespaceService)
+            return CaseServiceImpl(
+                agentService,
+                AgentConfigProperties(agentName = environmentAgentName),
+                caseRepository,
+                caseEventService,
+                userService,
+                namespaceService,
+            )
         }
 
         // -------------------------------------------------------------------------
@@ -268,7 +277,14 @@ class CaseServiceImplSpec :
                     every { findAgentByName(agentName, any()) } returns finishingAgent()
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
+            val service = CaseServiceImpl(
+                agentService,
+                AgentConfigProperties(),
+                InMemoryCaseRepository(),
+                caseEventService,
+                userService,
+                namespaceService,
+            )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -472,7 +488,7 @@ class CaseServiceImplSpec :
                     every { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
+            val service = CaseServiceImpl(agentService, AgentConfigProperties(), InMemoryCaseRepository(), caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
 
@@ -533,7 +549,138 @@ class CaseServiceImplSpec :
         // -------------------------------------------------------------------------
 
         // -------------------------------------------------------------------------
-        // Default agent routing
+        // Default agent routing — environment-level fallback
+        // -------------------------------------------------------------------------
+
+        "first message without @mention routes to environment default agent when namespace has none" {
+            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = null,  // no namespace-level default
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            val agentService = mockk<AgentService> {
+                every { resolveAgentName(agentName, namespaceId) } returns agentName
+                every { findAgentByName(agentName, any()) } returns finishingAgent()
+            }
+            val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val service = CaseServiceImpl(
+                agentService,
+                AgentConfigProperties(agentName = agentName),  // environment-level default
+                InMemoryCaseRepository(),
+                caseEventService,
+                userService,
+                namespaceService,
+            )
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE, CaseStatus.ERROR)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+            val persistedEvents = caseEventService.findByParent(case.id)
+            persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe agentName
+            persistedEvents.filterIsInstance<WarnEvent>() shouldBe emptyList()
+        }
+
+        "namespace default agent takes precedence over environment default agent" {
+            val namespaceDefaultName = "namespace-agent"
+            val environmentDefaultName = "env-agent"
+            val namespaceAgentId = UUID.nameUUIDFromBytes(namespaceDefaultName.toByteArray())
+            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = namespaceDefaultName,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            val namespaceAgent = mockk<Agent> {
+                every { metadata } returns EntityMetadata(id = namespaceAgentId)
+                every { name } returns namespaceDefaultName
+                every { run(any<List<CaseEvent>>(), any()) } answers {
+                    val caseId = firstArg<List<CaseEvent>>().first().caseId
+                    flow {
+                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId, agentId = namespaceAgentId, agentName = namespaceDefaultName))
+                    }
+                }
+            }
+            val agentService = mockk<AgentService> {
+                every { resolveAgentName(namespaceDefaultName, namespaceId) } returns namespaceDefaultName
+                every { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
+            }
+            val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val service = CaseServiceImpl(
+                agentService,
+                AgentConfigProperties(agentName = environmentDefaultName),
+                InMemoryCaseRepository(),
+                caseEventService,
+                userService,
+                namespaceService,
+            )
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE, CaseStatus.ERROR)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+            val persistedEvents = caseEventService.findByParent(case.id)
+            // namespace agent was selected, not the environment default
+            persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe namespaceDefaultName
+        }
+
+        "no default agent at any level produces WarnEvent and stops" {
+            val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+            val namespace = Namespace(
+                metadata = EntityMetadata(id = namespaceId),
+                name = "test-namespace",
+                defaultAgentName = null,
+            )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            val agentService = mockk<AgentService>(relaxed = true)
+            val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val service = CaseServiceImpl(
+                agentService,
+                AgentConfigProperties(agentName = null),  // no environment default either
+                InMemoryCaseRepository(),
+                caseEventService,
+                userService,
+                namespaceService,
+            )
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE, CaseStatus.ERROR)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+            val persistedEvents = caseEventService.findByParent(case.id)
+            persistedEvents.filterIsInstance<WarnEvent>() shouldHaveAtLeastSize 1
+            persistedEvents.filterIsInstance<AgentSelectedEvent>() shouldBe emptyList()
+        }
+
+        // -------------------------------------------------------------------------
+        // Default agent routing — basic
         // -------------------------------------------------------------------------
 
         "first message without @mention routes to namespace default agent" {
@@ -567,6 +714,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
                 userService,
@@ -620,6 +768,7 @@ class CaseServiceImplSpec :
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
                 userServiceMock,
@@ -707,7 +856,7 @@ class CaseServiceImplSpec :
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, caseRepository, caseEventService, userService, namespaceService)
+            val service = CaseServiceImpl(agentService, AgentConfigProperties(), caseRepository, caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)


### PR DESCRIPTION
## WZ-31893 — Environment-level Default Agent Fallback

Introduces a two-tier fallback for agent routing when no explicit `@mention` is present in a message.

### Resolution order

1. `Namespace.defaultAgentName` — existing namespace-level default (unchanged)
2. `agentos.defaults.agent-name` — new environment-level default (this PR)
3. `WarnEvent` + stop — existing silent-fail behaviour

### Changes

**`AgentConfigProperties`** — new `@ConfigurationProperties("agentos.defaults")` with a single `agentName: String?` field. Configurable via `AGENTOS_DEFAULTS_AGENT_NAME` env var.

**`CaseServiceImpl.selectDefaultAgent()`** — falls back to `agentConfigProperties.agentName` when the namespace has no default configured. A single `resolveAgentName()` call handles both cases; the log line identifies the source (`namespace` vs `environment`).

**`application.yml`** — property documented and commented out (opt-in, no behaviour change by default).

### Tests

Three new cases in `CaseServiceImplSpec`:
- Environment default used when namespace has none
- Namespace default takes precedence over environment default
- No default at either level → `WarnEvent`, no `AgentSelectedEvent`