### PR TITLE
fix(agentos): fix redirect tools in advanced mode (WZ-32112)

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -176,9 +176,36 @@ class AgentAdvanced(
         accumulatedEvents.add(parameters)
 
         if (!shouldContinue()) return
-        val response = executeTool(parameters, namespaceId, caseId)
+        // executeTool always returns a ToolResponseEvent, even on AgentInterrupt.
+        // We must emit and accumulate the response before re-throwing so the event
+        // history stays well-formed (every ToolRequestEvent has a matching response).
+        var interrupt: AgentInterrupt? = null
+        val response =
+            try {
+                executeTool(parameters, namespaceId, caseId)
+            } catch (e: AgentInterrupt) {
+                interrupt = e
+                // executeTool already built the ToolResponseEvent before throwing;
+                // the .also { throw e } pattern means the value was created but never
+                // returned. Re-create the response here so it can be emitted.
+                ToolResponseEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    toolRequestId = parameters.toolRequestId,
+                    toolName = parameters.toolName,
+                    output =
+                        MessageContent.Text(
+                            when (e) {
+                                is AgentInterrupt.Redirect -> "Redirecting to agent '${e.targetAgentName}'."
+                            },
+                        ),
+                    success = true,
+                )
+            }
         emitEvent(response)
         accumulatedEvents.add(response)
+        // Re-throw the interrupt after the response has been properly recorded.
+        interrupt?.let { throw it }
     }
 
     private suspend fun generateFinalResponse(
@@ -324,7 +351,8 @@ Intention: ${intentionEvent.intention}
                 durationMs = System.currentTimeMillis() - startMs,
             )
         } catch (e: AgentInterrupt) {
-            // Re-throw so the run() catch block can handle it — do not swallow as a tool error.
+            // Re-throw so handleToolExecution() can emit a proper ToolResponseEvent
+            // before the interrupt propagates to the run() catch block.
             throw e
         } catch (e: Exception) {
             ToolResponseEvent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -98,21 +98,25 @@ data class AgentAdvancedContext(
             AssistantMessage.ToolCall(event.toolRequestId, "function", event.toolName, normalizeArgs(event.args))
         val messages = mutableListOf<Message>(AssistantMessage.builder().toolCalls(listOf(toolCall)).build())
 
-        responsesByRequestId[event.toolRequestId]?.let { response ->
-            messages.add(
-                ToolResponseMessage
-                    .builder()
-                    .responses(
-                        listOf(
-                            ToolResponseMessage.ToolResponse(
-                                event.toolRequestId,
-                                event.toolName,
-                                extractText(response.output),
-                            ),
+        // Every AssistantMessage with tool_calls MUST be followed by a ToolResponseMessage
+        // for each tool_call_id — OpenAI returns 400 otherwise. Use the real response if
+        // available, or synthesize a placeholder so the message list stays well-formed.
+        val responseText =
+            responsesByRequestId[event.toolRequestId]?.let { extractText(it.output) }
+                ?: "[No response recorded]"
+        messages.add(
+            ToolResponseMessage
+                .builder()
+                .responses(
+                    listOf(
+                        ToolResponseMessage.ToolResponse(
+                            event.toolRequestId,
+                            event.toolName,
+                            responseText,
                         ),
-                    ).build(),
-            )
-        }
+                    ),
+                ).build(),
+        )
         return messages
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -15,12 +15,12 @@ import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import mu.KLogging
 import org.springframework.ai.chat.client.ChatClient
@@ -273,23 +273,23 @@ class AgentSimple(
                                 ).build(),
                         )
 
-                        // Add corresponding tool responses
+                        // Every AssistantMessage with tool_calls MUST be followed by a
+                        // ToolResponseMessage for each tool_call_id — OpenAI returns 400
+                        // otherwise. Use the real response when available, or a placeholder.
                         val toolResponseMessages =
-                            toolCallsForCurrentMessage.mapNotNull { toolCall ->
+                            toolCallsForCurrentMessage.map { toolCall ->
                                 val response = toolResponses[toolCall.id()]
-                                response?.let {
-                                    val output =
+                                val output =
+                                    response?.let {
                                         when (val content = it.output) {
                                             is MessageContent.Text -> content.content
                                             else -> content.toString()
                                         }
-                                    ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
-                                }
+                                    } ?: "[No response recorded]"
+                                ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
                             }
 
-                        if (toolResponseMessages.isNotEmpty()) {
-                            messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
-                        }
+                        messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
 
                         toolCallsForCurrentMessage.clear()
                     }
@@ -332,22 +332,23 @@ class AgentSimple(
                     ).build(),
             )
 
+            // Every AssistantMessage with tool_calls MUST be followed by a
+            // ToolResponseMessage for each tool_call_id — OpenAI returns 400
+            // otherwise. Use the real response when available, or a placeholder.
             val toolResponseMessages =
-                toolCallsForCurrentMessage.mapNotNull { toolCall ->
+                toolCallsForCurrentMessage.map { toolCall ->
                     val response = toolResponses[toolCall.id()]
-                    response?.let {
-                        val output =
+                    val output =
+                        response?.let {
                             when (val content = it.output) {
                                 is MessageContent.Text -> content.content
                                 else -> content.toString()
                             }
-                        ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
-                    }
+                        } ?: "[No response recorded]"
+                    ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
                 }
 
-            if (toolResponseMessages.isNotEmpty()) {
-                messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
-            }
+            messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
         }
 
         return messages

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
@@ -387,6 +387,59 @@ class AgentAdvancedContextSpec :
         }
 
         // -------------------------------------------------------------------------
