### PR TITLE
fix: bump release job to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://${{ vars.NPM_REGISTRY }}'
 


### PR DESCRIPTION
fix: bump release job to Node 24 to restore npm provenance publishing

npm publish for `client`, `server`, and `web` has been failing since
0.153.1 (2026-05-20) with a misleading 404 error on PUT to npmjs.org.

Root cause: a known bug in npm 10.x (shipped with Node 22) where
OIDC-based provenance publishing fails on GitHub Actions runners.
Tracked in https://github.com/npm/cli/issues/8730.

Fix: bump the `release` job to Node 24, which ships with npm 11.x
where the bug is resolved. NPM_CONFIG_PROVENANCE: true is kept so
published packages retain supply chain attestations.

Only the `release` job is affected — all other jobs remain on Node 22.