### PR TITLE
feat: #WZ-31982: enforce agent availability at runtime

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -32,10 +32,12 @@ interface AgentService {
      * Resolve the canonical name for [namePart] within [namespaceId] by
      * [io.whozoss.agentos.agentConfig.AgentConfig] name matching,
      * without instantiating a full Agent.
-     * Returns null if no [io.whozoss.agentos.agentConfig.AgentConfig] matches.
+     *
+     * Returns null if no matching [io.whozoss.agentos.agentConfig.AgentConfig] is found.
      */
     fun resolveAgentName(
         namePart: String,
         namespaceId: UUID,
+        userId: UUID? = null,
     ): String?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -58,7 +58,13 @@ class AgentServiceImpl(
     override fun resolveAgentName(
         namePart: String,
         namespaceId: UUID,
-    ): String? = agentConfigService.findByName(namespaceId, namePart)?.name
+        userId: UUID?,
+    ): String? =
+        if (userId != null) {
+            agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, namePart)?.name
+        } else {
+            agentConfigService.findByName(namespaceId, namePart)?.name
+        }
 
     // -------------------------------------------------------------------------
     // Resolution helpers

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -52,4 +52,42 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
             """,
     )
     fun findAvailableByUserExternalId(namespaceExternalId: String, userExternalId: String): List<AgentConfigNode>
+
+    /**
+     * Returns the first [AgentConfigNode] accessible to the user (matched by internal [userId])
+     * in the namespace (matched by internal [namespaceId]) whose name matches [name]
+     * case-insensitively.
+     *
+     * Applies the same graph rules as [findAvailableByUserExternalId] (UserGroup membership
+     * and direct Namespace MEMBER/ADMIN relations) with the name filter pushed into Cypher
+     * to avoid fetching the full agent list.
+     *
+     * Used by [io.whozoss.agentos.agent.AgentServiceImpl.resolveAgentName] during
+     * conversation runtime where only internal UUIDs are available.
+     */
+    @Query(
+        $$"""
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+              WHERE g.removed IS NULL OR g.removed = false
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
+              WHERE a.removed IS NULL OR a.removed = false
+              AND toLower(a.name) = toLower($name)
+            RETURN a
+            UNION
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER|ADMIN]->(ns)
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
+              WHERE a.removed IS NULL OR a.removed = false
+              AND toLower(a.name) = toLower($name)
+            RETURN a
+            """,
+    )
+    fun findAvailableByUserIdAndName(namespaceId: String, userId: String, name: String): List<AgentConfigNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -10,4 +10,10 @@ import java.util.*
  */
 interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
     fun findAvailableByUserExternalId(namespaceExternalId: String, userExternalId: String): List<AgentConfig>
+
+    /**
+     * Returns the first [AgentConfig] accessible to [userId] in [namespaceId] whose
+     * name matches [name] case-insensitively, or null if none is found.
+     */
+    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -25,4 +25,10 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
      * See [AgentConfigRepository.findAvailableByUserExternalId] for the full semantics.
      */
     fun findAvailableByUserExternalId(namespaceExternalId: String, userExternalId: String): List<AgentConfig>
+
+    /**
+     * Returns the first [AgentConfig] accessible to [userId] in [namespaceId] whose
+     * name matches [name] case-insensitively, or null if none is found.
+     */
+    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -32,4 +32,7 @@ class AgentConfigServiceImpl(
 
     override fun findAvailableByUserExternalId(namespaceExternalId: String, userExternalId: String): List<AgentConfig> =
         agentConfigRepository.findAvailableByUserExternalId(namespaceExternalId, userExternalId)
+
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+        agentConfigRepository.findAvailableByUserIdAndName(namespaceId, userId, name)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -48,6 +48,9 @@ class FilesystemAgentConfigRepository(
             ttl = ttl,
         )
 
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+        delegate.findAvailableByUserIdAndName(namespaceId, userId, name)
+
     override fun findByParent(parentId: UUID): List<AgentConfig> {
         val persisted = delegate.findByParent(parentId)
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -44,11 +44,16 @@ open class Neo4jAgentConfigRepository(
                 true
             } ?: false
 
-    override fun findAvailableByUserExternalId(namespaceExternalId: String, userExternalId: String): List<AgentConfig> {
-        return neo4jRepository
+    override fun findAvailableByUserExternalId(namespaceExternalId: String, userExternalId: String): List<AgentConfig> =
+        neo4jRepository
             .findAvailableByUserExternalId(namespaceExternalId, userExternalId)
             .map { it.toDomain() }
-    }
+
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+        neo4jRepository
+            .findAvailableByUserIdAndName(namespaceId.toString(), userId.toString(), name)
+            .firstOrNull()
+            ?.toDomain()
 
     @Transactional
     open override fun deleteByParent(parentId: UUID): Int {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -29,10 +29,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   The runtime then adds it to its list and emits it on the SSE flow itself —
  *   no reference to the runtime is ever passed outward.
  * @param selectAgent resolves which agent should handle the current message.
- *   Receives the message content and the full current event history, and returns an
- *   ordered list of events to store+emit (e.g. an optional
- *   [io.whozoss.agentos.sdk.caseEvent.WarnEvent] followed by an [AgentSelectedEvent],
- *   or just an [AgentSelectedEvent] for the default agent).
+ *   Receives the message content, the full current event history, and the [UUID] of
+ *   the user who sent the message (resolved from the event history, may be null for
+ *   anonymous/system messages), and returns an ordered list of events to store+emit
+ *   (e.g. an optional [io.whozoss.agentos.sdk.caseEvent.WarnEvent] followed by an
+ *   [AgentSelectedEvent], or just an [AgentSelectedEvent] for the default agent).
  *   Returns an empty list when no agent is configured and the loop should stop.
  * @param runAgent fetches the named agent, runs it against the current event history,
  *   and pipes each produced event through [storeEvent]. Error handling is the
@@ -43,7 +44,7 @@ class CaseRuntime(
     val namespaceId: UUID,
     private val updateStatus: (UUID, CaseStatus) -> Unit,
     private val storeEvent: (CaseEvent) -> CaseEvent,
-    private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>) -> List<CaseEvent>,
+    private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>, userId: UUID?) -> List<CaseEvent>,
     private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
 ) : CaseEventEmitter by DefaultCaseEventEmitter() {
@@ -181,8 +182,10 @@ class CaseRuntime(
             }
         }
 
-        storeAndEmitEvent(MessageEvent(caseId = id, namespaceId = namespaceId, actor = actor, content = content))
-        selectAgent(content, eventList.getAll()).forEach { storeAndEmitEvent(it) }
+        val messageEvent = MessageEvent(caseId = id, namespaceId = namespaceId, actor = actor, content = content)
+        storeAndEmitEvent(messageEvent)
+        val userId = resolveUserId(eventList.getAll())
+        selectAgent(content, eventList.getAll(), userId).forEach { storeAndEmitEvent(it) }
     }
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -125,7 +125,7 @@ class CaseServiceImpl(
             namespaceId = case.namespaceId,
             updateStatus = { caseId, newStatus -> handleStatusChange(caseId, newStatus) },
             storeEvent = { event -> storeEvent(event) },
-            selectAgent = { content, pastEvents -> selectAgent(content, pastEvents, case.namespaceId, case.id) },
+            selectAgent = { content, pastEvents, userId -> selectAgent(content, pastEvents, userId, case.namespaceId, case.id) },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue -> runAgent(agentName, case.id, events, eventsProvider, userId, shouldContinue) },
             inputEvents = inputEvents,
         )
@@ -171,6 +171,7 @@ class CaseServiceImpl(
     private fun selectAgent(
         content: List<MessageContent>,
         pastEvents: List<CaseEvent>,
+        userId: UUID?,
         namespaceId: UUID,
         caseId: UUID,
     ): List<CaseEvent> {
@@ -192,21 +193,21 @@ class CaseServiceImpl(
 
         return when {
             mentionedName != null -> {
-                val resolvedName = agentService.resolveAgentName(mentionedName, namespaceId)
+                val resolvedName = agentService.resolveAgentName(mentionedName, namespaceId, userId)
                 when {
                     resolvedName != null -> {
                         logger.info { "[CaseService] Agent mention resolved: @$mentionedName -> $resolvedName" }
                         listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
                     }
                     else -> {
-                        logger.warn { "[CaseService] Agent '@$mentionedName' not found, falling back to default" }
+                        logger.warn { "[CaseService] Agent '@$mentionedName' not found or not accessible, falling back to default" }
                         listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$mentionedName' not found")) +
-                            selectDefaultAgent(namespaceId, caseId)
+                            selectDefaultAgent(namespaceId, caseId, userId)
                     }
                 }
             }
             lastSelectedName != null -> {
-                val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId) != null
+                val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId, userId) != null
                 when {
                     stillAvailable -> {
                         logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
@@ -215,11 +216,11 @@ class CaseServiceImpl(
                     else -> {
                         logger.warn { "[CaseService] Last selected agent '$lastSelectedName' is no longer available, falling back to default" }
                         listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$lastSelectedName' is no longer available")) +
-                            selectDefaultAgent(namespaceId, caseId)
+                            selectDefaultAgent(namespaceId, caseId, userId)
                     }
                 }
             }
-            else -> selectDefaultAgent(namespaceId, caseId)
+            else -> selectDefaultAgent(namespaceId, caseId, userId)
         }
     }
 
@@ -237,6 +238,7 @@ class CaseServiceImpl(
     private fun selectDefaultAgent(
         namespaceId: UUID,
         caseId: UUID,
+        userId: UUID?,
     ): List<CaseEvent> {
         val defaultAgentName = namespaceService.findById(namespaceId)?.defaultAgentName
         return if (defaultAgentName == null) {
@@ -249,7 +251,7 @@ class CaseServiceImpl(
                 ),
             )
         } else {
-            val resolvedName = agentService.resolveAgentName(defaultAgentName, namespaceId)
+            val resolvedName = agentService.resolveAgentName(defaultAgentName, namespaceId, userId)
             if (resolvedName == null) {
                 logger.warn { "[CaseService] Default agent '$defaultAgentName' is not available in namespace $namespaceId" }
                 listOf(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -502,10 +502,10 @@ class AgentServiceImplUnitSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
-        // resolveAgentName
+        // resolveAgentName — anonymous path (userId == null)
         // -------------------------------------------------------------------------
 
-        "resolveAgentName returns AgentConfig name when one matches" {
+        "resolveAgentName returns AgentConfig name when one matches (no userId)" {
             val config = agentConfig(name = "my-agent")
             every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
 
@@ -514,10 +514,45 @@ class AgentServiceImplUnitSpec : StringSpec() {
             verify(exactly = 0) { aiModelService.findAiModel(any(), any()) }
         }
 
-        "resolveAgentName returns null when no AgentConfig matches" {
+        "resolveAgentName returns null when no AgentConfig matches (no userId)" {
             every { agentConfigService.findByName(namespaceId, "unknown") } returns null
 
             agentService.resolveAgentName("unknown", namespaceId) shouldBe null
+        }
+
+        // -------------------------------------------------------------------------
+        // resolveAgentName — user-scoped path (userId != null)
+        // -------------------------------------------------------------------------
+
+        "resolveAgentName with userId delegates to findAvailableByUserIdAndName" {
+            val userId = UUID.randomUUID()
+            val config = agentConfig(name = "my-agent")
+            every { agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, "my-agent") } returns config
+
+            agentService.resolveAgentName("my-agent", namespaceId, userId) shouldBe "my-agent"
+
+            verify(exactly = 0) { agentConfigService.findByName(any(), any()) }
+        }
+
+        "resolveAgentName with userId returns null when agent is not accessible to the user" {
+            val userId = UUID.randomUUID()
+            every { agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, "restricted") } returns null
+
+            agentService.resolveAgentName("restricted", namespaceId, userId) shouldBe null
+
+            verify(exactly = 0) { agentConfigService.findByName(any(), any()) }
+        }
+
+        "resolveAgentName with userId does not fall back to findByName" {
+            // Ensures the user-scoped path is strictly gated by Neo4j rights:
+            // an agent that exists in the namespace but is not deployed to the user
+            // must return null, not fall through to the namespace-wide lookup.
+            val userId = UUID.randomUUID()
+            every { agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, "my-agent") } returns null
+
+            agentService.resolveAgentName("my-agent", namespaceId, userId) shouldBe null
+
+            verify(exactly = 0) { agentConfigService.findByName(any(), any()) }
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -17,8 +17,11 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
                 parentIdExtractor = { it.namespaceId },
                 comparator = compareBy { it.name },
             ) {
-            // findAvailableByUserExternalId is a Neo4j-only query; not exercised in unit tests.
+            // findAvailableByUserExternalId and findAvailableByUserIdAndName are Neo4j-only queries; not exercised in unit tests.
             override fun findAvailableByUserExternalId(namespaceExternalId: String, userExternalId: String): List<AgentConfig> =
+                throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
+
+            override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -48,6 +48,10 @@ class RecordingRunAgent(
  * A simple recording wrapper for the selectAgent callback, avoiding MockK entirely.
  * MockK global state can bleed between specs when stubs from one spec are still
  * registered when the next spec runs. A plain wrapper has no such risk.
+ *
+ * The [userId] parameter mirrors the [CaseRuntime] callback signature: it carries
+ * the UUID of the user who sent the message (resolved from the event history) so
+ * that agent selection can apply per-user access rules.
  */
 class RecordingSelectAgent(
     private val delegate: (List<MessageContent>, List<CaseEvent>) -> List<CaseEvent>,
@@ -55,7 +59,7 @@ class RecordingSelectAgent(
     private val _calls = mutableListOf<List<MessageContent>>()
     val callCount: Int get() = _calls.size
 
-    val asCallback: (List<MessageContent>, List<CaseEvent>) -> List<CaseEvent> = { content, pastEvents ->
+    val asCallback: (List<MessageContent>, List<CaseEvent>, UUID?) -> List<CaseEvent> = { content, pastEvents, _ ->
         _calls += content
         delegate(content, pastEvents)
     }
@@ -213,6 +217,77 @@ class CaseRuntimeSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
+        // selectAgent receiving userId from event history
+        // -------------------------------------------------------------------------
+
+        "selectAgent callback receives userId resolved from the last user MessageEvent" {
+            val expectedUserId = UUID.randomUUID()
+            val actorWithUuid = Actor(id = expectedUserId.toString(), displayName = "Alice", role = ActorRole.USER)
+            val capturedUserIds = mutableListOf<UUID?>()
+            val runtimeId = UUID.randomUUID()
+            val agentName = "default-agent"
+            val savedEvents = mutableListOf<CaseEvent>()
+            val agent = finishingAgent(agentName)
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = runtimeId,
+                namespaceId = namespaceId,
+                updateStatus = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _, userId ->
+                    capturedUserIds += userId
+                    listOf(agentSelectedEvent(runtimeId, agentName))
+                },
+                runAgent = { _, events, _, _, _ ->
+                    agent.run(events).collect { event ->
+                        savedEvents.add(event)
+                        runtime.pushEvents(listOf(event))
+                    }
+                },
+            )
+
+            runtime.addUserMessage(actorWithUuid, userMessage)
+            runtime.run()
+
+            capturedUserIds shouldHaveAtLeastSize 1
+            capturedUserIds.first() shouldBe expectedUserId
+        }
+
+        "selectAgent callback receives null userId when actor id is not a valid UUID" {
+            val actorWithNonUuid = Actor(id = "not-a-uuid", displayName = "System", role = ActorRole.USER)
+            val capturedUserIds = mutableListOf<UUID?>()
+            val runtimeId = UUID.randomUUID()
+            val agentName = "default-agent"
+            val savedEvents = mutableListOf<CaseEvent>()
+            val agent = finishingAgent(agentName)
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = runtimeId,
+                namespaceId = namespaceId,
+                updateStatus = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _, userId ->
+                    capturedUserIds += userId
+                    listOf(agentSelectedEvent(runtimeId, agentName))
+                },
+                runAgent = { _, events, _, _, _ ->
+                    agent.run(events).collect { event ->
+                        savedEvents.add(event)
+                        runtime.pushEvents(listOf(event))
+                    }
+                },
+            )
+
+            runtime.addUserMessage(actorWithNonUuid, userMessage)
+            runtime.run()
+
+            capturedUserIds shouldHaveAtLeastSize 1
+            capturedUserIds.first() shouldBe null
+        }
+
+        // -------------------------------------------------------------------------
         // selectAgent returning a WarnEvent + AgentSelectedEvent
         // -------------------------------------------------------------------------
 
@@ -232,7 +307,7 @@ class CaseRuntimeSpec : StringSpec() {
                         savedEvents.add(event)
                         event
                     },
-                    selectAgent = { _, _ ->
+                    selectAgent = { _, _, _ ->
                         listOf(
                             WarnEvent(
                                 namespaceId = namespaceId,
@@ -298,7 +373,7 @@ class CaseRuntimeSpec : StringSpec() {
                         if (event is AgentRunningEvent) callOrder.add("AgentRunningEvent saved")
                         event
                     },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
                     runAgent = { _, events, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
@@ -338,7 +413,7 @@ class CaseRuntimeSpec : StringSpec() {
                     namespaceId = namespaceId,
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
@@ -372,7 +447,7 @@ class CaseRuntimeSpec : StringSpec() {
                     namespaceId = namespaceId,
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                     },
@@ -405,7 +480,7 @@ class CaseRuntimeSpec : StringSpec() {
                     namespaceId = namespaceId,
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     runAgent = { _, _, _, _, shouldContinue ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
@@ -466,7 +541,6 @@ class CaseRuntimeSpec : StringSpec() {
                 }
             }
 
-            // Agent B finishes normally.
             val agentBMock = mockk<Agent>(name = "mock-$agentB") {
                 every { metadata } returns EntityMetadata(id = agentBId)
                 every { name } returns agentB
@@ -555,7 +629,7 @@ class CaseRuntimeSpec : StringSpec() {
                         savedEvents.add(event)
                         event
                     },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
                     runAgent = recorder.asCallback,
                 )
             runtime.pushEvents(listOf(existingUserMessage, existingRunningEvent))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -147,7 +147,7 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(any(), any()) } returns agentName
+                    every { resolveAgentName(any(), any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns agent
                 }
             val caseRepository = InMemoryCaseRepository()
@@ -264,7 +264,7 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(any(), any()) } returns agentName
+                    every { resolveAgentName(any(), any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns finishingAgent()
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
@@ -468,7 +468,7 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(agentName, namespaceId) } returns agentName
+                    every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
@@ -608,13 +608,13 @@ class CaseServiceImplSpec :
             //   turn 2, default resolution: resolveAgentName(agentName) -> agentName (found)
             val resolveCallCount = java.util.concurrent.atomic.AtomicInteger(0)
             val agentService = mockk<AgentService> {
-                every { resolveAgentName(unavailableAgentName, namespaceId) } answers {
+                every { resolveAgentName(unavailableAgentName, namespaceId, any()) } answers {
                     when (resolveCallCount.incrementAndGet()) {
                         1 -> unavailableAgentName  // turn 1: @mention resolves
                         else -> null              // turn 2: sticky-agent check fails
                     }
                 }
-                every { resolveAgentName(agentName, namespaceId) } returns agentName
+                every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                 every { findAgentByName(any(), any()) } returns finishingAgent()
             }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
@@ -700,7 +700,7 @@ class CaseServiceImplSpec :
             val agentService =
                 mockk<AgentService> {
                     // @selected-agent resolves to selectedAgentName
-                    every { resolveAgentName(selectedAgentName, any()) } returns selectedAgentName
+                    every { resolveAgentName(selectedAgentName, any(), any()) } returns selectedAgentName
                     // no other mention resolution needed
                     every { findAgentByName(selectedAgentName, any()) } returns selectedAgent
                 }


### PR DESCRIPTION
Apply the same Neo4j graph rules (DEPLOYED_TO + MEMBER/ADMIN) to runtime agent selection as to the /search endpoint. Previously, any agent in the namespace could be selected by name regardless of user access rights.

- Add findAvailableByUserIdAndName Cypher query (by internal UUID)
- Wire userId from event history into selectAgent and resolveAgentName