### PR TITLE
feat(wz-32284): add dynamic confirmation mode hook for tools

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
@@ -85,6 +85,17 @@ interface StandardTool<T> {
      * Default delegates to the static [confirmationMode] for backward compatibility:
      * existing plugins that only override [confirmationMode] keep working without change.
      *
+     * ⚠️ HOT PATH — called on **every** tool call by the orchestrator, including those that
+     * resolve to [ConfirmationMode.NONE]. Overrides MUST be:
+     *   - **cheap** : no HTTP, no DB call, no LLM. Pure local computation on `argsJson`
+     *     and `context.caseEvents` only.
+     *   - **side-effect-free** : the orchestrator may call this multiple times for the
+     *     same tool call (e.g. on retry). Mutating state, writing logs at INFO+, or
+     *     emitting events here will leak / duplicate / mislead.
+     *
+     * `suspend` is allowed (the orchestrator awaits) so simple async lookups stay possible,
+     * but in practice prefer plain Kotlin matching against `context.caseEvents`.
+     *
      * @param argsJson Raw JSON args produced by the LLM for the impending tool call
      * @param context Execution context (namespaceId, userId, caseEvents)
      */
@@ -105,6 +116,12 @@ interface StandardTool<T> {
      * Examples:
      *   "Hesitant replies ('pourquoi pas', 'I guess') are not affirmative consent."
      *   "Updates that overwrite non-empty fields require explicit user authorization."
+     *
+     * **Intentionally static** — no args, no context, no suspend. The LLM judge already
+     * sees the proposed args (`proposedData` in tour 1, `pendingPayload` in tour 2) and
+     * the full conversation history, so per-call branching of the prompt would be
+     * redundant. For args/context-driven *decisions* (e.g. bypass), override
+     * [getConfirmationMode] instead — keep this method as fixed criteria for the LLM.
      *
      * Plugin authors MUST NOT include user-controlled strings here.
      */

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
@@ -62,7 +62,9 @@ interface StandardTool<T> {
     // through its standard [execute] path — same as a tool that never opted in.
 
     /**
-     * Declares how this tool participates in the user-confirmation flow.
+     * Static fallback for the confirmation mode. Read directly only by tools that
+     * don't need dynamic resolution. The orchestrator reads via [getConfirmationMode]
+     * which defaults to this value.
      *
      * - [ConfirmationMode.NONE]: no confirmation required — tool executes directly (default).
      * - [ConfirmationMode.INFER]: confirmation required, but the orchestrator may skip
@@ -74,11 +76,36 @@ interface StandardTool<T> {
     val confirmationMode: ConfirmationMode get() = ConfirmationMode.NONE
 
     /**
-     * Instructions appended to the `analyzeConfirmation` prompt to guide the LLM judge
-     * when interpreting the user's free-form reply. For destructive actions this SHOULD
-     * be a strict prompt (e.g. "Require explicit confirmation: a bare 'ok' is not enough
-     * unless the previous turn clearly described the destructive action."). Plugin authors
-     * MUST NOT include user-controlled strings here.
+     * Dynamic resolution of the confirmation mode. The orchestrator calls this with the
+     * proposed args and current case events before deciding whether to gate the tool call.
+     * Override to compute the mode from business logic — e.g. inspect prior tool calls in
+     * [ToolContext.caseEvents] to bypass confirmation when an in-session create makes a
+     * follow-up update implicit.
+     *
+     * Default delegates to the static [confirmationMode] for backward compatibility:
+     * existing plugins that only override [confirmationMode] keep working without change.
+     *
+     * @param argsJson Raw JSON args produced by the LLM for the impending tool call
+     * @param context Execution context (namespaceId, userId, caseEvents)
+     */
+    suspend fun getConfirmationMode(
+        argsJson: String? = null,
+        context: ToolContext? = null,
+    ): ConfirmationMode = confirmationMode
+
+    /**
+     * Tool-specific guidance injected as a structured `<tool_guidance>` block into BOTH:
+     *   1. the `shouldConfirm` prompt (tour 1 — decide whether to gate)
+     *   2. the `analyzeConfirmation` prompt (tour 2 — parse the user's free-form reply)
+     *
+     * Write phase-agnostic criteria, not imperative overrides. The LLM combines this
+     * guidance with the general decision rules of the prompt template.
+     *
+     * Examples:
+     *   "Hesitant replies ('pourquoi pas', 'I guess') are not affirmative consent."
+     *   "Updates that overwrite non-empty fields require explicit user authorization."
+     *
+     * Plugin authors MUST NOT include user-controlled strings here.
      */
     fun getConfirmationInstructions(): String = ""
 

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
@@ -94,7 +94,8 @@ interface StandardTool<T> {
     ): ConfirmationMode = confirmationMode
 
     /**
-     * Tool-specific guidance injected as a structured `<tool_guidance>` block into BOTH:
+     * Tool-specific guidance injected as a labelled `Tool-specific confirmation guidance:`
+     * section into BOTH:
      *   1. the `shouldConfirm` prompt (tour 1 — decide whether to gate)
      *   2. the `analyzeConfirmation` prompt (tour 2 — parse the user's free-form reply)
      *

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolSpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolSpec.kt
@@ -67,5 +67,67 @@ class StandardToolSpec : StringSpec() {
                 dummyContext,
             ).output shouldBe "America/New_York"
         }
+
+        // getConfirmationMode(args, ctx) default = lit la val statique confirmationMode.
+        // Garantit la backward-compat : un plugin existant qui n'override que la val
+        // continue de fonctionner sans changement après cette extension.
+        "getConfirmationMode default delegates to static confirmationMode" {
+            val noneTool =
+                object : StandardTool<Unit> {
+                    override val name = "None"
+                    override val description = ""
+                    override val version = "1.0"
+                    override val paramType: Class<Unit>? = null
+                    override val inputSchema = "{}"
+
+                    override suspend fun execute(input: Unit?, context: ToolContext) =
+                        ToolExecutionResult.success("")
+                    // confirmationMode = NONE (default)
+                }
+            val everyTimeTool =
+                object : StandardTool<Unit> {
+                    override val name = "EveryTime"
+                    override val description = ""
+                    override val version = "1.0"
+                    override val paramType: Class<Unit>? = null
+                    override val inputSchema = "{}"
+                    override val confirmationMode = ConfirmationMode.EVERY_TIME
+
+                    override suspend fun execute(input: Unit?, context: ToolContext) =
+                        ToolExecutionResult.success("")
+                }
+            noneTool.getConfirmationMode() shouldBe ConfirmationMode.NONE
+            noneTool.getConfirmationMode("{}", dummyContext) shouldBe ConfirmationMode.NONE
+            everyTimeTool.getConfirmationMode() shouldBe ConfirmationMode.EVERY_TIME
+            everyTimeTool.getConfirmationMode("{}", dummyContext) shouldBe ConfirmationMode.EVERY_TIME
+        }
+
+        // Override dynamique : un plugin peut décider du mode à partir des args/events,
+        // sans toucher à la val statique. C'est le mécanisme central de la PR — utilisé
+        // par CopilotStandardTool pour bypasser la confirmation quand un CreateProfile
+        // in-session rend un UpdateProfile implicite.
+        "getConfirmationMode dynamic override is honored" {
+            val dynamicTool =
+                object : StandardTool<Unit> {
+                    override val name = "Dynamic"
+                    override val description = ""
+                    override val version = "1.0"
+                    override val paramType: Class<Unit>? = null
+                    override val inputSchema = "{}"
+                    override val confirmationMode = ConfirmationMode.EVERY_TIME // static fallback
+
+                    override suspend fun getConfirmationMode(
+                        argsJson: String?,
+                        context: ToolContext?,
+                    ): ConfirmationMode =
+                        if (argsJson?.contains("bypass") == true) ConfirmationMode.NONE
+                        else confirmationMode
+
+                    override suspend fun execute(input: Unit?, context: ToolContext) =
+                        ToolExecutionResult.success("")
+                }
+            dynamicTool.getConfirmationMode("{}", dummyContext) shouldBe ConfirmationMode.EVERY_TIME
+            dynamicTool.getConfirmationMode("""{"bypass":true}""", dummyContext) shouldBe ConfirmationMode.NONE
+        }
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -289,10 +289,17 @@ class AgentAdvanced(
 
         val tool = context.tools.firstOrNull { it.name == intention.toolName }
         val toolCtx = tool?.let { buildToolContext(it.name, namespaceId) }
+        val confirmationMode =
+            if (tool != null && toolCtx != null) {
+                tool.getConfirmationMode(parameters.args, toolCtx)
+            } else {
+                ConfirmationMode.NONE
+            }
         return when {
-            tool != null && toolCtx != null && tool.confirmationMode != ConfirmationMode.NONE -> {
+            tool != null && toolCtx != null && confirmationMode != ConfirmationMode.NONE -> {
                 handleConfirmationGate(
                     tool = tool,
+                    mode = confirmationMode,
                     argsJson = parameters.args,
                     toolRequestId = toolRequestId,
                     parameters = parameters,
@@ -342,7 +349,11 @@ class AgentAdvanced(
     }
 
     /**
-     * Handles the confirmation gate for a tool whose [confirmationMode] is not [NONE].
+     * Handles the confirmation gate for a tool whose resolved mode is not [NONE].
+     * The mode is resolved by the caller via [StandardTool.getConfirmationMode] and
+     * passed in as [mode], allowing the tool to return a dynamic mode based on args
+     * and case events (e.g. bypass when an in-session create makes a follow-up update
+     * implicit).
      *
      * - [ConfirmationMode.EVERY_TIME]: always emits a [PendingConfirmationEvent] +
      *   IN-CHANNEL [MessageEvent] and returns [GateOutcome.AwaitingConfirmation].
@@ -352,6 +363,7 @@ class AgentAdvanced(
      */
     private suspend fun handleConfirmationGate(
         tool: StandardTool<*>,
+        mode: ConfirmationMode,
         argsJson: String?,
         toolRequestId: String,
         parameters: ToolRequestEvent,
@@ -363,7 +375,7 @@ class AgentAdvanced(
     ): GateOutcome {
         val history = context.buildMessages(accumulatedEvents)
         val needsExplicit =
-            when (tool.confirmationMode) {
+            when (mode) {
                 ConfirmationMode.EVERY_TIME -> {
                     true
                 }
@@ -374,6 +386,7 @@ class AgentAdvanced(
                         history = history,
                         actionLabel = "Tool ${tool.name}",
                         proposedData = argsJson ?: "{}",
+                        toolInstructions = tool.getConfirmationInstructions(),
                     )
                 }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -612,7 +612,7 @@ class AgentAdvanced(
                                 chatClient = context.chatClient,
                                 history = historyFromPending,
                                 pendingPayload = pending.inputJson,
-                                specificInstructions = pending.analysisInstructions,
+                                toolInstructions = pending.analysisInstructions,
                             )
                         when (decision) {
                             ConfirmationDecision.AMBIGUOUS -> {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -133,8 +133,10 @@ class ConfirmationManager(
      * @param chatClient The agent's ChatClient.
      * @param history The Spring AI conversation history that includes the latest user reply.
      * @param pendingPayload The payload that was emitted with the [PendingConfirmationEvent].
-     * @param specificInstructions Optional tool-supplied analysis instructions
-     *   (e.g. "Be strict: bare 'ok' is not enough for destructive actions").
+     * @param toolInstructions Optional tool-supplied guidance — same string and same
+     *   labelled section ("Tool-specific confirmation guidance:") as in [shouldConfirm].
+     *   Sourced from [StandardTool.getConfirmationInstructions], persisted on the
+     *   [PendingConfirmationEvent] and replayed here.
      * @return [ConfirmationDecision] — CONFIRMED on a clear yes, REJECTED on a clear no,
      *   AMBIGUOUS otherwise (undecodable LLM reply OR LLM call failure).
      */
@@ -142,10 +144,10 @@ class ConfirmationManager(
         chatClient: ChatClient,
         history: List<Message>,
         pendingPayload: Any,
-        specificInstructions: String,
+        toolInstructions: String = "",
     ): ConfirmationDecision {
         logger.info { "[ConfirmationManager] Analyze confirmation." }
-        val specificBlock = buildToolGuidanceSection(specificInstructions)
+        val toolGuidanceSection = buildToolGuidanceSection(toolInstructions)
 
         val payloadSummary = serializeSafely(pendingPayload)
 
@@ -157,7 +159,7 @@ class ConfirmationManager(
             $payloadSummary
 
             And especially based on the last user message, I need to identify if the user confirms the validation (without any modification) or not.
-            $specificBlock
+            $toolGuidanceSection
 
             Decide between three outcomes and put exactly one of "$CHOICE_YES", "$CHOICE_NO", "$CHOICE_UNCLEAR" between <$TAG_DECISION></$TAG_DECISION> tags:
             - "$CHOICE_YES" — the user clearly confirms the validation without modification.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -54,6 +54,10 @@ class ConfirmationManager(
      * @param proposedData The structured data the tool is about to apply.
      * @param originalData Optional pre-change state (Update tools). When non-null, the
      *   LLM gets it so it can reason about the delta — matches the back Copilot signature.
+     * @param toolInstructions Optional tool-supplied guidance injected as a structured
+     *   `<tool_guidance>` block alongside the general decision rules. The LLM is told to
+     *   take it as additional context, not as overriding rules — so a poorly written
+     *   guidance cannot bypass the general safety criteria.
      */
     fun shouldConfirm(
         chatClient: ChatClient,
@@ -61,14 +65,17 @@ class ConfirmationManager(
         actionLabel: String,
         proposedData: Any,
         originalData: Any? = null,
+        toolInstructions: String = "",
     ): Boolean {
         logger.info { "[ConfirmationManager] shouldConfirm? actionLabel='$actionLabel'" }
         return try {
             val dataSummary = serializeSafely(proposedData)
             val originalSection = buildOriginalObjectSection(originalData)
+            val toolGuidanceSection = buildToolGuidanceSection(toolInstructions)
             val prompt =
                 """
                 $originalSection
+                $toolGuidanceSection
 
                 Current Situation:
                 The agent is about to execute the following action:
@@ -79,6 +86,7 @@ class ConfirmationManager(
 
                 Task:
                 Analyze the end of the conversation. Has the user *already* explicitly agreed to or requested this specific action/update?
+                Take any tool-specific guidance above as additional context, not as overriding rules — apply both the general criteria below and any specific considerations the tool provided.
 
                 Return "$CHOICE_NO" if ANY of the following are true:
                 - The assistant proposed a general suggestion without details and the user just agreed to the general suggestion but hasn't seen the specific details yet
@@ -91,7 +99,7 @@ class ConfirmationManager(
 
                 Has the user *already* explicitly agreed to or requested this specific action/update? put it between <$TAG_DECISION></$TAG_DECISION>:
                 <$TAG_DECISION>
-                
+
                 Also give me the reasoning behind yor decision. put it between <$TAG_REASONING></$TAG_REASONING>:
                 <$TAG_REASONING>
                 """.trimIndent()
@@ -109,6 +117,18 @@ class ConfirmationManager(
             true
         }
     }
+
+    private fun buildToolGuidanceSection(toolInstructions: String): String =
+        if (toolInstructions.isBlank()) {
+            ""
+        } else {
+            """
+            |Tool-specific confirmation guidance:
+            |<tool_guidance>
+            |$toolInstructions
+            |</tool_guidance>
+            """.trimMargin()
+        }
 
     /**
      * @param chatClient The agent's ChatClient.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -123,10 +123,9 @@ class ConfirmationManager(
             ""
         } else {
             """
+            |
             |Tool-specific confirmation guidance:
-            |<tool_guidance>
             |$toolInstructions
-            |</tool_guidance>
             """.trimMargin()
         }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -54,10 +54,10 @@ class ConfirmationManager(
      * @param proposedData The structured data the tool is about to apply.
      * @param originalData Optional pre-change state (Update tools). When non-null, the
      *   LLM gets it so it can reason about the delta — matches the back Copilot signature.
-     * @param toolInstructions Optional tool-supplied guidance injected as a structured
-     *   `<tool_guidance>` block alongside the general decision rules. The LLM is told to
-     *   take it as additional context, not as overriding rules — so a poorly written
-     *   guidance cannot bypass the general safety criteria.
+     * @param toolInstructions Optional tool-supplied guidance injected as a labelled
+     *   `Tool-specific confirmation guidance:` section alongside the general decision
+     *   rules. The LLM is told to take it as additional context, not as overriding rules
+     *   — so a poorly written guidance cannot bypass the general safety criteria.
      */
     fun shouldConfirm(
         chatClient: ChatClient,
@@ -145,15 +145,7 @@ class ConfirmationManager(
         specificInstructions: String,
     ): ConfirmationDecision {
         logger.info { "[ConfirmationManager] Analyze confirmation." }
-        val specificBlock =
-            if (specificInstructions.isNotBlank()) {
-                """
-                |**Specific Context for this validation:**
-                |$specificInstructions
-                """.trimMargin()
-            } else {
-                ""
-            }
+        val specificBlock = buildToolGuidanceSection(specificInstructions)
 
         val payloadSummary = serializeSafely(pendingPayload)
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -16,6 +16,7 @@ import io.whozoss.agentos.redirect.RedirectTool
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.ConfirmationResolvedEvent
 import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
@@ -1210,6 +1211,86 @@ class AgentAdvancedSpec :
             agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
             toolInstructionsCaptured.captured shouldBe "Be strict: 'pourquoi pas' is not consent."
+        }
+
+        // Câblage : l'orchestrateur doit transmettre les args bruts générés par le LLM
+        // ET le caseEvents accumulé (non vide) au hook dynamique. Sans cela, un plugin
+        // ne peut pas faire de bypass programmatique (cas central de la PR).
+        "getConfirmationMode receives the LLM-generated args and the accumulated caseEvents" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+            val argsCaptured = java.util.concurrent.atomic.AtomicReference<String?>(null)
+            val eventsCaptured = java.util.concurrent.atomic.AtomicReference<List<CaseEvent>?>(null)
+            val tool =
+                object : StandardTool<Map<String, Any>> {
+                    override val name = "TEST__capturingTool"
+                    override val description = "captures args/ctx seen at getConfirmationMode"
+                    override val inputSchema = """{"type":"object","properties":{"id":{"type":"string"}}}"""
+                    override val version = "1.0.0"
+                    override val paramType = null
+                    override val confirmationMode = ConfirmationMode.NONE
+
+                    override suspend fun getConfirmationMode(
+                        argsJson: String?,
+                        context: ToolContext?,
+                    ): ConfirmationMode {
+                        argsCaptured.set(argsJson)
+                        eventsCaptured.set(context?.caseEvents)
+                        // Returns EVERY_TIME so the orchestrator still routes through the gate
+                        // — we want the seam exercised even when the result is "confirm".
+                        return ConfirmationMode.EVERY_TIME
+                    }
+
+                    override suspend fun execute(
+                        input: Map<String, Any>?,
+                        context: ToolContext,
+                    ): ToolExecutionResult = ToolExecutionResult.success("captured")
+                }
+            val confirmationManager = mockk<ConfirmationManager>(relaxed = true)
+            every {
+                confirmationManager.formulateQuestion(any(), any(), any(), any())
+            } returns "confirm?"
+            val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
+            // The args returned to the orchestrator by the LLM
+            val expectedArgs = """{"id":"abc-123"}"""
+            every { chatClient.prompt(any<Prompt>()).call().content() } returns expectedArgs
+
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every { mockGenerator.generate(any(), any(), any(), any(), any()) } returns
+                IntentionGeneratedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    intention = "call capturing tool",
+                    toolName = "TEST__capturingTool",
+                )
+
+            // Wire caseEventsProvider explicitly so the hook sees the same events the
+            // orchestrator emits during this run — mimicking CaseRuntime in production.
+            val initialEvents = makeInitialEvents(namespaceId, caseId)
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "TestAgent",
+                    context = ctx,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 2,
+                    caseEventsProvider = { initialEvents },
+                )
+            agent.run(initialEvents).toList()
+
+            // args : verbatim from the LLM response — same string the orchestrator
+            // persists on the resulting ToolRequestEvent.
+            argsCaptured.get() shouldBe expectedArgs
+
+            // caseEvents : non-null, includes at least the initial USER MessageEvent
+            // from `caseEventsProvider`. Proves the hook is wired to the live event
+            // history exposed by the orchestrator, not to an empty/default snapshot.
+            val seenEvents = eventsCaptured.get()
+            seenEvents shouldNotBe null
+            seenEvents!!.filterIsInstance<MessageEvent>().any { it.actor.role == ActorRole.USER } shouldBe true
         }
 
         "AC7: reload session without user reply emits AgentFinished, no ConfirmationResolved, file untouched" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -10,6 +10,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import io.whozoss.agentos.redirect.RedirectTool
 import io.whozoss.agentos.sdk.actor.Actor
@@ -959,7 +960,7 @@ class AgentAdvancedSpec :
             val target = tempDir.resolve("safe.txt").also { it.writeText("data") }
             val tool = TestRemoveTool(tempDir, name = "TEST__safe", confirmationMode = ConfirmationMode.INFER)
             val confirmationManager = mockk<ConfirmationManager>()
-            every { confirmationManager.shouldConfirm(any(), any(), any(), any()) } returns false
+            every { confirmationManager.shouldConfirm(any(), any(), any(), any(), any(), any()) } returns false
             val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
             every { chatClient.prompt(any<Prompt>()).call().content() } returns """{"path":"safe.txt"}"""
 
@@ -1021,7 +1022,7 @@ class AgentAdvancedSpec :
                     ): ToolExecutionResult = throw RuntimeException("boom")
                 }
             val confirmationManager = mockk<ConfirmationManager>()
-            every { confirmationManager.shouldConfirm(any(), any(), any(), any()) } returns false
+            every { confirmationManager.shouldConfirm(any(), any(), any(), any(), any(), any()) } returns false
             val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
             every { chatClient.prompt(any<Prompt>()).call().content() } returns "{}"
 
@@ -1062,6 +1063,153 @@ class AgentAdvancedSpec :
                 events.filterIsInstance<ToolResponseEvent>().single { it.toolName == "TEST__failing" }
             response.success shouldBe false
             (response.output as MessageContent.Text).content shouldContain "boom"
+        }
+
+        // Dynamique : un tool peut résoudre son mode au runtime via getConfirmationMode(args, ctx).
+        // Quand il retourne NONE, l'orchestrateur ne déclenche aucun gate de confirmation et
+        // exécute le tool directement, même si la val statique demande la confirmation.
+        // Cas d'usage central : bypass programmatique d'UpdateProfile quand CreateProfile a été
+        // appelé in-session pour le même profileId.
+        "Dynamic getConfirmationMode=NONE bypasses confirmation entirely" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+            val executed = java.util.concurrent.atomic.AtomicBoolean(false)
+            val tool =
+                object : StandardTool<Map<String, Any>> {
+                    override val name = "TEST__bypassable"
+                    override val description = "tool with dynamic NONE override"
+                    override val inputSchema = "{}"
+                    override val version = "1.0.0"
+                    override val paramType = null
+                    override val confirmationMode = ConfirmationMode.EVERY_TIME // static fallback
+
+                    // Always returns NONE dynamically — mimicking a bypass condition
+                    override suspend fun getConfirmationMode(
+                        argsJson: String?,
+                        context: ToolContext?,
+                    ): ConfirmationMode = ConfirmationMode.NONE
+
+                    override suspend fun execute(
+                        input: Map<String, Any>?,
+                        context: ToolContext,
+                    ): ToolExecutionResult {
+                        executed.set(true)
+                        return ToolExecutionResult.success("done")
+                    }
+                }
+            val confirmationManager = mockk<ConfirmationManager>(relaxed = true)
+            val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
+            every { chatClient.prompt(any<Prompt>()).call().content() } returns "{}"
+
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every { mockGenerator.generate(any(), any(), any(), any(), any()) } returnsMany
+                listOf(
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "call bypassable",
+                        toolName = "TEST__bypassable",
+                    ),
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "done",
+                        toolName = "Answer",
+                    ),
+                )
+
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "TestAgent",
+                    context = ctx,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 5,
+                )
+            val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
+
+            // Aucun PendingConfirmation : le dynamique override la val EVERY_TIME
+            events.filterIsInstance<PendingConfirmationEvent>() shouldHaveSize 0
+            // shouldConfirm n'est même pas appelé (mode = NONE → pas de gate)
+            verify(exactly = 0) {
+                confirmationManager.shouldConfirm(any(), any(), any(), any(), any(), any())
+            }
+            executed.get() shouldBe true
+        }
+
+        // L'orchestrateur doit transmettre les instructions tool-spécifiques au LLM-judge
+        // pour que le prompt template intègre la guidance custom (e.g. "pourquoi pas not consent").
+        "INFER mode forwards tool.getConfirmationInstructions() to shouldConfirm.toolInstructions" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+            val tool =
+                object : StandardTool<Map<String, Any>> {
+                    override val name = "TEST__withGuidance"
+                    override val description = "tool that injects guidance"
+                    override val inputSchema = "{}"
+                    override val version = "1.0.0"
+                    override val paramType = null
+                    override val confirmationMode = ConfirmationMode.INFER
+
+                    override fun getConfirmationInstructions(): String =
+                        "Be strict: 'pourquoi pas' is not consent."
+
+                    override suspend fun execute(
+                        input: Map<String, Any>?,
+                        context: ToolContext,
+                    ): ToolExecutionResult = ToolExecutionResult.success("ok")
+                }
+            val confirmationManager = mockk<ConfirmationManager>()
+            val toolInstructionsCaptured = slot<String>()
+            every {
+                confirmationManager.shouldConfirm(
+                    chatClient = any(),
+                    history = any(),
+                    actionLabel = any(),
+                    proposedData = any(),
+                    originalData = any(),
+                    toolInstructions = capture(toolInstructionsCaptured),
+                )
+            } returns false
+            val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
+            every { chatClient.prompt(any<Prompt>()).call().content() } returns "{}"
+
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every { mockGenerator.generate(any(), any(), any(), any(), any()) } returnsMany
+                listOf(
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "call with guidance",
+                        toolName = "TEST__withGuidance",
+                    ),
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "done",
+                        toolName = "Answer",
+                    ),
+                )
+
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "TestAgent",
+                    context = ctx,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 5,
+                )
+            agent.run(makeInitialEvents(namespaceId, caseId)).toList()
+
+            toolInstructionsCaptured.captured shouldBe "Be strict: 'pourquoi pas' is not consent."
         }
 
         "AC7: reload session without user reply emits AgentFinished, no ConfirmationResolved, file untouched" {
@@ -1290,6 +1438,7 @@ class AgentAdvancedSpec :
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
             every { mockTool.confirmationMode } returns ConfirmationMode.NONE
+            coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)
@@ -1357,6 +1506,7 @@ class AgentAdvancedSpec :
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
             every { mockTool.confirmationMode } returns ConfirmationMode.NONE
+            coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)
@@ -1429,6 +1579,7 @@ class AgentAdvancedSpec :
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
             every { mockTool.confirmationMode } returns ConfirmationMode.NONE
