### PR TITLE
feat: add case-level context to Case entity, merged with sessionContext in agent prompts

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -45,6 +45,8 @@ class AgentAdvanced(
     private val userExternalId: String? = null,
     private val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
     private val maxIterations: Int = 20,
+    /** Case-level context merged with per-message sessionContext in every prompt. */
+    private val caseContext: Map<String, Any?>? = null,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -361,7 +363,7 @@ class AgentAdvanced(
         caseId: UUID,
         emitEvent: suspend (CaseEvent) -> Unit,
     ): GateOutcome {
-        val history = context.buildMessages(accumulatedEvents)
+        val history = context.buildMessages(accumulatedEvents, caseContext)
         val needsExplicit =
             when (tool.confirmationMode) {
                 ConfirmationMode.EVERY_TIME -> {
@@ -593,7 +595,7 @@ class AgentAdvanced(
                         // Slice the history shown to analyzeConfirmation to events at-or-after the pending.
                         // Prevents the LLM judge from picking up a "yes" from an unrelated earlier turn
                         // (defense-in-depth for tools with confirmationMode=EVERY_TIME).
-                        val historyFromPending = context.buildMessages(events.subList(pendingIndex, events.size))
+                        val historyFromPending = context.buildMessages(events.subList(pendingIndex, events.size), caseContext)
                         val decision =
                             context.confirmationManager.analyzeConfirmation(
                                 chatClient = context.chatClient,
@@ -612,7 +614,7 @@ class AgentAdvanced(
                                         history = historyFromPending,
                                         fallbackLabel = pending.toolName,
                                         pendingData = pending.inputJson,
-                                    )
+                                    ) // historyFromPending already includes caseContext via buildMessages
                                 val clarification =
                                     MessageEvent(
                                         namespaceId = namespaceId,
@@ -792,7 +794,7 @@ class AgentAdvanced(
         val finalPromptText = "Based on the above conversation and your analysis, provide your response to the user."
         val intentionContext =
             lastIntention?.let { "Your analysis: ${it.intention}\n\n$finalPromptText" } ?: finalPromptText
-        val messages = context.buildMessages(accumulatedEvents) + UserMessage(intentionContext)
+        val messages = context.buildMessages(accumulatedEvents, caseContext) + UserMessage(intentionContext)
 
         logger.debug { "[$name] generateFinalResponse — sending ${messages.size} messages" }
         logger.trace { "[$name] generateFinalResponse intentionContext:\n$intentionContext" }
@@ -904,7 +906,7 @@ Intention: ${intentionEvent.intention}$enrichmentBlock
 **Generate ONLY the JSON object matching the input schema above. No explanation, no markdown fences.**
             """.trimIndent()
         val accumulatedEventsWithoutCurrentToolCall = accumulatedEvents.dropLast(1)
-        val baseMessages = context.buildMessages(accumulatedEventsWithoutCurrentToolCall)
+        val baseMessages = context.buildMessages(accumulatedEventsWithoutCurrentToolCall, caseContext)
 
         logger.debug { "[$name] generateParameters for '${tool.name}' — sending ${baseMessages.size + 1} messages" }
         logger.trace { "[$name] generateParameters prompt:\n$basePrompt" }
@@ -1025,7 +1027,7 @@ Intention: ${intentionEvent.intention}
                 """.trimIndent()
 
             val accumulatedEventsWithoutCurrentToolCall = accumulatedEvents.dropLast(1)
-            val messages = context.buildMessages(accumulatedEventsWithoutCurrentToolCall) + UserMessage(fullPrompt)
+            val messages = context.buildMessages(accumulatedEventsWithoutCurrentToolCall, caseContext) + UserMessage(fullPrompt)
 
             logger.debug { "[$name] enrichment phase $i for '${tool.name}' — sending ${messages.size} messages" }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -22,23 +22,28 @@ data class AgentAdvancedContext(
     val agentId: UUID,
     val confirmationManager: ConfirmationManager,
 ) {
-    internal fun buildMessages(events: List<CaseEvent>): List<Message> {
-        val history = convertEventsToMessages(events)
+    internal fun buildMessages(
+        events: List<CaseEvent>,
+        caseContext: Map<String, Any?>? = null,
+    ): List<Message> {
+        val history = convertEventsToMessages(events, caseContext = caseContext)
         return if (instructions != null) history + listOf(UserMessage(instructions)) else history
     }
 
     /**
      * Convert case events to Spring AI messages for the LLM prompt.
      *
-     * When the last user [MessageEvent] carries a non-null [MessageEvent.sessionContext],
-     * it is injected as a [UserMessage] immediately before that message to maintain the
-     * alternating user/assistant pattern expected by most LLM APIs. Session context on
-     * earlier messages is ignored.
+     * When the last user [MessageEvent] carries a non-null [MessageEvent.sessionContext]
+     * or when [caseContext] is non-null, the merged context is injected as a [UserMessage]
+     * immediately before that message to maintain the alternating user/assistant pattern
+     * expected by most LLM APIs. [MessageEvent.sessionContext] takes precedence over
+     * [caseContext] on key conflicts. Context on earlier messages is ignored.
      */
     internal fun convertEventsToMessages(
         events: List<CaseEvent>,
         maxDetailedToolCalls: Int = 6,
         maxDetailedMessagesWithSteps: Int = 3,
+        caseContext: Map<String, Any?>? = null,
     ): List<Message> {
         val responsesByRequestId = indexToolResponses(events)
         val detailedRequestIds =
@@ -53,10 +58,12 @@ data class AgentAdvancedContext(
             when (event) {
                 is MessageEvent -> {
                     val prefix: List<Message> =
-                        event
-                            .sessionContextPromptText()
-                            .takeIf { index == lastUserMsgIndex }
-                            ?.let { listOf(UserMessage(it)) } ?: emptyList()
+                        if (index == lastUserMsgIndex) {
+                            event.sessionContextPromptText(caseContext)
+                                ?.let { listOf(UserMessage(it)) } ?: emptyList()
+                        } else {
+                            emptyList()
+                        }
                     prefix + listOf(event.toSpringAiMessage(this.agentId.toString()))
                 }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
@@ -17,10 +17,14 @@ import java.util.UUID
  *   of invocation. Evaluated lazily so tool calls during a single agent run see events
  *   produced by prior tool calls in the same turn (e.g. a read before a write).
  *   Ignored when [caseId] is null.
+ * @param caseContext Opaque key-value context supplied at case creation time. Merged with
+ *   the last user message's sessionContext in the LLM prompt (sessionContext wins on key
+ *   conflicts). Null when the case was created without a context.
  */
 data class AgentExecutionContext(
     val namespaceId: UUID,
     val caseId: UUID? = null,
     val userId: UUID? = null,
     val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
+    val caseContext: Map<String, Any?>? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -246,6 +246,7 @@ class AgentServiceImpl(
                 userId = resolvedUser?.metadata?.id,
                 userExternalId = resolvedUser?.externalId,
                 caseEventsProvider = context.caseEventsProvider,
+                caseContext = context.caseContext,
             )
         } else {
             AgentSimple(
@@ -257,6 +258,7 @@ class AgentServiceImpl(
                 userId = resolvedUser?.metadata?.id,
                 userExternalId = resolvedUser?.externalId,
                 caseEventsProvider = context.caseEventsProvider,
+                caseContext = context.caseContext,
             )
         }
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -67,6 +67,8 @@ class AgentSimple(
     private val userExternalId: String? = null,
     /** Returns the live event list of the current case at the moment of invocation. */
     private val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
+    /** Case-level context merged with per-message sessionContext in every prompt. */
+    private val caseContext: Map<String, Any?>? = null,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -81,7 +83,7 @@ class AgentSimple(
 
             try {
                 // Convert events to messages
-                val messages = convertEventsToMessages(events)
+                val messages = convertEventsToMessages(events, caseContext)
 
                 // Add system instructions if provided
                 val allMessages =
@@ -261,7 +263,10 @@ class AgentSimple(
      * Session context on earlier messages is ignored — only the current turn's context
      * is relevant to the LLM.
      */
-    private fun convertEventsToMessages(events: List<CaseEvent>): List<Message> {
+    private fun convertEventsToMessages(
+        events: List<CaseEvent>,
+        caseContext: Map<String, Any?>? = null,
+    ): List<Message> {
         val messages = mutableListOf<Message>()
         val toolCallsForCurrentMessage = mutableListOf<AssistantMessage.ToolCall>()
         val toolResponses = mutableMapOf<String, ToolResponseEvent>()
@@ -280,9 +285,10 @@ class AgentSimple(
         events.forEachIndexed { index, event ->
             when (event) {
                 is MessageEvent -> {
-                    // Inject session context as a UserMessage immediately before the last user message.
+                    // Inject merged context (caseContext + sessionContext) as a UserMessage
+                    // immediately before the last user message.
                     if (index == lastUserMessageIndex) {
-                        event.sessionContextPromptText()?.let { messages.add(UserMessage(it)) }
+                        event.sessionContextPromptText(caseContext)?.let { messages.add(UserMessage(it)) }
                     }
                     // If we have accumulated tool calls, create AssistantMessage with them
                     if (toolCallsForCurrentMessage.isNotEmpty()) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
@@ -28,20 +28,31 @@ internal fun String.stripConversationTags(): String =
         .let { USER_TAG_REGEX.replace(it, "$1") }
 
 /**
- * Render the [MessageEvent.sessionContext] as a human-readable prompt fragment.
+ * Render the merged context as a human-readable prompt fragment.
  *
- * Formats the opaque context map as a simple key: value list inside an XML tag so the
- * LLM can identify it as structured metadata rather than conversational content.
- * Returns null when [MessageEvent.sessionContext] is null.
+ * Merges [caseContext] (stable case-level metadata) with [MessageEvent.sessionContext]
+ * (per-message context), with [MessageEvent.sessionContext] taking precedence on key
+ * conflicts. The result is formatted as a simple key: value list inside an XML tag so
+ * the LLM can identify it as structured metadata rather than conversational content.
+ *
+ * Returns null when both [caseContext] and [MessageEvent.sessionContext] are null.
  *
  * Keys and values are XML-escaped to prevent prompt injection via client-controlled
  * context values (e.g. a value containing `</session-context>` must not be able to
  * break the XML structure seen by the LLM).
  */
-internal fun MessageEvent.sessionContextPromptText(): String? =
-    sessionContext?.let { ctx ->
-        val entries = ctx.entries.joinToString("\n") { (k, v) -> "  ${escapeXml(k)}: ${escapeXml(v.toString())}" }
-        "<$SESSION_CONTEXT_TAG>\n$entries\n</$SESSION_CONTEXT_TAG>"
+internal fun MessageEvent.sessionContextPromptText(caseContext: Map<String, Any?>? = null): String? {
+    // Capture into a local val so the compiler can smart-cast across the when branches
+    // (cross-module public API properties are not eligible for smart cast directly).
+    val msgContext = sessionContext
+    val merged = when {
+        caseContext == null && msgContext == null -> return null
+        caseContext == null -> msgContext!!
+        msgContext == null -> caseContext
+        else -> caseContext + msgContext  // msgContext (message) wins on key conflict
+    }
+    val entries = merged.entries.joinToString("\n") { (k, v) -> "  ${escapeXml(k)}: ${escapeXml(v.toString())}" }
+    return "<$SESSION_CONTEXT_TAG>\n$entries\n</$SESSION_CONTEXT_TAG>"
 }
     /** Escapes XML special characters to prevent prompt injection. Delegates to Spring's [HtmlUtils.htmlEscape]. */
 private fun escapeXml(value: String): String = HtmlUtils.htmlEscape(value)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Case.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Case.kt
@@ -22,4 +22,10 @@ data class Case(
     val namespaceId: UUID,
     val status: CaseStatus = CaseStatus.PENDING,
     val title: String = "Case ${metadata.id}",
+    /**
+     * Opaque key-value context supplied by the integrating application at case creation time.
+     * Injected into every agent prompt alongside the last user message's [sessionContext],
+     * with [sessionContext] taking precedence on key conflicts.
+     */
+    val context: Map<String, Any?>? = null,
 ) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -60,6 +60,7 @@ class CaseController(
             status = entity.status,
             title = entity.title,
             created = entity.metadata.created,
+            context = entity.context,
         )
 
     override fun toDomain(resource: CaseResource): Case {
@@ -69,6 +70,7 @@ class CaseController(
             namespaceId = resource.namespaceId,
             status = resource.status,
             title = resource.title ?: "Case ${metadata.id}",
+            context = resource.context,
         )
     }
 
@@ -86,6 +88,7 @@ class CaseController(
     ): Case =
         existing.copy(
             title = resource.title ?: existing.title,
+            context = resource.context ?: existing.context,
         )
 
     @GetMapping("/{id}")

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNode.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.caseFlow
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.whozoss.agentos.namespace.NamespaceNode
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
@@ -25,10 +26,12 @@ data class CaseNode(
     val modified: Instant = Instant.now(),
     val modifiedBy: String? = null,
     val removed: Boolean? = null,
+    /** JSON-serialised [Case.context] map. Null when no context was supplied at creation. */
+    val contextJson: String? = null,
     @Relationship(type = "BELONGS_TO", direction = OUTGOING)
     var namespace: NamespaceNode? = null,
 ) {
-    fun toDomain(): Case =
+    fun toDomain(objectMapper: ObjectMapper): Case =
         Case(
             metadata =
                 EntityMetadata(
@@ -42,10 +45,17 @@ data class CaseNode(
             namespaceId = UUID.fromString(namespaceId),
             status = CaseStatus.valueOf(status),
             title = title,
+            context = contextJson?.let {
+                @Suppress("UNCHECKED_CAST")
+                objectMapper.readValue(it, Map::class.java) as Map<String, Any?>
+            },
         )
 
     companion object {
-        fun fromDomain(case: Case): CaseNode =
+        fun fromDomain(
+            case: Case,
+            objectMapper: ObjectMapper,
+        ): CaseNode =
             CaseNode(
                 id = case.id.toString(),
                 namespaceId = case.namespaceId.toString(),
@@ -56,6 +66,7 @@ data class CaseNode(
                 modified = case.metadata.modified,
                 modifiedBy = case.metadata.modifiedBy,
                 removed = case.metadata.removed.takeIf { it },
+                contextJson = case.context?.let { objectMapper.writeValueAsString(it) },
             )
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseResource.kt
@@ -20,4 +20,6 @@ data class CaseResource(
     val status: CaseStatus = CaseStatus.PENDING,
     val title: String? = null,
     val created: Instant? = null,
+    /** Opaque context supplied at case creation, merged with per-message sessionContext in agent prompts. */
+    val context: Map<String, Any?>? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -395,12 +395,14 @@ class CaseServiceImpl(
         }
 
         logger.info { "Running agent: $agentName for case $caseId" }
+        val case = caseRepository.findByIds(listOf(caseId)).firstOrNull()
         val context =
             AgentExecutionContext(
                 namespaceId = runtime.namespaceId,
                 caseId = caseId,
                 userId = userId,
                 caseEventsProvider = eventsProvider,
+                caseContext = case?.context,
             )
         agentService
             .findAgentByName(agentName, context)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Neo4jCaseRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Neo4jCaseRepository.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.caseFlow
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.whozoss.agentos.persistence.Neo4jChildLinkService
 import mu.KLogging
 import org.springframework.data.repository.findByIdOrNull
@@ -17,25 +18,26 @@ import java.util.UUID
 open class Neo4jCaseRepository(
     private val caseNodeNeo4jRepository: CaseNodeNeo4jRepository,
     private val childLinkService: Neo4jChildLinkService,
+    private val objectMapper: ObjectMapper,
 ) : CaseRepository {
     override fun save(entity: Case): Case =
         caseNodeNeo4jRepository
-            .save(CaseNode.fromDomain(entity))
+            .save(CaseNode.fromDomain(entity, objectMapper))
             .also { childLinkService.link("Case", it.id, "Namespace", entity.namespaceId.toString()) }
             .also { it.createdBy?.let { createdBy -> childLinkService.link("Case", it.id, "User", createdBy, relationship = "CREATED_BY") } }
-            .toDomain()
+            .toDomain(objectMapper)
             .also { logger.debug { "[Neo4jCaseRepository] Saved case ${it.id} under namespace ${entity.namespaceId}" } }
 
     override fun findByIds(ids: Collection<UUID>): List<Case> =
         caseNodeNeo4jRepository
             .findAllById(ids.map { it.toString() })
             .filter { it.removed != true }
-            .map { it.toDomain() }
+            .map { it.toDomain(objectMapper) }
 
     override fun findByParent(parentId: UUID): List<Case> =
         caseNodeNeo4jRepository
             .findActiveByNamespaceId(parentId.toString())
-            .map { it.toDomain() }
+            .map { it.toDomain(objectMapper) }
 
     override fun findAccessibleByUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
         caseNodeNeo4jRepository
@@ -43,12 +45,12 @@ open class Neo4jCaseRepository(
                 userId = userId.toString(),
                 namespaceId = namespaceId.toString(),
             )
-            .map { it.toDomain() }
+            .map { it.toDomain(objectMapper) }
 
     override fun findConcerningUser(userId: UUID): List<Case> =
         caseNodeNeo4jRepository
             .findConcerningUser(userId = userId.toString())
-            .map { it.toDomain() }
+            .map { it.toDomain(objectMapper) }
 
     override fun findConcerningUserInNamespace(userId: UUID, namespaceId: UUID): List<Case> =
         caseNodeNeo4jRepository
@@ -56,7 +58,7 @@ open class Neo4jCaseRepository(
                 userId = userId.toString(),
                 namespaceId = namespaceId.toString(),
             )
-            .map { it.toDomain() }
+            .map { it.toDomain(objectMapper) }
 
     override fun delete(id: UUID): Boolean =
         caseNodeNeo4jRepository
@@ -75,6 +77,9 @@ open class Neo4jCaseRepository(
         logger.debug { "[Neo4jCaseRepository] Soft-deleted ${active.size} cases under namespace $parentId" }
         return active.size
     }
+
+    // Note: deleteByParent only soft-deletes nodes without reading contextJson,
+    // so no objectMapper call is needed there.
 
     companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jPersistenceConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jPersistenceConfiguration.kt
@@ -102,9 +102,10 @@ class Neo4jPersistenceConfiguration {
     fun neo4jCaseRepository(
         caseNodeNeo4jRepository: CaseNodeNeo4jRepository,
         childLinkService: Neo4jChildLinkService,
+        objectMapper: ObjectMapper,
     ): CaseRepository {
         logger.info { "[Persistence] Neo4jCaseRepository active" }
-        return Neo4jCaseRepository(caseNodeNeo4jRepository, childLinkService)
+        return Neo4jCaseRepository(caseNodeNeo4jRepository, childLinkService, objectMapper)
     }
 
     @Bean

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/MessageConversionsUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/MessageConversionsUnitSpec.kt
@@ -1,0 +1,82 @@
+package io.whozoss.agentos.agent
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import java.util.UUID
+
+class MessageConversionsUnitSpec : StringSpec({
+
+    fun userMessage(
+        text: String,
+        sessionContext: Map<String, Any?>? = null,
+    ) = MessageEvent(
+        namespaceId = UUID.randomUUID(),
+        caseId = UUID.randomUUID(),
+        actor = Actor("user1", "Alice", ActorRole.USER),
+        content = listOf(MessageContent.Text(text)),
+        sessionContext = sessionContext,
+    )
+
+    // -------------------------------------------------------------------------
+    // sessionContextPromptText — merge semantics
+    // -------------------------------------------------------------------------
+
+    "returns null when both caseContext and sessionContext are null" {
+        val event = userMessage("hello")
+        event.sessionContextPromptText(caseContext = null) shouldBe null
+    }
+
+    "returns caseContext only when sessionContext is null" {
+        val event = userMessage("hello")
+        val result = event.sessionContextPromptText(caseContext = mapOf("tenant" to "acme"))
+        result shouldContain "tenant: acme"
+    }
+
+    "returns sessionContext only when caseContext is null" {
+        val event = userMessage("hello", sessionContext = mapOf("page" to "dashboard"))
+        val result = event.sessionContextPromptText(caseContext = null)
+        result shouldContain "page: dashboard"
+    }
+
+    "merges both contexts, sessionContext wins on key conflict" {
+        val event = userMessage(
+            "hello",
+            sessionContext = mapOf("env" to "prod", "page" to "settings"),
+        )
+        val result = event.sessionContextPromptText(
+            caseContext = mapOf("tenant" to "acme", "env" to "staging"),
+        )
+        // caseContext-only key present
+        result shouldContain "tenant: acme"
+        // sessionContext wins over caseContext for the shared key
+        result shouldContain "env: prod"
+        result shouldNotContain "env: staging"
+        // sessionContext-only key present
+        result shouldContain "page: settings"
+    }
+
+    "wraps merged context in session-context XML tag" {
+        val event = userMessage("hello", sessionContext = mapOf("k" to "v"))
+        val result = event.sessionContextPromptText(caseContext = null)
+        result shouldContain "<session-context>"
+        result shouldContain "</session-context>"
+    }
+
+    "XML-escapes keys and values to prevent prompt injection" {
+        val event = userMessage(
+            "hello",
+            sessionContext = mapOf("</session-context>" to "<script>alert(1)</script>"),
+        )
+        val result = event.sessionContextPromptText(caseContext = null)
+        // The raw injection string must not appear verbatim
+        result shouldNotContain "</session-context><script>"
+        // The tag structure must still close properly
+        result shouldContain "</session-context>"
+    }
+})


### PR DESCRIPTION
## What

Adds a `context: Map<String, Any?>?` field to `Case`, allowing integrating applications to pass stable key-value metadata at case creation time — independently of any user message.

## Why

The existing `sessionContext` on `AddMessageRequest` is the right place for per-message context (current page, entity in view, etc.), but it's only available from the first message onward. Integrators need a way to attach case-scoped metadata (tenant, user role, feature flags…) at creation time, before any message is sent.

## How

**Domain & persistence**
- `Case.kt`: new nullable `context` field
- `CaseNode.kt`: serialised as `contextJson: String?` (JSON, same pattern as `IntegrationConfigNode.parametersJson`). `toDomain`/`fromDomain` now take an `ObjectMapper` parameter.
- `Neo4jCaseRepository.kt`: injects `ObjectMapper`, passes it through to node conversion
- `Neo4jPersistenceConfiguration.kt`: passes `ObjectMapper` to the `Neo4jCaseRepository` bean

**HTTP layer**
- `CaseResource.kt`: exposes `context` field (readable and writable)
- `CaseController.kt`: maps `context` in `toResource`/`toDomain`; `toDomainForUpdate` merges with existing value (update is non-destructive — omitting `context` on PUT preserves the existing value)

**Agent prompt injection**
- `AgentExecutionContext.kt`: new `caseContext` field, populated in `CaseServiceImpl.runAgent` from the persisted `Case`
- `AgentServiceImpl.kt`: passes `context.caseContext` to both `AgentAdvanced` and `AgentSimple` constructors
- `AgentAdvanced.kt` / `AgentSimple.kt`: new `caseContext` constructor parameter, passed through to all `buildMessages`/`convertEventsToMessages` calls
- `AgentAdvancedContext.kt`: `buildMessages` and `convertEventsToMessages` accept optional `caseContext`
- `MessageConversions.kt`: `sessionContextPromptText` now takes `caseContext` and merges — `caseContext + sessionContext`, with `sessionContext` winning on key conflicts

**Tests**
- `MessageConversionsUnitSpec.kt`: new unit spec covering all merge scenarios (null/null → null, caseContext only, sessionContext only, merge with conflict, XML wrapping, injection escaping)
