### PR TITLE
feat: #31898 tag agent and user messages with XML in LLM context

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -157,7 +157,7 @@ class AgentAdvanced(
                             contentBuilder.append(chunk)
                             emit(TextChunkEvent(namespaceId = namespaceId, caseId = caseId, chunk = chunk))
                         }
-                    val content = contentBuilder.toString()
+                    val content = contentBuilder.toString().stripConversationTags()
                     if (content.isNotEmpty()) {
                         val msg =
                             MessageEvent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.reactive.asFlow
 import mu.KLogging
 import org.springframework.ai.chat.client.ChatClient
-import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
 import org.springframework.ai.chat.messages.SystemMessage
 import org.springframework.ai.chat.messages.UserMessage
@@ -475,32 +474,12 @@ Generate ONLY the JSON object matching the input schema above. No explanation, n
     /**
      * Convert CaseEvents to Spring AI Messages for LLM context.
      * Masks tool calls/responses and keeps only user-agent exchanges.
-     * Converts other agents to "user" role for LLM compatibility.
+     * Other agents' messages are wrapped with XML tags via [MessageEvent.toSpringAiMessage].
      */
     private fun convertEventsToMessages(events: List<CaseEvent>): List<Message> =
         events
             .filterIsInstance<MessageEvent>()
-            .map { messageEvent ->
-                val textContent =
-                    messageEvent.content
-                        .filterIsInstance<MessageContent.Text>()
-                        .joinToString("\n") { it.content }
-
-                when (messageEvent.actor.role) {
-                    ActorRole.USER -> {
-                        UserMessage(textContent)
-                    }
-
-                    ActorRole.AGENT -> {
-                        if (messageEvent.actor.id == id.toString()) {
-                            AssistantMessage(textContent)
-                        } else {
-                            // Convert other agents to user messages for LLM compatibility
-                            UserMessage("[${messageEvent.actor.displayName}]: $textContent")
-                        }
-                    }
-                }
-            }
+            .map { it.toSpringAiMessage(id.toString()) }
 
     internal class IntentionParsingException(
         message: String,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -177,7 +177,11 @@ class AgentSimple(
                     )
                 }
 
-                val content = contentBuilder.toString()
+                // Strip any conversation tags the LLM may have hallucinated in its response.
+                // TextChunkEvents are left as-is (tags split across chunks are harmless noise
+                // in the stream and render invisibly in markdown). Only the stored MessageEvent
+                // needs to be clean.
+                val content = contentBuilder.toString().stripConversationTags()
 
                 // Close tool event channel and emit remaining events
                 toolEventChannel.close()

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -26,7 +26,6 @@ import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
 import org.springframework.ai.chat.messages.SystemMessage
 import org.springframework.ai.chat.messages.ToolResponseMessage
-import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.ai.tool.ToolCallback
 import org.springframework.ai.tool.definition.DefaultToolDefinition
@@ -289,26 +288,7 @@ class AgentSimple(
                         toolCallsForCurrentMessage.clear()
                     }
 
-                    // Add the message event
-                    val textContent =
-                        event.content
-                            .filterIsInstance<MessageContent.Text>()
-                            .joinToString("\n") { it.content }
-
-                    when (event.actor.role) {
-                        ActorRole.USER -> {
-                            messages.add(UserMessage(textContent))
-                        }
-
-                        ActorRole.AGENT -> {
-                            if (event.actor.id == id.toString()) {
-                                messages.add(AssistantMessage(textContent))
-                            } else {
-                                // Convert other agents to user messages for LLM compatibility
-                                messages.add(UserMessage("[${event.actor.displayName}]: $textContent"))
-                            }
-                        }
-                    }
+                    messages.add(event.toSpringAiMessage(id.toString()))
                 }
 
                 is ToolRequestEvent -> {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
@@ -8,6 +8,23 @@ import org.springframework.ai.chat.messages.Message
 import org.springframework.ai.chat.messages.UserMessage
 
 /**
+ * Regex patterns for the XML conversation tags injected by [MessageEvent.toSpringAiMessage].
+ * Used to strip any tags the LLM may have hallucinated in its own response text.
+ */
+private val AGENT_TAG_REGEX = Regex("""<agent=[^>]+>(.*?)</agent>""", RegexOption.DOT_MATCHES_ALL)
+private val USER_TAG_REGEX = Regex("""<user name="[^"]*">(.*?)</user>""", RegexOption.DOT_MATCHES_ALL)
+
+/**
+ * Strip any conversation tags ([AGENT_TAG_REGEX], [USER_TAG_REGEX]) from a string.
+ *
+ * Called on the final LLM response text before emitting the [MessageEvent] so that
+ * tags the LLM hallucinated in its own output are not stored or displayed.
+ */
+internal fun String.stripConversationTags(): String =
+    AGENT_TAG_REGEX.replace(this, "$1")
+        .let { USER_TAG_REGEX.replace(it, "$1") }
+
+/**
  * Convert a [MessageEvent] to a Spring AI [Message], as seen from the perspective of [currentAgentId].
  *
  * Role assignment:

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
@@ -1,0 +1,41 @@
+package io.whozoss.agentos.agent
+
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.messages.UserMessage
+
+/**
+ * Convert a [MessageEvent] to a Spring AI [Message], as seen from the perspective of [currentAgentId].
+ *
+ * Role assignment:
+ * - USER messages → [UserMessage] wrapped in `<user name="...">` XML tag so the LLM can
+ *   distinguish human messages from agent messages in multi-agent conversations.
+ * - AGENT messages from the current agent → [AssistantMessage] (unchanged — this is the LLM's own voice).
+ * - AGENT messages from other agents → [UserMessage] wrapped in `<agent=Name>` XML tag,
+ *   following the same convention as Coday's `convertAgentMessages`. The LLM sees them as
+ *   user-role messages but can identify their origin from the tag.
+ *
+ * The XML tagging convention (`<agent=Name>`, `<user name="...">`) is deliberately kept
+ * consistent with the Coday `AiClient.convertAgentMessages` implementation.
+ */
+internal fun MessageEvent.toSpringAiMessage(currentAgentId: String): Message {
+    val textContent =
+        content
+            .filterIsInstance<MessageContent.Text>()
+            .joinToString("\n") { it.content }
+
+    return when (actor.role) {
+        ActorRole.USER ->
+            UserMessage("<user name=\"${actor.displayName}\">$textContent</user>")
+
+        ActorRole.AGENT ->
+            if (actor.id == currentAgentId) {
+                AssistantMessage(textContent)
+            } else {
+                UserMessage("<agent=${actor.displayName}>$textContent</agent>")
+            }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleUnitSpec.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
@@ -150,15 +151,16 @@ class AgentSimpleUnitSpec :
             events.filterIsInstance<AgentFinishedEvent>().firstOrNull() shouldNotBe null
         }
 
-        "should convert other agents to user messages" {
+        "should convert other agents to user messages with XML agent tag" {
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
             val agentId = UUID.randomUUID()
             val otherAgentId = UUID.randomUUID()
 
+            val capturedPrompt = slot<Prompt>()
             val mockChatClient = mockk<ChatClient>(relaxed = true)
             val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
-            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            every { mockChatClient.prompt(capture(capturedPrompt)).stream() } returns mockStreamSpec
             every { mockStreamSpec.content() } returns Flux.just("Response considering ", "other agent's input")
 
             val agent = makeAgent(agentId, mockChatClient)
@@ -180,6 +182,40 @@ class AgentSimpleUnitSpec :
 
             events shouldHaveAtLeastSize 4
             events.last() as? AgentFinishedEvent shouldNotBe null
+
+            // The other agent's message must be wrapped with <agent=Name> XML tag
+            // so the current agent's LLM knows who said what in a multi-agent conversation.
+            val promptMessages = capturedPrompt.captured.instructions
+            val userMessages = promptMessages.filterIsInstance<org.springframework.ai.chat.messages.UserMessage>()
+            val otherAgentMsg = userMessages.firstOrNull { it.text.contains("<agent=OtherAgent>") }
+            otherAgentMsg shouldNotBe null
+            otherAgentMsg!!.text shouldContain "Other agent's response"
+            otherAgentMsg.text shouldContain "</agent>"
+        }
+
+        "should wrap user messages with XML user tag" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            val capturedPrompt = slot<Prompt>()
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(capture(capturedPrompt)).stream() } returns mockStreamSpec
+            every { mockStreamSpec.content() } returns Flux.just("Hello!")
+
+            val agent = makeAgent(agentId, mockChatClient)
+
+            agent.run(listOf(userMessage(namespaceId, caseId, "Hello, can you help me?"))).toList()
+
+            val promptMessages = capturedPrompt.captured.instructions
+            val userMessages = promptMessages.filterIsInstance<org.springframework.ai.chat.messages.UserMessage>()
+            userMessages shouldHaveAtLeastSize 1
+            // User messages must be tagged with <user name="..."> so the LLM can distinguish
+            // them from agent messages in multi-agent conversations.
+            userMessages.first().text shouldContain "<user name=\"User One\">"
+            userMessages.first().text shouldContain "Hello, can you help me?"
+            userMessages.first().text shouldContain "</user>"
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleUnitSpec.kt
@@ -193,6 +193,29 @@ class AgentSimpleUnitSpec :
             otherAgentMsg.text shouldContain "</agent>"
         }
 
+        "should strip conversation tags hallucinated by the LLM in its response" {
+            // If the LLM mimics the context format and wraps its own response in <agent=...>
+            // or <user name="..."> tags, those must be stripped from the stored MessageEvent.
+            // TextChunkEvents are left as-is (tags split across chunks are invisible in markdown).
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            // LLM wraps its own answer in an agent tag
+            every { mockStreamSpec.content() } returns Flux.just("<agent=SimpleAgent>", "Hello!", "</agent>")
+
+            val agent = makeAgent(agentId, mockChatClient, name = "SimpleAgent")
+            val events = agent.run(listOf(userMessage(namespaceId, caseId, "Hi"))).toList()
+
+            val messageEvent = events.filterIsInstance<MessageEvent>().firstOrNull()
+            messageEvent shouldNotBe null
+            // Tags must be stripped from the stored message
+            messageEvent!!.content.filterIsInstance<MessageContent.Text>().first().content shouldBe "Hello!"
+        }
+
         "should wrap user messages with XML user tag" {
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()


### PR DESCRIPTION
## WZ-31898 — Missing agent identification on LLM calls

### Problem

In multi-agent conversations, the LLM had no way to know which agent (or user) produced each message in the history. Other agents' messages were converted to `UserMessage` with a plain `[AgentName]: content` prefix — functional but not structured.

### Solution

Introduce XML tagging on all messages sent to the LLM, following the same convention as Coday's `AiClient.convertAgentMessages`:

- **Other agents** → `UserMessage("<agent=AgentName>content</agent>")`
- **User messages** → `UserMessage("<user name=\"DisplayName\">content</user>")`
- **Current agent's own messages** → `AssistantMessage(content)` unchanged

### Implementation

- `MessageConversions.kt` — new `MessageEvent.toSpringAiMessage(currentAgentId)` extension function, single source of truth for the XML tagging convention
- `AgentSimple` — uses `toSpringAiMessage()`, `UserMessage` import removed
- `AgentAdvanced` — was duplicating the old `[Name]:` logic; now also uses `toSpringAiMessage()`, `AssistantMessage` import removed
- Tests updated to assert on the XML tag format