### PR TITLE
feat: #WZ-31982: enforce agent availability at runtime

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -85,6 +85,7 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
     /**
      * Same as [findAvailableByUserId] but filters by agent name (case-insensitive)
      * directly in Cypher, avoiding a full list fetch when only existence matters.
+     * Called via [findAvailableByNamespaceIdAndUserIdAndName] in the repository layer.
      */
     @Query(
         $$"""

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -13,7 +13,7 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
     @Query(
         $$"""
             MATCH (a:AgentConfig)
-            WHERE a.namespaceId = $namespaceId AND (a.removed IS NULL OR a.removed = false)
+            WHERE a.namespaceId = $namespaceId AND NOT COALESCE(a.removed, false)
             RETURN a ORDER BY a.name ASC
             """,
     )
@@ -31,25 +31,25 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
     @Query(
         $$"""
             MATCH (u:User {id: $userId})
-              WHERE u.removed IS NULL OR u.removed = false
+              WHERE NOT COALESCE(u.removed, false)
             MATCH (ns:Namespace {id: $namespaceId})
-              WHERE ns.removed IS NULL OR ns.removed = false
+              WHERE NOT COALESCE(ns.removed, false)
             MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
-              WHERE g.removed IS NULL OR g.removed = false
+              WHERE NOT COALESCE(g.removed, false)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
-              WHERE (a.removed IS NULL OR a.removed = false)
+              WHERE NOT COALESCE(a.removed, false)
                 AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
-            RETURN a
+            RETURN DISTINCT a
             UNION
             MATCH (u:User {id: $userId})
-              WHERE u.removed IS NULL OR u.removed = false
+              WHERE NOT COALESCE(u.removed, false)
             MATCH (ns:Namespace {id: $namespaceId})
-              WHERE ns.removed IS NULL OR ns.removed = false
+              WHERE NOT COALESCE(ns.removed, false)
             MATCH (u)-[:MEMBER|ADMIN]->(ns)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
-              WHERE (a.removed IS NULL OR a.removed = false)
+              WHERE NOT COALESCE(a.removed, false)
                 AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
-            RETURN a
+            RETURN DISTINCT a
             """,
     )
     fun findAvailableByNamespaceIdAndUserId(namespaceId: String, userId: String, agentName: String?): List<AgentConfigNode>

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -52,4 +52,61 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
             """,
     )
     fun findAvailableByUserExternalId(namespaceId: String, userExternalId: String): List<AgentConfigNode>
+
+    /**
+     * Same graph rules as [findAvailableByUserExternalId] but matched by internal
+     * [userId] (UUID) rather than [externalId]. Used at runtime where only the
+     * internal UUID is available.
+     */
+    @Query(
+        $$"""
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+              WHERE g.removed IS NULL OR g.removed = false
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
+              WHERE a.removed IS NULL OR a.removed = false
+            RETURN a
+            UNION
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER|ADMIN]->(ns)
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
+              WHERE a.removed IS NULL OR a.removed = false
+            RETURN a
+            """,
+    )
+    fun findAvailableByUserId(namespaceId: String, userId: String): List<AgentConfigNode>
+
+    /**
+     * Same as [findAvailableByUserId] but filters by agent name (case-insensitive)
+     * directly in Cypher, avoiding a full list fetch when only existence matters.
+     */
+    @Query(
+        $$"""
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+              WHERE g.removed IS NULL OR g.removed = false
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
+              WHERE (a.removed IS NULL OR a.removed = false) AND toLower(a.name) = toLower($agentName)
+            RETURN a
+            UNION
+            MATCH (u:User {id: $userId})
+              WHERE u.removed IS NULL OR u.removed = false
+            MATCH (ns:Namespace {id: $namespaceId})
+              WHERE ns.removed IS NULL OR ns.removed = false
+            MATCH (u)-[:MEMBER|ADMIN]->(ns)
+            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
+              WHERE (a.removed IS NULL OR a.removed = false) AND toLower(a.name) = toLower($agentName)
+            RETURN a
+            """,
+    )
+    fun findAvailableByUserIdAndName(namespaceId: String, userId: String, agentName: String): List<AgentConfigNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -54,9 +54,12 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
     fun findAvailableByUserExternalId(namespaceId: String, userExternalId: String): List<AgentConfigNode>
 
     /**
-     * Same graph rules as [findAvailableByUserExternalId] but matched by internal
-     * [userId] (UUID) rather than [externalId]. Used at runtime where only the
-     * internal UUID is available.
+     * Returns the union of [AgentConfigNode]s accessible to [userId] in [namespaceId]:
+     * - agents deployed on a [io.whozoss.agentos.userGroup.UserGroup] the user is a member of (within the namespace)
+     * - agents deployed directly on the namespace, for a user holding MEMBER or ADMIN
+     *
+     * When [agentName] is non-null, the result is filtered to configs whose name
+     * matches case-insensitively. When null, all accessible configs are returned.
      */
     @Query(
         $$"""
@@ -67,7 +70,8 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
             MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
               WHERE g.removed IS NULL OR g.removed = false
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
-              WHERE a.removed IS NULL OR a.removed = false
+              WHERE (a.removed IS NULL OR a.removed = false)
+                AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
             RETURN a
             UNION
             MATCH (u:User {id: $userId})
@@ -76,38 +80,10 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
               WHERE ns.removed IS NULL OR ns.removed = false
             MATCH (u)-[:MEMBER|ADMIN]->(ns)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
-              WHERE a.removed IS NULL OR a.removed = false
+              WHERE (a.removed IS NULL OR a.removed = false)
+                AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
             RETURN a
             """,
     )
-    fun findAvailableByUserId(namespaceId: String, userId: String): List<AgentConfigNode>
-
-    /**
-     * Same as [findAvailableByUserId] but filters by agent name (case-insensitive)
-     * directly in Cypher, avoiding a full list fetch when only existence matters.
-     * Called via [findAvailableByNamespaceIdAndUserIdAndName] in the repository layer.
-     */
-    @Query(
-        $$"""
-            MATCH (u:User {id: $userId})
-              WHERE u.removed IS NULL OR u.removed = false
-            MATCH (ns:Namespace {id: $namespaceId})
-              WHERE ns.removed IS NULL OR ns.removed = false
-            MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
-              WHERE g.removed IS NULL OR g.removed = false
-            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
-              WHERE (a.removed IS NULL OR a.removed = false) AND toLower(a.name) = toLower($agentName)
-            RETURN a
-            UNION
-            MATCH (u:User {id: $userId})
-              WHERE u.removed IS NULL OR u.removed = false
-            MATCH (ns:Namespace {id: $namespaceId})
-              WHERE ns.removed IS NULL OR ns.removed = false
-            MATCH (u)-[:MEMBER|ADMIN]->(ns)
-            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
-              WHERE (a.removed IS NULL OR a.removed = false) AND toLower(a.name) = toLower($agentName)
-            RETURN a
-            """,
-    )
-    fun findAvailableByUserIdAndName(namespaceId: String, userId: String, agentName: String): List<AgentConfigNode>
+    fun findAvailableByNamespaceIdAndUserId(namespaceId: String, userId: String, agentName: String?): List<AgentConfigNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -21,39 +21,6 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
 
 
     /**
-     * Returns the union of:
-     * - agents deployed on a [UserGroup] belonging to the target namespace, of which the user is a member
-     *   (no direct relation from user to namespace required)
-     * - agents deployed directly on the target namespace, for a user holding MEMBER or ADMIN on it
-     *
-     * Each branch is fully self-contained (UNION branches share no variable bindings).
-     * The namespace scope is enforced in both branches via the namespace id.
-     */
-    @Query(
-        $$"""
-            MATCH (u:User {externalId: $userExternalId})
-              WHERE u.removed IS NULL OR u.removed = false
-            MATCH (ns:Namespace {id: $namespaceId})
-              WHERE ns.removed IS NULL OR ns.removed = false
-            MATCH (u)-[:MEMBER]->(g:UserGroup)-[:BELONGS_TO]->(ns)
-              WHERE g.removed IS NULL OR g.removed = false
-            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
-              WHERE a.removed IS NULL OR a.removed = false
-            RETURN a
-            UNION
-            MATCH (u:User {externalId: $userExternalId})
-              WHERE u.removed IS NULL OR u.removed = false
-            MATCH (ns:Namespace {id: $namespaceId})
-              WHERE ns.removed IS NULL OR ns.removed = false
-            MATCH (u)-[:MEMBER|ADMIN]->(ns)
-            MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
-              WHERE a.removed IS NULL OR a.removed = false
-            RETURN a
-            """,
-    )
-    fun findAvailableByUserExternalId(namespaceId: String, userExternalId: String): List<AgentConfigNode>
-
-    /**
      * Returns the union of [AgentConfigNode]s accessible to [userId] in [namespaceId]:
      * - agents deployed on a [io.whozoss.agentos.userGroup.UserGroup] the user is a member of (within the namespace)
      * - agents deployed directly on the namespace, for a user holding MEMBER or ADMIN

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -9,8 +9,6 @@ import java.util.*
  * Agent configs are scoped under a namespace — [parentId] is the namespace UUID.
  */
 interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