+            coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ConfirmationManagerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ConfirmationManagerSpec.kt
@@ -136,7 +136,7 @@ class ConfirmationManagerSpec :
                 chatClient = chatClient,
                 history = listOf(UserMessage("oui supprime")),
                 pendingPayload = mapOf("path" to "/tmp/x"),
-                specificInstructions = "",
+                toolInstructions = "",
             ) shouldBe ConfirmationDecision.CONFIRMED
         }
 
@@ -146,7 +146,7 @@ class ConfirmationManagerSpec :
                 chatClient = chatClient,
                 history = listOf(UserMessage("annule")),
                 pendingPayload = mapOf("path" to "/tmp/x"),
-                specificInstructions = "",
+                toolInstructions = "",
             ) shouldBe ConfirmationDecision.REJECTED
         }
 
@@ -156,7 +156,7 @@ class ConfirmationManagerSpec :
                 chatClient = chatClient,
                 history = listOf(UserMessage("euh quoi ?")),
                 pendingPayload = mapOf("path" to "/tmp/x"),
-                specificInstructions = "",
+                toolInstructions = "",
             ) shouldBe ConfirmationDecision.AMBIGUOUS
         }
 
@@ -167,7 +167,7 @@ class ConfirmationManagerSpec :
                 chatClient = chatClient,
                 history = emptyList(),
                 pendingPayload = mapOf("path" to "/tmp/x"),
