### PR TITLE
fix: #WZ-32242 inject language hint in final response prompt

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -789,7 +789,10 @@ class AgentAdvanced(
         shouldContinue: () -> Boolean,
         emitEvent: suspend (CaseEvent) -> Unit,
     ) {
-        val finalPromptText = "Based on the above conversation and your analysis, provide your response to the user."
+        val languageHint = buildLanguageHint(accumulatedEvents)
+        val finalPromptText =
+            "Based on the above conversation and your analysis, provide your response to the user." +
+                (languageHint?.let { "\n\n$it" } ?: "")
         val intentionContext =
             lastIntention?.let { "Your analysis: ${it.intention}\n\n$finalPromptText" } ?: finalPromptText
         val messages = context.buildMessages(accumulatedEvents) + UserMessage(intentionContext)
@@ -819,6 +822,44 @@ class AgentAdvanced(
                 )
             emitEvent(msg)
         }
+    }
+
+    /**
+     * Builds a language hint from the most recent user [MessageEvent]s in [events].
+     *
+     * Collects user messages from newest to oldest until the combined text reaches
+     * [minChars], then returns an instruction anchored on the actual user text so the
+     * LLM has a concrete language signal rather than an abstract directive.
+     *
+     * Returns `null` when no user messages are present (e.g. agent-only conversations),
+     * so the caller can omit the hint entirely rather than defaulting to a hardcoded
+     * language.
+     */
+    internal fun buildLanguageHint(
+        events: List<CaseEvent>,
+        targetChars: Int = LANGUAGE_HINT_TARGET_CHARS,
+    ): String? {
+        val userTexts =
+            events
+                .filterIsInstance<MessageEvent>()
+                .filter { it.actor.role == ActorRole.USER }
+                .flatMap { it.content.filterIsInstance<MessageContent.Text>() }
+                .map { it.content.trim() }
+                .filter { it.isNotEmpty() }
+                .reversed()
+
+        if (userTexts.isEmpty()) return null
+
+        val collected = mutableListOf<String>()
+        var total = 0
+        for (text in userTexts) {
+            collected.add(text)
+            total += text.length
+            if (total >= targetChars) break
+        }
+
+        val sample = collected.reversed().joinToString(" / ") { "\"$it\"" }
+        return "Respond in the same language the user is writing in (reference: $sample)."
     }
 
     internal fun detectRepetitionLoop(events: List<CaseEvent>): String? {
@@ -1124,6 +1165,13 @@ Intention: ${intentionEvent.intention}
     companion object : KLogging() {
         /** How many recent tool responses to inspect for repetition. */
         internal const val REPETITION_WINDOW = 5
+
+        /**
+         * Target character count for the language hint sample: collect user messages
+         * newest-first until this threshold is reached, or until all messages are
+         * exhausted — whichever comes first.
+         */
+        internal const val LANGUAGE_HINT_TARGET_CHARS = 200
 
         /** How many identical (toolName, args) calls within the window trigger a warning. */
         internal const val REPETITION_THRESHOLD = 3

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -839,24 +839,27 @@ class AgentAdvanced(
         events: List<CaseEvent>,
         targetChars: Int = LANGUAGE_HINT_TARGET_CHARS,
     ): String? {
-        val userTexts =
+        // Reverse the messages first so we collect newest-first, then extract text per message.
+        // Reversing after flatMap would operate on individual text blocks, not on messages.
+        val userMessages =
             events
                 .filterIsInstance<MessageEvent>()
                 .filter { it.actor.role == ActorRole.USER }
-                .flatMap { it.content.filterIsInstance<MessageContent.Text>() }
-                .map { it.content.trim() }
-                .filter { it.isNotEmpty() }
                 .reversed()
 
-        if (userTexts.isEmpty()) return null
+        if (userMessages.isEmpty()) return null
 
         val collected = mutableListOf<String>()
         var total = 0
-        for (text in userTexts) {
+        for (message in userMessages) {
+            val text = message.content.filterIsInstance<MessageContent.Text>().joinToString(" ") { it.content.trim() }.trim()
+            if (text.isEmpty()) continue
             collected.add(text)
             total += text.length
             if (total >= targetChars) break
         }
+
+        if (collected.isEmpty()) return null
 
         val sample = collected.reversed().joinToString(" / ") { "\"$it\"" }
         return "Respond in the same language the user is writing in (reference: $sample)."

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -508,6 +508,117 @@ class AgentAdvancedSpec :
         // detectRepetitionLoop unit tests
         // -------------------------------------------------------------------------
 
+        // -------------------------------------------------------------------------
+        // buildLanguageHint unit tests
+        // -------------------------------------------------------------------------
+
+        "buildLanguageHint returns null when no user messages" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events = listOf(
+                MessageEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = Actor("agent1", "Astra", ActorRole.AGENT),
+                    content = listOf(MessageContent.Text("Bonjour, comment puis-je vous aider ?")),
+                ),
+            )
+            agent.buildLanguageHint(events) shouldBe null
+        }
+
+        "buildLanguageHint returns hint with single message when it meets minChars" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val longMessage = "a".repeat(250)
+            val events = listOf(
+                MessageEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = Actor("user1", "User One", ActorRole.USER),
+                    content = listOf(MessageContent.Text(longMessage)),
+                ),
+            )
+            val hint = agent.buildLanguageHint(events)
+            hint shouldNotBe null
+            hint!! shouldContain longMessage
+            hint shouldContain "Respond in the same language"
+        }
+
+        "buildLanguageHint accumulates multiple short messages until minChars is reached" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            // Each message is 50 chars, minChars=200 → needs at least 4
+            val messages = (1..6).map { i ->
+                MessageEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = Actor("user1", "User One", ActorRole.USER),
+                    content = listOf(MessageContent.Text("message-$i-" + "x".repeat(45))),
+                )
+            }
+            val hint = agent.buildLanguageHint(messages, targetChars = 200)
+            hint shouldNotBe null
+            // Should contain the last few messages (collected newest-first, displayed oldest-first)
+            hint!! shouldContain "message-6"
+            hint shouldContain "message-5"
+            // Should not need to go all the way back to message-1
+            hint shouldContain "Respond in the same language"
+        }
+
+        "buildLanguageHint returns a hint even when all messages combined are below targetChars" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events = listOf(
+                MessageEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = Actor("user1", "User One", ActorRole.USER),
+                    content = listOf(MessageContent.Text("oui")),
+                ),
+                MessageEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = Actor("user1", "User One", ActorRole.USER),
+                    content = listOf(MessageContent.Text("ok")),
+                ),
+            )
+            // Total = 5 chars, well below targetChars=200 — hint must still be produced
+            val hint = agent.buildLanguageHint(events)
+            hint shouldNotBe null
+            hint!! shouldContain "oui"
+            hint shouldContain "ok"
+            hint shouldContain "Respond in the same language"
+        }
+
+        "buildLanguageHint uses newest messages first when accumulating" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events = listOf(
+                MessageEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = Actor("user1", "User One", ActorRole.USER),
+                    content = listOf(MessageContent.Text("old english message from the beginning")),
+                ),
+                MessageEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = Actor("user1", "User One", ActorRole.USER),
+                    content = listOf(MessageContent.Text("cherche-moi des développeurs Angular à Paris avec 5 ans d'expérience")),
+                ),
+            )
+            val hint = agent.buildLanguageHint(events, targetChars = 50)
+            hint shouldNotBe null
+            // The latest message alone exceeds minChars=50, so only it should appear
+            hint!! shouldContain "Angular"
+            hint shouldContain "Respond in the same language"
+        }
+
         "detectRepetitionLoop returns null when fewer than REPETITION_WINDOW tool responses" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()


### PR DESCRIPTION
## Problem

Astra always responds in French regardless of the user's language, because the final response prompt carries no language signal — the LLM defaults to the agent's system prompt language.

## Approach

No extra LLM call (unlike the Copilot approach). Instead, `generateFinalResponse()` now builds a concrete language hint from the most recent user `MessageEvent`s in the accumulated history and appends it to the final prompt:

```
Respond in the same language the user is writing in (reference: "cherche-moi des développeurs Angular à Paris").
```

The `buildLanguageHint()` function collects user messages newest-first until ~200 chars are reached, or until all messages are exhausted — so short messages like "oui" / "ok" are still included rather than silently dropped. Returns `null` when no user messages exist (no hardcoded English fallback).

## Files changed

- `AgentAdvanced.kt` — `buildLanguageHint()` + injection in `generateFinalResponse()`
- `AgentAdvancedSpec.kt` — 5 new unit tests covering: no user messages, single long message, accumulation of short messages, newest-first ordering, and below-threshold case