### PR TITLE
feat(wz-32284): dynamic confirmation mode resolution hook

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
@@ -62,7 +62,9 @@ interface StandardTool<T> {
     // through its standard [execute] path — same as a tool that never opted in.
 
     /**
-     * Declares how this tool participates in the user-confirmation flow.
+     * Static fallback for the confirmation mode. Read directly only by tools that
+     * don't need dynamic resolution. The orchestrator reads via [getConfirmationMode]
+     * which defaults to this value.
      *
      * - [ConfirmationMode.NONE]: no confirmation required — tool executes directly (default).
      * - [ConfirmationMode.INFER]: confirmation required, but the orchestrator may skip
@@ -72,6 +74,35 @@ interface StandardTool<T> {
      *   is never trusted. Use this for irreversible side-effects (e.g. file deletion).
      */
     val confirmationMode: ConfirmationMode get() = ConfirmationMode.NONE
+
+    /**
+     * Dynamic resolution of the confirmation mode. The orchestrator calls this with the
+     * proposed args and current case events before deciding whether to gate the tool call.
+     * Override to compute the mode from business logic — e.g. inspect prior tool calls in
+     * [ToolContext.caseEvents] to bypass confirmation when an in-session create makes a
+     * follow-up update implicit.
+     *
+     * Default delegates to the static [confirmationMode] for backward compatibility:
+     * existing plugins that only override [confirmationMode] keep working without change.
+     *
+     * ⚠️ HOT PATH — called on **every** tool call by the orchestrator, including those that
+     * resolve to [ConfirmationMode.NONE]. Overrides MUST be:
+     *   - **cheap** : no HTTP, no DB call, no LLM. Pure local computation on `argsJson`
+     *     and `context.caseEvents` only.
+     *   - **side-effect-free** : the orchestrator may call this multiple times for the
+     *     same tool call (e.g. on retry). Mutating state, writing logs at INFO+, or
+     *     emitting events here will leak / duplicate / mislead.
+     *
+     * `suspend` is allowed (the orchestrator awaits) so simple async lookups stay possible,
+     * but in practice prefer plain Kotlin matching against `context.caseEvents`.
+     *
+     * @param argsJson Raw JSON args produced by the LLM for the impending tool call
+     * @param context Execution context (namespaceId, userId, caseEvents)
+     */
+    suspend fun getConfirmationMode(
+        argsJson: String? = null,
+        context: ToolContext? = null,
+    ): ConfirmationMode = confirmationMode
 
     /**
      * Instructions appended to the `analyzeConfirmation` prompt to guide the LLM judge

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolSpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolSpec.kt
@@ -67,5 +67,67 @@ class StandardToolSpec : StringSpec() {
                 dummyContext,
             ).output shouldBe "America/New_York"
         }
+
+        // getConfirmationMode(args, ctx) default = lit la val statique confirmationMode.
+        // Garantit la backward-compat : un plugin existant qui n'override que la val
+        // continue de fonctionner sans changement après cette extension.
+        "getConfirmationMode default delegates to static confirmationMode" {
+            val noneTool =
+                object : StandardTool<Unit> {
+                    override val name = "None"
+                    override val description = ""
+                    override val version = "1.0"
+                    override val paramType: Class<Unit>? = null
+                    override val inputSchema = "{}"
+
+                    override suspend fun execute(input: Unit?, context: ToolContext) =
+                        ToolExecutionResult.success("")
+                    // confirmationMode = NONE (default)
+                }
+            val everyTimeTool =
+                object : StandardTool<Unit> {
+                    override val name = "EveryTime"
+                    override val description = ""
+                    override val version = "1.0"
+                    override val paramType: Class<Unit>? = null
+                    override val inputSchema = "{}"
+                    override val confirmationMode = ConfirmationMode.EVERY_TIME
+
+                    override suspend fun execute(input: Unit?, context: ToolContext) =
+                        ToolExecutionResult.success("")
+                }
+            noneTool.getConfirmationMode() shouldBe ConfirmationMode.NONE
+            noneTool.getConfirmationMode("{}", dummyContext) shouldBe ConfirmationMode.NONE
+            everyTimeTool.getConfirmationMode() shouldBe ConfirmationMode.EVERY_TIME
+            everyTimeTool.getConfirmationMode("{}", dummyContext) shouldBe ConfirmationMode.EVERY_TIME
+        }
+
+        // Override dynamique : un plugin peut décider du mode à partir des args/events,
+        // sans toucher à la val statique. C'est le mécanisme central de la PR — utilisé
+        // par CopilotStandardTool pour bypasser la confirmation quand un CreateProfile
+        // in-session rend un UpdateProfile implicite.
+        "getConfirmationMode dynamic override is honored" {
+            val dynamicTool =
+                object : StandardTool<Unit> {
+                    override val name = "Dynamic"
+                    override val description = ""
+                    override val version = "1.0"
+                    override val paramType: Class<Unit>? = null
+                    override val inputSchema = "{}"
+                    override val confirmationMode = ConfirmationMode.EVERY_TIME // static fallback
+
+                    override suspend fun getConfirmationMode(
+                        argsJson: String?,
+                        context: ToolContext?,
+                    ): ConfirmationMode =
+                        if (argsJson?.contains("bypass") == true) ConfirmationMode.NONE
+                        else confirmationMode
+
+                    override suspend fun execute(input: Unit?, context: ToolContext) =
+                        ToolExecutionResult.success("")
+                }
+            dynamicTool.getConfirmationMode("{}", dummyContext) shouldBe ConfirmationMode.EVERY_TIME
+            dynamicTool.getConfirmationMode("""{"bypass":true}""", dummyContext) shouldBe ConfirmationMode.NONE
+        }
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -289,10 +289,17 @@ class AgentAdvanced(
 
         val tool = context.tools.firstOrNull { it.name == intention.toolName }
         val toolCtx = tool?.let { buildToolContext(it.name, namespaceId) }
+        val confirmationMode =
+            if (tool != null && toolCtx != null) {
+                tool.getConfirmationMode(parameters.args, toolCtx)
+            } else {
+                ConfirmationMode.NONE
+            }
         return when {
-            tool != null && toolCtx != null && tool.confirmationMode != ConfirmationMode.NONE -> {
+            tool != null && toolCtx != null && confirmationMode != ConfirmationMode.NONE -> {
                 handleConfirmationGate(
                     tool = tool,
+                    mode = confirmationMode,
                     argsJson = parameters.args,
                     toolRequestId = toolRequestId,
                     parameters = parameters,
@@ -342,7 +349,11 @@ class AgentAdvanced(
     }
 
     /**
-     * Handles the confirmation gate for a tool whose [confirmationMode] is not [NONE].
+     * Handles the confirmation gate for a tool whose resolved mode is not [NONE].
+     * The mode is resolved by the caller via [StandardTool.getConfirmationMode] and
+     * passed in as [mode], allowing the tool to return a dynamic mode based on args
+     * and case events (e.g. bypass when an in-session create makes a follow-up update
+     * implicit).
      *
      * - [ConfirmationMode.EVERY_TIME]: always emits a [PendingConfirmationEvent] +
      *   IN-CHANNEL [MessageEvent] and returns [GateOutcome.AwaitingConfirmation].
@@ -352,6 +363,7 @@ class AgentAdvanced(
      */
     private suspend fun handleConfirmationGate(
         tool: StandardTool<*>,
+        mode: ConfirmationMode,
         argsJson: String?,
         toolRequestId: String,
         parameters: ToolRequestEvent,
@@ -363,7 +375,7 @@ class AgentAdvanced(
     ): GateOutcome {
         val history = context.buildMessages(accumulatedEvents)
         val needsExplicit =
-            when (tool.confirmationMode) {
+            when (mode) {
                 ConfirmationMode.EVERY_TIME -> {
                     true
                 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -15,6 +15,7 @@ import io.whozoss.agentos.redirect.RedirectTool
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.ConfirmationResolvedEvent
 import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
@@ -1064,6 +1065,162 @@ class AgentAdvancedSpec :
             (response.output as MessageContent.Text).content shouldContain "boom"
         }
 
+        // Dynamique : un tool peut résoudre son mode au runtime via getConfirmationMode(args, ctx).
+        // Quand il retourne NONE, l'orchestrateur ne déclenche aucun gate de confirmation et
+        // exécute le tool directement, même si la val statique demande la confirmation.
+        // Cas d'usage central : bypass programmatique d'UpdateProfile quand CreateProfile a été
+        // appelé in-session pour le même profileId.
+        "Dynamic getConfirmationMode=NONE bypasses confirmation entirely" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+            val executed = java.util.concurrent.atomic.AtomicBoolean(false)
+            val tool =
+                object : StandardTool<Map<String, Any>> {
+                    override val name = "TEST__bypassable"
+                    override val description = "tool with dynamic NONE override"
+                    override val inputSchema = "{}"
+                    override val version = "1.0.0"
+                    override val paramType = null
+                    override val confirmationMode = ConfirmationMode.EVERY_TIME // static fallback
+
+                    // Always returns NONE dynamically — mimicking a bypass condition
+                    override suspend fun getConfirmationMode(
+                        argsJson: String?,
+                        context: ToolContext?,
+                    ): ConfirmationMode = ConfirmationMode.NONE
+
+                    override suspend fun execute(
+                        input: Map<String, Any>?,
+                        context: ToolContext,
+                    ): ToolExecutionResult {
+                        executed.set(true)
+                        return ToolExecutionResult.success("done")
+                    }
+                }
+            val confirmationManager = mockk<ConfirmationManager>(relaxed = true)
+            val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
+            every { chatClient.prompt(any<Prompt>()).call().content() } returns "{}"
+
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every { mockGenerator.generate(any(), any(), any(), any(), any()) } returnsMany
+                listOf(
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "call bypassable",
+                        toolName = "TEST__bypassable",
+                    ),
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "done",
+                        toolName = "Answer",
+                    ),
+                )
+
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "TestAgent",
+                    context = ctx,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 5,
+                )
+            val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
+
+            // Aucun PendingConfirmation : le dynamique override la val EVERY_TIME
+            events.filterIsInstance<PendingConfirmationEvent>() shouldHaveSize 0
+            // shouldConfirm n'est même pas appelé (mode = NONE → pas de gate)
+            verify(exactly = 0) {
+                confirmationManager.shouldConfirm(any(), any(), any(), any(), any())
+            }
+            executed.get() shouldBe true
+        }
+
+        // Câblage : l'orchestrateur doit transmettre les args bruts générés par le LLM
+        // ET le caseEvents accumulé (non vide) au hook dynamique. Sans cela, un plugin
+        // ne peut pas faire de bypass programmatique (cas central de la PR).
+        "getConfirmationMode receives the LLM-generated args and the accumulated caseEvents" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+            val argsCaptured = java.util.concurrent.atomic.AtomicReference<String?>(null)
+            val eventsCaptured = java.util.concurrent.atomic.AtomicReference<List<CaseEvent>?>(null)
+            val tool =
+                object : StandardTool<Map<String, Any>> {
+                    override val name = "TEST__capturingTool"
+                    override val description = "captures args/ctx seen at getConfirmationMode"
+                    override val inputSchema = """{"type":"object","properties":{"id":{"type":"string"}}}"""
+                    override val version = "1.0.0"
+                    override val paramType = null
+                    override val confirmationMode = ConfirmationMode.NONE
+
+                    override suspend fun getConfirmationMode(
+                        argsJson: String?,
+                        context: ToolContext?,
+                    ): ConfirmationMode {
+                        argsCaptured.set(argsJson)
+                        eventsCaptured.set(context?.caseEvents)
+                        // Returns EVERY_TIME so the orchestrator still routes through the gate
+                        // — we want the seam exercised even when the result is "confirm".
+                        return ConfirmationMode.EVERY_TIME
+                    }
+
+                    override suspend fun execute(
+                        input: Map<String, Any>?,
+                        context: ToolContext,
+                    ): ToolExecutionResult = ToolExecutionResult.success("captured")
+                }
+            val confirmationManager = mockk<ConfirmationManager>()
+            every {
+                confirmationManager.formulateQuestion(any(), any(), any(), any())
+            } returns "confirm?"
+            val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
+            // The args returned to the orchestrator by the LLM
+            val expectedArgs = """{"id":"abc-123"}"""
+            every { chatClient.prompt(any<Prompt>()).call().content() } returns expectedArgs
+
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every { mockGenerator.generate(any(), any(), any(), any(), any()) } returns
+                IntentionGeneratedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    intention = "call capturing tool",
+                    toolName = "TEST__capturingTool",
+                )
+
+            // Wire caseEventsProvider explicitly so the hook sees the same events the
+            // orchestrator emits during this run — mimicking CaseRuntime in production.
+            val initialEvents = makeInitialEvents(namespaceId, caseId)
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "TestAgent",
+                    context = ctx,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 2,
+                    caseEventsProvider = { initialEvents },
+                )
+            agent.run(initialEvents).toList()
+
+            // args : verbatim from the LLM response — same string the orchestrator
+            // persists on the resulting ToolRequestEvent.
+            argsCaptured.get() shouldBe expectedArgs
+
+            // caseEvents : non-null, includes at least the initial USER MessageEvent
+            // from `caseEventsProvider`. Proves the hook is wired to the live event
+            // history exposed by the orchestrator, not to an empty/default snapshot.
+            val seenEvents = eventsCaptured.get()
+            seenEvents shouldNotBe null
+            seenEvents!!.filterIsInstance<MessageEvent>().any { it.actor.role == ActorRole.USER } shouldBe true
+        }
+
         "AC7: reload session without user reply emits AgentFinished, no ConfirmationResolved, file untouched" {
             val tempDir = Files.createTempDirectory("agentadvanced-ac7-").also { it.toFile().deleteOnExit() }
             val target = tempDir.resolve("old.txt").also { it.writeText("data") }
@@ -1290,6 +1447,7 @@ class AgentAdvancedSpec :
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
             every { mockTool.confirmationMode } returns ConfirmationMode.NONE
+            coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)
@@ -1357,6 +1515,7 @@ class AgentAdvancedSpec :
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
             every { mockTool.confirmationMode } returns ConfirmationMode.NONE
