### PR TITLE
feat(cases): add namespace-scoped endpoint for listing cases by user

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -10,6 +10,7 @@ import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.security.declarative.HideOnAccessDenied
+import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.user.UserService
 import jakarta.validation.Valid
 import mu.KLogging
@@ -46,6 +47,7 @@ import java.util.UUID
 )
 class CaseController(
     private val caseService: CaseService,
+    private val namespaceService: NamespaceService,
     userService: UserService,
     permissionService: PermissionService,
 ) : EntityController<Case, UUID, CaseResource>(caseService, userService, permissionService) {
@@ -210,6 +212,30 @@ class CaseController(
         return caseService.findConcerningUser(user.id).map { toResource(it) }
     }
 
+    /**
+     * POST /api/cases/by-user/in-namespace — list cases concerning a user scoped to a
+     * single namespace, identified by their respective external IDs.
+     *
+     * Resolves the user from [ListByUserInNamespaceRequest.externalId] and the namespace
+     * from [ListByUserInNamespaceRequest.namespaceExternalId], then returns only cases
+     * at the intersection. Returns 404 if no user or namespace matches.
+     */
+    @PostMapping("/by-user/in-namespace", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun listByUserInNamespace(
+        @RequestBody request: ListByUserInNamespaceRequest,
+    ): List<CaseResource> {
+        val user =
+            userService.findByExternalId(request.userExternalId)
+                ?: throw io.whozoss.agentos.exception
+                    .ResourceNotFoundException("User not found: ${request.userExternalId}")
+        val namespace =
+            namespaceService.findByExternalId(request.namespaceExternalId)
+                ?: throw io.whozoss.agentos.exception
+                    .ResourceNotFoundException("Namespace not found: ${request.namespaceExternalId}")
+        logger.debug { "Listing cases for user ${user.id} in namespace ${namespace.id}" }
+        return caseService.findConcerningUserInNamespace(user.id, namespace.id).map { toResource(it) }
+    }
+
     /** POST /api/cases/{caseId}/messages — add a user message to a running case. */
     @PostMapping("/{caseId}/messages")
     @PreAuthorize("hasPermission(#caseId, 'Case', 'WRITE')")
@@ -261,6 +287,11 @@ class CaseController(
 
     companion object : KLogging()
 }
+
+data class ListByUserInNamespaceRequest(
+    val userExternalId: String,
+    val namespaceExternalId: String,
+)
 
 data class AddMessageRequest(
     val content: String,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNodeNeo4jRepository.kt
@@ -67,4 +67,19 @@ interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
             """,
     )
     fun findConcerningUser(userId: String): List<CaseNode>
+
+    /**
+     * Find all non-removed cases concerning a user scoped to a single namespace.
+     *
+     * Same permission rule as [findConcerningUser] (direct ADMIN or MEMBER on the case),
+     * but restricted to the given namespace.
+     */
+    @Query(
+        $$"""MATCH (c:Case)-[r:BELONGS_TO]->(ns:Namespace {id: $namespaceId})
+            WHERE (c.removed IS NULL OR c.removed = false)
+              AND EXISTS { MATCH (:User {id: $userId})-[:ADMIN|MEMBER]->(c) }
+            RETURN c, r, ns ORDER BY c.created ASC
+            """,
+    )
+    fun findConcerningUserInNamespace(userId: String, namespaceId: String): List<CaseNode>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRepository.kt
@@ -33,4 +33,13 @@ interface CaseRepository : EntityRepository<Case, UUID> {
      * Implementations must exclude soft-deleted cases.
      */
     fun findConcerningUser(userId: UUID): List<Case>
+
+    /**
+     * Find all cases concerning [userId] scoped to a single [namespaceId].
+     *
+     * Same permission rule as [findConcerningUser] (direct ADMIN or MEMBER on the case),
+     * but restricted to the given namespace.
+     * Implementations must exclude soft-deleted cases.
+     */
+    fun findConcerningUserInNamespace(userId: UUID, namespaceId: UUID): List<Case>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseService.kt
@@ -46,6 +46,13 @@ interface CaseService : EntityService<Case, UUID> {
      */
     fun findConcerningUser(userId: UUID): List<Case>
 
+    /**
+     * List all cases concerning [userId] scoped to a single [namespaceId].
+     *
+     * Same permission rule as [findConcerningUser] but restricted to one namespace.
+     */
+    fun findConcerningUserInNamespace(userId: UUID, namespaceId: UUID): List<Case>
+
     // ========================================
     // Runtime Instance Management
     // ========================================

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -90,6 +90,10 @@ class CaseServiceImpl(
     @PreAuthorize("hasRole('SUPER_ADMIN') or #userId.toString() == authentication.name")
     override fun findConcerningUser(userId: UUID): List<Case> = caseRepository.findConcerningUser(userId)
 
+    @PreAuthorize("hasRole('SUPER_ADMIN') or #userId.toString() == authentication.name")
+    override fun findConcerningUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
+        caseRepository.findConcerningUserInNamespace(userId, namespaceId)
+
     override fun delete(id: UUID): Boolean {
         if (activeRuntimes.containsKey(id)) {
             killCase(id)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Neo4jCaseRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Neo4jCaseRepository.kt
@@ -50,6 +50,14 @@ open class Neo4jCaseRepository(
             .findConcerningUser(userId = userId.toString())
             .map { it.toDomain() }
 
+    override fun findConcerningUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
+        caseNodeNeo4jRepository
+            .findConcerningUserInNamespace(
+                userId = userId.toString(),
+                namespaceId = namespaceId.toString(),
+            )
+            .map { it.toDomain() }
+
     override fun delete(id: UUID): Boolean =
         caseNodeNeo4jRepository
             .findByIdOrNull(id.toString())

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
@@ -38,9 +38,10 @@ import java.util.UUID
 class CaseControllerSpec : StringSpec({
 
     val caseService = mockk<CaseService>()
+    val namespaceService = mockk<io.whozoss.agentos.namespace.NamespaceService>()
     val userService = mockk<UserService>()
     val permissionService = mockk<PermissionService>()
-    val controller = CaseController(caseService, userService, permissionService)
+    val controller = CaseController(caseService, namespaceService, userService, permissionService)
 
     val callerId = UUID.randomUUID()
     val caller = User(
@@ -278,6 +279,68 @@ class CaseControllerSpec : StringSpec({
         every { caseService.findConcerningUser(callerId) } returns emptyList()
 
         controller.listByUserExternalId(caller.externalId) shouldBe emptyList()
+    }
+
+    // -------------------------------------------------------------------------
+    // listByUserInNamespace — POST /api/cases/by-user/in-namespace
+    // -------------------------------------------------------------------------
+
+    "listByUserInNamespace returns only cases in the requested namespace" {
+        val caseInNs = caseEntity(title = "in ns")
+        val namespaceExternalId = "ext-ns-1"
+        val namespace = io.whozoss.agentos.namespace.Namespace(
+            metadata = io.whozoss.agentos.sdk.entity.EntityMetadata(id = namespaceId),
+            name = "test-ns",
+            externalId = namespaceExternalId,
+        )
+        every { userService.findByExternalId(caller.externalId) } returns caller
+        every { namespaceService.findByExternalId(namespaceExternalId) } returns namespace
+        every { caseService.findConcerningUserInNamespace(callerId, namespaceId) } returns listOf(caseInNs)
+
+        val result = controller.listByUserInNamespace(
+            ListByUserInNamespaceRequest(userExternalId = caller.externalId, namespaceExternalId = namespaceExternalId)
+        )
+
+        result.map { it.id } shouldBe listOf(caseInNs.metadata.id)
+        verify(exactly = 1) { caseService.findConcerningUserInNamespace(callerId, namespaceId) }
+        verify(exactly = 0) { caseService.findConcerningUser(any()) }
+    }
+
+    "listByUserInNamespace returns empty list when user has no cases in the namespace" {
+        val namespaceExternalId = "ext-ns-empty"
+        val namespace = io.whozoss.agentos.namespace.Namespace(
+            metadata = io.whozoss.agentos.sdk.entity.EntityMetadata(id = namespaceId),
+            name = "test-ns",
+            externalId = namespaceExternalId,
+        )
+        every { userService.findByExternalId(caller.externalId) } returns caller
+        every { namespaceService.findByExternalId(namespaceExternalId) } returns namespace
+        every { caseService.findConcerningUserInNamespace(callerId, namespaceId) } returns emptyList()
+
+        controller.listByUserInNamespace(
+            ListByUserInNamespaceRequest(userExternalId = caller.externalId, namespaceExternalId = namespaceExternalId)
+        ) shouldBe emptyList()
+    }
+
+    "listByUserInNamespace throws 404 when no user matches the external id" {
+        every { userService.findByExternalId("unknown@example.com") } returns null
+
+        shouldThrow<io.whozoss.agentos.exception.ResourceNotFoundException> {
+            controller.listByUserInNamespace(
+                ListByUserInNamespaceRequest(userExternalId = "unknown@example.com", namespaceExternalId = "any")
+            )
+        }
+    }
+
+    "listByUserInNamespace throws 404 when no namespace matches the namespaceExternalId" {
+        every { userService.findByExternalId(caller.externalId) } returns caller
+        every { namespaceService.findByExternalId("unknown-ns") } returns null
+
+        shouldThrow<io.whozoss.agentos.exception.ResourceNotFoundException> {
+            controller.listByUserInNamespace(
+                ListByUserInNamespaceRequest(userExternalId = caller.externalId, namespaceExternalId = "unknown-ns")
+            )
+        }
     }
 
     "listByParent short-circuits for super-admin (hasPermission WRITE returns true via bypass)" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/InMemoryCaseRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/InMemoryCaseRepository.kt
@@ -25,4 +25,8 @@ class InMemoryCaseRepository : CaseRepository {
 
     /** In tests all cases are visible to every user (no permission graph). */
     override fun findConcerningUser(userId: UUID): List<Case> = delegate.findAll()
+
+    /** In tests all cases in the namespace are visible (no permission graph). */
+    override fun findConcerningUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
+        delegate.findByParent(namespaceId)
 }

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -1065,6 +1065,26 @@ paths:
       responses:
         "200":
           description: OK
+  /api/cases/by-user/in-namespace:
+    post:
+      tags:
+      - case-controller
+      operationId: listByUserInNamespaceCase
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListByUserInNamespaceRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Case"
   /api/cases/by-ids:
     post:
       tags:
@@ -2111,6 +2131,16 @@ components:
           additionalProperties: {}
       required:
       - content
+    ListByUserInNamespaceRequest:
+      type: object
+      properties:
+        userExternalId:
+          type: string
+        namespaceExternalId:
+          type: string
+      required:
+      - namespaceExternalId
+      - userExternalId
     Actor:
       type: object
       properties:


### PR DESCRIPTION
## Summary
Adds `POST /api/cases/by-user/in-namespace` to scope case listing to a single namespace, with `userExternalId` and `namespaceExternalId` as body parameters.

## Changes
- New Cypher query `findConcerningUserInNamespace` filtering by user + namespace
- New endpoint wired through repository → service → controller