### PR TITLE
feat: #WZ-31982: enforce agent availability at runtime

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
@@ -20,5 +20,4 @@ data class AgentExecutionContext(
     val caseId: UUID,
     val userId: UUID? = null,
     val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
-    val authorizedAgentNames: Set<String> = emptySet(),
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
@@ -20,4 +20,5 @@ data class AgentExecutionContext(
     val caseId: UUID,
     val userId: UUID? = null,
     val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
+    val authorizedAgentNames: Set<String> = emptySet(),
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -32,10 +32,17 @@ interface AgentService {
      * Resolve the canonical name for [namePart] within [namespaceId] by
      * [io.whozoss.agentos.agentConfig.AgentConfig] name matching,
      * without instantiating a full Agent.
-     * Returns null if no [io.whozoss.agentos.agentConfig.AgentConfig] matches.
+     *
+     * When [userId] is provided, only agents accessible to that user are considered
+     * (same Neo4j graph rules as the /search endpoint: UserGroup membership and
+     * direct Namespace MEMBER/ADMIN relations). When [userId] is null, falls back
+     * to a namespace-wide lookup (legacy/anonymous path).
+     *
+     * Returns null if no matching [io.whozoss.agentos.agentConfig.AgentConfig] is found.
      */
     fun resolveAgentName(
         namePart: String,
         namespaceId: UUID,
+        userId: UUID? = null,
     ): String?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -3,6 +3,7 @@ package io.whozoss.agentos.agent
 import io.whozoss.agentos.sdk.agent.Agent
 import java.util.UUID
 
+
 /**
  * Service for managing agent runtime instances.
  *
@@ -28,21 +29,5 @@ interface AgentService {
         context: AgentExecutionContext,
     ): Agent
 
-    /**
-     * Resolve the canonical name for [namePart] within [namespaceId] by
-     * [io.whozoss.agentos.agentConfig.AgentConfig] name matching,
-     * without instantiating a full Agent.
-     *
-     * When [userId] is provided, only agents accessible to that user are considered
-     * (same Neo4j graph rules as the /search endpoint: UserGroup membership and
-     * direct Namespace MEMBER/ADMIN relations). When [userId] is null, falls back
-     * to a namespace-wide lookup (legacy/anonymous path).
-     *
-     * Returns null if no matching [io.whozoss.agentos.agentConfig.AgentConfig] is found.
-     */
-    fun resolveAgentName(
-        namePart: String,
-        namespaceId: UUID,
-        userId: UUID? = null,
-    ): String?
+
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -262,7 +262,18 @@ class AgentServiceImpl(
                 }
             }
 
-        return listOfNotNull(baseInstructions.takeUnless { it.isNullOrBlank() }, namespaceBlock, integrationsBlock, userBlock)
+        val agentsBlock = context.authorizedAgentNames
+            .takeIf { it.isNotEmpty() }
+            ?.let { names ->
+                buildString {
+                    appendLine()
+                    appendLine("## Available agents")
+                    appendLine("You may redirect to the following agents by name:")
+                    names.sorted().forEach { appendLine("- $it") }
+                }.trimEnd()
+            }
+
+        return listOfNotNull(baseInstructions.takeUnless { it.isNullOrBlank() }, namespaceBlock, integrationsBlock, userBlock, agentsBlock)
             .joinToString("\n")
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -58,7 +58,13 @@ class AgentServiceImpl(
     override fun resolveAgentName(
         namePart: String,
         namespaceId: UUID,
-    ): String? = agentConfigService.findByName(namespaceId, namePart)?.name
+        userId: UUID?,
+    ): String? =
+        if (userId != null) {
+            agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, namePart)?.name
+        } else {
+            agentConfigService.findByName(namespaceId, namePart)?.name
+        }
 
     // -------------------------------------------------------------------------
     // Resolution helpers

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -55,17 +55,6 @@ class AgentServiceImpl(
         return createAgentFromConfig(agentConfig, context)
     }
 
-    override fun resolveAgentName(
-        namePart: String,
-        namespaceId: UUID,
-        userId: UUID?,
-    ): String? =
-        if (userId != null) {
-            agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, namePart)?.name
-        } else {
-            agentConfigService.findByName(namespaceId, namePart)?.name
-        }
-
     // -------------------------------------------------------------------------
     // Resolution helpers
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -262,18 +262,7 @@ class AgentServiceImpl(
                 }
             }
 
-        val agentsBlock = context.authorizedAgentNames
-            .takeIf { it.isNotEmpty() }
-            ?.let { names ->
-                buildString {
-                    appendLine()
-                    appendLine("## Available agents")
-                    appendLine("You may redirect to the following agents by name:")
-                    names.sorted().forEach { appendLine("- $it") }
-                }.trimEnd()
-            }
-
-        return listOfNotNull(baseInstructions.takeUnless { it.isNullOrBlank() }, namespaceBlock, integrationsBlock, userBlock, agentsBlock)
+        return listOfNotNull(baseInstructions.takeUnless { it.isNullOrBlank() }, namespaceBlock, integrationsBlock, userBlock)
             .joinToString("\n")
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -54,12 +54,13 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
     fun findAvailableByUserExternalId(namespaceId: String, userExternalId: String): List<AgentConfigNode>
 
     /**
-     * Returns the first [AgentConfigNode] accessible to the user (matched by internal [userId])
-     * in the namespace (matched by internal [namespaceId]) whose name matches [name]
-     * case-insensitively.
+     * Returns all [AgentConfigNode]s accessible to the user (matched by internal [userId])
+     * in the namespace (matched by internal [namespaceId]).
      *
-     * Used by [io.whozoss.agentos.agent.AgentServiceImpl.resolveAgentName] during
-     * conversation runtime where only internal UUIDs are available.
+     * Same graph rules as [findAvailableByUserExternalId] but matched by internal [userId]
+     * rather than [externalId]. Returns the full authorized set without name filtering.
+     * Called once per user message to build the authorized agent set used
+     * for routing and redirect enforcement.
      */
     @Query(
         $$"""
@@ -71,7 +72,6 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
               WHERE g.removed IS NULL OR g.removed = false
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
               WHERE a.removed IS NULL OR a.removed = false
-              AND toLower(a.name) = toLower($name)
             RETURN a
             UNION
             MATCH (u:User {id: $userId})
@@ -81,9 +81,8 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
             MATCH (u)-[:MEMBER|ADMIN]->(ns)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
               WHERE a.removed IS NULL OR a.removed = false
-              AND toLower(a.name) = toLower($name)
             RETURN a
             """,
     )