+            coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)
@@ -1429,6 +1588,7 @@ class AgentAdvancedSpec :
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
             every { mockTool.confirmationMode } returns ConfirmationMode.NONE
+            coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)


### PR DESCRIPTION
## Summary

Adds `suspend fun getConfirmationMode(argsJson, context): ConfirmationMode` on `StandardTool` so plugins can resolve the confirmation mode at runtime from the proposed args and the current case events, instead of being limited to the static `val confirmationMode`.

This is the **first of two** companion PRs splitting the original WZ-32284 work:

1. **This PR — dynamic mode hook** : the runtime extension required for plugins to do args-dependent gating (e.g. legacy bypass-programmatically behaviour for UpdateProfile).
2. **Follow-up — tool guidance injection** : routes `getConfirmationInstructions()` into the `shouldConfirm` prompt template, on top of the dynamic mode hook.

## Why

The AgentOS Copilot plugin needs to reproduce the Whoz Copilot legacy `UpdateProfileTool.shouldBypassProgrammatically` behaviour: bypass the confirmation prompt when a `CreateProfile` tool call earlier in the same conversation emitted a `PROFILE_CREATED` action on the same `profileId`. Without a dynamic hook, this requires either an HTTP round-trip back to Copilot for every tool call, or a per-call override of the static val, neither of which scales cleanly.

