### PR TITLE
feat: user group member list and role management API

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
@@ -13,6 +13,13 @@ private data class UserExternalIdGroupRow(
     val groupName: String,
 )
 
+private data class UserGroupMemberRow(
+    val userId: String,
+    val externalId: String,
+    val email: String,
+    val role: String,
+)
+
 open class Neo4jUserGroupRepository(
     private val neo4jRepository: UserGroupNodeNeo4jRepository,
     private val childLinkService: Neo4jChildLinkService,
@@ -37,49 +44,112 @@ open class Neo4jUserGroupRepository(
             .findActiveByNamespaceId(parentId.toString())
             .map { it.toDomain() }
 
+    /**
+     * List query — returns count only, members list is empty.
+     * Loading full member lists for every group in a namespace listing is not acceptable
+     * at scale (thousands of users per group).
+     */
     override fun findByNamespaceId(namespaceId: UUID): List<UserGroupSearchResult> =
-        querySearchResults(
-            whereClause = $$"ns.id = $namespaceId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
-            paramName = "namespaceId",
-            paramValue = namespaceId.toString(),
-        ).all().toList()
+        neo4jClient
+            .query(
+                """
+                    MATCH (g:UserGroup)-[:BELONGS_TO]->(ns:Namespace)
+                    WHERE ns.id = ${'$'}namespaceId
+                      AND NOT COALESCE(g.removed, false)
+                      AND NOT COALESCE(ns.removed, false)
+                    OPTIONAL MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
+                      WHERE NOT COALESCE(a.removed, false)
+                    OPTIONAL MATCH (u:User)-[:ADMIN|MEMBER]->(g)
+                      WHERE NOT COALESCE(u.removed, false)
+                    RETURN g.id AS userGroupId, ns.id AS namespaceId, ns.externalId AS namespaceExternalId,
+                           g.name AS name, collect(DISTINCT a.id) AS agentIds, count(DISTINCT u) AS userCount
+                    ORDER BY g.name ASC
+                """,
+            ).bindAll(mapOf("namespaceId" to namespaceId.toString()))
+            .fetchAs(UserGroupSearchResult::class.java)
+            .mappedBy { _, record ->
+                UserGroupSearchResult(
+                    userGroupId = UUID.fromString(record["userGroupId"].asString()),
+                    namespaceId = UUID.fromString(record["namespaceId"].asString()),
+                    namespaceExternalId = record["namespaceExternalId"].asString(),
+                    name = record["name"].asString(),
+                    agentIds = record["agentIds"].asList { UUID.fromString(it.asString()) },
+                    userCount = record["userCount"].asInt(),
+                )
+            }.all().toList()
 
-    override fun findByIdWithDetails(id: UUID): UserGroupSearchResult? =
-        querySearchResults(
-            whereClause = $$"g.id = $userGroupId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
-            paramName = "userGroupId",
-            paramValue = id.toString(),
-        ).one().orElse(null)
+    /**
+     * Detail query — returns the full member list with roles alongside agents.
+     *
+     * Two separate Cypher round-trips:
+     * 1. Group metadata + agent ids + member count (same shape as the list query).
+     * 2. Member list with roles (ADMIN or MEMBER) via `type(r)`.
+     *
+     * A single query cannot simultaneously aggregate agent ids and return per-member
+     * role data without a cartesian explosion or complex WITH/UNWIND gymnastics.
+     * Two simple queries are cleaner and each runs in O(members + agents).
+     */
+    override fun findByIdWithDetails(id: UUID): UserGroupSearchResult? {
+        val base = neo4jClient
+            .query(
+                """
+                    MATCH (g:UserGroup)-[:BELONGS_TO]->(ns:Namespace)
+                    WHERE g.id = ${'$'}userGroupId
+                      AND NOT COALESCE(g.removed, false)
+                      AND NOT COALESCE(ns.removed, false)
+                    OPTIONAL MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
+                      WHERE NOT COALESCE(a.removed, false)
+                    OPTIONAL MATCH (u:User)-[:ADMIN|MEMBER]->(g)
+                      WHERE NOT COALESCE(u.removed, false)
+                    RETURN g.id AS userGroupId, ns.id AS namespaceId, ns.externalId AS namespaceExternalId,
+                           g.name AS name, collect(DISTINCT a.id) AS agentIds, count(DISTINCT u) AS userCount
+                """,
+            ).bindAll(mapOf("userGroupId" to id.toString()))
+            .fetchAs(UserGroupSearchResult::class.java)
+            .mappedBy { _, record ->
+                UserGroupSearchResult(
+                    userGroupId = UUID.fromString(record["userGroupId"].asString()),
+                    namespaceId = UUID.fromString(record["namespaceId"].asString()),
+                    namespaceExternalId = record["namespaceExternalId"].asString(),
+                    name = record["name"].asString(),
+                    agentIds = record["agentIds"].asList { UUID.fromString(it.asString()) },
+                    userCount = record["userCount"].asInt(),
+                )
+            }.one().orElse(null) ?: return null
 
-    private fun querySearchResults(
-        whereClause: String,
-        paramName: String,
-        paramValue: String,
-    ) = neo4jClient
-        .query(
-            """
-                MATCH (g:UserGroup)-[:BELONGS_TO]->(ns:Namespace)
-                WHERE $whereClause
-                OPTIONAL MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
-                  WHERE NOT COALESCE(a.removed, false)
-                OPTIONAL MATCH (u:User)-[:MEMBER]->(g)
-                  WHERE NOT COALESCE(u.removed, false)
-                RETURN g.id AS userGroupId, ns.id AS namespaceId, ns.externalId AS namespaceExternalId, g.name AS name, collect(DISTINCT a.id) AS agentIds, count(DISTINCT u) AS userCount
-                ORDER BY g.name ASC
-            """,
-        ).bind(paramValue)
-        .to(paramName)
-        .fetchAs(UserGroupSearchResult::class.java)
-        .mappedBy { _, record ->
-            UserGroupSearchResult(
-                userGroupId = UUID.fromString(record["userGroupId"].asString()),
-                namespaceId = UUID.fromString(record["namespaceId"].asString()),
-                namespaceExternalId = record["namespaceExternalId"].asString(),
-                name = record["name"].asString(),
-                agentIds = record["agentIds"].asList { UUID.fromString(it.asString()) },
-                userCount = record["userCount"].asInt(),
-            )
-        }
+        val members = neo4jClient
+            .query(
+                """
+                    MATCH (u:User)-[r:ADMIN|MEMBER]->(g:UserGroup {id: ${'$'}userGroupId})
+                    WHERE NOT COALESCE(u.removed, false)
+                      AND NOT COALESCE(g.removed, false)
+                    RETURN u.id AS userId, u.externalId AS externalId, u.email AS email,
+                           type(r) AS role
+                    ORDER BY u.email ASC
+                """,
+            ).bindAll(mapOf("userGroupId" to id.toString()))
+            .fetchAs(UserGroupMemberRow::class.java)
+            .mappedBy { _, record ->
+                UserGroupMemberRow(
+                    userId = record["userId"].asString(),
+                    externalId = record["externalId"].asString(),
+                    email = record["email"].asString(),
+                    role = record["role"].asString(),
+                )
+            }.all().toList()
+
+        return base.copy(
+            members = members.map {
+                UserGroupMember(
+                    userId = UUID.fromString(it.userId),
+                    externalId = it.externalId,
+                    email = it.email,
+                    role = it.role,
+                )
+            },
+            userCount = members.size,
+        )
+    }
 
     override fun addAgents(
         userGroupId: UUID,
@@ -106,12 +176,22 @@ open class Neo4jUserGroupRepository(
         neo4jRepository.removeUsers(userGroupId.toString(), userExternalIds.toList())
     }
 
+    override fun updateMemberships(userGroupId: UUID, entries: List<Pair<UUID, String?>>) {
+        entries.forEach { (userId, role) ->
+            neo4jRepository.upsertMembership(
+                groupId = userGroupId.toString(),
+                userId = userId.toString(),
+                role = role,
+            )
+        }
+    }
+
     override fun findGroupsByUserExternalIds(externalIds: Collection<String>): Map<String, List<UserGroupSummary>> {
         if (externalIds.isEmpty()) return emptyMap()
         return neo4jClient
             .query(
                 $$"""
-                    MATCH (u:User)-[:MEMBER]->(g:UserGroup)
+                    MATCH (u:User)-[:ADMIN|MEMBER]->(g:UserGroup)
                     WHERE u.externalId IN $externalIds
                       AND NOT COALESCE(g.removed, false)
                       AND NOT COALESCE(u.removed, false)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -48,13 +49,32 @@ class UserGroupController(
     ): UserGroupSearchResultResource =
         userGroupService.createFromRequest(request).toResource()
 
-    @PostMapping("/{userGroupId}", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @PutMapping("/{userGroupId}", consumes = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("hasPermission(#userGroupId, 'UserGroup', 'WRITE')")
     fun update(
         @PathVariable userGroupId: UUID,
         @Valid @RequestBody request: UserGroupUpdateRequest,
     ): UserGroupSearchResultResource =
         userGroupService.updateFromRequest(userGroupId, request).toResource()
+
+    /**
+     * PUT /api/user-groups/{userGroupId}/members
+     *
+     * Upsert memberships for a batch of users. Each entry drives one of three operations:
+     * - role = ADMIN: ensure the user is ADMIN on the group (revoke MEMBER first if needed).
+     * - role = MEMBER: ensure the user is MEMBER on the group (revoke ADMIN first if needed).
+     * - role = null: remove the user from the group entirely.
+     *
+     * Idempotent. Unknown userIds are silently skipped.
+     * Authorization: WRITE on the group (namespace ADMIN via transitive permission).
+     */
+    @PutMapping("/{userGroupId}/members", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("hasPermission(#userGroupId, 'UserGroup', 'WRITE')")
+    fun updateMemberships(
+        @PathVariable userGroupId: UUID,
+        @Valid @RequestBody entries: List<UserGroupMembershipEntry>,
+    ): UserGroupSearchResultResource =
+        userGroupService.updateMemberships(userGroupId, entries).toResource()
 
     @DeleteMapping("/{userGroupId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -73,6 +93,14 @@ class UserGroupController(
             namespaceExternalId = namespaceExternalId,
             name = name,
             agentIds = agentIds,
+            members = members.map {
+                UserGroupMemberResource(
+                    userId = it.userId,
+                    externalId = it.externalId,
+                    email = it.email,
+                    role = it.role,
+                )
+            },
             userCount = userCount,
         )
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupMember.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupMember.kt
@@ -1,0 +1,25 @@
+package io.whozoss.agentos.userGroup
+
+import java.util.UUID
+
+/**
+ * A user's membership in a [UserGroup], with their role on that group.
+ *
+ * [role] is either [MEMBER] or [ADMIN]. The distinction matters for admin UI:
+ * an ADMIN can manage the group's members and agent assignments; a MEMBER can only
+ * use the agents deployed to the group.
+ *
+ * Both [:MEMBER] and [:ADMIN] graph edges are unified through [PermissionService] —
+ * the edge type is the role, there is always at most one edge per (user, group) pair.
+ */
+data class UserGroupMember(
+    val userId: UUID,
+    val externalId: String,
+    val email: String,
+    val role: String,
+) {
+    companion object {
+        const val ROLE_MEMBER = "MEMBER"
+        const val ROLE_ADMIN = "ADMIN"
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupMemberResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupMemberResource.kt
@@ -1,0 +1,13 @@
+package io.whozoss.agentos.userGroup
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(name = "UserGroupMember")
+data class UserGroupMemberResource(
+    val userId: UUID,
+    val externalId: String,
+    val email: String,
+    @Schema(description = "Role on the group", allowableValues = ["ADMIN", "MEMBER"])
+    val role: String,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupMembershipRequest.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupMembershipRequest.kt
@@ -1,0 +1,20 @@
+package io.whozoss.agentos.userGroup
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Pattern
+import java.util.UUID
+
+/**
+ * One entry in a membership update batch.
+ *
+ * [role] values:
+ * - `"ADMIN"` — grant or promote to ADMIN (revokes any existing MEMBER edge first)
+ * - `"MEMBER"` — grant or demote to MEMBER (revokes any existing ADMIN edge first)
+ * - `null` — remove the user from the group entirely (revokes both edges)
+ */
+@Schema(name = "UserGroupMembershipEntry")
+data class UserGroupMembershipEntry(
+    val userId: UUID,
+    @field:Pattern(regexp = "ADMIN|MEMBER", message = "role must be ADMIN or MEMBER")
+    val role: String?,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupNodeNeo4jRepository.kt
@@ -63,4 +63,32 @@ interface UserGroupNodeNeo4jRepository : Neo4jRepository<UserGroupNode, String> 
         groupId: String,
         userExternalIds: List<String>,
     )
+
+    /**
+     * Revoke both [:ADMIN] and [:MEMBER] edges from [userId] to [groupId],
+     * then MERGE the desired [role] edge. Called once per entry in the admin
+     * membership update batch.
+     *
+     * The OPTIONAL MATCH + DELETE pattern is idempotent: if the edge does not
+     * exist the DELETE is a no-op.
+     */
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})
+          WHERE u.removed IS NULL OR u.removed = false
+        MATCH (g:UserGroup {id: $groupId})
+          WHERE g.removed IS NULL OR g.removed = false
+        OPTIONAL MATCH (u)-[rm:MEMBER]->(g) DELETE rm
+        WITH u, g
+        OPTIONAL MATCH (u)-[ra:ADMIN]->(g)  DELETE ra
+        WITH u, g
+        FOREACH (_ IN CASE $role WHEN 'ADMIN'   THEN [1] ELSE [] END | MERGE (u)-[:ADMIN]->(g))
+        FOREACH (_ IN CASE $role WHEN 'MEMBER'  THEN [1] ELSE [] END | MERGE (u)-[:MEMBER]->(g))
+        """,
+    )
+    fun upsertMembership(
+        groupId: String,
+        userId: String,
+        role: String?,
+    )
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupRepository.kt
@@ -8,7 +8,20 @@ interface UserGroupRepository : EntityRepository<UserGroup, UUID> {
     fun findByIdWithDetails(id: UUID): UserGroupSearchResult?
     fun addAgents(userGroupId: UUID, agentConfigIds: Collection<UUID>)
     fun removeAllAgents(userGroupId: UUID)
+    /** Legacy sync path — adds [:MEMBER] edges by externalId. Used by the Whoz sync. */
     fun addUsers(userGroupId: UUID, userExternalIds: Collection<String>)
+    /** Legacy sync path — removes [:MEMBER] edges by externalId. Used by the Whoz sync. */
     fun removeUsers(userGroupId: UUID, userExternalIds: Collection<String>)
     fun findGroupsByUserExternalIds(externalIds: Collection<String>): Map<String, List<UserGroupSummary>>
+    /**
+     * Upsert memberships for a batch of users.
+     *
+     * For each entry:
+     * - role = ADMIN: revoke any [:MEMBER] edge, MERGE a [:ADMIN] edge.
+     * - role = MEMBER: revoke any [:ADMIN] edge, MERGE a [:MEMBER] edge.
+     * - role = null: revoke both [:ADMIN] and [:MEMBER] edges (remove from group).
+     *
+     * Unknown [userId]s (not found in the graph) are silently skipped by the Cypher MATCH.
+     */
+    fun updateMemberships(userGroupId: UUID, entries: List<Pair<UUID, String?>>)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupSearchResult.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupSearchResult.kt
@@ -8,5 +8,17 @@ data class UserGroupSearchResult(
     val namespaceExternalId: String,
     val name: String,
     val agentIds: List<UUID> = emptyList(),
+    /**
+     * Full member list with roles. Returned by [UserGroupRepository.findByIdWithDetails].
+     * Empty by default on list queries ([UserGroupRepository.findByNamespaceId]) which
+     * return [userCount] instead for performance — loading thousands of members per group
+     * in a namespace listing is not acceptable.
+     */
+    val members: List<UserGroupMember> = emptyList(),
+    /**
+     * Member count for list queries. Set to [members].size when members are loaded.
+     * When [members] is empty and [userCount] is 0 it means no members; when [members]
+     * is empty and [userCount] > 0 it means this is a list result (members not loaded).
+     */
     val userCount: Int = 0,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupSearchResultResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupSearchResultResource.kt
@@ -10,5 +10,11 @@ data class UserGroupSearchResultResource(
     val namespaceExternalId: String,
     val name: String,
     val agentIds: List<UUID> = emptyList(),
+    /**
+     * Full member list with roles. Populated on single-group GET; empty on list queries.
+     * Use [userCount] for display in list contexts.
+     */
+    val members: List<UserGroupMemberResource> = emptyList(),
+    /** Member count. On single-group GET this equals members.size. */
     val userCount: Int = 0,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupService.kt
@@ -9,4 +9,17 @@ interface UserGroupService : EntityService<UserGroup, UUID> {
     fun createFromRequest(request: UserGroupCreateRequest): UserGroupSearchResult
     fun updateFromRequest(userGroupId: UUID, request: UserGroupUpdateRequest): UserGroupSearchResult
     fun findGroupsByUserExternalIds(externalIds: Collection<String>): Map<String, List<UserGroupSummary>>
+    /**
+     * Upsert memberships for a batch of users on [userGroupId].
+     *
+     * Each entry's [role] drives the operation:
+     * - ADMIN / MEMBER: revoke the opposite edge, MERGE the desired one (idempotent).
+     * - null: remove the user from the group entirely.
+     *
+     * Unknown [userId]s are silently skipped. The group must exist and be non-removed;
+     * throws [io.whozoss.agentos.exception.ResourceNotFoundException] otherwise.
+     *
+     * Returns the updated group detail.
+     */
+    fun updateMemberships(userGroupId: UUID, entries: List<UserGroupMembershipEntry>): UserGroupSearchResult
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImpl.kt
@@ -119,6 +119,23 @@ class UserGroupServiceImpl(
     override fun findGroupsByUserExternalIds(externalIds: Collection<String>): Map<String, List<UserGroupSummary>> =
         userGroupRepository.findGroupsByUserExternalIds(externalIds)
 
+    @Transactional
+    override fun updateMemberships(
+        userGroupId: UUID,
+        entries: List<UserGroupMembershipEntry>,
+    ): UserGroupSearchResult {
+        // Validate the group exists before touching any edges.
+        getById(userGroupId)
+
+        userGroupRepository.updateMemberships(
+            userGroupId,
+            entries.map { it.userId to it.role },
+        )
+
+        return userGroupRepository.findByIdWithDetails(userGroupId)
+            ?: throw IllegalStateException("UserGroup $userGroupId not found after membership update")
+    }
+
     private fun validateAgentsInNamespace(
         agentIds: Set<UUID>,
         namespaceId: UUID,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractUserGroupPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractUserGroupPersistenceSpec.kt
@@ -12,6 +12,7 @@ import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserRepository
 import io.whozoss.agentos.userGroup.UserGroup
+import io.whozoss.agentos.userGroup.UserGroupMember
 import io.whozoss.agentos.userGroup.UserGroupRepository
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
@@ -145,6 +146,133 @@ abstract class AbstractUserGroupPersistenceSpec : StringSpec() {
 
             results shouldHaveSize 1
             results.first().userCount shouldBe 1
+        }
+
+        // -------------------------------------------------------------------------
+        // findByIdWithDetails — member list with roles
+        // -------------------------------------------------------------------------
+
+        "findByIdWithDetails returns empty members list when group has no members" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-detail-empty"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Empty Group"))
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)
+
+            result!!.members.shouldBeEmpty()
+            result.userCount shouldBe 0
+        }
+
+        "findByIdWithDetails returns members with MEMBER role added via addUsers" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-detail-member"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Group Detail"))
+            val alice = userRepo.save(user("alice-detail@example.com"))
+            userGroupRepo.addUsers(g.id, listOf(alice.externalId))
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)!!
+
+            result.members shouldHaveSize 1
+            result.userCount shouldBe 1
+            result.members.first().let {
+                it.userId shouldBe alice.id
+                it.externalId shouldBe alice.externalId
+                it.role shouldBe UserGroupMember.ROLE_MEMBER
+            }
+        }
+
+        "findByIdWithDetails does not return soft-deleted members" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-detail-del"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Group Detail Del"))
+            val alice = userRepo.save(user("alice-dd@example.com"))
+            val bob = userRepo.save(user("bob-dd@example.com"))
+            userGroupRepo.addUsers(g.id, listOf(alice.externalId, bob.externalId))
+            userRepo.delete(alice.id)
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)!!
+
+            result.members shouldHaveSize 1
+            result.members.first().externalId shouldBe bob.externalId
+            result.userCount shouldBe 1
+        }
+
+        // -------------------------------------------------------------------------
+        // updateMemberships
+        // -------------------------------------------------------------------------
+
+        "updateMemberships grants ADMIN role and revokes any existing MEMBER" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-upsert-admin"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Upsert Admin"))
+            val alice = userRepo.save(user("alice-ua@example.com"))
+            // Start as MEMBER via legacy sync
+            userGroupRepo.addUsers(g.id, listOf(alice.externalId))
+
+            userGroupRepo.updateMemberships(g.id, listOf(alice.id to UserGroupMember.ROLE_ADMIN))
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)!!
+            result.members shouldHaveSize 1
+            result.members.first().role shouldBe UserGroupMember.ROLE_ADMIN
+        }
+
+        "updateMemberships demotes ADMIN to MEMBER" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-upsert-demote"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Upsert Demote"))
+            val alice = userRepo.save(user("alice-ud@example.com"))
+            userGroupRepo.updateMemberships(g.id, listOf(alice.id to UserGroupMember.ROLE_ADMIN))
+
+            userGroupRepo.updateMemberships(g.id, listOf(alice.id to UserGroupMember.ROLE_MEMBER))
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)!!
+            result.members shouldHaveSize 1
+            result.members.first().role shouldBe UserGroupMember.ROLE_MEMBER
+        }
+
+        "updateMemberships with null role removes user from group" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-upsert-remove"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Upsert Remove"))
+            val alice = userRepo.save(user("alice-ur@example.com"))
+            userGroupRepo.updateMemberships(g.id, listOf(alice.id to UserGroupMember.ROLE_MEMBER))
+
+            userGroupRepo.updateMemberships(g.id, listOf(alice.id to null))
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)!!
+            result.members.shouldBeEmpty()
+        }
+
+        "updateMemberships is idempotent for MEMBER" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-upsert-idem"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Upsert Idempotent"))
+            val alice = userRepo.save(user("alice-ui@example.com"))
+            userGroupRepo.updateMemberships(g.id, listOf(alice.id to UserGroupMember.ROLE_MEMBER))
+            userGroupRepo.updateMemberships(g.id, listOf(alice.id to UserGroupMember.ROLE_MEMBER))
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)!!
+            result.members shouldHaveSize 1
+            result.members.first().role shouldBe UserGroupMember.ROLE_MEMBER
+        }
+
+        "updateMemberships silently skips unknown userIds" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-upsert-unknown"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Upsert Unknown"))
+
+            userGroupRepo.updateMemberships(g.id, listOf(UUID.randomUUID() to UserGroupMember.ROLE_MEMBER))
+
+            val result = userGroupRepo.findByIdWithDetails(g.id)!!
+            result.members.shouldBeEmpty()
+        }
+
+        "findByNamespaceId counts both ADMIN and MEMBER edges" {
+            val ns = namespaceRepo.save(namespace(externalId = "fed-count-both"))
+            val g = userGroupRepo.save(userGroup(ns.id, "Count Both"))
+            val alice = userRepo.save(user("alice-cb@example.com"))
+            val bob = userRepo.save(user("bob-cb@example.com"))
+            userGroupRepo.updateMemberships(g.id, listOf(
+                alice.id to UserGroupMember.ROLE_ADMIN,
+                bob.id to UserGroupMember.ROLE_MEMBER,
+            ))
+
+            val results = userGroupRepo.findByNamespaceId(ns.id)
+
+            results shouldHaveSize 1
+            results.first().userCount shouldBe 2
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImplUnitSpec.kt
@@ -389,6 +389,58 @@ class UserGroupServiceImplUnitSpec :
             }
         }
 