-                specificInstructions = "",
+                toolInstructions = "",
             ) shouldBe ConfirmationDecision.AMBIGUOUS
         }
 
@@ -177,7 +177,7 @@ class ConfirmationManagerSpec :
                 chatClient = chatClient,
                 history = listOf(UserMessage("ok delete it")),
                 pendingPayload = mapOf("path" to "/tmp/x"),
-                specificInstructions = "Be strict: a bare 'ok' is acceptable only if the previous turn described the deletion.",
+                toolInstructions = "Be strict: a bare 'ok' is acceptable only if the previous turn described the deletion.",
             ) shouldBe ConfirmationDecision.CONFIRMED
         }
 
@@ -187,7 +187,7 @@ class ConfirmationManagerSpec :
                 chatClient = chatClient,
                 history = listOf(UserMessage("idiomatic ambiguous reply")),
                 pendingPayload = mapOf("path" to "/tmp/x"),
-                specificInstructions = "",
+                toolInstructions = "",
             ) shouldBe ConfirmationDecision.AMBIGUOUS
         }
 
@@ -199,7 +199,7 @@ class ConfirmationManagerSpec :
                 chatClient = chatClient,
                 history = emptyList(),
                 pendingPayload = mapOf("path" to "/tmp/x"),
-                specificInstructions = "",
+                toolInstructions = "",
             ) shouldBe ConfirmationDecision.CONFIRMED
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ConfirmationManagerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ConfirmationManagerSpec.kt
@@ -79,11 +79,12 @@ class ConfirmationManagerSpec :
             ) shouldBe false
         }
 