+        // Orphaned tool requests (defensive safeguard)
+        // -------------------------------------------------------------------------
+
+        "orphaned tool request in detail window produces a placeholder ToolResponseMessage" {
+            // When a ToolRequestEvent has no matching ToolResponseEvent (e.g. after an
+            // AgentInterrupt), the message conversion must still produce a
+            // ToolResponseMessage — OpenAI returns 400 if an AssistantMessage with
+            // tool_calls is not followed by a ToolResponseMessage for each call.
+            val events =
+                listOf(
+                    userMessage("go"),
+                    toolRequest("orphan-1", "REDIRECT__redirect"),
+                )
+            val messages = context.convertEventsToMessages(events)
+
+            messages shouldHaveSize 3
+            messages[0].shouldBeInstanceOf<UserMessage>()
+            // AssistantMessage with tool_calls
+            val assistantMsg = messages[1].shouldBeInstanceOf<AssistantMessage>()
+            assistantMsg.toolCalls shouldHaveSize 1
+            assistantMsg.toolCalls[0].id() shouldBe "orphan-1"
+            // ToolResponseMessage with placeholder
+            val toolRespMsg = messages[2].shouldBeInstanceOf<ToolResponseMessage>()
+            toolRespMsg.responses shouldHaveSize 1
+            toolRespMsg.responses[0].id() shouldBe "orphan-1"
+            toolRespMsg.responses[0].responseData() shouldContain "No response recorded"
+        }
+
+        "orphaned tool request in summary window produces a success summary" {
+            // When an orphaned ToolRequestEvent falls outside the detail window,
+            // it is summarized. A missing response should not crash — it should
+            // default to Success (same as null response in toToolSummaryMessage).
+            val events =
+                listOf(
+                    userMessage("go"),
+                    toolRequest("orphan-old", "REDIRECT__redirect"),
+                    // Add enough recent tool calls to push orphan-old out of the detail window
+                    toolRequest("r1", "TOOL__x"),
+                    toolResponse("r1", "TOOL__x", "ok"),
+                )
+            val messages = context.convertEventsToMessages(events, maxDetailedToolCalls = 1)
+
+            // The orphaned request should be summarized, not detailed
+            val summaries =
+                messages.filterIsInstance<AssistantMessage>().filter {
+                    it.text?.contains("[Step summary]") == true
+                }
+            summaries shouldHaveSize 1
+            summaries[0].text shouldContain "REDIRECT__redirect"
+            summaries[0].text shouldContain "Success" // null response → Success
+        }
+
+        // -------------------------------------------------------------------------
         // buildMessages with/without instructions
         // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -195,6 +195,88 @@ class AgentAdvancedSpec :
             events.filterIsInstance<WarnEvent>() shouldHaveSize 0
         }
 
