### PR TITLE
feat: #wz-32045 add headers editing to ai-provider form

### DIFF
--- a/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.html
+++ b/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.html
@@ -83,6 +83,40 @@
         />
       </div>
 
+      <div class="ai-provider-form__headers" [formArrayName]="'headers'">
+        <div class="ai-provider-form__headers-title">
+          <span class="ai-provider-form__label">Custom headers</span>
+          <button class="ai-provider-form__headers-add" type="button" (click)="addHeader()">+ Add header</button>
+        </div>
+        @for (headerGroup of headersArray.controls; track $index) {
+          <div class="ai-provider-form__header-row" [formGroupName]="$index">
+            <input
+              class="ai-provider-form__input"
+              type="text"
+              placeholder="Header name"
+              formControlName="key"
+              autocomplete="off"
+            />
+            <input
+              class="ai-provider-form__input"
+              type="text"
+              placeholder="Value"
+              formControlName="value"
+              autocomplete="off"
+            />
+            <button
+              class="ai-provider-form__header-remove"
+              type="button"
+              (click)="removeHeader($index)"
+              title="Remove header"
+              aria-label="Remove header"
+            >
+              &times;
+            </button>
+          </div>
+        }
+      </div>
+
       <div class="ai-provider-form__actions">
         <button
           class="ai-provider-form__btn ai-provider-form__btn--primary"

--- a/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.scss
+++ b/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.scss
@@ -117,6 +117,59 @@
     letter-spacing: 0.05em;
   }
 