-        // Le tool fournit des instructions custom via getConfirmationInstructions();
-        // ConfirmationManager les injecte comme bloc structuré <tool_guidance> dans le
-        // prompt envoyé au LLM-judge. La phrase "additional context, not overriding"
-        // désamorce un conflit avec les règles génériques.
-        "shouldConfirm injects toolInstructions as a structured tool_guidance block" {
+        // Le tool fournit des instructions custom via getConfirmationInstructions() ;
+        // ConfirmationManager les injecte comme une section nommée "Tool-specific
+        // confirmation guidance:" dans le prompt — même pattern que les autres sections
+        // contextuelles (Original object, Current Situation, Proposed changes…). La phrase
+        // "additional context, not overriding" désamorce un conflit avec les règles génériques.
+        "shouldConfirm injects toolInstructions as a labelled section" {
             val promptCaptured = slot<Prompt>()
             val chatClient = mockk<ChatClient>()
             val reqSpec = mockk<ChatClient.ChatClientRequestSpec>()
@@ -101,13 +102,12 @@ class ConfirmationManagerSpec :
             ) shouldBe true
 
             val promptText = promptCaptured.captured.instructions.joinToString("\n") { it.text ?: "" }
-            promptText shouldContain "<tool_guidance>"
+            promptText shouldContain "Tool-specific confirmation guidance:"
             promptText shouldContain "Hesitant phrasing like 'pourquoi pas' is not consent."
-            promptText shouldContain "</tool_guidance>"
             promptText shouldContain "additional context, not as overriding rules"
         }
 