+        "on redirect, a ToolResponseEvent is emitted before AgentFinishedEvent" {
+            // The redirect tool throws AgentInterrupt.Redirect. handleToolExecution()
+            // must catch it, create and emit a ToolResponseEvent, add it to
+            // accumulatedEvents, then re-throw. This ensures the event history is
+            // well-formed: every ToolRequestEvent has a matching ToolResponseEvent.
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            val redirectTool =
+                RedirectTool(
+                    configName = "REDIRECT",
+                    eligibleAgents = listOf(RedirectTool.EligibleAgent("TargetAgent", "does stuff")),
+                )
+
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every {
+                mockChatClient.prompt(any<Prompt>()).call().content()
+            } returns """{"agentName":"TargetAgent"}"""
+            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            every { mockStreamSpec.content() } returns Flux.empty()
+
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every {
+                mockGenerator.generate(any(), any(), any(), any(), any())
+            } returns
+                IntentionGeneratedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    intention = "Redirect to TargetAgent.",
+                    toolName = "REDIRECT__redirect",
+                )
+
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = listOf(redirectTool),
+                    instructions = null,
+                    agentId = agentId,
+                )
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "TestAgent",
+                    context = context,
+                    intentionGenerator = mockGenerator,
+                    maxIterations = 5,
+                )
+
+            val events =
+                agent
+                    .run(
+                        listOf(
+                            MessageEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                actor = Actor("user1", "User One", ActorRole.USER),
+                                content = listOf(MessageContent.Text("do the thing")),
+                            ),
+                        ),
+                    ).toList()
+
+            // A ToolRequestEvent must exist for the redirect tool
+            val toolRequests = events.filterIsInstance<ToolRequestEvent>()
+            toolRequests shouldHaveSize 1
+            toolRequests[0].toolName shouldBe "REDIRECT__redirect"
+
+            // A matching ToolResponseEvent must exist
+            val toolResponses = events.filterIsInstance<ToolResponseEvent>()
+            toolResponses shouldHaveSize 1
+            toolResponses[0].toolRequestId shouldBe toolRequests[0].toolRequestId
+            toolResponses[0].success shouldBe true
+            (toolResponses[0].output as MessageContent.Text).content shouldContain "TargetAgent"
+
+            // ToolResponseEvent must appear before AgentFinishedEvent
+            val responseIndex = events.indexOf(toolResponses[0])
+            val finishedIndex = events.indexOfFirst { it is AgentFinishedEvent }
+            (responseIndex < finishedIndex) shouldBe true
+        }
+
         // -------------------------------------------------------------------------
         // Orchestration integration tests
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
@@ -9,10 +9,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.whozoss.agentos.redirect.RedirectTool
-import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
@@ -106,7 +106,10 @@ class AgentSimpleToolCallbackUnitSpec :
                     override val version = "1.0.0"
                     override val paramType: Class<Nothing>? = null
 
-                    override suspend fun execute(input: Nothing?, context: ToolContext): String = ""
+                    override suspend fun execute(
+                        input: Nothing?,
+                        context: ToolContext,
+                    ): String = ""
                 }
 
             val capturedCallbacks = slot<List<ToolCallback>>()
@@ -150,9 +153,15 @@ class AgentSimpleToolCallbackUnitSpec :
                     override val version = "1.0.0"
                     override val paramType: Class<Nothing>? = null
 
-                    override suspend fun execute(input: Nothing?, context: ToolContext): String = ""
+                    override suspend fun execute(
+                        input: Nothing?,
+                        context: ToolContext,
+                    ): String = ""
 
