### PR TITLE
fix: #32262 tool repetition detection now compares args alongside tool name

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -240,12 +240,12 @@ class AgentAdvanced(
             else -> {
                 val msg =
                     "Calling a tool with the same parameters will produce the same results.\n" +
-                        "You have called the tool $repeatedTool $REPETITION_DETECTION_WINDOW times consecutively. " +
+                        "You have called the tool $repeatedTool $REPETITION_THRESHOLD times within the last $REPETITION_WINDOW tool calls. " +
                         "If the tool has not added meaningful information to the conversation, " +
                         "stop calling it and consider the next step toward achieving the user's goal. " +
                         "If you do not have enough information to proceed, use ${AgentIntentionGenerator.ANSWER_TOOL} to ask the user for further instructions."
                 if (!warningAlreadyEmitted) {
-                    logger.warn { "Repetition loop detected: $repeatedTool called $REPETITION_DETECTION_WINDOW consecutive times" }
+                    logger.warn { "Repetition loop detected: $repeatedTool called $REPETITION_THRESHOLD times within the last $REPETITION_WINDOW tool calls" }
                     emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = msg))
                 }
                 msg
@@ -831,20 +831,35 @@ class AgentAdvanced(
                 .filter { it.metadata.id in resolvedPendingIds }
                 .mapTo(mutableSetOf()) { it.toolRequestId }
 
-        // Take last N raw ToolResponseEvent (success only) — preserves the original
-        // "consecutive" semantics. If the window contains any synthetic (= confirmation
-        // resolution), do not signal repetition — those are user-validated, not auto.
+        // Build a lookup of toolRequestId → args for quick pairing with ToolResponseEvent.
+        val argsByRequestId =
+            events
+                .filterIsInstance<ToolRequestEvent>()
+                .associate { it.toolRequestId to (it.args?.trim() ?: "") }
+
+        // Take last REPETITION_WINDOW ToolResponseEvent (success or failure) — a tool
+        // that consistently fails with the same input is also a repetition loop.
+        // If the window contains any synthetic (= confirmation resolution), do not signal
+        // repetition — those are user-validated, not auto.
         val window =
             events
                 .filterIsInstance<ToolResponseEvent>()
-                .filter { it.success }
-                .takeLast(REPETITION_DETECTION_WINDOW)
+                .takeLast(REPETITION_WINDOW)
 
+        if (window.size < REPETITION_WINDOW || window.any { it.toolRequestId in syntheticToolRequestIds }) return null
+
+        // A repetition is detected when the same (toolName, args) pair appears at least
+        // REPETITION_THRESHOLD times in the window. This catches two-tool alternation
+        // loops (A, B, A, B, A) as well as straight repetition (A, A, A, ...).
+        // Calls to the same tool with different payloads are legitimate exploration
+        // and do not count toward the threshold (WZ-32262).
         return window
-            .takeIf { it.size == REPETITION_DETECTION_WINDOW && it.none { e -> e.toolRequestId in syntheticToolRequestIds } }
-            ?.map { it.toolName }
-            ?.toSet()
-            ?.singleOrNull()
+            .groupingBy { e -> e.toolName to (argsByRequestId[e.toolRequestId] ?: "") }
+            .eachCount()
+            .entries
+            .firstOrNull { it.value >= REPETITION_THRESHOLD }
+            ?.key
+            ?.first
     }
 
     private fun generateParameters(
@@ -967,7 +982,11 @@ Intention: ${intentionEvent.intention}
     }
 
     companion object : KLogging() {
-        internal const val REPETITION_DETECTION_WINDOW = 3
+        /** How many recent tool responses to inspect for repetition. */
+        internal const val REPETITION_WINDOW = 5
+
+        /** How many identical (toolName, args) calls within the window trigger a warning. */
+        internal const val REPETITION_THRESHOLD = 3
 
         private val JSON_FENCE_REGEX =
             Regex(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -419,34 +419,21 @@ class AgentAdvancedSpec :
             every { mockTool.paramType } returns String::class.java
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("file content")
 
-            // The generator returns FILES__ReadFile 3 times, then Answer on the 4th call
+            // The generator returns FILES__ReadFile 5 times (filling the window with 3+ identical
+            // calls), then Answer once the repetition warning is passed to the LLM
             val mockGenerator = mockk<AgentIntentionGenerator>()
             every {
                 mockGenerator.generate(any(), any(), any(), any(), isNull())
             } returnsMany
-                listOf(
+                (1..5).map {
                     IntentionGeneratedEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
                         agentId = UUID.randomUUID(),
-                        intention = "Reading the file.",
+                        intention = "Reading the file (iteration $it).",
                         toolName = "FILES__ReadFile",
-                    ),
-                    IntentionGeneratedEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        agentId = UUID.randomUUID(),
-                        intention = "Reading the file again.",
-                        toolName = "FILES__ReadFile",
-                    ),
-                    IntentionGeneratedEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        agentId = UUID.randomUUID(),
-                        intention = "Reading the file yet again.",
-                        toolName = "FILES__ReadFile",
-                    ),
-                )
+                    )
+                }
             every {
                 mockGenerator.generate(any(), any(), any(), any(), not(isNull()))
             } returns