-        "shouldConfirm omits the tool_guidance block when toolInstructions is blank" {
+        "shouldConfirm omits the tool guidance section when toolInstructions is blank" {
             val promptCaptured = slot<Prompt>()
             val chatClient = mockk<ChatClient>()
             val reqSpec = mockk<ChatClient.ChatClientRequestSpec>()
@@ -125,7 +125,6 @@ class ConfirmationManagerSpec :
             ) shouldBe false
 
             val promptText = promptCaptured.captured.instructions.joinToString("\n") { it.text ?: "" }
-            promptText shouldNotContain "<tool_guidance>"
             promptText shouldNotContain "Tool-specific confirmation guidance"
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ConfirmationManagerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ConfirmationManagerSpec.kt
@@ -3,9 +3,11 @@ package io.whozoss.agentos.agent
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.prompt.Prompt
@@ -75,6 +77,56 @@ class ConfirmationManagerSpec :
                 proposedData = mapOf("name" to "new"),
                 originalData = mapOf("name" to "old"),
             ) shouldBe false
+        }
+
+        // Le tool fournit des instructions custom via getConfirmationInstructions();
+        // ConfirmationManager les injecte comme bloc structuré <tool_guidance> dans le
+        // prompt envoyé au LLM-judge. La phrase "additional context, not overriding"
+        // désamorce un conflit avec les règles génériques.
+        "shouldConfirm injects toolInstructions as a structured tool_guidance block" {
+            val promptCaptured = slot<Prompt>()
+            val chatClient = mockk<ChatClient>()
+            val reqSpec = mockk<ChatClient.ChatClientRequestSpec>()
+            val callSpec = mockk<ChatClient.CallResponseSpec>()
+            every { chatClient.prompt(capture(promptCaptured)) } returns reqSpec
+            every { reqSpec.call() } returns callSpec
+            every { callSpec.content() } returns "<decision>no</decision>"
+
+            manager.shouldConfirm(
+                chatClient = chatClient,
+                history = emptyList(),
+                actionLabel = "Update profile",
+                proposedData = mapOf("name" to "new"),
+                toolInstructions = "Hesitant phrasing like 'pourquoi pas' is not consent.",
+            ) shouldBe true
+
+            val promptText = promptCaptured.captured.instructions.joinToString("\n") { it.text ?: "" }
+            promptText shouldContain "<tool_guidance>"
+            promptText shouldContain "Hesitant phrasing like 'pourquoi pas' is not consent."
+            promptText shouldContain "</tool_guidance>"
+            promptText shouldContain "additional context, not as overriding rules"
+        }
+
+        "shouldConfirm omits the tool_guidance block when toolInstructions is blank" {
+            val promptCaptured = slot<Prompt>()
+            val chatClient = mockk<ChatClient>()
+            val reqSpec = mockk<ChatClient.ChatClientRequestSpec>()
+            val callSpec = mockk<ChatClient.CallResponseSpec>()
+            every { chatClient.prompt(capture(promptCaptured)) } returns reqSpec
+            every { reqSpec.call() } returns callSpec
+            every { callSpec.content() } returns "<decision>yes</decision>"
+
+            manager.shouldConfirm(
+                chatClient = chatClient,
+                history = emptyList(),
+                actionLabel = "Update profile",
+                proposedData = mapOf("name" to "new"),
+                toolInstructions = "",
+            ) shouldBe false
+
+            val promptText = promptCaptured.captured.instructions.joinToString("\n") { it.text ?: "" }
+            promptText shouldNotContain "<tool_guidance>"
+            promptText shouldNotContain "Tool-specific confirmation guidance"
         }
 
         // ─── analyzeConfirmation ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends `StandardTool` with a **dynamic** `getConfirmationMode(argsJson, context)` hook and **routes `getConfirmationInstructions()`** into the `shouldConfirm` prompt template (tour 1) in addition to its existing use in `analyzeConfirmation` (tour 2). Paired with whoz-oss/whoz#5076 which uses these hooks to reproduce the legacy Copilot `UpdateProfileTool.shouldBypassProgrammatically` and to inject a "pourquoi pas not consent" guidance block for `UpdateProfile`.

