### PR TITLE
fix: #WZ-32044 pass ToolContext with namespaceId to provideTools in ToolResolverService

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -5,6 +5,7 @@ import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.exception.ConfigNotFoundException
 import io.whozoss.agentos.reconciliation.ConfigMergeService
 import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
 import mu.KLogging
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -37,8 +38,11 @@ class ToolResolverService(
             }
             try {
                 val allowedToolNames = agentIntegrations?.get(config.name)
-                val providedTools = plugin.provideTools(config.parameters, config.name)
-                    .filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
+                val providedTools = plugin.provideTools(
+                    config.parameters,
+                    config.name,
+                    ToolContext(namespaceId = namespaceId, userId = null, userExternalId = null, caseEvents = emptyList()),
+                ).filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
                 providedTools.forEach { tool ->
                     if (resolved.containsKey(tool.name)) {
                         logger.warn { "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${config.integrationType}' overrides an existing entry" }
@@ -107,8 +111,11 @@ class ToolResolverService(
 
             try {
                 val allowedToolNames = agentIntegrations?.get(resolvedConfig.name)
-                val tools = plugin.provideTools(resolvedConfig.parameters, resolvedConfig.name)
-                    .filter { tool -> isToolAllowed(tool.name, resolvedConfig.name, allowedToolNames) }
+                val tools = plugin.provideTools(
+                    resolvedConfig.parameters,
+                    resolvedConfig.name,
+                    ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList()),
+                ).filter { tool -> isToolAllowed(tool.name, resolvedConfig.name, allowedToolNames) }
                 tools.forEach { tool ->
                     if (resolved.containsKey(tool.name)) {
                         logger.warn { "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${resolvedConfig.integrationType}'" }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -1,8 +1,8 @@
 package io.whozoss.agentos.tool
 
+import io.whozoss.agentos.exception.ConfigNotFoundException
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
-import io.whozoss.agentos.exception.ConfigNotFoundException
 import io.whozoss.agentos.reconciliation.ConfigMergeService
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
@@ -16,7 +16,6 @@ class ToolResolverService(
     private val integrationConfigService: IntegrationConfigService,
     private val integrationConfigMergeService: ConfigMergeService<IntegrationConfig>,
 ) {
-
     fun resolveToolsForNamespace(
         namespaceId: UUID,
         agentIntegrations: Map<String, List<String>?>? = null,
@@ -33,23 +32,37 @@ class ToolResolverService(
             }
             val plugin = toolRegistryService.findPlugin(config.integrationType)
             if (plugin == null) {
-                logger.warn { "[ToolResolver] No plugin found for integrationType='${config.integrationType}' (config id=${config.metadata.id}) — skipping" }
+                logger.warn {
+                    "[ToolResolver] No plugin found for integrationType='${config.integrationType}' (config id=${config.metadata.id}) — skipping"
+                }
                 return@forEach
             }
             try {
                 val allowedToolNames = agentIntegrations?.get(config.name)
-                val providedTools = plugin.provideTools(
-                    config.parameters,
-                    config.name,
-                    ToolContext(namespaceId = namespaceId, userId = null, userExternalId = null, caseEvents = emptyList()),
-                ).filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
+                val providedTools =
+                    plugin
+                        .provideTools(
+                            config = config.parameters,
+                            configName = config.name,
+                            context =
+                                ToolContext(
+                                    namespaceId = namespaceId,
+                                    userId = null,
+                                    userExternalId = null,
+                                    caseEvents = emptyList(),
+                                ),
+                        ).filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
                 providedTools.forEach { tool ->
                     if (resolved.containsKey(tool.name)) {
-                        logger.warn { "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${config.integrationType}' overrides an existing entry" }
+                        logger.warn {
+                            "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${config.integrationType}' overrides an existing entry"
+                        }
                     }
                     resolved[tool.name] = tool
                 }
-                logger.info { "[ToolResolver] Resolved ${providedTools.size} tool(s) from integrationType='${config.integrationType}' for namespace $namespaceId" }
+                logger.info {
+                    "[ToolResolver] Resolved ${providedTools.size} tool(s) from integrationType='${config.integrationType}' for namespace $namespaceId"
+                }
             } catch (e: Exception) {
                 logger.error(e) { "[ToolResolver] Error instantiating tools for integrationType='${config.integrationType}': ${e.message}" }
             }
@@ -67,8 +80,10 @@ class ToolResolverService(
         val resolved = mutableMapOf<String, StandardTool<*>>()
 
         val sharedConfigs = integrationConfigService.findByNamespaceShared(namespaceId)
-        val userOverrides = integrationConfigService.findByUserId(userId)
-            .filter { it.namespaceId == null || it.namespaceId == namespaceId }
+        val userOverrides =
+            integrationConfigService
+                .findByUserId(userId)
+                .filter { it.namespaceId == null || it.namespaceId == namespaceId }
         val sharedNames = sharedConfigs.map { it.name }.toSet()
         val distinctNames = sharedNames + userOverrides.map { it.name }
 
@@ -93,32 +108,44 @@ class ToolResolverService(
                 return@forEach
             }
 
-            val resolvedConfig = try {
-                integrationConfigMergeService.resolve(namespaceId, userId, name)
-            } catch (e: ConfigNotFoundException) {
-                if (name in sharedNames) {
-                    logger.error { "[ToolResolver] Reconciliation failed for namespace-shared name='$name' — failing the run" }
-                    throw e
+            val resolvedConfig =
+                try {
+                    integrationConfigMergeService.resolve(namespaceId, userId, name)
+                } catch (e: ConfigNotFoundException) {
+                    if (name in sharedNames) {
+                        logger.error { "[ToolResolver] Reconciliation failed for namespace-shared name='$name' — failing the run" }
+                        throw e
+                    }
+                    logger.warn { "[ToolResolver] Dormant user override for name='$name' (no matching shared config): ${e.message}" }
+                    return@forEach
                 }
-                logger.warn { "[ToolResolver] Dormant user override for name='$name' (no matching shared config): ${e.message}" }
-                return@forEach
-            }
 
-            val plugin = toolRegistryService.findPlugin(resolvedConfig.integrationType) ?: run {
-                logger.warn { "[ToolResolver] No plugin for integrationType='${resolvedConfig.integrationType}' (name='$name')" }
-                return@forEach
-            }
+            val plugin =
+                toolRegistryService.findPlugin(resolvedConfig.integrationType) ?: run {
+                    logger.warn { "[ToolResolver] No plugin for integrationType='${resolvedConfig.integrationType}' (name='$name')" }
+                    return@forEach
+                }
 
             try {
                 val allowedToolNames = agentIntegrations?.get(resolvedConfig.name)
-                val tools = plugin.provideTools(
-                    resolvedConfig.parameters,
-                    resolvedConfig.name,
-                    ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList()),
-                ).filter { tool -> isToolAllowed(tool.name, resolvedConfig.name, allowedToolNames) }
+                val tools =
+                    plugin
+                        .provideTools(
+                            config = resolvedConfig.parameters,
+                            configName = resolvedConfig.name,
+                            context =
+                                ToolContext(
+                                    namespaceId = namespaceId,
+                                    userId = userId,
+                                    userExternalId = null,
+                                    caseEvents = emptyList(),
+                                ),
+                        ).filter { tool -> isToolAllowed(tool.name, resolvedConfig.name, allowedToolNames) }
                 tools.forEach { tool ->
                     if (resolved.containsKey(tool.name)) {
-                        logger.warn { "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${resolvedConfig.integrationType}'" }
+                        logger.warn {
+                            "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${resolvedConfig.integrationType}'"
+                        }
                     }
                     resolved[tool.name] = tool
                 }
@@ -139,7 +166,7 @@ class ToolResolverService(
     ): Boolean {
         if (allowedNames == null) return true
         return allowedNames.any { allowed ->
-            toolName == allowed || toolName == "${integrationKey}__${allowed}"
+            toolName == allowed || toolName == "${integrationKey}__$allowed"
         }
     }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
@@ -447,6 +447,69 @@ class ToolResolverServiceSpec : StringSpec({
         tools shouldHaveSize 0
     }
 
+    // -------------------------------------------------------------------------
+    // RedirectToolPlugin: ToolContext must be forwarded so namespaceId is available
+    // -------------------------------------------------------------------------
+
+    "resolveToolsForNamespace passes namespaceId via ToolContext to plugins that need it" {
+        // Regression: ToolResolverService called provideTools(config, name) without a ToolContext.
+        // RedirectToolPlugin requires context?.namespaceId to resolve eligible agents;
+        // without it, it returns emptyList() regardless of the config patterns.
+        val namespaceId = UUID.randomUUID()
+        var capturedContext: ToolContext? = null
+        val contextCapturingPlugin = object : ToolPlugin {
+            override val integrationType = "REDIRECT"
+            override val configSchema: JsonNode = mockk(relaxed = true)
+            override fun provideTools(config: JsonNode?, configName: String?, context: ToolContext?): List<StandardTool<*>> {
+                capturedContext = context
+                // Simulate what RedirectToolPlugin does: return empty when context is null
+                if (context?.namespaceId == null) return emptyList()
+                return listOf(makeTool("redirect"))
+            }
+        }
+        val config = integrationConfig(namespaceId, "REDIRECT_all", "REDIRECT")
+        val service = buildService(plugins = listOf(contextCapturingPlugin), configs = listOf(config))
+
+        val tools = service.resolveToolsForNamespace(namespaceId)
+
+        capturedContext shouldNotBe null
+        capturedContext!!.namespaceId shouldBe namespaceId
+        tools shouldHaveSize 1
+    }
+
+    "resolveToolsForRun passes namespaceId via ToolContext to plugins that need it" {
+        // Same regression for the user-scoped resolution path.
+        val namespaceId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        var capturedContext: ToolContext? = null
+        val contextCapturingPlugin = object : ToolPlugin {
+            override val integrationType = "REDIRECT"
+            override val configSchema: JsonNode = mockk(relaxed = true)
+            override fun provideTools(config: JsonNode?, configName: String?, context: ToolContext?): List<StandardTool<*>> {
+                capturedContext = context
+                if (context?.namespaceId == null) return emptyList()
+                return listOf(makeTool("redirect"))
+            }
+        }
+        val shared = IntegrationConfig(
+            metadata = EntityMetadata(),
+            namespaceId = namespaceId,
+            name = "REDIRECT_all",
+            integrationType = "REDIRECT",
+        )
+        val service = buildServiceForRun(
+            plugins = listOf(contextCapturingPlugin),
+            sharedConfigs = listOf(shared),
+            reconciledConfigs = mapOf("REDIRECT_all" to shared),
+        )
+
+        val tools = service.resolveToolsForRun(namespaceId, userId)
+
+        capturedContext shouldNotBe null
+        capturedContext!!.namespaceId shouldBe namespaceId
+        tools shouldHaveSize 1
+    }
+
     "resolveToolsForRun combines config-less and configured tools when both have IntegrationConfigs" {
         val namespaceId = UUID.randomUUID()
         val userId = UUID.randomUUID()


### PR DESCRIPTION
## Root cause

`ToolResolverService` called `plugin.provideTools(config.parameters, config.name)` in both `resolveToolsForNamespace` and `resolveToolsForRun` without passing a `ToolContext`. The third parameter defaulted to `null`.

`RedirectToolPlugin.provideTools` starts by checking `context?.namespaceId` — when `null`, it immediately returns `emptyList()` and logs a warning. This meant the redirect tool was never instantiated regardless of the configured patterns (`\"*\"` or explicit names).

## Fix

Pass a `ToolContext` at both callsites:
- `resolveToolsForNamespace`: `ToolContext(namespaceId, userId=null, userExternalId=null, caseEvents=emptyList())`
- `resolveToolsForRun`: `ToolContext(namespaceId, userId=userId, userExternalId=null, caseEvents=emptyList())`

`userExternalId` and `caseEvents` are not available at tool-resolution time (they belong to the per-invocation runtime context), so they are passed as `null`/`emptyList()`. `RedirectToolPlugin` only needs `namespaceId` to resolve eligible agents.

## Tests

Two new unit tests added to `ToolResolverServiceSpec`:
- `resolveToolsForNamespace passes namespaceId via ToolContext to plugins that need it`
- `resolveToolsForRun passes namespaceId via ToolContext to plugins that need it`

Both used a context-capturing plugin that returns `emptyList()` when `context?.namespaceId == null`, mirroring the exact guard in `RedirectToolPlugin`. Both failed before the fix, both pass after."