-    fun findAvailableByUserIdAndName(namespaceId: String, userId: String, name: String): List<AgentConfigNode>
+    fun findAvailableByUserId(namespaceId: String, userId: String): List<AgentConfigNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -52,4 +52,38 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
             """,
     )
     fun findAvailableByUserExternalId(namespaceId: String, userExternalId: String): List<AgentConfigNode>
+
+    /**
+     * Returns the first [AgentConfigNode] accessible to the user (matched by internal [userId])
+     * in the namespace (matched by internal [namespaceId]) whose name matches [name]
+     * case-insensitively.
+     *
+     * Used by [io.whozoss.agentos.agent.AgentServiceImpl.resolveAgentName] during
+     * conversation runtime where only internal UUIDs are available.
+     */
+    @Query(
+        $$"""
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+              WHERE g.removed IS NULL OR g.removed = false
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
+              WHERE a.removed IS NULL OR a.removed = false
+              AND toLower(a.name) = toLower($name)
+            RETURN a
+            UNION
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER|ADMIN]->(ns)
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
+              WHERE a.removed IS NULL OR a.removed = false
+              AND toLower(a.name) = toLower($name)
+            RETURN a
+            """,
+    )
+    fun findAvailableByUserIdAndName(namespaceId: String, userId: String, name: String): List<AgentConfigNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -10,4 +10,12 @@ import java.util.*
  */
 interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
+
+    /**
+     * Returns the first [AgentConfig] accessible to [userId] in [namespaceId] whose
+     * name matches [name] case-insensitively, or null if none is found.
+     *
+     * The name filter is applied in Neo4j — no in-memory scan.
+     */
+    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -12,10 +12,9 @@ interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
 
     /**
-     * Returns the first [AgentConfig] accessible to [userId] in [namespaceId] whose
-     * name matches [name] case-insensitively, or null if none is found.
-     *
-     * The name filter is applied in Neo4j — no in-memory scan.
+     * Returns all [AgentConfig]s accessible to [userId] in [namespaceId].
+     * Called once per user message to build the authorized agent set used
+     * for routing and redirect enforcement.
      */
-    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig?
+    fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -27,10 +27,9 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
 
     /**
-     * Returns the first [AgentConfig] accessible to [userId] in [namespaceId] whose
-     * name matches [name] case-insensitively, or null if none is found.
-     *
-     * The name filter is applied in Neo4j — no in-memory scan.
+     * Returns all [AgentConfig]s accessible to [userId] in [namespaceId].
+     * Called once per user message to build the authorized agent set used
+     * for routing and redirect enforcement.
      */
-    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig?
+    fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -25,4 +25,12 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
      * See [AgentConfigRepository.findAvailableByUserExternalId] for the full semantics.
      */
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
+
+    /**
+     * Returns the first [AgentConfig] accessible to [userId] in [namespaceId] whose
+     * name matches [name] case-insensitively, or null if none is found.
+     *
+     * The name filter is applied in Neo4j — no in-memory scan.
+     */
+    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -32,4 +32,7 @@ class AgentConfigServiceImpl(
 
     override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
         agentConfigRepository.findAvailableByUserExternalId(namespaceId, userExternalId)
+
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+        agentConfigRepository.findAvailableByUserIdAndName(namespaceId, userId, name)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -33,6 +33,6 @@ class AgentConfigServiceImpl(
     override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
         agentConfigRepository.findAvailableByUserExternalId(namespaceId, userExternalId)
 
-    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
-        agentConfigRepository.findAvailableByUserIdAndName(namespaceId, userId, name)
+    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
+        agentConfigRepository.findAvailableByUserId(namespaceId, userId)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -48,8 +48,8 @@ class FilesystemAgentConfigRepository(
             ttl = ttl,
         )
 
-    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
-        delegate.findAvailableByUserIdAndName(namespaceId, userId, name)
+    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
+        delegate.findAvailableByUserId(namespaceId, userId)
 
     override fun findByParent(parentId: UUID): List<AgentConfig> {
         val persisted = delegate.findByParent(parentId)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -48,6 +48,9 @@ class FilesystemAgentConfigRepository(
             ttl = ttl,
         )
 
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+        delegate.findAvailableByUserIdAndName(namespaceId, userId, name)
+
     override fun findByParent(parentId: UUID): List<AgentConfig> {
         val persisted = delegate.findByParent(parentId)
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -49,11 +49,10 @@ open class Neo4jAgentConfigRepository(
             .findAvailableByUserExternalId(namespaceId.toString(), userExternalId)
             .map { it.toDomain() }
 
-    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
         neo4jRepository
-            .findAvailableByUserIdAndName(namespaceId.toString(), userId.toString(), name)
-            .firstOrNull()
-            ?.toDomain()
+            .findAvailableByUserId(namespaceId.toString(), userId.toString())
+            .map { it.toDomain() }
 
     @Transactional
     open override fun deleteByParent(parentId: UUID): Int {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -44,11 +44,16 @@ open class Neo4jAgentConfigRepository(
                 true
             } ?: false
 
-    override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> {
-        return neo4jRepository
+    override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
+        neo4jRepository
             .findAvailableByUserExternalId(namespaceId.toString(), userExternalId)
             .map { it.toDomain() }
-    }
+
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+        neo4jRepository
+            .findAvailableByUserIdAndName(namespaceId.toString(), userId.toString(), name)
+            .firstOrNull()
+            ?.toDomain()
 
     @Transactional
     open override fun deleteByParent(parentId: UUID): Int {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -183,7 +183,7 @@ class CaseRuntime(
         }
 
         storeAndEmitEvent(MessageEvent(caseId = id, namespaceId = namespaceId, actor = actor, content = content))
-        val userId = resolveUserId(eventList.getAll())
+        val userId = runCatching { UUID.fromString(actor.id) }.getOrNull()
         selectAgent(content, eventList.getAll(), userId).forEach { storeAndEmitEvent(it) }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -29,10 +29,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   The runtime then adds it to its list and emits it on the SSE flow itself —
  *   no reference to the runtime is ever passed outward.
  * @param selectAgent resolves which agent should handle the current message.
- *   Receives the message content and the full current event history, and returns an
- *   ordered list of events to store+emit (e.g. an optional
- *   [io.whozoss.agentos.sdk.caseEvent.WarnEvent] followed by an [AgentSelectedEvent],
- *   or just an [AgentSelectedEvent] for the default agent).
+ *   Receives the message content, the full current event history, and the [UUID] of
+ *   the user who sent the message (resolved from the event history, may be null for
+ *   system messages), and returns an ordered list of events to store+emit (e.g. an
+ *   optional [io.whozoss.agentos.sdk.caseEvent.WarnEvent] followed by an
+ *   [AgentSelectedEvent], or just an [AgentSelectedEvent] for the default agent).
  *   Returns an empty list when no agent is configured and the loop should stop.
  * @param runAgent fetches the named agent, runs it against the current event history,
  *   and pipes each produced event through [storeEvent]. Error handling is the
@@ -43,7 +44,7 @@ class CaseRuntime(
     val namespaceId: UUID,
     private val updateStatus: (UUID, CaseStatus) -> Unit,
     private val storeEvent: (CaseEvent) -> CaseEvent,
-    private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>) -> List<CaseEvent>,
+    private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>, userId: UUID?) -> List<CaseEvent>,
     private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
 ) : CaseEventEmitter by DefaultCaseEventEmitter() {
@@ -182,7 +183,8 @@ class CaseRuntime(
         }
 
         storeAndEmitEvent(MessageEvent(caseId = id, namespaceId = namespaceId, actor = actor, content = content))
-        selectAgent(content, eventList.getAll()).forEach { storeAndEmitEvent(it) }
+        val userId = resolveUserId(eventList.getAll())
+        selectAgent(content, eventList.getAll(), userId).forEach { storeAndEmitEvent(it) }
     }
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -119,6 +119,8 @@ class CaseRuntime(
 
     fun isRunning(): Boolean = runInFlight.get()
 
+    fun getAuthorizedAgentNames(): Set<String> = authorizedAgentNames
+
     fun pushEvents(events: Collection<CaseEvent>) {
         events.forEach { eventList.add(it) }
     }
@@ -306,7 +308,7 @@ class CaseRuntime(
                             "transitioning to running"
                     }
                     val authorized = authorizedAgentNames
-                    if (authorized.isNotEmpty() && event.agentName.lowercase() !in authorized) {
+                    if (authorized.isNotEmpty() && authorized.none { it.lowercase() == event.agentName.lowercase() }) {
                         logger.warn {
                             "[CaseRuntime $id] Agent '${event.agentName}' is not in the authorized " +
                                 "agent set — redirect blocked"

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -29,12 +29,15 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   The runtime then adds it to its list and emits it on the SSE flow itself —
  *   no reference to the runtime is ever passed outward.
  * @param selectAgent resolves which agent should handle the current message.
- *   Receives the message content, the full current event history, and the [UUID] of
- *   the user who sent the message (resolved from the event history, may be null for
- *   system messages), and returns an ordered list of events to store+emit (e.g. an
- *   optional [io.whozoss.agentos.sdk.caseEvent.WarnEvent] followed by an
- *   [AgentSelectedEvent], or just an [AgentSelectedEvent] for the default agent).
+ *   Receives the message content, the full current event history, and the pre-computed
+ *   set of authorized agent names for the current user (empty = anonymous/system).
+ *   Returns an ordered list of events to store+emit (e.g. an optional
+ *   [io.whozoss.agentos.sdk.caseEvent.WarnEvent] followed by an [AgentSelectedEvent],
+ *   or just an [AgentSelectedEvent] for the default agent).
  *   Returns an empty list when no agent is configured and the loop should stop.
+ * @param authorizedAgentNames the set of agent names the current user is authorized
+ *   to interact with, computed once at conversation start from the Neo4j graph.
+ *   Used to validate agent-to-agent redirects without additional Neo4j round-trips.
  * @param runAgent fetches the named agent, runs it against the current event history,
  *   and pipes each produced event through [storeEvent]. Error handling is the
  *   responsibility of the service implementation.
@@ -44,11 +47,18 @@ class CaseRuntime(
     val namespaceId: UUID,
     private val updateStatus: (UUID, CaseStatus) -> Unit,
     private val storeEvent: (CaseEvent) -> CaseEvent,
-    private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>, userId: UUID?) -> List<CaseEvent>,
+    private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>, authorizedAgents: Set<String>) -> List<CaseEvent>,
     private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
 ) : CaseEventEmitter by DefaultCaseEventEmitter() {
     private val eventList = InMemoryCaseEventList(inputEvents)
+
+    /**
+     * Authorized agent names for the current turn, computed once per user message
+     * from the Neo4j graph by [CaseService]. Empty set means no restriction (anonymous
+     * or system turn).
+     */
+    private var authorizedAgentNames: Set<String> = emptySet()
 
     /**
      * Set by [processNextStep] when it finds an [AgentFinishedEvent] for the current
@@ -148,7 +158,9 @@ class CaseRuntime(
         actor: Actor,
         content: List<MessageContent>,
         answerToEventId: UUID? = null,
+        authorizedAgents: Set<String> = emptySet(),
     ) {
+        authorizedAgentNames = authorizedAgents
         logger.info {
             "[CaseRuntime $id] addUserMessage - actor: ${actor.id}, " +
                 "content: ${content.size} part(s), answerTo: $answerToEventId"
@@ -183,8 +195,7 @@ class CaseRuntime(
         }
 
         storeAndEmitEvent(MessageEvent(caseId = id, namespaceId = namespaceId, actor = actor, content = content))
-        val userId = runCatching { UUID.fromString(actor.id) }.getOrNull()
-        selectAgent(content, eventList.getAll(), userId).forEach { storeAndEmitEvent(it) }
+        selectAgent(content, eventList.getAll(), authorizedAgentNames).forEach { storeAndEmitEvent(it) }
     }
 
     // -------------------------------------------------------------------------
@@ -293,6 +304,22 @@ class CaseRuntime(
                     logger.info {
                         "[CaseRuntime $id] Found AgentSelectedEvent for agent: ${event.agentName}, " +
                             "transitioning to running"
+                    }
+                    val authorized = authorizedAgentNames
+                    if (authorized.isNotEmpty() && event.agentName.lowercase() !in authorized) {
+                        logger.warn {
+                            "[CaseRuntime $id] Agent '${event.agentName}' is not in the authorized " +
+                                "agent set — redirect blocked"
+                        }
+                        storeAndEmitEvent(
+                            io.whozoss.agentos.sdk.caseEvent.WarnEvent(
+                                namespaceId = namespaceId,
+                                caseId = id,
+                                message = "Agent '${event.agentName}' is not accessible to the current user",
+                            ),
+                        )
+                        interruptRequested.set(true)
+                        return
                     }
                     storeAndEmitEvent(
                         AgentRunningEvent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -119,8 +119,6 @@ class CaseRuntime(
 
     fun isRunning(): Boolean = runInFlight.get()
 
-    fun getAuthorizedAgentNames(): Set<String> = authorizedAgentNames
-
     fun pushEvents(events: Collection<CaseEvent>) {
         events.forEach { eventList.add(it) }
     }
@@ -308,7 +306,7 @@ class CaseRuntime(
                             "transitioning to running"
                     }
                     val authorized = authorizedAgentNames
-                    if (authorized.isNotEmpty() && authorized.none { it.lowercase() == event.agentName.lowercase() }) {
+                    if (authorized.isNotEmpty() && event.agentName.lowercase() !in authorized) {
                         logger.warn {
                             "[CaseRuntime $id] Agent '${event.agentName}' is not in the authorized " +
                                 "agent set — redirect blocked"

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -149,7 +149,7 @@ class CaseServiceImpl(
             return
         }
         val authorizedAgents = agentConfigService.findAvailableByUserId(runtime.namespaceId, userId)
-            .map { config -> config.name.lowercase() }
+            .map { config -> config.name }
             .toSet()
         runtime.addUserMessage(actor, content, answerToEventId, authorizedAgents)
         // run() is self-guarding via an AtomicBoolean — launch unconditionally.
@@ -241,7 +241,7 @@ class CaseServiceImpl(
     private fun resolveFromAuthorized(
         name: String,
         authorizedAgents: Set<String>,
-    ): String? = authorizedAgents.firstOrNull { it == name.lowercase() }
+    ): String? = authorizedAgents.firstOrNull { it.lowercase() == name.lowercase() }
 
     /**
      * Resolves the namespace default agent by name from [Namespace.defaultAgentName].
@@ -325,6 +325,7 @@ class CaseServiceImpl(
             caseId = caseId,
             userId = userId,
             caseEventsProvider = eventsProvider,
+            authorizedAgentNames = runtime.getAuthorizedAgentNames(),
         )
         agentService
             .findAgentByName(agentName, context)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.caseFlow
 
 import io.whozoss.agentos.agent.AgentExecutionContext
 import io.whozoss.agentos.agent.AgentService
+import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.namespace.NamespaceService
@@ -31,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Service
 class CaseServiceImpl(
     private val agentService: AgentService,
+    private val agentConfigService: AgentConfigService,
     private val caseRepository: CaseRepository,
     private val caseEventService: CaseEventService,
     private val userService: UserService,
@@ -125,7 +127,7 @@ class CaseServiceImpl(
             namespaceId = case.namespaceId,
             updateStatus = { caseId, newStatus -> handleStatusChange(caseId, newStatus) },
             storeEvent = { event -> storeEvent(event) },
-            selectAgent = { content, pastEvents, userId -> selectAgent(content, pastEvents, userId, case.namespaceId, case.id) },
+            selectAgent = { content, pastEvents, authorizedAgents -> selectAgent(content, pastEvents, authorizedAgents, case.namespaceId, case.id) },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue -> runAgent(agentName, case.id, events, eventsProvider, userId, shouldContinue) },
             inputEvents = inputEvents,
         )
@@ -141,7 +143,13 @@ class CaseServiceImpl(
         answerToEventId: UUID?,
     ) {
         val runtime = getCaseRuntime(caseId)
-        runtime.addUserMessage(actor, content, answerToEventId)
+        val userId = runCatching { UUID.fromString(actor.id) }.getOrNull()
+        val authorizedAgents = userId?.let {
+            agentConfigService.findAvailableByUserId(runtime.namespaceId, it)
+                .map { config -> config.name.lowercase() }
+                .toSet()
+        } ?: emptySet()
+        runtime.addUserMessage(actor, content, answerToEventId, authorizedAgents)
         // run() is self-guarding via an AtomicBoolean — launch unconditionally.
         scope.launch { runtime.run() }
     }
@@ -171,7 +179,7 @@ class CaseServiceImpl(
     private fun selectAgent(
         content: List<MessageContent>,
         pastEvents: List<CaseEvent>,
-        userId: UUID?,
+        authorizedAgents: Set<String>,
         namespaceId: UUID,
         caseId: UUID,
     ): List<CaseEvent> {
@@ -193,7 +201,7 @@ class CaseServiceImpl(
 
         return when {
             mentionedName != null -> {
-                val resolvedName = agentService.resolveAgentName(mentionedName, namespaceId, userId)
+                val resolvedName = resolveFromAuthorized(mentionedName, authorizedAgents, namespaceId)
                 when {
                     resolvedName != null -> {
                         logger.info { "[CaseService] Agent mention resolved: @$mentionedName -> $resolvedName" }
@@ -202,12 +210,12 @@ class CaseServiceImpl(
                     else -> {
                         logger.warn { "[CaseService] Agent '@$mentionedName' not found or not accessible, falling back to default" }
                         listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$mentionedName' not found")) +
-                            selectDefaultAgent(namespaceId, caseId, userId)
+                            selectDefaultAgent(namespaceId, caseId, authorizedAgents)
                     }
                 }
             }
             lastSelectedName != null -> {
-                val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId, userId) != null
+                val stillAvailable = resolveFromAuthorized(lastSelectedName, authorizedAgents, namespaceId) != null
                 when {
                     stillAvailable -> {
                         logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
@@ -216,13 +224,31 @@ class CaseServiceImpl(
                     else -> {
                         logger.warn { "[CaseService] Last selected agent '$lastSelectedName' is no longer available, falling back to default" }
                         listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$lastSelectedName' is no longer available")) +
-                            selectDefaultAgent(namespaceId, caseId, userId)
+                            selectDefaultAgent(namespaceId, caseId, authorizedAgents)
                     }
                 }
             }
-            else -> selectDefaultAgent(namespaceId, caseId, userId)
+            else -> selectDefaultAgent(namespaceId, caseId, authorizedAgents)
         }
     }
+
+    /**
+     * Resolves a canonical agent name from the pre-computed [authorizedAgents] set.
+     *
+     * When the set is non-empty (authenticated user), performs a case-insensitive
+     * lookup against authorized names only. When empty (anonymous/system), falls
+     * back to a namespace-wide lookup via [AgentConfigService.findByName].
+     */
+    private fun resolveFromAuthorized(
+        name: String,
+        authorizedAgents: Set<String>,
+        namespaceId: UUID,
+    ): String? =
+        if (authorizedAgents.isNotEmpty()) {
+            authorizedAgents.firstOrNull { it == name.lowercase() }
+        } else {
+            agentConfigService.findByName(namespaceId, name)?.name
+        }
 
     /**
      * Resolves the namespace default agent by name from [Namespace.defaultAgentName].
@@ -238,7 +264,7 @@ class CaseServiceImpl(
     private fun selectDefaultAgent(
         namespaceId: UUID,
         caseId: UUID,
-        userId: UUID?,
+        authorizedAgents: Set<String>,
     ): List<CaseEvent> {
         val defaultAgentName = namespaceService.findById(namespaceId)?.defaultAgentName
         return if (defaultAgentName == null) {
@@ -251,7 +277,7 @@ class CaseServiceImpl(
                 ),
             )
         } else {
-            val resolvedName = agentService.resolveAgentName(defaultAgentName, namespaceId, userId)
+            val resolvedName = resolveFromAuthorized(defaultAgentName, authorizedAgents, namespaceId)
             if (resolvedName == null) {
                 logger.warn { "[CaseService] Default agent '$defaultAgentName' is not available in namespace $namespaceId" }
                 listOf(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -143,12 +143,14 @@ class CaseServiceImpl(
         answerToEventId: UUID?,
     ) {
         val runtime = getCaseRuntime(caseId)
-        val userId = runCatching { UUID.fromString(actor.id) }.getOrNull()
-        val authorizedAgents = userId?.let {
-            agentConfigService.findAvailableByUserId(runtime.namespaceId, it)
-                .map { config -> config.name.lowercase() }
-                .toSet()
-        } ?: emptySet()
+        val userId = runCatching { UUID.fromString(actor.id) }.getOrElse {
+            logger.error { "[CaseService] Invalid actor id '${actor.id}' for case $caseId — cannot resolve user" }
+            handleStatusChange(caseId, CaseStatus.ERROR)
+            return
+        }
+        val authorizedAgents = agentConfigService.findAvailableByUserId(runtime.namespaceId, userId)
+            .map { config -> config.name.lowercase() }
+            .toSet()
         runtime.addUserMessage(actor, content, answerToEventId, authorizedAgents)
         // run() is self-guarding via an AtomicBoolean — launch unconditionally.
         scope.launch { runtime.run() }
@@ -201,7 +203,7 @@ class CaseServiceImpl(
 
         return when {
             mentionedName != null -> {
-                val resolvedName = resolveFromAuthorized(mentionedName, authorizedAgents, namespaceId)
+                val resolvedName = resolveFromAuthorized(mentionedName, authorizedAgents)
                 when {
                     resolvedName != null -> {
                         logger.info { "[CaseService] Agent mention resolved: @$mentionedName -> $resolvedName" }
@@ -215,7 +217,7 @@ class CaseServiceImpl(
                 }
             }
             lastSelectedName != null -> {
-                val stillAvailable = resolveFromAuthorized(lastSelectedName, authorizedAgents, namespaceId) != null
+                val stillAvailable = resolveFromAuthorized(lastSelectedName, authorizedAgents) != null
                 when {
                     stillAvailable -> {
                         logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
@@ -234,21 +236,12 @@ class CaseServiceImpl(
 
     /**
      * Resolves a canonical agent name from the pre-computed [authorizedAgents] set.
-     *
-     * When the set is non-empty (authenticated user), performs a case-insensitive
-     * lookup against authorized names only. When empty (anonymous/system), falls
-     * back to a namespace-wide lookup via [AgentConfigService.findByName].
+     * Returns null if the name is not in the set — no fallback to namespace-wide lookup.
      */
     private fun resolveFromAuthorized(
         name: String,
         authorizedAgents: Set<String>,
-        namespaceId: UUID,
-    ): String? =
-        if (authorizedAgents.isNotEmpty()) {
-            authorizedAgents.firstOrNull { it == name.lowercase() }
-        } else {
-            agentConfigService.findByName(namespaceId, name)?.name
-        }
+    ): String? = authorizedAgents.firstOrNull { it == name.lowercase() }
 
     /**
      * Resolves the namespace default agent by name from [Namespace.defaultAgentName].
@@ -277,7 +270,7 @@ class CaseServiceImpl(
                 ),
             )
         } else {
-            val resolvedName = resolveFromAuthorized(defaultAgentName, authorizedAgents, namespaceId)
+            val resolvedName = resolveFromAuthorized(defaultAgentName, authorizedAgents)
             if (resolvedName == null) {
                 logger.warn { "[CaseService] Default agent '$defaultAgentName' is not available in namespace $namespaceId" }
                 listOf(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -149,7 +149,7 @@ class CaseServiceImpl(
             return
         }
         val authorizedAgents = agentConfigService.findAvailableByUserId(runtime.namespaceId, userId)
-            .map { config -> config.name }
+            .map { config -> config.name.lowercase() }
             .toSet()
         runtime.addUserMessage(actor, content, answerToEventId, authorizedAgents)
         // run() is self-guarding via an AtomicBoolean — launch unconditionally.
@@ -241,7 +241,7 @@ class CaseServiceImpl(
     private fun resolveFromAuthorized(
         name: String,
         authorizedAgents: Set<String>,
-    ): String? = authorizedAgents.firstOrNull { it.lowercase() == name.lowercase() }
+    ): String? = authorizedAgents.firstOrNull { it == name.lowercase() }
 
     /**
      * Resolves the namespace default agent by name from [Namespace.defaultAgentName].
@@ -325,7 +325,6 @@ class CaseServiceImpl(
             caseId = caseId,
             userId = userId,
             caseEventsProvider = eventsProvider,
-            authorizedAgentNames = runtime.getAuthorizedAgentNames(),
         )
         agentService
             .findAgentByName(agentName, context)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -125,7 +125,7 @@ class CaseServiceImpl(
             namespaceId = case.namespaceId,
             updateStatus = { caseId, newStatus -> handleStatusChange(caseId, newStatus) },
             storeEvent = { event -> storeEvent(event) },
-            selectAgent = { content, pastEvents -> selectAgent(content, pastEvents, case.namespaceId, case.id) },
+            selectAgent = { content, pastEvents, userId -> selectAgent(content, pastEvents, userId, case.namespaceId, case.id) },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue -> runAgent(agentName, case.id, events, eventsProvider, userId, shouldContinue) },
             inputEvents = inputEvents,
         )
@@ -171,6 +171,7 @@ class CaseServiceImpl(
     private fun selectAgent(
         content: List<MessageContent>,
         pastEvents: List<CaseEvent>,
+        userId: UUID?,
         namespaceId: UUID,
         caseId: UUID,
     ): List<CaseEvent> {
@@ -192,21 +193,21 @@ class CaseServiceImpl(
 
         return when {
             mentionedName != null -> {
-                val resolvedName = agentService.resolveAgentName(mentionedName, namespaceId)
+                val resolvedName = agentService.resolveAgentName(mentionedName, namespaceId, userId)
                 when {
                     resolvedName != null -> {
                         logger.info { "[CaseService] Agent mention resolved: @$mentionedName -> $resolvedName" }
                         listOf(agentSelectedEvent(resolvedName, namespaceId, caseId))
                     }
                     else -> {
-                        logger.warn { "[CaseService] Agent '@$mentionedName' not found, falling back to default" }
+                        logger.warn { "[CaseService] Agent '@$mentionedName' not found or not accessible, falling back to default" }
                         listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$mentionedName' not found")) +
-                            selectDefaultAgent(namespaceId, caseId)
+                            selectDefaultAgent(namespaceId, caseId, userId)
                     }
                 }
             }
             lastSelectedName != null -> {
-                val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId) != null
+                val stillAvailable = agentService.resolveAgentName(lastSelectedName, namespaceId, userId) != null
                 when {
                     stillAvailable -> {
                         logger.info { "[CaseService] Re-using last selected agent: $lastSelectedName" }
@@ -215,11 +216,11 @@ class CaseServiceImpl(
                     else -> {
                         logger.warn { "[CaseService] Last selected agent '$lastSelectedName' is no longer available, falling back to default" }
                         listOf(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = "Agent '$lastSelectedName' is no longer available")) +
-                            selectDefaultAgent(namespaceId, caseId)
+                            selectDefaultAgent(namespaceId, caseId, userId)
                     }
                 }
             }
-            else -> selectDefaultAgent(namespaceId, caseId)
+            else -> selectDefaultAgent(namespaceId, caseId, userId)
         }
     }
 
@@ -237,6 +238,7 @@ class CaseServiceImpl(
     private fun selectDefaultAgent(
         namespaceId: UUID,
         caseId: UUID,
+        userId: UUID?,
     ): List<CaseEvent> {
         val defaultAgentName = namespaceService.findById(namespaceId)?.defaultAgentName
         return if (defaultAgentName == null) {
@@ -249,7 +251,7 @@ class CaseServiceImpl(
                 ),
             )
         } else {
-            val resolvedName = agentService.resolveAgentName(defaultAgentName, namespaceId)
+            val resolvedName = agentService.resolveAgentName(defaultAgentName, namespaceId, userId)
             if (resolvedName == null) {
                 logger.warn { "[CaseService] Default agent '$defaultAgentName' is not available in namespace $namespaceId" }
                 listOf(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -501,44 +501,6 @@ class AgentServiceImplUnitSpec : StringSpec() {
             verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, integrations) }
         }
 
-        // -------------------------------------------------------------------------
-        // resolveAgentName
-        // -------------------------------------------------------------------------
 
-        // userId == null: falls back to namespace-wide findByName
-        "resolveAgentName returns AgentConfig name when one matches (no userId)" {
-            val config = agentConfig(name = "my-agent")
-            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
-
-            agentService.resolveAgentName("my-agent", namespaceId) shouldBe "my-agent"
-
-            verify(exactly = 0) { aiModelService.findAiModel(any(), any()) }
-        }
-
-        "resolveAgentName returns null when no AgentConfig matches (no userId)" {
-            every { agentConfigService.findByName(namespaceId, "unknown") } returns null
-
-            agentService.resolveAgentName("unknown", namespaceId) shouldBe null
-        }
-
-        // userId != null: delegates to findAvailableByUserIdAndName (Neo4j graph rules)
-        "resolveAgentName with userId returns name when agent is accessible" {
-            val userId = UUID.randomUUID()
-            val config = agentConfig(name = "my-agent")
-            every { agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, "my-agent") } returns config
-
-            agentService.resolveAgentName("my-agent", namespaceId, userId) shouldBe "my-agent"
-
-            verify(exactly = 0) { agentConfigService.findByName(any(), any()) }
-        }
-
-        "resolveAgentName with userId returns null when agent is not accessible" {
-            val userId = UUID.randomUUID()
-            every { agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, "restricted") } returns null
-
-            agentService.resolveAgentName("restricted", namespaceId, userId) shouldBe null
-
-            verify(exactly = 0) { agentConfigService.findByName(any(), any()) }
-        }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -505,7 +505,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
         // resolveAgentName
         // -------------------------------------------------------------------------
 
-        "resolveAgentName returns AgentConfig name when one matches" {
+        // userId == null: falls back to namespace-wide findByName
+        "resolveAgentName returns AgentConfig name when one matches (no userId)" {
             val config = agentConfig(name = "my-agent")
             every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
 
@@ -514,10 +515,30 @@ class AgentServiceImplUnitSpec : StringSpec() {
             verify(exactly = 0) { aiModelService.findAiModel(any(), any()) }
         }
 
-        "resolveAgentName returns null when no AgentConfig matches" {
+        "resolveAgentName returns null when no AgentConfig matches (no userId)" {
             every { agentConfigService.findByName(namespaceId, "unknown") } returns null
 
             agentService.resolveAgentName("unknown", namespaceId) shouldBe null
+        }
+
+        // userId != null: delegates to findAvailableByUserIdAndName (Neo4j graph rules)
+        "resolveAgentName with userId returns name when agent is accessible" {
+            val userId = UUID.randomUUID()
+            val config = agentConfig(name = "my-agent")
+            every { agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, "my-agent") } returns config
+
+            agentService.resolveAgentName("my-agent", namespaceId, userId) shouldBe "my-agent"
+
+            verify(exactly = 0) { agentConfigService.findByName(any(), any()) }
+        }
+
+        "resolveAgentName with userId returns null when agent is not accessible" {
+            val userId = UUID.randomUUID()
+            every { agentConfigService.findAvailableByUserIdAndName(namespaceId, userId, "restricted") } returns null
+
+            agentService.resolveAgentName("restricted", namespaceId, userId) shouldBe null
+
+            verify(exactly = 0) { agentConfigService.findByName(any(), any()) }
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -484,6 +484,47 @@ class AgentServiceImplUnitSpec : StringSpec() {
             verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, null) }
         }
 
+        // -------------------------------------------------------------------------
+        // Available agents block injection into instructions
+        // -------------------------------------------------------------------------
+
+        "findAgentByName appends available agents block when authorizedAgentNames is non-empty" {
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val contextWithAgents = AgentExecutionContext(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                authorizedAgentNames = setOf("AgentA", "AgentB"),
+            )
+            val agent = agentService.findAgentByName("my-agent", contextWithAgents) as AgentSimple
+
+            agent.instructions shouldContain "## Available agents"
+            agent.instructions shouldContain "- AgentA"
+            agent.instructions shouldContain "- AgentB"
+        }
+
+        "findAgentByName omits available agents block when authorizedAgentNames is empty" {
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions shouldNotContain "## Available agents"
+        }
+
         "findAgentByName passes integrations map to ToolResolverService when agentConfig has integrations" {
             val integrations = mapOf("FILES" to null, "JIRA_PROD" to listOf("GetIssue"))
             val config = agentConfig(name = "my-agent", modelName = "sonnet").copy(integrations = integrations)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -484,47 +484,6 @@ class AgentServiceImplUnitSpec : StringSpec() {
             verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, null) }
         }
 
-        // -------------------------------------------------------------------------
-        // Available agents block injection into instructions
-        // -------------------------------------------------------------------------
-
-        "findAgentByName appends available agents block when authorizedAgentNames is non-empty" {
-            val config = agentConfig(name = "my-agent", modelName = "sonnet")
-            val model = modelConfig(alias = "sonnet")
-            val provider = providerConfig()
-            val chatClient = mockk<ChatClient>(relaxed = true)
-            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
-            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
-            every { aiProviderService.getById(aiProviderId) } returns provider
-            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
-
-            val contextWithAgents = AgentExecutionContext(
-                namespaceId = namespaceId,
-                caseId = caseId,
-                authorizedAgentNames = setOf("AgentA", "AgentB"),
-            )
-            val agent = agentService.findAgentByName("my-agent", contextWithAgents) as AgentSimple
-
-            agent.instructions shouldContain "## Available agents"
-            agent.instructions shouldContain "- AgentA"
-            agent.instructions shouldContain "- AgentB"
-        }
-
-        "findAgentByName omits available agents block when authorizedAgentNames is empty" {
-            val config = agentConfig(name = "my-agent", modelName = "sonnet")
-            val model = modelConfig(alias = "sonnet")
-            val provider = providerConfig()
-            val chatClient = mockk<ChatClient>(relaxed = true)
-            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
-            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
-            every { aiProviderService.getById(aiProviderId) } returns provider
-            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
-
-            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
-
-            agent.instructions shouldNotContain "## Available agents"
-        }
-
         "findAgentByName passes integrations map to ToolResolverService when agentConfig has integrations" {
             val integrations = mapOf("FILES" to null, "JIRA_PROD" to listOf("GetIssue"))
             val config = agentConfig(name = "my-agent", modelName = "sonnet").copy(integrations = integrations)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -17,11 +17,11 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
                 parentIdExtractor = { it.namespaceId },
                 comparator = compareBy { it.name },
             ) {
-            // findAvailableByUserExternalId and findAvailableByUserIdAndName are Neo4j-only queries; not exercised in unit tests.
+            // findAvailableByUserExternalId and findAvailableByUserId are Neo4j-only queries; not exercised in unit tests.
             override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
 
-            override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
+            override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -17,8 +17,11 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
                 parentIdExtractor = { it.namespaceId },
                 comparator = compareBy { it.name },
             ) {
-            // findAvailableByUserExternalId is a Neo4j-only query; not exercised in unit tests.
+            // findAvailableByUserExternalId and findAvailableByUserIdAndName are Neo4j-only queries; not exercised in unit tests.
             override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
+                throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
+
+            override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, name: String): AgentConfig? =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -48,20 +48,16 @@ class RecordingRunAgent(
  * A simple recording wrapper for the selectAgent callback, avoiding MockK entirely.
  * MockK global state can bleed between specs when stubs from one spec are still
  * registered when the next spec runs. A plain wrapper has no such risk.
- *
- * The [userId] parameter mirrors the [CaseRuntime] callback signature: it carries
- * the UUID of the user who sent the message (resolved from the event history) so
- * that agent selection can apply per-user access rules.
  */
 class RecordingSelectAgent(
-    private val delegate: (List<MessageContent>, List<CaseEvent>) -> List<CaseEvent>,
+    private val delegate: (List<MessageContent>, List<CaseEvent>, Set<String>) -> List<CaseEvent>,
 ) {
     private val _calls = mutableListOf<List<MessageContent>>()
     val callCount: Int get() = _calls.size
 
-    val asCallback: (List<MessageContent>, List<CaseEvent>, UUID?) -> List<CaseEvent> = { content, pastEvents, _ ->
+    val asCallback: (List<MessageContent>, List<CaseEvent>, Set<String>) -> List<CaseEvent> = { content, pastEvents, authorizedAgents ->
         _calls += content
-        delegate(content, pastEvents)
+        delegate(content, pastEvents, authorizedAgents)
     }
 }
 
@@ -131,7 +127,7 @@ class CaseRuntimeSpec : StringSpec() {
         val savedEvents = mutableListOf<CaseEvent>()
         val runtimeId = UUID.randomUUID()
 
-        val selectAgent = RecordingSelectAgent { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) }
+        val selectAgent = RecordingSelectAgent { _, _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) }
 
         lateinit var runtime: CaseRuntime
         val runAgent =
@@ -483,7 +479,7 @@ class CaseRuntimeSpec : StringSpec() {
                 }
             }
 
-            val selectAgent = RecordingSelectAgent { _, _ -> listOf(agentSelectedEvent(runtimeId, agentA)) }
+            val selectAgent = RecordingSelectAgent { _, _, _ -> listOf(agentSelectedEvent(runtimeId, agentA)) }
 
             val runAgent = RecordingRunAgent { name, events ->
                 runOrder += name

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -48,6 +48,10 @@ class RecordingRunAgent(
  * A simple recording wrapper for the selectAgent callback, avoiding MockK entirely.
  * MockK global state can bleed between specs when stubs from one spec are still
  * registered when the next spec runs. A plain wrapper has no such risk.
+ *
+ * The [userId] parameter mirrors the [CaseRuntime] callback signature: it carries
+ * the UUID of the user who sent the message (resolved from the event history) so
+ * that agent selection can apply per-user access rules.
  */
 class RecordingSelectAgent(
     private val delegate: (List<MessageContent>, List<CaseEvent>) -> List<CaseEvent>,
@@ -55,7 +59,7 @@ class RecordingSelectAgent(
     private val _calls = mutableListOf<List<MessageContent>>()
     val callCount: Int get() = _calls.size
 
-    val asCallback: (List<MessageContent>, List<CaseEvent>) -> List<CaseEvent> = { content, pastEvents ->
+    val asCallback: (List<MessageContent>, List<CaseEvent>, UUID?) -> List<CaseEvent> = { content, pastEvents, _ ->
         _calls += content
         delegate(content, pastEvents)
     }
@@ -232,7 +236,7 @@ class CaseRuntimeSpec : StringSpec() {
                         savedEvents.add(event)
                         event
                     },
-                    selectAgent = { _, _ ->
+                    selectAgent = { _, _, _ ->
                         listOf(
                             WarnEvent(
                                 namespaceId = namespaceId,
@@ -298,7 +302,7 @@ class CaseRuntimeSpec : StringSpec() {
                         if (event is AgentRunningEvent) callOrder.add("AgentRunningEvent saved")
                         event
                     },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
                     runAgent = { _, events, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
@@ -338,7 +342,7 @@ class CaseRuntimeSpec : StringSpec() {
                     namespaceId = namespaceId,
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
@@ -372,7 +376,7 @@ class CaseRuntimeSpec : StringSpec() {
                     namespaceId = namespaceId,
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                     },
@@ -405,7 +409,7 @@ class CaseRuntimeSpec : StringSpec() {
                     namespaceId = namespaceId,
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     runAgent = { _, _, _, _, shouldContinue ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
@@ -555,7 +559,7 @@ class CaseRuntimeSpec : StringSpec() {
                         savedEvents.add(event)
                         event
                     },
-                    selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                    selectAgent = { _, _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
                     runAgent = recorder.asCallback,
                 )
             runtime.pushEvents(listOf(existingUserMessage, existingRunningEvent))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -155,7 +155,6 @@ class CaseServiceImplSpec :
                 every { findAvailableByUserId(any(), any()) } returns listOf(
                     AgentConfig(namespaceId = namespaceId, name = agentName)
                 )
-                every { findByName(any(), any()) } returns AgentConfig(namespaceId = namespaceId, name = agentName)
             }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -7,6 +7,8 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
 import io.whozoss.agentos.agent.AgentService
+import io.whozoss.agentos.agentConfig.AgentConfig
+import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
 import io.whozoss.agentos.caseEvent.InMemoryCaseEventRepository
 import io.whozoss.agentos.namespace.Namespace
@@ -147,12 +149,17 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(any(), any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns agent
                 }
+            val agentConfigService = mockk<AgentConfigService> {
+                every { findAvailableByUserId(any(), any()) } returns listOf(
+                    AgentConfig(namespaceId = namespaceId, name = agentName)
+                )
+                every { findByName(any(), any()) } returns AgentConfig(namespaceId = namespaceId, name = agentName)
+            }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            return CaseServiceImpl(agentService, caseRepository, caseEventService, userService, namespaceService)
+            return CaseServiceImpl(agentService, agentConfigService, caseRepository, caseEventService, userService, namespaceService)
         }
 
         // -------------------------------------------------------------------------
@@ -264,11 +271,13 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(any(), any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns finishingAgent()
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
+            val agentConfigService = mockk<AgentConfigService> {
+                every { findAvailableByUserId(any(), any()) } returns listOf(AgentConfig(namespaceId = namespaceId, name = agentName))
+            }
+            val service = CaseServiceImpl(agentService, agentConfigService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -468,11 +477,13 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
+            val agentConfigService = mockk<AgentConfigService> {
+                every { findAvailableByUserId(any(), any()) } returns listOf(AgentConfig(namespaceId = namespaceId, name = agentName))
+            }
+            val service = CaseServiceImpl(agentService, agentConfigService, InMemoryCaseRepository(), caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
 
@@ -565,8 +576,12 @@ class CaseServiceImplSpec :
             // resolveAgentName is never reached because selectDefaultAgent short-circuits on null
             val agentService = mockk<AgentService>(relaxed = true)
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val agentConfigService = mockk<AgentConfigService> {
+                every { findAvailableByUserId(any(), any()) } returns emptyList<AgentConfig>()
+            }
             val service = CaseServiceImpl(
                 agentService,
+                agentConfigService,
                 InMemoryCaseRepository(),
                 caseEventService,
                 userService,
@@ -602,24 +617,24 @@ class CaseServiceImplSpec :
                 defaultAgentName = agentName,
             )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
-            // resolveAgentName call sequence:
-            //   turn 1, @mention path: resolveAgentName(unavailableAgentName) -> unavailableAgentName (found)
-            //   turn 2, sticky-agent availability check: resolveAgentName(unavailableAgentName) -> null (gone)
-            //   turn 2, default resolution: resolveAgentName(agentName) -> agentName (found)
-            val resolveCallCount = java.util.concurrent.atomic.AtomicInteger(0)
+            // Turn 1: unavailableAgent is in the authorized set → @mention resolves
+            // Turn 2: unavailableAgent is gone from the authorized set → sticky-agent check fails, fallback to default
+            val callCount = java.util.concurrent.atomic.AtomicInteger(0)
             val agentService = mockk<AgentService> {
-                every { resolveAgentName(unavailableAgentName, namespaceId, any()) } answers {
-                    when (resolveCallCount.incrementAndGet()) {
-                        1 -> unavailableAgentName  // turn 1: @mention resolves
-                        else -> null              // turn 2: sticky-agent check fails
+                every { findAgentByName(any(), any()) } returns finishingAgent()
+            }
+            val agentConfigService = mockk<AgentConfigService> {
+                every { findAvailableByUserId(any(), any()) } answers {
+                    when (callCount.incrementAndGet()) {
+                        1 -> listOf(AgentConfig(namespaceId = namespaceId, name = unavailableAgentName))
+                        else -> listOf(AgentConfig(namespaceId = namespaceId, name = agentName))
                     }
                 }
-                every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
-                every { findAgentByName(any(), any()) } returns finishingAgent()
             }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                agentConfigService,
                 InMemoryCaseRepository(),
                 caseEventService,
                 userServiceMock,
@@ -699,15 +714,17 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    // @selected-agent resolves to selectedAgentName
-                    every { resolveAgentName(selectedAgentName, any(), any()) } returns selectedAgentName
-                    // no other mention resolution needed
                     every { findAgentByName(selectedAgentName, any()) } returns selectedAgent
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, caseRepository, caseEventService, userService, namespaceService)
+            val agentConfigService = mockk<AgentConfigService> {
+                every { findAvailableByUserId(any(), any()) } returns listOf(
+                    AgentConfig(namespaceId = namespaceId, name = selectedAgentName)
+                )
+            }
+            val service = CaseServiceImpl(agentService, agentConfigService, caseRepository, caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -147,7 +147,7 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(any(), any()) } returns agentName
+                    every { resolveAgentName(any(), any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns agent
                 }
             val caseRepository = InMemoryCaseRepository()
@@ -264,7 +264,7 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(any(), any()) } returns agentName
+                    every { resolveAgentName(any(), any(), any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns finishingAgent()
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
@@ -468,7 +468,7 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
-                    every { resolveAgentName(agentName, namespaceId) } returns agentName
+                    every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     every { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
@@ -608,13 +608,13 @@ class CaseServiceImplSpec :
             //   turn 2, default resolution: resolveAgentName(agentName) -> agentName (found)
             val resolveCallCount = java.util.concurrent.atomic.AtomicInteger(0)
             val agentService = mockk<AgentService> {
-                every { resolveAgentName(unavailableAgentName, namespaceId) } answers {
+                every { resolveAgentName(unavailableAgentName, namespaceId, any()) } answers {
                     when (resolveCallCount.incrementAndGet()) {
                         1 -> unavailableAgentName  // turn 1: @mention resolves
                         else -> null              // turn 2: sticky-agent check fails
                     }
                 }
-                every { resolveAgentName(agentName, namespaceId) } returns agentName
+                every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                 every { findAgentByName(any(), any()) } returns finishingAgent()
             }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
@@ -700,7 +700,7 @@ class CaseServiceImplSpec :
             val agentService =
                 mockk<AgentService> {
                     // @selected-agent resolves to selectedAgentName
-                    every { resolveAgentName(selectedAgentName, any()) } returns selectedAgentName
+                    every { resolveAgentName(selectedAgentName, any(), any()) } returns selectedAgentName
                     // no other mention resolution needed
                     every { findAgentByName(selectedAgentName, any()) } returns selectedAgent
                 }


### PR DESCRIPTION
Apply the same Neo4j graph rules (DEPLOYED_TO + MEMBER/ADMIN) to runtime agent selection as to the /search endpoint. Previously, any agent in the namespace could be selected by name regardless of user access rights.

Compute the authorized agent set once per user message via `findAvailableByUserId` and thread it through `addUserMessage` -> `selectAgent` -> `processNextStep`. Agent selection and agent-to-agent redirects are both enforced against this set.


Unauthorized redirects emit a WarnEvent and stop the turn.