@@ -495,96 +482,181 @@ class AgentAdvancedSpec :
         // detectRepetitionLoop unit tests
         // -------------------------------------------------------------------------
 
-        "detectRepetitionLoop returns null when fewer than WINDOW tool responses" {
+        "detectRepetitionLoop returns null when fewer than REPETITION_WINDOW tool responses" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
+            // Only 4 responses — window requires 5
             val events =
-                listOf(
-                    ToolResponseEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        toolRequestId = "req-1",
-                        toolName = "FILES__ReadFile",
-                        output = MessageContent.Text("content"),
-                    ),
-                    ToolResponseEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        toolRequestId = "req-2",
-                        toolName = "FILES__ReadFile",
-                        output = MessageContent.Text("content"),
-                    ),
-                )
-
-            agent.detectRepetitionLoop(events) shouldBe null
-        }
-
-        "detectRepetitionLoop returns tool name when WINDOW consecutive same-tool responses" {
-            val agent = makeParserAgent()
-            val namespaceId = UUID.randomUUID()
-            val caseId = UUID.randomUUID()
-            val events =
-                (1..AgentAdvanced.REPETITION_DETECTION_WINDOW).map { i ->
+                (1..4).map { i ->
                     ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
                         toolRequestId = "req-$i",
                         toolName = "FILES__ReadFile",
                         output = MessageContent.Text("content"),
+                    )
+                }
+
+            agent.detectRepetitionLoop(events) shouldBe null
+        }
+
+        "detectRepetitionLoop returns tool name when THRESHOLD identical calls within WINDOW" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val sameArgs = """{"path":"foo.txt"}"""
+            // Window of 5 with all 5 identical — clearly a repetition
+            val events =
+                (1..AgentAdvanced.REPETITION_WINDOW).flatMap { i ->
+                    listOf(
+                        ToolRequestEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            args = sameArgs,
+                        ),
+                        ToolResponseEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            output = MessageContent.Text("content"),
+                        ),
                     )
                 }
 
             agent.detectRepetitionLoop(events) shouldBe "FILES__ReadFile"
         }
 