+  &__headers {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__headers-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__headers-add {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    font-family: inherit;
+    color: var(--color-primary, #007aff);
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  &__header-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  &__header-remove {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    background: none;
+    border: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1rem;
+    color: var(--color-text-secondary, #6e6e73);
+    transition: background 0.15s ease;
+    flex-shrink: 0;
+
+    &:hover {
+      background: var(--color-surface-hover, rgba(0, 0, 0, 0.04));
+    }
+  }
+
   &__actions {
     display: flex;
     gap: 0.75rem;

--- a/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, effect, inject, signal } from '@angular/core'
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop'
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms'
+import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms'
 import { ActivatedRoute, Router } from '@angular/router'
 import { AiProvider, AiProviderApiTypeEnum } from '@whoz-oss/agentos-api-client'
 import { AiProviderConfigStateService, AiProviderScope } from '../../services/ai-provider-config-state.service'
@@ -83,6 +83,7 @@ export class AiProviderFormComponent implements OnInit {
     baseUrl: new FormControl<string>('', { nonNullable: true }),
     apiKey: new FormControl<string>('', { nonNullable: true }),
     scope: new FormControl<AiProviderScope>('namespace', { nonNullable: true }),
+    headers: new FormArray<FormGroup<{ key: FormControl<string>; value: FormControl<string> }>>([], { validators: [] }),
   })
 
   protected get nameControl() {
@@ -102,6 +103,23 @@ export class AiProviderFormComponent implements OnInit {
   }
   protected get scopeControl() {
     return this.form.controls.scope
+  }
+
+  protected get headersArray() {
+    return this.form.controls.headers
+  }
+
+  protected addHeader(): void {
+    this.headersArray.push(
+      new FormGroup({
+        key: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
+        value: new FormControl<string>('', { nonNullable: true }),
+      })
+    )
+  }
+
+  protected removeHeader(index: number): void {
+    this.headersArray.removeAt(index)
   }
 
   protected readonly isEditMode = signal(false)
@@ -238,6 +256,16 @@ export class AiProviderFormComponent implements OnInit {
     const loadedApiKey = config.apiKey ?? ''
     this.apiKeyControl.setValue(loadedApiKey)
     this.initialApiKey = loadedApiKey
+    // Hydrate headers from the loaded config
+    this.headersArray.clear()
+    for (const [key, value] of Object.entries(config.headers ?? {})) {
+      this.headersArray.push(
+        new FormGroup({
+          key: new FormControl<string>(key, { nonNullable: true, validators: [Validators.required] }),
+          value: new FormControl<string>(value, { nonNullable: true }),
+        })
+      )
+    }
   }
 
   protected submit(): void {
@@ -257,12 +285,18 @@ export class AiProviderFormComponent implements OnInit {
     // means "no key" (sent as null too — backend accepts no apiKey on create).
     const apiKey = this.isEditMode() && currentApiKey === this.initialApiKey ? null : currentApiKey
 
+    const headerEntries = this.headersArray.controls
+      .filter((g) => g.controls.key.value.trim())
+      .map((g) => [g.controls.key.value.trim(), g.controls.value.value] as [string, string])
+    const headers = headerEntries.length > 0 ? Object.fromEntries(headerEntries) : null
+
     const draft = {
       name: this.nameControl.value.trim(),
       apiType: this.apiTypeControl.value,
       description: trimmedDescription ? trimmedDescription : null,
       baseUrl: baseUrl ? baseUrl : null,
       apiKey,
+      headers,
     }
     const scope = this.form.getRawValue().scope
 

--- a/libs/agentos-ui/src/lib/services/ai-provider-config-state.service.ts
+++ b/libs/agentos-ui/src/lib/services/ai-provider-config-state.service.ts
@@ -41,6 +41,11 @@ export interface AiProviderDraft {
   description: string | null
   baseUrl: string | null
   apiKey: string | null
+  /**
+   * Custom HTTP headers forwarded to the provider's API.
+   * `null` means no headers (omitted from payload). Empty object clears all headers.
+   */
+  headers: Record<string, string> | null
 }
 
 /** Sentinel accepted by the backend's `?namespaceId=` to filter on `namespaceId IS NULL`. */
@@ -156,6 +161,7 @@ export class AiProviderConfigStateService {
         description: draft.description as string | undefined,
         baseUrl: draft.baseUrl as string | undefined,
         apiKey: draft.apiKey as string | undefined,
+        headers: draft.headers ?? undefined,
         namespaceId,
       }
       return this.nsController.createAiProvider(payload).pipe(tap(() => this.refresh()))
@@ -174,6 +180,7 @@ export class AiProviderConfigStateService {
       description: draft.description as string | undefined,
       baseUrl: draft.baseUrl as string | undefined,
       apiKey: draft.apiKey as string | undefined,
+      headers: draft.headers ?? undefined,
       userId: myId,
       namespaceId: scope === 'userOnNs' ? (namespaceId as string) : undefined,
     }
@@ -198,6 +205,7 @@ export class AiProviderConfigStateService {
       apiType: draft.apiType,
       description: draft.description as string | undefined,
       baseUrl: draft.baseUrl as string | undefined,
+      headers: draft.headers ?? undefined,
       namespaceId: existing.namespaceId,
       userId: existing.userId,
       ...apiKeyField,


### PR DESCRIPTION
## Summary

Adds custom HTTP headers editing to the AI provider create/edit form.

## Changes

### `AiProviderDraft` (state service)
- New field `headers: Record<string, string> | null` — `null` means no headers (omitted from payload), empty object clears all headers

### `AiProviderConfigStateService`
- `create()` and `update()` now forward `headers` from the draft to the backend payload

### `AiProviderFormComponent`
- `FormArray` of `FormGroup<{ key, value }>` for dynamic header rows
- `addHeader()` / `removeHeader(index)` methods
- Edit mode: existing headers hydrated from the loaded provider (`applyConfigToForm`)
- Submit: serialises the array to `Record<string, string>`, rows with empty key are filtered out, returns `null` if no headers

### Template
- "Custom headers" section with title + "Add header" button
- One row per header: key input / value input / remove button (×)

### Styles
- New BEM blocks following the existing component convention: `__headers`, `__headers-title`, `__headers-add`, `__header-row`, `__header-remove`
- Grid layout (1fr 1fr auto), CSS tokens only