-                    override suspend fun executeWithJson(json: String?, context: ToolContext): String {
+                    override suspend fun executeWithJson(
+                        json: String?,
+                        context: ToolContext,
+                    ): String {
                         receivedArgs += json
                         return """{"success":true,"datetime":"2026-02-27T11:02:37-05:00","timezone":"America/New_York"}"""
                     }
@@ -213,14 +222,14 @@ class AgentSimpleToolCallbackUnitSpec :
             val historyWithEmptyArgs =
                 listOf(
                     userMessage(namespaceId, caseId, "what time is it in New York?"),
-                    io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent(
+                    ToolRequestEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
                         toolRequestId = "prior-request-id",
                         toolName = "GetCurrentDateTime",
                         args = "", // empty — would crash AnthropicChatModel before the fix
                     ),
-                    io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent(
+                    ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
                         toolRequestId = "prior-request-id",
@@ -257,10 +266,11 @@ class AgentSimpleToolCallbackUnitSpec :
             val caseId = UUID.randomUUID()
             val agentId = UUID.randomUUID()
 
-            val redirectTool = RedirectTool(
-                configName = "REDIRECT",
-                eligibleAgents = listOf(RedirectTool.EligibleAgent("TargetAgent", "does stuff")),
-            )
+            val redirectTool =
+                RedirectTool(
+                    configName = "REDIRECT",
+                    eligibleAgents = listOf(RedirectTool.EligibleAgent("TargetAgent", "does stuff")),
+                )
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)
             val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
@@ -290,6 +300,52 @@ class AgentSimpleToolCallbackUnitSpec :
             events.filterIsInstance<ToolResponseEvent>().first().success shouldBe true
         }
 
+        "convertEventsToMessages produces placeholder for orphaned ToolRequestEvent in history" {
+            // When a ToolRequestEvent exists without a matching ToolResponseEvent
+            // (e.g. after an AgentInterrupt that wasn't properly recorded), the
+            // message conversion must still produce a ToolResponseMessage — OpenAI
+            // returns 400 if an AssistantMessage with tool_calls is not followed
+            // by a ToolResponseMessage for each call.
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            every { mockStreamSpec.content() } returns Flux.just("response")
+
+            val agent = makeAgent(agentId, mockChatClient, emptyList())
+
+            // History with an orphaned ToolRequestEvent (no matching ToolResponseEvent)
+            val historyWithOrphanedRequest =
+                listOf(
+                    userMessage(namespaceId, caseId, "redirect me"),
+                    ToolRequestEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        toolRequestId = "orphan-request-id",
+                        toolName = "REDIRECT__redirect",
+                        args = """{"agentName":"TargetAgent"}""",
+                    ),
+                    // No ToolResponseEvent for orphan-request-id!
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor(agentId.toString(), "TestAgent", ActorRole.AGENT),
+                        content = listOf(MessageContent.Text("Redirected.")),
+                    ),
+                    userMessage(namespaceId, caseId, "follow-up after redirect"),
+                )
+
+            // Must not throw — before the fix this would produce a malformed message
+            // list that OpenAI would reject with 400
+            val events = agent.run(historyWithOrphanedRequest).toList()
+
+            events shouldHaveAtLeastSize 3
+            events.filterIsInstance<AgentFinishedEvent>().firstOrNull() shouldNotBe null
+        }
+
         "convertEventsToMessages should not crash when history contains a ToolRequestEvent with null args" {
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -305,14 +361,14 @@ class AgentSimpleToolCallbackUnitSpec :
             val historyWithNullArgs =
                 listOf(
                     userMessage(namespaceId, caseId, "what time is it?"),
-                    io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent(
+                    ToolRequestEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
                         toolRequestId = "prior-request-id",
                         toolName = "GetCurrentDateTime",
                         args = null, // null — also unsafe before the fix
                     ),
-                    io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent(
+                    ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
                         toolRequestId = "prior-request-id",


### PR DESCRIPTION
Emit ToolResponseEvent before re-throwing AgentInterrupt to maintain well-formed event history improve orphan tool request event conversion to avoid error 400 on openai