## What this PR does

### `StandardTool.kt` — new hook

```kotlin
suspend fun getConfirmationMode(
    argsJson: String? = null,
    context: ToolContext? = null,
): ConfirmationMode = confirmationMode   // default delegates to the static val
```

- Backward-compat preserved: every existing plugin (file, datetime, bash, tmux, filesystem-aiproviders) inherits the default that reads the static `confirmationMode`. No change required on their side.
- KDoc explicitly flags the contract: **HOT PATH** — overrides MUST be cheap (no HTTP/DB/LLM) and side-effect-free (the orchestrator may retry within a single tool call). `suspend` is permitted but Kotlin-local matching on `context.caseEvents` is the intended pattern.

### `AgentAdvanced.kt` — read the dynamic mode + thread it through

The resolved mode is computed once per tool call before `handleConfirmationGate`:

```kotlin
val confirmationMode =
    if (tool != null && toolCtx != null) {
        tool.getConfirmationMode(parameters.args, toolCtx)
    } else {
        ConfirmationMode.NONE
    }
```

`handleConfirmationGate(mode: ConfirmationMode, …)` now takes the mode as an explicit parameter instead of re-reading `tool.confirmationMode` inside its `when` dispatch. The dispatch behaviour is unchanged.

## Test coverage

| Spec | New tests | Verifies |
|---|---|---|
| `StandardToolSpec` | 2 | Default delegate to static + dynamic override honored |
| `AgentAdvancedSpec` | 2 | E2E `NONE`-bypass-entirely (no `PendingConfirmation`, no `shouldConfirm` call) + seam test asserting that args/caseEvents reach the hook verbatim from the orchestrator |

Existing mocks of `mockTool.confirmationMode` updated with paired `coEvery { mockTool.getConfirmationMode(any(), any()) }` to keep them functional after the orchestrator now reads via the dynamic hook.

All `StandardToolSpec` (6/6) and `AgentAdvancedSpec` (32/32) pass locally.

## Backward compatibility

- Existing plugins keep working — `getConfirmationMode` default = `confirmationMode` (static val).
- `handleConfirmationGate` is private (only called by `AgentAdvanced` itself) — adding the `mode` param has no external impact.
- No DTO changes, no surface REST change.

## Paired PR

`feat(wz-32284): inject tool guidance in shouldConfirm prompt` will follow on top of this branch and add the `<tool_guidance>` injection. Splitting them keeps each diff focused on a single concern.

## Supersedes

Closes #939 (was bundling mode hook + guidance injection together).

## Test plan

- [x] `./gradlew :agentos-sdk:test --tests StandardToolSpec` → 6/6
- [x] `./gradlew :agentos-service:test --tests AgentAdvancedSpec` → 32/32
- [ ] E2E validated on version-rc (cf. transcript whoz#5076): create file via editFiles → remove → bypass confirmé via log `[getConfirmationMode] touchedInSession=true → NONE`