+        // -------------------------------------------------------------------------
+        // updateMemberships
+        // -------------------------------------------------------------------------
+
+        "updateMemberships delegates to repository after validating group exists" {
+            val groupId = randomUUID()
+            val userId1 = randomUUID()
+            val userId2 = randomUUID()
+            val existing = UserGroup(metadata = EntityMetadata(id = groupId), namespaceId = namespaceId, name = "Team")
+            val searchResult = UserGroupSearchResult(
+                userGroupId = groupId,
+                namespaceId = namespaceId,
+                namespaceExternalId = externalId,
+                name = "Team",
+                userCount = 2,
+            )
+
+            val userGroupRepository = mockk<UserGroupRepository>(relaxed = true)
+            every { userGroupRepository.findByIds(listOf(groupId)) } returns listOf(existing)
+            every { userGroupRepository.findByIdWithDetails(groupId) } returns searchResult
+
+            val service = buildService(userGroupRepository)
+            service.updateMemberships(
+                groupId,
+                listOf(
+                    UserGroupMembershipEntry(userId1, "ADMIN"),
+                    UserGroupMembershipEntry(userId2, null),
+                ),
+            )
+
+            verify(exactly = 1) {
+                userGroupRepository.updateMemberships(
+                    groupId,
+                    match { entries ->
+                        entries.toSet() == setOf(userId1 to "ADMIN", userId2 to null)
+                    },
+                )
+            }
+        }
+
+        "updateMemberships throws 404 when group does not exist" {
+            val groupId = randomUUID()
+            val userGroupRepository = mockk<UserGroupRepository>(relaxed = true)
+            every { userGroupRepository.findByIds(listOf(groupId)) } returns emptyList()
+
+            val service = buildService(userGroupRepository)
+
+            shouldThrow<ResourceNotFoundException> {
+                service.updateMemberships(groupId, listOf(UserGroupMembershipEntry(randomUUID(), "MEMBER")))
+            }
+        }
+
         "createFromRequest with no userExternalIds skips addUsers" {
             val groupId = randomUUID()
             val group = UserGroup(metadata = EntityMetadata(id = groupId), namespaceId = namespaceId, name = "Team F")


### PR DESCRIPTION
## What

Extends the UserGroup API to support proper internal administration.

### GET `/api/user-groups/{id}`
Now returns the full member list with roles instead of a bare count:
```json
{
  "members": [
    { "userId": "...", "externalId": "alice@example.com", "email": "alice@example.com", "role": "ADMIN" },
    { "userId": "...", "externalId": "bob@example.com",   "email": "bob@example.com",   "role": "MEMBER" }
  ],
  "userCount": 2
}
```
The list query (`GET ?namespaceId=`) keeps the count-only shape — loading thousands of members per group in a namespace listing would be unacceptable at scale.

### PUT `/api/user-groups/{id}/members` (new)
Batch upsert of memberships. Each entry carries `{ userId, role }`:
- `role = "ADMIN"` — promote/grant ADMIN (revokes any existing MEMBER edge first)
- `role = "MEMBER"` — demote/grant MEMBER (revokes any existing ADMIN edge first)
- `role = null` — remove the user from the group entirely

Idempotent. Unknown `userId`s are silently skipped. Authorization: `WRITE` on the group (namespace ADMIN via transitive permission).

### PUT `/api/user-groups/{id}` (was POST)
Group update verb aligned with the rest of the API (`AgentConfigController`, `UserController`, etc.).

## Design notes

The Whoz sync paths (`addUsers`/`removeUsers` by `externalId`) are unchanged. Both mechanisms converge on the same `[:MEMBER]`/`[:ADMIN]` Neo4j edges — origin doesn't matter, there is always at most one edge per (user, group) pair.

The `upsertMembership` Cypher query uses `OPTIONAL MATCH … DELETE` + `FOREACH … MERGE` to atomically revoke the opposite edge and set the desired one in a single round-trip per entry.

## Tests

- 18 persistence contract tests (`EmbeddedNeo4jUserGroupPersistenceSpec`) covering `findByIdWithDetails` member list, `updateMemberships` promote/demote/remove/idempotency/unknown-user
- 14 service unit tests (`UserGroupServiceImplUnitSpec`) including the two new `updateMemberships` cases
- All green