## Why

Observed on `version-rc` (case `e4e08a89-23b5-4d47-a5d7-f962822bd5e7`, 2026-06-02):

1. **Bypass programmatique perdu** — legacy Copilot `UpdateProfileTool.kt:124-150` skips `confirmationManager.shouldConfirm` when `chatContext.previousActions` contains a `CreateProfile` action for the same `profileId` (profile-filling UX). In `agentos` mode, `AgentOsConfirmationManager` is a no-op and the SDK had no equivalent hook — so the user sees a confirmation on every `UpdateProfile` even right after `CreateProfile`. The static `val confirmationMode` (introduced in WZ-31596) cannot express args-dependent decisions.

2. **LLM-judge trop laxiste** — *"pourquoi pas"* answered to *"Veux-tu que j'ajoute cette expérience…"* was classified CONFIRMED by `analyzeConfirmation` with no `specificInstructions` (because `getConfirmationInstructions()` was empty by default). The same guidance, applied at decision-time (`shouldConfirm` INFER), would also help prevent inferring consent from ambiguous conversation context.

## What this PR does

### 1. `StandardTool.getConfirmationMode(args, ctx)` — dynamic mode hook

```kotlin
suspend fun getConfirmationMode(
    argsJson: String? = null,
    context: ToolContext? = null,
): ConfirmationMode = confirmationMode   // default delegate to static val
```