-        "detectRepetitionLoop returns null when WINDOW consecutive responses are all failures" {
+        "detectRepetitionLoop returns tool name on two-tool alternation loop (A,B,A,B,A)" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
-            val events =
-                (1..AgentAdvanced.REPETITION_DETECTION_WINDOW).map { i ->
+            val argsA = """{"q":"B2"}"""
+            val argsB = """{"q":"E2"}"""
+            // A appears 3 times in the window of 5 — threshold reached
+            val calls = listOf(
+                "toolA" to argsA,
+                "toolB" to argsB,
+                "toolA" to argsA,
+                "toolB" to argsB,
+                "toolA" to argsA,
+            )
+            val events = calls.mapIndexed { i, (tool, args) ->
+                listOf(
+                    ToolRequestEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        toolRequestId = "req-$i",
+                        toolName = tool,
+                        args = args,
+                    ),
                     ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
                         toolRequestId = "req-$i",
-                        toolName = "FILES__ReadFile",
-                        output = MessageContent.Text("Error: file not found"),
-                        success = false,
+                        toolName = tool,
+                        output = MessageContent.Text("result"),
+                    ),
+                )
+            }.flatten()
+
+            agent.detectRepetitionLoop(events) shouldBe "toolA"
+        }
+
+        "detectRepetitionLoop returns null when WINDOW consecutive same-tool responses have different args (WZ-32262)" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val argsList = listOf(
+                """{"qualificationNameInput":"B2","rootCategory":"GRADE"}""",
+                """{"qualificationNameInput":"E2","rootCategory":"GRADE"}""",
+                """{"qualificationNameInput":"E4","rootCategory":"GRADE"}""",
+            )
+            val events =
+                argsList.mapIndexed { i, args ->
+                    listOf(
+                        ToolRequestEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "SearchQualifications",
+                            args = args,
+                        ),
+                        ToolResponseEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "SearchQualifications",
+                            output = MessageContent.Text("result $i"),
+                        ),
                     )
-                }
+                }.flatten()
 
             agent.detectRepetitionLoop(events) shouldBe null
         }
 
-        "detectRepetitionLoop returns null when tools are mixed in the window" {
+        "detectRepetitionLoop returns tool name when THRESHOLD failures with same args within WINDOW" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
+            val sameArgs = """{"path":"missing.txt"}"""
             val events =
+                (1..AgentAdvanced.REPETITION_WINDOW).flatMap { i ->
+                    listOf(
+                        ToolRequestEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            args = sameArgs,
+                        ),
+                        ToolResponseEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            output = MessageContent.Text("Error: file not found"),
+                            success = false,
+                        ),
+                    )
+                }
+
+            agent.detectRepetitionLoop(events) shouldBe "FILES__ReadFile"
+        }
+
+        "detectRepetitionLoop returns null when no (toolName, args) pair reaches THRESHOLD in the window" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            // 5 calls: FILES__ReadFile appears twice, JIRA__GetIssue three times but with different args each time
+            val calls = listOf(
+                "FILES__ReadFile" to """{"path":"a.txt"}""",
+                "JIRA__GetIssue" to """{"id":"WZ-1"}""",
+                "FILES__ReadFile" to """{"path":"a.txt"}""",
+                "JIRA__GetIssue" to """{"id":"WZ-2"}""",
+                "JIRA__GetIssue" to """{"id":"WZ-3"}""",
+            )
+            val events = calls.mapIndexed { i, (tool, args) ->
                 listOf(
-                    ToolResponseEvent(
+                    ToolRequestEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
-                        toolRequestId = "req-1",
-                        toolName = "FILES__ReadFile",
-                        output = MessageContent.Text("content"),
+                        toolRequestId = "req-$i",
+                        toolName = tool,
+                        args = args,
                     ),
                     ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
-                        toolRequestId = "req-2",
-                        toolName = "JIRA__GetIssue",
-                        output = MessageContent.Text("content"),
-                    ),
-                    ToolResponseEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        toolRequestId = "req-3",
-                        toolName = "FILES__ReadFile",
+                        toolRequestId = "req-$i",
+                        toolName = tool,
                         output = MessageContent.Text("content"),
                     ),
                 )
+            }.flatten()
 
             agent.detectRepetitionLoop(events) shouldBe null
         }


### PR DESCRIPTION
## Problem

`detectRepetitionLoop` was comparing only the **tool name** across the last 3 successful `ToolResponseEvent`s. An advanced agent calling the same tool with different payloads (e.g. `SearchQualifications` with `B2`, then `E2`, then `E4`) would incorrectly trigger the repetition warning, confusing the LLM and blocking legitimate tool usage.

## Fix

Build an index `toolRequestId → args` from the `ToolRequestEvent`s in the event history, then compare `(toolName, args)` pairs instead of just `toolName`. The warning now fires only when the same tool is called with the **identical payload** across the entire detection window.

## Tests

- Existing positive test made explicit: paired `ToolRequestEvent` + `ToolResponseEvent` with identical args → detection fires.
- New test covering WZ-32262: same tool, different args across the window → `null` (no warning).

Fixes WZ-32262.