### PR TITLE
fix: #942 anchor scheduler nextRun to startTimestamp phase

### DIFF
--- a/libs/service/src/lib/scheduler.service.ts
+++ b/libs/service/src/lib/scheduler.service.ts
@@ -284,62 +284,36 @@ export class SchedulerService {
   }
 
   /**
-   * Calculate next run time, skipping missed occurrences
+   * Calculate next run time, skipping missed occurrences.
+   *
+   * With the phase-anchored calculateNextRun(), a single call with `now` as fromDate
+   * directly returns the correct next slot regardless of how many occurrences were
+   * missed — no iterative loop is needed.
+   *
+   * The occurrenceCount is left unchanged: missed executions are not counted as
+   * completed occurrences (they were skipped, not executed).
    */
   private calculateNextRunSkippingMissed(scheduler: Scheduler): { nextRun: string | null; occurrenceCount: number } {
     const now = new Date()
-    let occurrenceCount = scheduler.occurrenceCount ?? 0
-    let nextRun = scheduler.nextRun
+    const occurrenceCount = scheduler.occurrenceCount ?? 0
 
-    // If no nextRun, calculate from now
-    if (!nextRun) {
-      return {
-        nextRun: calculateNextRun(scheduler.schedule, now, occurrenceCount),
-        occurrenceCount,
-      }
+    // If nextRun is already in the future, keep it as-is
+    if (scheduler.nextRun && new Date(scheduler.nextRun) >= now) {
+      return { nextRun: scheduler.nextRun, occurrenceCount }
     }
 
-    // If nextRun is in the future, keep it
-    if (new Date(nextRun) >= now) {
-      return { nextRun, occurrenceCount }
+    // nextRun is missing or in the past — compute the next phase-aligned slot from now.
+    // calculateNextRun() anchors to startTimestamp, so this preserves the configured
+    // time-of-day regardless of how long Coday was down.
+    const nextRun = calculateNextRun(scheduler.schedule, now, occurrenceCount)
+
+    if (scheduler.nextRun && new Date(scheduler.nextRun) < now) {
+      console.log(
+        `[SCHEDULER] Scheduler "${scheduler.name}" (${scheduler.id}) had missed nextRun, recalculated to: ${nextRun}`
+      )
     }
 
-    // nextRun is in the past - skip missed occurrences
-    const maxIterations = 1000
-    let iterations = 0
-    let skippedCount = 0
-
-    while (iterations < maxIterations) {
-      occurrenceCount++
-      skippedCount++
-
-      nextRun = calculateNextRun(scheduler.schedule, now, occurrenceCount)
-
-      if (!nextRun) {
-        if (skippedCount > 0) {
-          console.log(
-            `[SCHEDULER] Scheduler "${scheduler.name}" (${scheduler.id}) expired after skipping ${skippedCount} missed occurrence(s)`
-          )
-        }
-        return { nextRun: null, occurrenceCount }
-      }
-
-      if (new Date(nextRun) >= now) {
-        if (skippedCount > 0) {
-          console.log(
-            `[SCHEDULER] Scheduler "${scheduler.name}" (${scheduler.id}) skipped ${skippedCount} missed occurrence(s), next run: ${nextRun}`
-          )
-        }
-        return { nextRun, occurrenceCount }
-      }
-
-      iterations++
-    }
-
-    console.warn(
-      `[SCHEDULER] Could not find future nextRun for scheduler ${scheduler.id} after ${maxIterations} iterations`
-    )
-    return { nextRun: null, occurrenceCount }
+    return { nextRun, occurrenceCount }
   }
 
   /**

--- a/libs/utils/src/lib/interval-schedule.utils.test.ts
+++ b/libs/utils/src/lib/interval-schedule.utils.test.ts
@@ -312,6 +312,76 @@ describe('interval-schedule.utils', () => {
       })
     })
 
+    describe('Phase stability (startTimestamp as anchor)', () => {
+      it('should schedule daily-at-8:30 correctly when fromDate is 11 PM', () => {
+        // Scheduler configured to run daily at 08:30 UTC
+        const schedule: IntervalSchedule = {
+          startTimestamp: '2025-01-01T08:30:00Z', // 8:30 AM anchor
+          interval: '1d',
+        }
+        // Coday restarts at 11 PM — next run should be 8:30 AM next day, not 11 PM next day
+        const fromDate = new Date('2025-06-15T23:00:00Z')
+        const nextRun = calculateNextRun(schedule, fromDate)
+
+        expect(nextRun).toBe('2025-06-16T08:30:00.000Z')
+        expect(new Date(nextRun!).getUTCHours()).toBe(8)
+        expect(new Date(nextRun!).getUTCMinutes()).toBe(30)
+      })
+
+      it('should maintain time-of-day after multiple missed days', () => {
+        // Daily at 08:30, but Coday was down for 5 days
+        const schedule: IntervalSchedule = {
+          startTimestamp: '2025-01-01T08:30:00Z',
+          interval: '1d',
+        }
+        // fromDate simulates "now" after 5 days of downtime (mid-afternoon)
+        const fromDate = new Date('2025-01-06T14:00:00Z')
+        const nextRun = calculateNextRun(schedule, fromDate)
+
+        // Should be Jan 7 at 08:30, not Jan 7 at 14:00
+        expect(nextRun).toBe('2025-01-07T08:30:00.000Z')
+      })
+
+      it('should phase-align hourly scheduler (every 2h from 08:00) when fromDate is 09:15', () => {
+        // Every 2h starting at 08:00: runs at 08:00, 10:00, 12:00, ...
+        const schedule: IntervalSchedule = {
+          startTimestamp: '2025-03-10T08:00:00Z',
+          interval: '2h',
+        }
+        const fromDate = new Date('2025-03-10T09:15:00Z')
+        const nextRun = calculateNextRun(schedule, fromDate)
+
+        // Next phase-aligned slot after 09:15 is 10:00, not 11:15
+        expect(nextRun).toBe('2025-03-10T10:00:00.000Z')
+      })
+
+      it('should phase-align monthly scheduler when fromDate is mid-month', () => {
+        // Monthly on the 1st at 08:00 AM
+        const schedule: IntervalSchedule = {
+          startTimestamp: '2025-01-01T08:00:00Z',
+          interval: '1M',
+        }
+        const fromDate = new Date('2025-03-15T12:00:00Z') // mid-March
+        const nextRun = calculateNextRun(schedule, fromDate)
+
+        // Next occurrence should be April 1st at 08:00, not April 15th at 12:00
+        expect(nextRun).toBe('2025-04-01T08:00:00.000Z')
+      })
+
+      it('should return correct next slot when fromDate exactly equals a phase point', () => {
+        // Every 30min from 10:00; fromDate is exactly 10:30 (a phase point)
+        const schedule: IntervalSchedule = {
+          startTimestamp: '2025-01-01T10:00:00Z',
+          interval: '30min',
+        }
+        const fromDate = new Date('2025-01-01T10:30:00Z')
+        const nextRun = calculateNextRun(schedule, fromDate)
+
+        // Must be strictly AFTER 10:30, so next is 11:00
+        expect(nextRun).toBe('2025-01-01T11:00:00.000Z')
+      })
+    })
+
     describe('Edge cases', () => {
       it('should return start time when fromDate is before start', () => {
         const schedule: IntervalSchedule = {
@@ -358,15 +428,15 @@ describe('interval-schedule.utils', () => {
         expect(nextRun).toBe('2025-01-06T12:00:00.000Z')
         expect(new Date(nextRun!).getUTCDay()).toBe(1) // Monday
 
-        // From Monday 23:00, +2h = Tuesday 01:00 (not Monday)
+        // From Monday 23:00, phase anchor: start=10:00, diff=13h, n=7, candidate=Jan 7 00:00 (Tue)
         const fromLateMonday = new Date('2025-01-06T23:00:00Z')
         const nextRunFromLate = calculateNextRun(schedule, fromLateMonday)
 
         // Should skip Tuesday-Sunday and land on next Monday
-        // +2h = Tue 01:00 (skip), +2h = Tue 03:00 (skip), ...
-        // Eventually reaches Monday Jan 13th
+        // Phase-anchored candidate: Jan 7 00:00 (Tue)
+        // daysOfWeek=[1]: keep adding 2h until Monday Jan 13 00:00
         expect(new Date(nextRunFromLate!).getUTCDay()).toBe(1) // Monday
-        expect(nextRunFromLate).toBe('2025-01-13T01:00:00.000Z') // Next Monday 01:00
+        expect(nextRunFromLate).toBe('2025-01-13T00:00:00.000Z') // Next Monday 00:00
       })
 
       it('should skip to next valid day when 3d interval lands on non-selected day', () => {

--- a/libs/utils/src/lib/interval-schedule.utils.ts
+++ b/libs/utils/src/lib/interval-schedule.utils.ts
@@ -162,12 +162,15 @@ export function validateIntervalSchedule(schedule: IntervalSchedule): { valid: b
  * - End timestamp (stops if exceeded)
  *
  * Logic:
- * - If no daysOfWeek constraint: simply add interval to fromDate
- * - If daysOfWeek constraint: add interval repeatedly until we land on a valid day
- *   This ensures the interval is respected while filtering by day of week
+ * - Uses startTimestamp as a phase anchor: next run = startTimestamp + N × interval
+ *   where N is the smallest integer such that the result is strictly after fromDate.
+ * - This prevents time-of-day drift after missed executions or restarts.
+ * - If no daysOfWeek constraint: return the phase-aligned next slot.
+ * - If daysOfWeek constraint: add interval repeatedly from the phase-aligned candidate
+ *   until we land on a valid day.
  *
  * @param schedule - Interval schedule configuration
- * @param fromDate - Starting date (default: now)
+ * @param fromDate - Threshold date: returned time must be strictly after this (default: now)
  * @param currentOccurrences - Current occurrence count (default: 0)
  * @returns ISO 8601 timestamp of next run, or null if no more occurrences
  *
@@ -188,14 +191,14 @@ export function calculateNextRun(
   if (!parsed) throw new Error(`Invalid interval: ${schedule.interval}`)
 
   const start = new Date(schedule.startTimestamp)
-  let next = new Date(fromDate)
+  let next: Date
 
-  // If we're before start, next run is start time
-  if (next < start) {
+  // If we're before start, next run is the start time itself
+  if (fromDate < start) {
     next = new Date(start)
   } else {
-    // Calculate next occurrence based on interval
-    next = addInterval(next, parsed)
+    // Phase-anchor: find the smallest N such that start + N × interval > fromDate
+    next = calculatePhaseAnchoredNext(start, parsed, fromDate)
   }
 
   // Check end conditions before searching for valid day
@@ -251,6 +254,53 @@ export function calculateNextRun(
   }
 
   return next.toISOString()
+}
+
+/**
+ * Compute the next phase-anchored occurrence strictly after fromDate.
+ *
+ * For uniform-duration units (min, h, d): uses arithmetic to jump directly to
+ * the correct N in O(1). For months (non-uniform): iterates forward from start.
+ *
+ * @param start - Phase anchor (startTimestamp)
+ * @param interval - Parsed interval
+ * @param fromDate - The result must be strictly after this date
+ * @returns Next occurrence strictly after fromDate
+ */
+function calculatePhaseAnchoredNext(start: Date, interval: ParsedInterval, fromDate: Date): Date {
+  if (interval.unit === 'M') {
+    // Months are non-uniform — iterate forward from start
+    let candidate = new Date(start)
+    while (candidate <= fromDate) {
+      candidate = addInterval(candidate, interval)
+    }
+    return candidate
+  }
+
+  // Uniform-duration units: compute N arithmetically
+  const intervalMs = intervalToMs(interval)
+  const diff = fromDate.getTime() - start.getTime()
+  // N is the smallest integer such that start + N * intervalMs > fromDate
+  const n = Math.floor(diff / intervalMs) + 1
+  const candidate = new Date(start.getTime() + n * intervalMs)
+  return candidate
+}
+
+/**
+ * Convert a parsed interval to milliseconds (only for uniform units: min, h, d).
+ * Months are not supported here — use addInterval iteratively instead.
+ */
+function intervalToMs(interval: ParsedInterval): number {
+  switch (interval.unit) {
+    case 'min':
+      return interval.value * 60 * 1000
+    case 'h':
+      return interval.value * 60 * 60 * 1000
+    case 'd':
+      return interval.value * 24 * 60 * 60 * 1000
+    default:
+      throw new Error(`intervalToMs does not support unit: ${interval.unit}`)
+  }
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,39 +599,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/agent/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/coday-events/dist:
-    dependencies:
-      tslib:
-        specifier: ^2.3.0
-        version: 2.8.1
-
   libs/coday-services:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/coday-services/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -651,42 +619,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/core/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/function:
-    dependencies:
-      '@vscode/ripgrep':
-        specifier: 'catalog:'
-        version: 1.15.9
-      glob:
-        specifier: 'catalog:'
-        version: 11.1.0
-      pdf2json:
-        specifier: 'catalog:'
-        version: 4.0.0
-      sharp:
-        specifier: 'catalog:'
-        version: 0.34.4
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      '@jest/globals':
-        specifier: catalog:dev
-        version: 30.2.0
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/function/dist:
     dependencies:
       '@vscode/ripgrep':
         specifier: 'catalog:'
@@ -730,36 +663,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handler/dist:
-    dependencies:
-      '@anthropic-ai/sdk':
-        specifier: 'catalog:'
-        version: 0.65.0(zod@4.3.6)
-      openai:
-        specifier: 'catalog:'
-        version: 6.16.0(ws@8.20.0)(zod@4.3.6)
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/config:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/handlers/config/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -779,16 +683,6 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/load/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/looper:
     dependencies:
       tslib:
@@ -799,27 +693,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/looper/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/memory:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/handlers/memory/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -842,19 +716,6 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/openai/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/stats:
     dependencies:
       tslib:
@@ -865,27 +726,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/stats/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integration:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integration/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -908,33 +749,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/ai/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/basecamp:
-    dependencies:
-      oauth4webapi:
-        specifier: 'catalog:'
-        version: 3.8.3
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/basecamp/dist:
     dependencies:
       oauth4webapi:
         specifier: 'catalog:'
@@ -966,36 +781,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/confluence/dist:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      turndown:
-        specifier: 'catalog:'
-        version: 7.2.2
-    devDependencies:
-      '@types/turndown':
-        specifier: catalog:dev
-        version: 5.0.6
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/file:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/file/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -1015,30 +801,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/git/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/gitlab:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/gitlab/dist:
     dependencies:
       axios:
         specifier: 'catalog:'
@@ -1067,36 +830,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/http/dist:
-    dependencies:
-      oauth4webapi:
-        specifier: 'catalog:'
-        version: 3.8.3
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/jira:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/jira/dist:
     dependencies:
       axios:
         specifier: 'catalog:'
@@ -1119,43 +853,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/slack/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/team/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/zendesk-articles:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/zendesk-articles/dist:
     dependencies:
       axios:
         specifier: 'catalog:'
@@ -1181,19 +879,6 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/mcp/dist:
-    dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: 'catalog:'
-        version: 1.23.1(zod@4.3.6)
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/model:
     dependencies:
       rxjs:
@@ -1207,33 +892,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/model/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/repository:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/repository/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -1262,46 +921,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/service/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/team/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/utils:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/utils/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -2419,7 +2039,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -5473,6 +5093,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -5674,6 +5295,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -6103,6 +5725,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -9807,7 +9430,6 @@ packages:
     resolution: {integrity: sha512-WkezNsLK8sGpuFC7+PPP0DsXROwdoOxmXPBTtUWWkCwCi/Vi97MRC52Ly6FWIJjOKIywpm/L2oaUgSrmtU+7ZQ==}
     engines: {node: '>=20.18.0'}
     hasBin: true
-    bundledDependencies: []
 
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
@@ -11628,7 +11250,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,21 @@ packages:
   - 'libs/*'
   - 'libs/**/*'
   - 'plugins/*'
+allowBuilds:
+  '@nestjs/core': set this to true or false
+  '@openapitools/openapi-generator-cli': set this to true or false
+  '@parcel/watcher': set this to true or false
+  '@swc/core': set this to true or false
+  '@vscode/ripgrep': set this to true or false
+  electron: set this to true or false
+  electron-winstaller: set this to true or false
+  esbuild: set this to true or false
+  less: set this to true or false
+  lmdb: set this to true or false
+  msgpackr-extract: set this to true or false
+  nx: set this to true or false
+  sharp: set this to true or false
+  unrs-resolver: set this to true or false
 catalog:
   '@angular/animations': '21.2.6'
   '@angular/cdk': '21.2.4'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,21 +4,6 @@ packages:
   - 'libs/*'
   - 'libs/**/*'
   - 'plugins/*'
-allowBuilds:
-  '@nestjs/core': set this to true or false
-  '@openapitools/openapi-generator-cli': set this to true or false
-  '@parcel/watcher': set this to true or false
-  '@swc/core': set this to true or false
-  '@vscode/ripgrep': set this to true or false
-  electron: set this to true or false
-  electron-winstaller: set this to true or false
-  esbuild: set this to true or false
-  less: set this to true or false
-  lmdb: set this to true or false
-  msgpackr-extract: set this to true or false
-  nx: set this to true or false
-  sharp: set this to true or false
-  unrs-resolver: set this to true or false
 catalog:
   '@angular/animations': '21.2.6'
   '@angular/cdk': '21.2.4'


### PR DESCRIPTION
Fixes #942

## Problem

`calculateNextRun()` computed the next run as `fromDate + 1 × interval`, where `fromDate` was typically `new Date()`. This meant that if Coday was restarted at 11 PM after being down all day, a "daily at 8:30 AM" scheduler would schedule its next run for 11 PM the next day — permanently losing the 8:30 AM anchor.

## Fix

Rewrote `calculateNextRun()` to use `startTimestamp` as a **phase anchor**. The next occurrence is now computed as `startTimestamp + N × interval` (smallest N such that the result is strictly after `fromDate`).

- **Minutes, hours, days** (uniform duration): N computed arithmetically in O(1)
- **Months** (non-uniform): iterates forward from startTimestamp (bounded, fast)
- **daysOfWeek filtering**: unchanged — still iterates forward from the candidate

Also simplified `calculateNextRunSkippingMissed()` in `SchedulerService` from an iterative loop to a single `calculateNextRun()` call, since the phase-anchored function now directly returns the correct next slot.

## Files changed

- `libs/utils/src/lib/interval-schedule.utils.ts` — core fix
- `libs/utils/src/lib/interval-schedule.utils.test.ts` — added phase-stability tests
- `libs/service/src/lib/scheduler.service.ts` — simplified `calculateNextRunSkippingMissed()`

## Tests

- 85 tests pass (6 suites), lint clean on both utils and service