-    fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
-
     /**
      * Returns [AgentConfig]s accessible to [userId] in [namespaceId].
      * When [agentName] is non-null, further filters to configs whose name matches

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -12,16 +12,10 @@ interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
 
     /**
-     * Returns all [AgentConfig]s accessible to [userId] in [namespaceId].
-     * Called once per user message to build the authorized agent set used
-     * for routing and redirect enforcement.
+     * Returns [AgentConfig]s accessible to [userId] in [namespaceId].
+     * When [agentName] is non-null, further filters to configs whose name matches
+     * [agentName] case-insensitively. The comparison is pushed to Neo4j via
+     * `toLower()` — no Kotlin-side filtering needed.
      */
-    fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig>
-
-    /**
-     * Returns [AgentConfig]s accessible to [userId] in [namespaceId] whose name
-     * matches [agentName] case-insensitively. The comparison is pushed to Neo4j
-     * via `toLower()` — no Kotlin-side filtering needed.
-     */
-    fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
+    fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String? = null): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -23,5 +23,5 @@ interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
      * matches [agentName] case-insensitively. The comparison is pushed to Neo4j
      * via `toLower()` — no Kotlin-side filtering needed.
      */
-    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
+    fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -10,4 +10,18 @@ import java.util.*
  */
 interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
+
+    /**
+     * Returns all [AgentConfig]s accessible to [userId] in [namespaceId].
+     * Called once per user message to build the authorized agent set used
+     * for routing and redirect enforcement.
+     */
+    fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig>
+
+    /**
+     * Returns [AgentConfig]s accessible to [userId] in [namespaceId] whose name
+     * matches [agentName] case-insensitively. The comparison is pushed to Neo4j
+     * via `toLower()` — no Kotlin-side filtering needed.
+     */
+    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -15,5 +15,5 @@ interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
      * [agentName] case-insensitively. The comparison is pushed to Neo4j via
      * `toLower()` — no Kotlin-side filtering needed.
      */
-    fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String? = null): List<AgentConfig>
+    fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -27,16 +27,10 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
 
     /**
-     * Returns all [AgentConfig]s accessible to [userId] in [namespaceId].
-     * Called once per user message to build the authorized agent set used
-     * for routing and redirect enforcement.
+     * Returns [AgentConfig]s accessible to [userId] in [namespaceId].
+     * When [agentName] is non-null, further filters to configs whose name matches
+     * [agentName] case-insensitively. The comparison is pushed to Neo4j via
+     * `toLower()` — no Kotlin-side filtering needed.
      */
-    fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig>
-
-    /**
-     * Returns [AgentConfig]s accessible to [userId] in [namespaceId] whose name
-     * matches [agentName] case-insensitively. The comparison is pushed to Neo4j
-     * via `toLower()` — no Kotlin-side filtering needed.
-     */
-    fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
+    fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String? = null): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -25,4 +25,18 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
      * See [AgentConfigRepository.findAvailableByUserExternalId] for the full semantics.
      */
     fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig>
+
+    /**
+     * Returns all [AgentConfig]s accessible to [userId] in [namespaceId].
+     * Called once per user message to build the authorized agent set used
+     * for routing and redirect enforcement.
+     */
+    fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig>
+
+    /**
+     * Returns [AgentConfig]s accessible to [userId] in [namespaceId] whose name
+     * matches [agentName] case-insensitively. The comparison is pushed to Neo4j
+     * via `toLower()` — no Kotlin-side filtering needed.
+     */
+    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -38,5 +38,5 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
      * matches [agentName] case-insensitively. The comparison is pushed to Neo4j
      * via `toLower()` — no Kotlin-side filtering needed.
      */
-    fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
+    fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -36,6 +36,6 @@ class AgentConfigServiceImpl(
     override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
         agentConfigRepository.findAvailableByUserId(namespaceId, userId)
 
-    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
-        agentConfigRepository.findAvailableByUserIdAndName(namespaceId, userId, agentName)
+    override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+        agentConfigRepository.findAvailableByNamespaceIdAndUserIdAndName(namespaceId, userId, agentName)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -1,6 +1,8 @@
 package io.whozoss.agentos.agentConfig
 
+import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.user.UserService
+import mu.KLogging
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -33,9 +35,15 @@ class AgentConfigServiceImpl(
             .firstOrNull { it.name.equals(name, ignoreCase = true) }
 
     override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> {
-        val user = userService.findByExternalId(userExternalId) ?: return emptyList()
+        val user = userService.findByExternalId(userExternalId)
+            ?: run {
+                logger.warn { "[AgentConfigService] User not found for externalId: $userExternalId" }
+                throw ResourceNotFoundException("User not found for externalId: $userExternalId")
+            }
         return agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = user.id, agentName = null)
     }
+
+    companion object : KLogging()
 
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
         agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = userId, agentName = agentName)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -34,9 +34,9 @@ class AgentConfigServiceImpl(
 
     override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> {
         val user = userService.findByExternalId(userExternalId) ?: return emptyList()
-        return agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId, user.id)
+        return agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = user.id)
     }
 
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
-        agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName)
+        agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = userId, agentName = agentName)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -33,9 +33,6 @@ class AgentConfigServiceImpl(
     override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
         agentConfigRepository.findAvailableByUserExternalId(namespaceId, userExternalId)
 
-    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
-        agentConfigRepository.findAvailableByUserId(namespaceId, userId)
-
-    override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
-        agentConfigRepository.findAvailableByNamespaceIdAndUserIdAndName(namespaceId, userId, agentName)
+    override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
+        agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -34,7 +34,7 @@ class AgentConfigServiceImpl(
 
     override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> {
         val user = userService.findByExternalId(userExternalId) ?: return emptyList()
-        return agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = user.id)
+        return agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = user.id, agentName = null)
     }
 
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.agentConfig
 
