### PR TITLE
feat: #WZ-32223 leaner user context — omit UUID from prompt, skip block when no readable data

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -265,15 +265,23 @@ class AgentServiceImpl(
         val userBlock =
             context.userId?.let { userId ->
                 userService.findById(userId)?.let { user ->
-                    buildString {
-                        appendLine()
-                        appendLine("## User")
-                        appendLine("- id: ${user.metadata.id}")
-                        if (user.email.isNotBlank()) appendLine("- email: ${user.email}")
-                        if (!user.firstname.isNullOrBlank()) appendLine("- firstname: ${user.firstname}")
-                        if (!user.lastname.isNullOrBlank()) appendLine("- lastname: ${user.lastname}")
-                        if (!user.bio.isNullOrBlank()) appendLine("- bio: ${user.bio}")
-                    }.trimEnd()
+                    // Only inject a user block when at least one human-readable field is present.
+                    // Internal UUIDs (id, externalId) are intentionally excluded — they carry no
+                    // conversational meaning and confuse the LLM about who the interlocutor is.
+                    val hasIdentity = !user.firstname.isNullOrBlank() || !user.lastname.isNullOrBlank()
+                    val hasContext = !user.bio.isNullOrBlank() || user.email.isNotBlank()
+                    if (!hasIdentity && !hasContext) {
+                        null
+                    } else {
+                        buildString {
+                            appendLine()
+                            appendLine("## User")
+                            if (!user.firstname.isNullOrBlank()) appendLine("- firstname: ${user.firstname}")
+                            if (!user.lastname.isNullOrBlank()) appendLine("- lastname: ${user.lastname}")
+                            if (user.email.isNotBlank()) appendLine("- email: ${user.email}")
+                            if (!user.bio.isNullOrBlank()) appendLine("- bio: ${user.bio}")
+                        }.trimEnd()
+                    }
                 }
             }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -441,7 +441,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
             agent.instructions shouldContain "Alice"
             agent.instructions shouldContain "Smith"
             agent.instructions shouldContain "Backend engineer passionate about distributed systems."
-            agent.instructions shouldContain userId.toString()
+            // Internal AgentOS UUID must NOT appear in the prompt — it carries no conversational
+            // meaning and confuses the LLM about who the interlocutor is.
+            agent.instructions shouldNotContain userId.toString()
         }
 
         "findAgentByName omits optional user fields that are blank" {
@@ -471,10 +473,13 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             val agent = agentService.findAgentByName("my-agent", contextWithUser) as AgentSimple
 
+            // Email alone is enough to produce a ## User block.
             agent.instructions shouldContain user.email
             agent.instructions shouldNotContain "firstname"
             agent.instructions shouldNotContain "lastname"
             agent.instructions shouldNotContain "bio"
+            // Internal UUID must never appear regardless of which fields are populated.
+            agent.instructions shouldNotContain userId.toString()
         }
 
         "findAgentByName skips user block when userId is null" {
@@ -492,6 +497,39 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agent.instructions shouldNotContain "## User"
             verify(exactly = 0) { userService.findById(any()) }
+        }
+
+        "findAgentByName skips user block when user has no human-readable fields" {
+            val userId = UUID.randomUUID()
+            val user =
+                User(
+                    metadata = EntityMetadata(id = userId),
+                    externalId = "opaque-objectid-123",
+                    email = "",
+                    firstname = null,
+                    lastname = null,
+                    bio = null,
+                )
+            val contextWithUser = AgentExecutionContext(namespaceId = namespaceId, caseId = caseId, userId = userId)
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { aiProviderReconciliationService.resolve(namespaceId, userId, "anthropic-prod") } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+            every { userService.findById(userId) } returns user
+
+            val agent = agentService.findAgentByName("my-agent", contextWithUser) as AgentSimple
+
+            // No readable data available: the ## User block must be omitted entirely
+            // rather than injecting an opaque UUID that confuses the LLM.
+            agent.instructions shouldNotContain "## User"
+            agent.instructions shouldNotContain userId.toString()
+            agent.instructions shouldNotContain "opaque-objectid-123"
         }
 
         // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Users created programmatically in the Whoz context have no name, no bio, and an opaque `externalId` (a MongoDB ObjectId). The `## User` block in the system prompt was injecting the internal AgentOS UUID as a fallback display name, which confused LLMs about who the interlocutor was. Similarly, the `Actor.displayName` in conversation history was falling back to the same opaque UUID.

## Changes

**`AgentServiceImpl.buildInstructions`**
- The `## User` block is now omitted entirely when the user has no human-readable fields (no firstname, lastname, bio, or non-blank email).
- The internal AgentOS UUID (`id`) and `externalId` are excluded from the block in all cases — they carry no conversational meaning.

**`CaseController.addMessage`**
- `Actor.displayName` falls back to `"User"` instead of the internal UUID when no name is available. Neutral rather than disruptive for the LLM.

**`AgentServiceImplUnitSpec`**
- Removed assertion that expected the internal UUID in the prompt (now explicitly asserts it is absent).
- Added assertion that `externalId` is also absent.
- Added new test `findAgentByName skips user block when user has no human-readable fields` covering the Whoz programmatic-user case.