Backward-compat preserved: all existing plugins (file, datetime, bash, tmux, filesystem-aiproviders) inherit the default that reads the static `val confirmationMode` — no change required on their side. The Copilot plugin (whoz#5076) overrides this hook to inspect `ToolContext.caseEvents` and return `ConfirmationMode.NONE` when the legacy bypass condition holds.

### 2. `AgentAdvanced.handleConfirmationGate` — read dynamic mode + forward instructions

The resolved mode is computed once per tool call via `tool.getConfirmationMode(parameters.args, toolCtx)` and passed explicitly to `handleConfirmationGate(mode, …)`. The `when (mode)` dispatch is unchanged. INFER now also forwards `tool.getConfirmationInstructions()` to `shouldConfirm.toolInstructions`.

### 3. `ConfirmationManager.shouldConfirm` — `<tool_guidance>` block

```kotlin
private fun buildToolGuidanceSection(toolInstructions: String): String =
    if (toolInstructions.isBlank()) ""
    else """
        |Tool-specific confirmation guidance:
        |<tool_guidance>
        |$toolInstructions
        |</tool_guidance>
    """.trimMargin()
```

Injected as a structured block in the prompt, alongside the existing original-object section. The Task block has an explicit instruction: *"Take any tool-specific guidance above as additional context, not as overriding rules — apply both the general criteria below and any specific considerations the tool provided."* — designed to prevent a poorly-written or malicious tool guidance from bypassing the general safety criteria (target ambiguity, destructive action without exact target match, etc.).

`analyzeConfirmation` is **unchanged** — it already receives `specificInstructions` from `pending.analysisInstructions` (which itself is set by `getConfirmationInstructions()` at emit time in AgentAdvanced.kt:417).

## Test coverage

| Spec | New tests | Verifies |
|---|---|---|
| `StandardToolSpec` | 2 | Default delegate to static + dynamic override honored |
| `ConfirmationManagerSpec` | 2 | `<tool_guidance>` block present when `toolInstructions` set, omitted when blank |
| `AgentAdvancedSpec` | 2 | E2E `NONE`-bypass-entirely (no `shouldConfirm` call, no `PendingConfirmation`) + INFER forwards `getConfirmationInstructions()` to `shouldConfirm.toolInstructions` |

Existing mocks of `mockTool.confirmationMode` updated with paired `coEvery { mockTool.getConfirmationMode(any(), any()) }` to keep them functional after the orchestrator now reads via the dynamic hook.

All 32 `AgentAdvancedSpec`, 13 `ConfirmationManagerSpec`, 6 `StandardToolSpec` tests pass locally.

## Backward compatibility

- Existing plugins keep working — `getConfirmationMode` default = `confirmationMode` (static val).
- `shouldConfirm` new param `toolInstructions: String = ""` — existing callers compile unchanged.
- Existing `analyzeConfirmation` wiring untouched.

## Paired PR

[whoz-oss/whoz#5076](https://github.com/biznet-io/whoz/pull/5076) — `CopilotStandardTool` overrides `getConfirmationMode` (legacy bypass parity) and `getConfirmationInstructions` ("pourquoi pas not consent" guidance for `UpdateProfile`). Requires this SDK PR to release first, then bump `agentos-version` in `whoz/backend/agentos/gradle/libs.versions.toml`.

## Test plan

- [x] Unit tests pass: `./gradlew :agentos-sdk:test --tests StandardToolSpec :agentos-service:test --tests ConfirmationManagerSpec --tests AgentAdvancedSpec`.
- [ ] After release + plugin bump on Whoz side, replay the case `e4e08a89-…` pattern on version-rc: *"pourquoi pas"* on a not-just-created profile should now be classified UNCLEAR (re-ask), not CONFIRMED.
- [ ] Canva scenario: `CreateProfile(X)` → `UpdateProfile(X)` in the same conversation → **no** `PendingConfirmationEvent` emitted (bypass effective).