+import io.whozoss.agentos.user.UserService
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -9,6 +10,7 @@ import java.util.UUID
 @Service
 class AgentConfigServiceImpl(
     private val agentConfigRepository: AgentConfigRepository,
+    private val userService: UserService,
 ) : AgentConfigService {
     override fun create(entity: AgentConfig): AgentConfig = agentConfigRepository.save(entity)
 
@@ -30,8 +32,10 @@ class AgentConfigServiceImpl(
             .findByParent(namespaceId)
             .firstOrNull { it.name.equals(name, ignoreCase = true) }
 
-    override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
-        agentConfigRepository.findAvailableByUserExternalId(namespaceId, userExternalId)
+    override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> {
+        val user = userService.findByExternalId(userExternalId) ?: return emptyList()
+        return agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId, user.id)
+    }
 
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
         agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -32,4 +32,10 @@ class AgentConfigServiceImpl(
 
     override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
         agentConfigRepository.findAvailableByUserExternalId(namespaceId, userExternalId)
+
+    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
+        agentConfigRepository.findAvailableByUserId(namespaceId, userId)
+
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+        agentConfigRepository.findAvailableByUserIdAndName(namespaceId, userId, agentName)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -48,6 +48,12 @@ class FilesystemAgentConfigRepository(
             ttl = ttl,
         )
 
+    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
+        delegate.findAvailableByUserId(namespaceId, userId)
+
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+        delegate.findAvailableByUserIdAndName(namespaceId, userId, agentName)
+
     override fun findByParent(parentId: UUID): List<AgentConfig> {
         val persisted = delegate.findByParent(parentId)
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -49,7 +49,7 @@ class FilesystemAgentConfigRepository(
         )
 
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
-        delegate.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName)
+        delegate.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = userId, agentName = agentName)
 
     override fun findByParent(parentId: UUID): List<AgentConfig> {
         val persisted = delegate.findByParent(parentId)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -48,11 +48,8 @@ class FilesystemAgentConfigRepository(
             ttl = ttl,
         )
 
-    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
-        delegate.findAvailableByUserId(namespaceId, userId)
-
-    override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
-        delegate.findAvailableByNamespaceIdAndUserIdAndName(namespaceId, userId, agentName)
+    override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
+        delegate.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName)
 
     override fun findByParent(parentId: UUID): List<AgentConfig> {
         val persisted = delegate.findByParent(parentId)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -51,8 +51,8 @@ class FilesystemAgentConfigRepository(
     override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
         delegate.findAvailableByUserId(namespaceId, userId)
 
-    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
-        delegate.findAvailableByUserIdAndName(namespaceId, userId, agentName)
+    override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+        delegate.findAvailableByNamespaceIdAndUserIdAndName(namespaceId, userId, agentName)
 
     override fun findByParent(parentId: UUID): List<AgentConfig> {
         val persisted = delegate.findByParent(parentId)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -49,14 +49,9 @@ open class Neo4jAgentConfigRepository(
             .findAvailableByUserExternalId(namespaceId.toString(), userExternalId)
             .map { it.toDomain() }
 
-    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
+    override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
         neo4jRepository
-            .findAvailableByUserId(namespaceId.toString(), userId.toString())
-            .map { it.toDomain() }
-
-    override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
-        neo4jRepository
-            .findAvailableByUserIdAndName(namespaceId.toString(), userId.toString(), agentName)
+            .findAvailableByNamespaceIdAndUserId(namespaceId.toString(), userId.toString(), agentName)
             .map { it.toDomain() }
 
     @Transactional

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -54,7 +54,7 @@ open class Neo4jAgentConfigRepository(
             .findAvailableByUserId(namespaceId.toString(), userId.toString())
             .map { it.toDomain() }
 
-    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+    override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
         neo4jRepository
             .findAvailableByUserIdAndName(namespaceId.toString(), userId.toString(), agentName)
             .map { it.toDomain() }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -44,11 +44,20 @@ open class Neo4jAgentConfigRepository(
                 true
             } ?: false
 
-    override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> {
-        return neo4jRepository
+    override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
+        neo4jRepository
             .findAvailableByUserExternalId(namespaceId.toString(), userExternalId)
             .map { it.toDomain() }
-    }
+
+    override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
+        neo4jRepository
+            .findAvailableByUserId(namespaceId.toString(), userId.toString())
+            .map { it.toDomain() }
+
+    override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+        neo4jRepository
+            .findAvailableByUserIdAndName(namespaceId.toString(), userId.toString(), agentName)
+            .map { it.toDomain() }
 
     @Transactional
     open override fun deleteByParent(parentId: UUID): Int {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -46,7 +46,7 @@ open class Neo4jAgentConfigRepository(
 
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
         neo4jRepository
-            .findAvailableByNamespaceIdAndUserId(namespaceId.toString(), userId.toString(), agentName)
+            .findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId.toString(), userId = userId.toString(), agentName = agentName)
             .map { it.toDomain() }
 
     @Transactional

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -44,11 +44,6 @@ open class Neo4jAgentConfigRepository(
                 true
             } ?: false
 
-    override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
-        neo4jRepository
-            .findAvailableByUserExternalId(namespaceId.toString(), userExternalId)
-            .map { it.toDomain() }
-
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
         neo4jRepository
             .findAvailableByNamespaceIdAndUserId(namespaceId.toString(), userId.toString(), agentName)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -12,6 +12,7 @@ import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import mu.KLogging
 import java.util.UUID
@@ -303,7 +304,7 @@ class CaseRuntime(
                                 "to user $userId — redirect blocked"
                         }
                         storeAndEmitEvent(
-                            io.whozoss.agentos.sdk.caseEvent.WarnEvent(
+                            WarnEvent(
                                 namespaceId = namespaceId,
                                 caseId = id,
                                 message = "Agent '${event.agentName}' is not accessible to the current user",

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -34,6 +34,9 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   [io.whozoss.agentos.sdk.caseEvent.WarnEvent] followed by an [AgentSelectedEvent],
  *   or just an [AgentSelectedEvent] for the default agent).
  *   Returns an empty list when no agent is configured and the loop should stop.
+ * @param isAgentAuthorized defensive check called when [processNextStep] encounters an
+ *   [AgentSelectedEvent] emitted by an agent (redirect). Returns true if the target agent
+ *   is accessible to the current user. Called at redirect time — not pre-computed.
  * @param runAgent fetches the named agent, runs it against the current event history,
  *   and pipes each produced event through [storeEvent]. Error handling is the
  *   responsibility of the service implementation.
@@ -44,6 +47,7 @@ class CaseRuntime(
     private val updateStatus: (UUID, CaseStatus) -> Unit,
     private val storeEvent: (CaseEvent) -> CaseEvent,
     private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>) -> List<CaseEvent>,
+    private val isAgentAuthorized: (agentName: String, userId: UUID?) -> Boolean,
     private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
 ) : CaseEventEmitter by DefaultCaseEventEmitter() {
@@ -292,6 +296,22 @@ class CaseRuntime(
                         "[CaseRuntime $id] Found AgentSelectedEvent for agent: ${event.agentName}, " +
                             "transitioning to running"
                     }
+                    val userId = resolveUserId(events)
+                    if (!isAgentAuthorized(event.agentName, userId)) {
+                        logger.warn {
+                            "[CaseRuntime $id] Agent '${event.agentName}' is not accessible " +
+                                "to user $userId — redirect blocked"
+                        }
+                        storeAndEmitEvent(
+                            io.whozoss.agentos.sdk.caseEvent.WarnEvent(
+                                namespaceId = namespaceId,
+                                caseId = id,
+                                message = "Agent '${event.agentName}' is not accessible to the current user",
+                            ),
+                        )
+                        interruptRequested.set(true)
+                        return
+                    }
                     storeAndEmitEvent(
                         AgentRunningEvent(
                             namespaceId = namespaceId,
@@ -328,5 +348,8 @@ class CaseRuntime(
             ?.id
             ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        /** Authorization check that grants access to all agents — for use in tests only. */
+        val ALLOW_ALL: (String, UUID?) -> Boolean = { _, _ -> true }
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -348,8 +348,5 @@ class CaseRuntime(
             ?.id
             ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
 
-    companion object : KLogging() {
-        /** Authorization check that grants access to all agents — for use in tests only. */
-        val ALLOW_ALL: (String, UUID?) -> Boolean = { _, _ -> true }
-    }
+    companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -132,7 +132,7 @@ class CaseServiceImpl(
             selectAgent = { content, pastEvents -> selectAgent(content, pastEvents, case.namespaceId, case.id) },
             isAgentAuthorized = { agentName, userId ->
                 userId == null || agentConfigService
-                    .findAvailableByUserIdAndName(case.namespaceId, userId, agentName)
+                    .findAvailableByNamespaceIdAndUserIdAndName(case.namespaceId, userId, agentName)
                     .isNotEmpty()
             },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue -> runAgent(agentName, case.id, events, eventsProvider, userId, shouldContinue) },

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -132,7 +132,7 @@ class CaseServiceImpl(
             selectAgent = { content, pastEvents -> selectAgent(content, pastEvents, case.namespaceId, case.id) },
             isAgentAuthorized = { agentName, userId ->
                 userId == null || agentConfigService
-                    .findAvailableByNamespaceIdAndUserId(case.namespaceId, userId, agentName)
+                    .findAvailableByNamespaceIdAndUserId(namespaceId = case.namespaceId, userId = userId, agentName = agentName)
                     .isNotEmpty()
             },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue -> runAgent(agentName, case.id, events, eventsProvider, userId, shouldContinue) },

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -132,7 +132,7 @@ class CaseServiceImpl(
             selectAgent = { content, pastEvents -> selectAgent(content, pastEvents, case.namespaceId, case.id) },
             isAgentAuthorized = { agentName, userId ->
                 userId == null || agentConfigService
-                    .findAvailableByNamespaceIdAndUserIdAndName(case.namespaceId, userId, agentName)
+                    .findAvailableByNamespaceIdAndUserId(case.namespaceId, userId, agentName)
                     .isNotEmpty()
             },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue -> runAgent(agentName, case.id, events, eventsProvider, userId, shouldContinue) },

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -3,6 +3,7 @@ package io.whozoss.agentos.caseFlow
 import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentExecutionContext
 import io.whozoss.agentos.agent.AgentService
+import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.namespace.NamespaceService
@@ -32,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Service
 class CaseServiceImpl(
     private val agentService: AgentService,
+    private val agentConfigService: AgentConfigService,
     private val agentConfigProperties: AgentConfigProperties,
     private val caseRepository: CaseRepository,
     private val caseEventService: CaseEventService,
@@ -128,6 +130,11 @@ class CaseServiceImpl(
             updateStatus = { caseId, newStatus -> handleStatusChange(caseId, newStatus) },
             storeEvent = { event -> storeEvent(event) },
             selectAgent = { content, pastEvents -> selectAgent(content, pastEvents, case.namespaceId, case.id) },
+            isAgentAuthorized = { agentName, userId ->
+                userId == null || agentConfigService
+                    .findAvailableByUserIdAndName(case.namespaceId, userId, agentName)
+                    .isNotEmpty()
+            },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue -> runAgent(agentName, case.id, events, eventsProvider, userId, shouldContinue) },
             inputEvents = inputEvents,
         )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectConfiguration.kt
@@ -35,10 +35,13 @@ class RedirectConfiguration(
      */
     @Bean
     fun redirectToolPlugin(): ToolPlugin =
-        RedirectToolPlugin { namespaceId, patterns ->
+        RedirectToolPlugin { namespaceId, userId, patterns ->
             val regexes = patterns.map { globToRegex(it) }
-            agentConfigService
-                .findByParent(namespaceId)
-                .filter { config -> regexes.any { it.matches(config.name) } }
+            val candidates = if (userId != null) {
+                agentConfigService.findAvailableByUserId(namespaceId, userId)
+            } else {
+                agentConfigService.findByParent(namespaceId)
+            }
+            candidates.filter { config -> regexes.any { it.matches(config.name) } }
         }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectConfiguration.kt
@@ -38,7 +38,7 @@ class RedirectConfiguration(
         RedirectToolPlugin { namespaceId, userId, patterns ->
             val regexes = patterns.map { globToRegex(it) }
             val candidates = if (userId != null) {
-                agentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId)
+                agentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = userId)
             } else {
                 agentConfigService.findByParent(namespaceId)
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectConfiguration.kt
@@ -38,7 +38,7 @@ class RedirectConfiguration(
         RedirectToolPlugin { namespaceId, userId, patterns ->
             val regexes = patterns.map { globToRegex(it) }
             val candidates = if (userId != null) {
-                agentConfigService.findAvailableByUserId(namespaceId, userId)
+                agentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId)
             } else {
                 agentConfigService.findByParent(namespaceId)
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
@@ -36,12 +36,19 @@ import java.util.UUID
  * that run. Agents that do not exist in the namespace are silently excluded — the LLM
  * never receives a stale or inaccessible name.
  *
+ * ## Authorization
+ *
+ * When [ToolContext.userId] is available, [agentResolver] applies the same Neo4j graph
+ * rules as the /search endpoint (DEPLOYED_TO + MEMBER/ADMIN): only agents accessible
+ * to the requesting user are eligible for redirection. When [userId] is null (anonymous
+ * or system call), all namespace agents matching the patterns are eligible.
+ *
  * @param agentResolver Lambda injected by [io.whozoss.agentos.redirect.RedirectConfiguration]
- *   to avoid a circular Spring dependency. Given a namespace UUID and a list of glob
- *   patterns, returns the matching [AgentConfig]s from that namespace.
+ *   to avoid a circular Spring dependency. Given a namespace UUID, an optional user UUID,
+ *   and a list of glob patterns, returns the matching [AgentConfig]s accessible to that user.
  */
 class RedirectToolPlugin(
-    private val agentResolver: (namespaceId: UUID, patterns: List<String>) -> List<AgentConfig>,
+    private val agentResolver: (namespaceId: UUID, userId: UUID?, patterns: List<String>) -> List<AgentConfig>,
 ) : ToolPlugin {
     override val integrationType: String = INTEGRATION_TYPE
 
@@ -66,7 +73,8 @@ class RedirectToolPlugin(
             ?.takeIf { it.isNotEmpty() }
             ?: listOf("*")
 
-        val eligibleAgents = agentResolver(namespaceId, patterns)
+        val userId = context?.userId
+        val eligibleAgents = agentResolver(namespaceId, userId, patterns)
             .map { RedirectTool.EligibleAgent(name = it.name, description = it.description) }
 
         if (eligibleAgents.isEmpty()) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
@@ -73,7 +73,7 @@ class RedirectToolPlugin(
             ?.takeIf { it.isNotEmpty() }
             ?: listOf("*")
 
-        val userId = context?.userId
+        val userId = context.userId
         val eligibleAgents = agentResolver(namespaceId, userId, patterns)
             .map { RedirectTool.EligibleAgent(name = it.name, description = it.description) }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
@@ -39,14 +39,14 @@ open class Neo4jUserGroupRepository(
 
     override fun findByNamespaceId(namespaceId: UUID): List<UserGroupSearchResult> =
         querySearchResults(
-            whereClause = $$"ns.id = $namespaceId AND (g.removed IS NULL OR g.removed = false) AND (ns.removed IS NULL OR ns.removed = false)",
+            whereClause = $$"ns.id = $namespaceId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
             paramName = "namespaceId",
             paramValue = namespaceId.toString(),
         ).all().toList()
 
     override fun findByIdWithDetails(id: UUID): UserGroupSearchResult? =
         querySearchResults(
-            whereClause = $$"g.id = $userGroupId AND (g.removed IS NULL OR g.removed = false) AND (ns.removed IS NULL OR ns.removed = false)",
+            whereClause = $$"g.id = $userGroupId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
             paramName = "userGroupId",
             paramValue = id.toString(),
         ).one().orElse(null)
@@ -61,9 +61,9 @@ open class Neo4jUserGroupRepository(
                 MATCH (g:UserGroup)-[:BELONGS_TO]->(ns:Namespace)
                 WHERE $whereClause
                 OPTIONAL MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
-                  WHERE a.removed IS NULL OR a.removed = false
+                  WHERE NOT COALESCE(a.removed, false)
                 OPTIONAL MATCH (u:User)-[:MEMBER]->(g)
-                  WHERE u.removed IS NULL OR u.removed = false
+                  WHERE NOT COALESCE(u.removed, false)
                 RETURN g.id AS userGroupId, ns.id AS namespaceId, ns.externalId AS namespaceExternalId, g.name AS name, collect(DISTINCT a.id) AS agentIds, count(DISTINCT u) AS userCount
                 ORDER BY g.name ASC
             """,
@@ -113,8 +113,8 @@ open class Neo4jUserGroupRepository(
                 $$"""
                     MATCH (u:User)-[:MEMBER]->(g:UserGroup)
                     WHERE u.externalId IN $externalIds
-                      AND (g.removed IS NULL OR g.removed = false)
-                      AND (u.removed IS NULL OR u.removed = false)
+                      AND NOT COALESCE(g.removed, false)
+                      AND NOT COALESCE(u.removed, false)
                     RETURN u.externalId AS externalId, g.id AS groupId, g.name AS groupName
                     ORDER BY u.externalId ASC, g.name ASC
                 """.trimIndent(),

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerIntegrationSpec.kt
@@ -258,14 +258,12 @@ class AgentConfigControllerIntegrationSpec : StringSpec() {
             ).andExpect(status().isBadRequest)
         }
 
-        "POST /api/agent-configs/search with unknown namespace and user returns 200 with empty list" {
+        "POST /api/agent-configs/search with unknown user returns 404" {
             mockMvc.perform(
                 post("/api/agent-configs/search")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{ "namespaceId": "242c4c1b-a41f-4a90-9613-e13b2a51c377", "userExternalId": "ghost@example.com" }""")
-            )
-                .andExpect(status().isOk)
-                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize<Any>(0)))
+            ).andExpect(status().isNotFound)
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -24,7 +24,7 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
             override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
 
-            override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+            override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -3,8 +3,10 @@ package io.whozoss.agentos.agentConfig
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
 import io.whozoss.agentos.entity.InMemoryEntityRepository
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.UserService
 import java.util.UUID
 
 class AgentConfigServiceImplUnitSpec : StringSpec({
@@ -17,15 +19,14 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
                 parentIdExtractor = { it.namespaceId },
                 comparator = compareBy { it.name },
             ) {
-            // findAvailableByUserExternalId and findAvailableByNamespaceIdAndUserId are Neo4j-only queries; not exercised in unit tests.
-            override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
-                throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
-
+            // findAvailableByNamespaceIdAndUserId is a Neo4j-only query; not exercised in unit tests.
             override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 
-    fun service(repo: AgentConfigRepository = repository()) = AgentConfigServiceImpl(repo)
+    val userService = mockk<UserService>(relaxed = true)
+
+    fun service(repo: AgentConfigRepository = repository()) = AgentConfigServiceImpl(repo, userService)
 
     val namespaceId: UUID = UUID.randomUUID()
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -23,6 +23,9 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
 
             override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
+
+            override fun findAvailableByUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+                throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 
     fun service(repo: AgentConfigRepository = repository()) = AgentConfigServiceImpl(repo)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -17,8 +17,11 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
                 parentIdExtractor = { it.namespaceId },
                 comparator = compareBy { it.name },
             ) {
-            // findAvailableByUserExternalId is a Neo4j-only query; not exercised in unit tests.
+            // findAvailableByUserExternalId and findAvailableByUserId are Neo4j-only queries; not exercised in unit tests.
             override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
+                throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
+
+            override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -17,14 +17,11 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
                 parentIdExtractor = { it.namespaceId },
                 comparator = compareBy { it.name },
             ) {
-            // findAvailableByUserExternalId and findAvailableByUserId are Neo4j-only queries; not exercised in unit tests.
+            // findAvailableByUserExternalId and findAvailableByNamespaceIdAndUserId are Neo4j-only queries; not exercised in unit tests.
             override fun findAvailableByUserExternalId(namespaceId: UUID, userExternalId: String): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
 
-            override fun findAvailableByUserId(namespaceId: UUID, userId: UUID): List<AgentConfig> =
-                throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
-
-            override fun findAvailableByNamespaceIdAndUserIdAndName(namespaceId: UUID, userId: UUID, agentName: String): List<AgentConfig> =
+            override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -1,10 +1,13 @@
 package io.whozoss.agentos.agentConfig
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import io.whozoss.agentos.entity.InMemoryEntityRepository
+import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.UserService
 import java.util.UUID
@@ -26,7 +29,7 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
 
     val userService = mockk<UserService>(relaxed = true)
 
-    fun service(repo: AgentConfigRepository = repository()) = AgentConfigServiceImpl(repo, userService)
+    fun service(repo: AgentConfigRepository = repository(), us: UserService = userService) = AgentConfigServiceImpl(repo, us)
 
     val namespaceId: UUID = UUID.randomUUID()
 
@@ -66,6 +69,19 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
         val svc = service()
 
         svc.findByName(namespaceId, "unknown").shouldBeNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // findAvailableByUserExternalId
+    // -------------------------------------------------------------------------
+
+    "findAvailableByUserExternalId throws ResourceNotFoundException when user is not found" {
+        val us = mockk<UserService> { every { findByExternalId("ghost@example.com") } returns null }
+        val svc = service(us = us)
+
+        shouldThrow<ResourceNotFoundException> {
+            svc.findAvailableByUserExternalId(namespaceId, "ghost@example.com")
+        }
     }
 
     "findByName is scoped to the given namespace" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.flow
 import java.util.UUID
 
 /** Authorization check that grants access to all agents. */
-private val ALLOW_ALL_AGENTS: (String, UUID?) -> Boolean = { _, _ -> true }
+private val TRUE_FOR_ANY_AGENTS: (String, UUID?) -> Boolean = { _, _ -> true }
 
 /**
  * A simple recording wrapper for the runAgent callback.
@@ -152,7 +152,7 @@ class CaseRuntimeSpec : StringSpec() {
                     event
                 },
                 selectAgent = selectAgent.asCallback,
-                isAgentAuthorized = ALLOW_ALL_AGENTS,
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                 runAgent = runAgent.asCallback,
             )
 
@@ -246,7 +246,7 @@ class CaseRuntimeSpec : StringSpec() {
                             agentSelectedEvent(runtimeId, agentName),
                         )
                     },
-                    isAgentAuthorized = ALLOW_ALL_AGENTS,
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                     runAgent = { _, events, _, _, _ ->
                         agent.run(events).collect { event ->
                             savedEvents.add(event)
@@ -304,7 +304,7 @@ class CaseRuntimeSpec : StringSpec() {
                         event
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
-                    isAgentAuthorized = ALLOW_ALL_AGENTS,
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                     runAgent = { _, events, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
@@ -345,7 +345,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
-                    isAgentAuthorized = ALLOW_ALL_AGENTS,
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
@@ -380,7 +380,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
-                    isAgentAuthorized = ALLOW_ALL_AGENTS,
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                     },
@@ -414,7 +414,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
-                    isAgentAuthorized = ALLOW_ALL_AGENTS,
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                     runAgent = { _, _, _, _, shouldContinue ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
@@ -506,7 +506,7 @@ class CaseRuntimeSpec : StringSpec() {
                 updateStatus = { _, _ -> },
                 storeEvent = { event -> savedEvents.add(event); event },
                 selectAgent = selectAgent.asCallback,
-                isAgentAuthorized = ALLOW_ALL_AGENTS,
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                 runAgent = runAgent.asCallback,
             )
 
@@ -624,7 +624,7 @@ class CaseRuntimeSpec : StringSpec() {
                         event
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
-                    isAgentAuthorized = ALLOW_ALL_AGENTS,
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                     runAgent = recorder.asCallback,
                 )
             runtime.pushEvents(listOf(existingUserMessage, existingRunningEvent))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -22,6 +22,9 @@ import io.whozoss.agentos.sdk.entity.EntityMetadata
 import kotlinx.coroutines.flow.flow
 import java.util.UUID
 
+/** Authorization check that grants access to all agents. */
+private val ALLOW_ALL_AGENTS: (String, UUID?) -> Boolean = { _, _ -> true }
+
 /**
  * A simple recording wrapper for the runAgent callback.
  *
@@ -149,7 +152,7 @@ class CaseRuntimeSpec : StringSpec() {
                     event
                 },
                 selectAgent = selectAgent.asCallback,
-                isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                isAgentAuthorized = ALLOW_ALL_AGENTS,
                 runAgent = runAgent.asCallback,
             )
 
@@ -243,7 +246,7 @@ class CaseRuntimeSpec : StringSpec() {
                             agentSelectedEvent(runtimeId, agentName),
                         )
                     },
-                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                    isAgentAuthorized = ALLOW_ALL_AGENTS,
                     runAgent = { _, events, _, _, _ ->
                         agent.run(events).collect { event ->
                             savedEvents.add(event)
@@ -301,7 +304,7 @@ class CaseRuntimeSpec : StringSpec() {
                         event
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
-                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                    isAgentAuthorized = ALLOW_ALL_AGENTS,
                     runAgent = { _, events, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
@@ -342,7 +345,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
-                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                    isAgentAuthorized = ALLOW_ALL_AGENTS,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
@@ -377,7 +380,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
-                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                    isAgentAuthorized = ALLOW_ALL_AGENTS,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                     },
@@ -411,7 +414,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
-                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                    isAgentAuthorized = ALLOW_ALL_AGENTS,
                     runAgent = { _, _, _, _, shouldContinue ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
@@ -503,7 +506,7 @@ class CaseRuntimeSpec : StringSpec() {
                 updateStatus = { _, _ -> },
                 storeEvent = { event -> savedEvents.add(event); event },
                 selectAgent = selectAgent.asCallback,
-                isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                isAgentAuthorized = ALLOW_ALL_AGENTS,
                 runAgent = runAgent.asCallback,
             )
 
@@ -621,7 +624,7 @@ class CaseRuntimeSpec : StringSpec() {
                         event
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
-                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
+                    isAgentAuthorized = ALLOW_ALL_AGENTS,
                     runAgent = recorder.asCallback,
                 )
             runtime.pushEvents(listOf(existingUserMessage, existingRunningEvent))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -149,6 +149,7 @@ class CaseRuntimeSpec : StringSpec() {
                     event
                 },
                 selectAgent = selectAgent.asCallback,
+                isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                 runAgent = runAgent.asCallback,
             )
 
@@ -242,6 +243,7 @@ class CaseRuntimeSpec : StringSpec() {
                             agentSelectedEvent(runtimeId, agentName),
                         )
                     },
+                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                     runAgent = { _, events, _, _, _ ->
                         agent.run(events).collect { event ->
                             savedEvents.add(event)
@@ -299,6 +301,7 @@ class CaseRuntimeSpec : StringSpec() {
                         event
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
+                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                     runAgent = { _, events, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
@@ -339,6 +342,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
@@ -373,6 +377,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                     },
@@ -406,6 +411,7 @@ class CaseRuntimeSpec : StringSpec() {
                     updateStatus = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                     runAgent = { _, _, _, _, shouldContinue ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
@@ -497,6 +503,7 @@ class CaseRuntimeSpec : StringSpec() {
                 updateStatus = { _, _ -> },
                 storeEvent = { event -> savedEvents.add(event); event },
                 selectAgent = selectAgent.asCallback,
+                isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                 runAgent = runAgent.asCallback,
             )
 
@@ -511,6 +518,64 @@ class CaseRuntimeSpec : StringSpec() {
             // Agent B's AgentFinishedEvent must be in the saved events
             val finishedEvents = savedEvents.filterIsInstance<AgentFinishedEvent>()
             finishedEvents.any { it.agentName == agentB } shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // Defensive authorization check on AgentSelectedEvent (redirect)
+        // -------------------------------------------------------------------------
+
+        "redirect to unauthorized agent emits WarnEvent and stops turn" {
+            val agentA = "agent-a"
+            val agentB = "agent-b"
+            val runtimeId = UUID.randomUUID()
+            val savedEvents = mutableListOf<CaseEvent>()
+            val runOrder = mutableListOf<String>()
+
+            lateinit var runtime: CaseRuntime
+
+            val agentAMock = mockk<Agent>(name = "mock-$agentA") {
+                every { metadata } returns EntityMetadata(id = UUID.nameUUIDFromBytes(agentA.toByteArray()))
+                every { name } returns agentA
+                every { run(any<List<CaseEvent>>(), any()) } answers {
+                    val caseId = firstArg<List<CaseEvent>>().first().caseId
+                    flow {
+                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId,
+                            agentId = UUID.nameUUIDFromBytes(agentA.toByteArray()), agentName = agentA))
+                        emit(AgentSelectedEvent(namespaceId = namespaceId, caseId = caseId,
+                            agentId = UUID.nameUUIDFromBytes(agentB.toByteArray()), agentName = agentB))
+                    }
+                }
+            }
+
+            val selectAgent = RecordingSelectAgent { _, _ -> listOf(agentSelectedEvent(runtimeId, agentA)) }
+            val runAgent = RecordingRunAgent { name, events ->
+                runOrder += name
+                agentAMock.run(events).collect { event ->
+                    savedEvents.add(event)
+                    runtime.emitEvent(event)
+                    runtime.pushEvents(listOf(event))
+                }
+            }
+
+            runtime = CaseRuntime(
+                id = runtimeId,
+                namespaceId = namespaceId,
+                updateStatus = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = selectAgent.asCallback,
+                isAgentAuthorized = { name, _ -> name == agentA }, // agentB not authorized
+                runAgent = runAgent.asCallback,
+            )
+
+            runtime.addUserMessage(userActor, userMessage)
+            runtime.run()
+
+            // agentA ran, agentB was blocked
+            runAgent.callCount shouldBe 1
+            runOrder shouldBe listOf(agentA)
+            savedEvents.filterIsInstance<WarnEvent>().any {
+                it.message.contains(agentB)
+            } shouldBe true
         }
 
         "runAgent is called exactly once when AgentRunningEvent is already in the event list" {
@@ -556,6 +621,7 @@ class CaseRuntimeSpec : StringSpec() {
                         event
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                    isAgentAuthorized = CaseRuntime.ALLOW_ALL,
                     runAgent = recorder.asCallback,
                 )
             runtime.pushEvents(listOf(existingUserMessage, existingRunningEvent))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -4,8 +4,10 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentService
 import io.whozoss.agentos.agentConfig.AgentConfig
@@ -141,12 +143,16 @@ class CaseServiceImplSpec :
          * Returns a list containing every agent name used across this spec so that
          * [isAgentAuthorized] always passes regardless of which agent is targeted.
          */
-        fun allowAllAgentConfigService(): AgentConfigService = mockk {
+        val allowAllAgentConfigService: AgentConfigService = mockk {
             every { findAvailableByNamespaceIdAndUserId(any(), any(), any()) } answers {
                 val ns = firstArg<UUID>()
                 val name = thirdArg<String?>()
                 if (name != null) listOf(AgentConfig(namespaceId = ns, name = name)) else emptyList()
             }
+        }
+
+        beforeTest {
+            clearMocks(allowAllAgentConfigService, answers = false)
         }
 
         /** Build a fully-wired [CaseServiceImpl] backed by in-memory repositories. */
@@ -155,7 +161,7 @@ class CaseServiceImplSpec :
             userService: UserService = mockk { every { findById(userId) } returns activeUser },
             defaultAgentName: String? = agentName,
             environmentAgentName: String? = null,
-            agentConfigService: AgentConfigService = allowAllAgentConfigService(),
+            agentConfigService: AgentConfigService = allowAllAgentConfigService,
         ): CaseServiceImpl {
             val namespace = Namespace(
                 metadata = EntityMetadata(id = namespaceId),
@@ -232,6 +238,8 @@ class CaseServiceImplSpec :
 
             runCallCount shouldBe 1
             service.getById(case.id).status shouldBe CaseStatus.IDLE
+            // isAgentAuthorized must have been called once with the agent name to authorize the redirect
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
         }
 
         // -------------------------------------------------------------------------
@@ -254,6 +262,8 @@ class CaseServiceImplSpec :
             awaiter.join()
 
             service.getById(case.id).status shouldBe CaseStatus.ERROR
+            // userId is not a valid UUID so isAgentAuthorized is never reached (userId is null)
+            verify(exactly = 0) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(any(), any(), any()) }
         }
 
         "case transitions to ERROR when userId does not resolve to a known user" {
@@ -274,6 +284,8 @@ class CaseServiceImplSpec :
             awaiter.join()
 
             service.getById(case.id).status shouldBe CaseStatus.ERROR
+            // isAgentAuthorized is called before runAgent fails on user lookup
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(any(), any(), agentName) }
         }
 
         // -------------------------------------------------------------------------
@@ -296,7 +308,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
-                allowAllAgentConfigService(),
+                allowAllAgentConfigService,
                 AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -331,6 +343,8 @@ class CaseServiceImplSpec :
             agentEvents[1].shouldBeInstanceOf<AgentSelectedEvent>()
             agentEvents[2].shouldBeInstanceOf<AgentRunningEvent>()
             agentEvents[3].shouldBeInstanceOf<AgentFinishedEvent>()
+            // isAgentAuthorized called once for the AgentSelectedEvent -> AgentRunningEvent transition
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
         }
 
         // -------------------------------------------------------------------------
@@ -506,7 +520,7 @@ class CaseServiceImplSpec :
                     every { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, allowAllAgentConfigService(), AgentConfigProperties(), InMemoryCaseRepository(), caseEventService, userService, namespaceService)
+            val service = CaseServiceImpl(agentService, allowAllAgentConfigService, AgentConfigProperties(), InMemoryCaseRepository(), caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
 
@@ -585,7 +599,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
-                allowAllAgentConfigService(),
+                allowAllAgentConfigService,
                 AgentConfigProperties(agentName = agentName),  // environment-level default
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -608,6 +622,7 @@ class CaseServiceImplSpec :
             val persistedEvents = caseEventService.findByParent(case.id)
             persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe agentName
             persistedEvents.filterIsInstance<WarnEvent>() shouldBe emptyList()
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
         }
 
         "namespace default agent takes precedence over environment default agent" {
@@ -638,7 +653,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
-                allowAllAgentConfigService(),
+                allowAllAgentConfigService,
                 AgentConfigProperties(agentName = environmentDefaultName),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -661,6 +676,7 @@ class CaseServiceImplSpec :
             val persistedEvents = caseEventService.findByParent(case.id)
             // namespace agent was selected, not the environment default
             persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe namespaceDefaultName
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, namespaceDefaultName) }
         }
 
         "no default agent at any level produces WarnEvent and stops" {
@@ -675,7 +691,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
-                allowAllAgentConfigService(),
+                allowAllAgentConfigService,
                 AgentConfigProperties(agentName = null),  // no environment default either
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -698,6 +714,8 @@ class CaseServiceImplSpec :
             val persistedEvents = caseEventService.findByParent(case.id)
             persistedEvents.filterIsInstance<WarnEvent>() shouldHaveAtLeastSize 1
             persistedEvents.filterIsInstance<AgentSelectedEvent>() shouldBe emptyList()
+            // no AgentSelectedEvent means isAgentAuthorized is never reached
+            verify(exactly = 0) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(any(), any(), any()) }
         }
 
         // -------------------------------------------------------------------------
@@ -719,6 +737,7 @@ class CaseServiceImplSpec :
             awaiter.join()
 
             service.getById(case.id).status shouldBe CaseStatus.IDLE
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
         }
 
         "first message without @mention produces WarnEvent and stops when namespace has no default agent" {
@@ -735,7 +754,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
-                allowAllAgentConfigService(),
+                allowAllAgentConfigService,
                 AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -761,6 +780,8 @@ class CaseServiceImplSpec :
             persistedEvents.filterIsInstance<WarnEvent>() shouldHaveAtLeastSize 1
             // No AgentSelectedEvent: routing stopped at the WarnEvent
             persistedEvents.filterIsInstance<AgentSelectedEvent>() shouldBe emptyList()
+            // no AgentSelectedEvent means isAgentAuthorized is never reached
+            verify(exactly = 0) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(any(), any(), any()) }
         }
 
         "last active agent unavailable falls back to namespace default" {
@@ -790,7 +811,7 @@ class CaseServiceImplSpec :
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
-                allowAllAgentConfigService(),
+                allowAllAgentConfigService,
                 AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -826,6 +847,9 @@ class CaseServiceImplSpec :
             persistedEvents.filterIsInstance<WarnEvent>() shouldHaveAtLeastSize 1
             // Default agent was ultimately selected after the warn
             persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe agentName
+            // turn 1: authorized for unavailableAgentName, turn 2: authorized for agentName (fallback)
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, unavailableAgentName) }
+            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
         }
 
         "second message without @mention uses the same agent as the first" {
@@ -879,7 +903,7 @@ class CaseServiceImplSpec :
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, allowAllAgentConfigService(), AgentConfigProperties(), caseRepository, caseEventService, userService, namespaceService)
+            val service = CaseServiceImpl(agentService, allowAllAgentConfigService, AgentConfigProperties(), caseRepository, caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -908,6 +932,8 @@ class CaseServiceImplSpec :
             secondIdle.join()
 
             agentCallNames shouldBe listOf(selectedAgentName, selectedAgentName)
+            // called once per message for the same agent
+            verify(exactly = 2) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, selectedAgentName) }
         }
 
         "agent runs once per message when two messages are sent sequentially" {
@@ -964,5 +990,6 @@ class CaseServiceImplSpec :
 
             runCallCount shouldBe 2
             service.getById(case.id).status shouldBe CaseStatus.IDLE
+            verify(exactly = 2) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
         }
     })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -142,7 +142,7 @@ class CaseServiceImplSpec :
          * [isAgentAuthorized] always passes regardless of which agent is targeted.
          */
         fun allowAllAgentConfigService(): AgentConfigService = mockk {
-            every { findAvailableByUserIdAndName(any(), any(), any()) } answers {
+            every { findAvailableByNamespaceIdAndUserIdAndName(any(), any(), any()) } answers {
                 val ns = firstArg<UUID>()
                 val name = thirdArg<String>()
                 listOf(AgentConfig(namespaceId = ns, name = name))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -142,10 +142,10 @@ class CaseServiceImplSpec :
          * [isAgentAuthorized] always passes regardless of which agent is targeted.
          */
         fun allowAllAgentConfigService(): AgentConfigService = mockk {
-            every { findAvailableByNamespaceIdAndUserIdAndName(any(), any(), any()) } answers {
+            every { findAvailableByNamespaceIdAndUserId(any(), any(), any()) } answers {
                 val ns = firstArg<UUID>()
-                val name = thirdArg<String>()
-                listOf(AgentConfig(namespaceId = ns, name = name))
+                val name = thirdArg<String?>()
+                if (name != null) listOf(AgentConfig(namespaceId = ns, name = name)) else emptyList()
             }
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -8,6 +8,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentService
+import io.whozoss.agentos.agentConfig.AgentConfig
+import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
 import io.whozoss.agentos.caseEvent.InMemoryCaseEventRepository
 import io.whozoss.agentos.namespace.Namespace
@@ -134,12 +136,26 @@ class CaseServiceImplSpec :
                 }
             }
 
+        /**
+         * [AgentConfigService] mock that authorizes any agent name — Neo4j not available in unit tests.
+         * Returns a list containing every agent name used across this spec so that
+         * [isAgentAuthorized] always passes regardless of which agent is targeted.
+         */
+        fun allowAllAgentConfigService(): AgentConfigService = mockk {
+            every { findAvailableByUserIdAndName(any(), any(), any()) } answers {
+                val ns = firstArg<UUID>()
+                val name = thirdArg<String>()
+                listOf(AgentConfig(namespaceId = ns, name = name))
+            }
+        }
+
         /** Build a fully-wired [CaseServiceImpl] backed by in-memory repositories. */
         fun buildService(
             agent: Agent = finishingAgent(),
             userService: UserService = mockk { every { findById(userId) } returns activeUser },
             defaultAgentName: String? = agentName,
             environmentAgentName: String? = null,
+            agentConfigService: AgentConfigService = allowAllAgentConfigService(),
         ): CaseServiceImpl {
             val namespace = Namespace(
                 metadata = EntityMetadata(id = namespaceId),
@@ -156,6 +172,7 @@ class CaseServiceImplSpec :
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             return CaseServiceImpl(
                 agentService,
+                agentConfigService,
                 AgentConfigProperties(agentName = environmentAgentName),
                 caseRepository,
                 caseEventService,
@@ -279,6 +296,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                allowAllAgentConfigService(),
                 AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -488,7 +506,7 @@ class CaseServiceImplSpec :
                     every { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, AgentConfigProperties(), InMemoryCaseRepository(), caseEventService, userService, namespaceService)
+            val service = CaseServiceImpl(agentService, allowAllAgentConfigService(), AgentConfigProperties(), InMemoryCaseRepository(), caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
 
@@ -567,6 +585,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                allowAllAgentConfigService(),
                 AgentConfigProperties(agentName = agentName),  // environment-level default
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -619,6 +638,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                allowAllAgentConfigService(),
                 AgentConfigProperties(agentName = environmentDefaultName),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -655,6 +675,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                allowAllAgentConfigService(),
                 AgentConfigProperties(agentName = null),  // no environment default either
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -714,6 +735,7 @@ class CaseServiceImplSpec :
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                allowAllAgentConfigService(),
                 AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -768,6 +790,7 @@ class CaseServiceImplSpec :
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
                 agentService,
+                allowAllAgentConfigService(),
                 AgentConfigProperties(),
                 InMemoryCaseRepository(),
                 caseEventService,
@@ -856,7 +879,7 @@ class CaseServiceImplSpec :
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, AgentConfigProperties(), caseRepository, caseEventService, userService, namespaceService)
+            val service = CaseServiceImpl(agentService, allowAllAgentConfigService(), AgentConfigProperties(), caseRepository, caseEventService, userService, namespaceService)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
@@ -248,5 +248,116 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
             agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com").shouldBeEmpty()
         }
+
+        // -------------------------------------------------------------------------
+        // findAvailableByNamespaceIdAndUserId — agentName = null (all accessible)
+        // -------------------------------------------------------------------------
+
+        "findAvailableByNamespaceIdAndUserId with null agentName returns all accessible agents via group path" {
+            val ns = namespaceRepo.save(namespace())
+            val user = userRepo.save(user("alice@example.com"))
+            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a"))
+            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b"))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userGroupRepo.addAgents(group.id, listOf(agentA.id, agentB.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, null)
+
+            result.map { it.name } shouldContainExactlyInAnyOrder listOf("agent-a", "agent-b")
+        }
+
+        "findAvailableByNamespaceIdAndUserId with null agentName returns all accessible agents via namespace path" {
+            val ns = namespaceRepo.save(namespace())
+            val user = userRepo.save(user("alice@example.com"))
+            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a"))
+            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b"))
+            namespaceRepo.deployAgents(ns.id, listOf(agentA.id, agentB.id))
+            grantMember("alice@example.com", ns.id.toString())
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, null)
+
+            result.map { it.name } shouldContainExactlyInAnyOrder listOf("agent-a", "agent-b")
+        }
+
+        "findAvailableByNamespaceIdAndUserId with null agentName returns union of group and namespace paths" {
+            val ns = namespaceRepo.save(namespace())
+            val user = userRepo.save(user("alice@example.com"))
+            val groupAgent = agentConfigRepo.save(agentConfig(ns.id, "group-agent"))
+            val nsAgent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent"))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userGroupRepo.addAgents(group.id, listOf(groupAgent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            namespaceRepo.deployAgents(ns.id, listOf(nsAgent.id))
+            grantMember("alice@example.com", ns.id.toString())
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, null)
+
+            result.map { it.name } shouldContainExactlyInAnyOrder listOf("group-agent", "ns-agent")
+        }
+
+        // -------------------------------------------------------------------------
+        // findAvailableByNamespaceIdAndUserId — agentName filter (exact, case-insensitive)
+        // -------------------------------------------------------------------------
+
+        "findAvailableByNamespaceIdAndUserId with agentName returns only the matching agent" {
+            val ns = namespaceRepo.save(namespace())
+            val user = userRepo.save(user("alice@example.com"))
+            val agentA = agentConfigRepo.save(agentConfig(ns.id, "my-agent"))
+            val agentB = agentConfigRepo.save(agentConfig(ns.id, "other-agent"))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userGroupRepo.addAgents(group.id, listOf(agentA.id, agentB.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "my-agent")
+
+            result shouldHaveSize 1
+            result.first().name shouldBe "my-agent"
+        }
+
+        "findAvailableByNamespaceIdAndUserId with agentName is case-insensitive" {
+            val ns = namespaceRepo.save(namespace())
+            val user = userRepo.save(user("alice@example.com"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "My-Agent"))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "MY-AGENT")
+
+            result shouldHaveSize 1
+            result.first().name shouldBe "My-Agent"
+        }
+
+        "findAvailableByNamespaceIdAndUserId with nonexistent agentName returns empty list" {
+            val ns = namespaceRepo.save(namespace())
+            val user = userRepo.save(user("alice@example.com"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "real-agent"))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "nonexistent")
+
+            result.shouldBeEmpty()
+        }
+
+        "findAvailableByNamespaceIdAndUserId with agentName matches across both group and namespace paths" {
+            val ns = namespaceRepo.save(namespace())
+            val user = userRepo.save(user("alice@example.com"))
+            val targetAgent = agentConfigRepo.save(agentConfig(ns.id, "target-agent"))
+            val otherAgent = agentConfigRepo.save(agentConfig(ns.id, "other-agent"))
+            // target-agent reachable via group; other-agent reachable via namespace
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userGroupRepo.addAgents(group.id, listOf(targetAgent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            namespaceRepo.deployAgents(ns.id, listOf(otherAgent.id))
+            grantMember("alice@example.com", ns.id.toString())
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "target-agent")
+
+            result shouldHaveSize 1
+            result.first().name shouldBe "target-agent"
+        }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
@@ -20,9 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
 
 /**
- * Persistence contract tests for [AgentConfigRepository.findAvailableByUserExternalId].
+ * Persistence contract tests for [AgentConfigRepository.findAvailableByNamespaceIdAndUserId].
  *
- * The query is scoped to a namespace identified by its [Namespace.externalId].
+ * The query is scoped to a namespace by its UUID, and the user is identified by their internal UUID.
  * Availability is the union of:
  * 1. Agents deployed on a [UserGroup] belonging to that namespace, of which the user is a member
  * 2. Agents deployed directly on that namespace, for a user holding MEMBER or ADMIN on it
@@ -71,18 +71,19 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         // No membership — empty result
         // -------------------------------------------------------------------------
 
-        "returns empty list for unknown userExternalId" {
+        "returns empty list for unknown userId" {
             val ns = namespaceRepo.save(namespace())
-            agentConfigRepo.findAvailableByUserExternalId(ns.id, "ghost@example.com").shouldBeEmpty()
+            val ghost = userRepo.save(user("ghost@example.com"))
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, ghost.id, null).shouldBeEmpty()
         }
 
         "returns empty list for user with no group and no namespace membership" {
             val ns = namespaceRepo.save(namespace())
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             agentConfigRepo.save(agentConfig(ns.id, "agent-a"))
             // no DEPLOYED_TO, no group, no namespace relation
 
-            agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com").shouldBeEmpty()
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         // -------------------------------------------------------------------------
@@ -93,11 +94,11 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id, "group-agent"))
             val group = userGroupRepo.save(userGroup(ns.id))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
 
-            val result = agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result shouldHaveSize 1
             result.first().name shouldBe "group-agent"
@@ -107,12 +108,12 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id, "other-group-agent"))
             val group = userGroupRepo.save(userGroup(ns.id))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             userRepo.save(user("bob@example.com"))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
             userGroupRepo.addUsers(group.id, listOf("bob@example.com"))
 
-            agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com").shouldBeEmpty()
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         "does not return agents from a group belonging to a different namespace" {
@@ -120,12 +121,12 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val otherNs = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(otherNs.id, "other-ns-group-agent"))
             val group = userGroupRepo.save(userGroup(otherNs.id))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
 
             // alice is in a group with an agent, but that group belongs to otherNs, not ns
-            agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com").shouldBeEmpty()
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         // -------------------------------------------------------------------------
@@ -135,11 +136,11 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "returns agents deployed on a namespace the user has MEMBER relation on" {
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent"))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(agent.id))
             grantMember("alice@example.com", ns.id.toString())
 
-            val result = agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result shouldHaveSize 1
             result.first().name shouldBe "ns-agent"
@@ -148,11 +149,11 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "returns agents deployed on a namespace the user has ADMIN relation on" {
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id, "admin-ns-agent"))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(agent.id))
             grantAdmin("alice@example.com", ns.id.toString())
 
-            val result = agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result shouldHaveSize 1
             result.first().name shouldBe "admin-ns-agent"
@@ -160,24 +161,23 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "does not return agents on a namespace the user has no relation to" {
             val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "unreachable-agent"))
-            userRepo.save(user("alice@example.com"))
-            namespaceRepo.deployAgents(ns.id, listOf(agent.id))
+            agentConfigRepo.save(agentConfig(ns.id, "unreachable-agent"))
+            val alice = userRepo.save(user("alice@example.com"))
             // alice has no MEMBER/ADMIN on ns
 
-            agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com").shouldBeEmpty()
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         "does not return agents deployed on a different namespace" {
             val ns = namespaceRepo.save(namespace())
             val otherNs = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(otherNs.id, "other-ns-agent"))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             namespaceRepo.deployAgents(otherNs.id, listOf(agent.id))
             grantMember("alice@example.com", otherNs.id.toString())
 
             // querying ns, not otherNs
-            agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com").shouldBeEmpty()
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         // -------------------------------------------------------------------------
@@ -189,13 +189,13 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val agent = agentConfigRepo.save(agentConfig(ns.id, "shared-agent"))
             val group1 = userGroupRepo.save(userGroup(ns.id))
             val group2 = userGroupRepo.save(userGroup(ns.id))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group1.id, listOf(agent.id))
             userGroupRepo.addAgents(group2.id, listOf(agent.id))
             userGroupRepo.addUsers(group1.id, listOf("alice@example.com"))
             userGroupRepo.addUsers(group2.id, listOf("alice@example.com"))
 
-            val result = agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result shouldHaveSize 1
             result.first().name shouldBe "shared-agent"
@@ -205,13 +205,13 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id, "shared-agent"))
             val group = userGroupRepo.save(userGroup(ns.id))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(agent.id))
             grantMember("alice@example.com", ns.id.toString())
 
-            val result = agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result shouldHaveSize 1
             result.first().name shouldBe "shared-agent"
@@ -222,13 +222,13 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val groupAgent = agentConfigRepo.save(agentConfig(ns.id, "group-agent"))
             val nsAgent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent"))
             val group = userGroupRepo.save(userGroup(ns.id))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(groupAgent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(nsAgent.id))
             grantMember("alice@example.com", ns.id.toString())
 
-            val result = agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result.map { it.name } shouldContainExactlyInAnyOrder listOf("group-agent", "ns-agent")
         }
@@ -241,12 +241,12 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id, "deleted-agent"))
             val group = userGroupRepo.save(userGroup(ns.id))
-            userRepo.save(user("alice@example.com"))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
             agentConfigRepo.delete(agent.id)
 
-            agentConfigRepo.findAvailableByUserExternalId(ns.id, "alice@example.com").shouldBeEmpty()
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
@@ -1,0 +1,114 @@
+package io.whozoss.agentos.redirect
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.agentConfig.AgentConfig
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.sdk.tool.ToolContext
+import java.util.UUID
+
+/**
+ * Unit tests for [RedirectToolPlugin].
+ *
+ * Verifies that the [agentResolver] lambda is called with the correct arguments
+ * and that the resulting [RedirectTool] contains only the eligible agents.
+ */
+class RedirectToolPluginSpec : StringSpec({
+
+    val namespaceId: UUID = UUID.randomUUID()
+    val userId: UUID = UUID.randomUUID()
+
+    fun agentConfig(name: String, description: String? = null) = AgentConfig(
+        metadata = EntityMetadata(id = UUID.randomUUID()),
+        namespaceId = namespaceId,
+        name = name,
+        description = description,
+    )
+
+    fun context(userId: UUID? = null) = ToolContext(
+        namespaceId = namespaceId,
+        userId = userId,
+        userExternalId = null,
+        caseEvents = emptyList(),
+    )
+
+    // -------------------------------------------------------------------------
+    // userId propagation
+    // -------------------------------------------------------------------------
+
+    "provideTools passes userId from context to agentResolver" {
+        var capturedUserId: UUID? = UUID.randomUUID() // sentinel — must be overwritten
+        val plugin = RedirectToolPlugin { _, uid, _ ->
+            capturedUserId = uid
+            emptyList()
+        }
+
+        plugin.provideTools(config = null, context = context(userId = userId))
+
+        capturedUserId shouldBe userId
+    }
+
+    "provideTools passes null userId when context has no userId" {
+        var capturedUserId: UUID? = UUID.randomUUID() // sentinel
+        val plugin = RedirectToolPlugin { _, uid, _ ->
+            capturedUserId = uid
+            emptyList()
+        }
+
+        plugin.provideTools(config = null, context = context(userId = null))
+
+        capturedUserId shouldBe null
+    }
+
+    "provideTools returns empty list when context is null" {
+        // context == null means no namespaceId: the plugin short-circuits before calling
+        // agentResolver, so the resolver is never invoked and an empty list is returned.
+        var resolverCalled = false
+        val plugin = RedirectToolPlugin { _, _, _ ->
+            resolverCalled = true
+            emptyList()
+        }
+
+        val tools = plugin.provideTools(config = null, context = null)
+
+        tools.shouldBeEmpty()
+        resolverCalled shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // Eligible agents
+    // -------------------------------------------------------------------------
+
+    "provideTools returns a RedirectTool with eligible agents from resolver" {
+        val agents = listOf(
+            agentConfig("AgentA", "Does A"),
+            agentConfig("AgentB", "Does B"),
+        )
+        val plugin = RedirectToolPlugin { _, _, _ -> agents }
+
+        val tools = plugin.provideTools(config = null, context = context(userId = userId))
+
+        tools shouldHaveSize 1
+        val tool = tools.first() as RedirectTool
+        tool.eligibleAgents.map { it.name } shouldBe listOf("AgentA", "AgentB")
+    }
+
+    "provideTools returns empty list when resolver returns no agents" {
+        val plugin = RedirectToolPlugin { _, _, _ -> emptyList() }
+
+        val tools = plugin.provideTools(config = null, context = context(userId = userId))
+
+        tools.shouldBeEmpty()
+    }
+
+    "provideTools returns empty list when context has no namespaceId" {
+        val plugin = RedirectToolPlugin { _, _, _ -> listOf(agentConfig("AgentA")) }
+
+        // ToolContext requires namespaceId — pass null context to simulate missing namespace
+        val tools = plugin.provideTools(config = null, context = null)
+
+        tools.shouldBeEmpty()
+    }
+})


### PR DESCRIPTION
Adds a defensive authorization check in CaseRuntime when an agent emits an AgentSelectedEvent (redirect). Before transitioning to AgentRunningEvent, the runtime verifies that the target agent is accessible to the current user via a Neo4j query. If the check fails, a WarnEvent is persisted and the turn stops cleanly. Without this guard, an agent could redirect to any other agent in the namespace regardless of the user's permissions.

On the tool side, RedirectToolPlugin restricts the list of agents exposed to the LLM: only agents the user can access appear as redirect options.

The availability queries (findAvailableByUserId and findAvailableByUserIdAndName) have been consolidated into a single method findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName?) with an optional agentName parameter. A single Cypher query using COALESCE handles both the unfiltered case (all accessible agents) and the name-filtered case, eliminating duplication across the repository, service, and decorator layers. Integration tests cover both paths.