### PR TITLE
fix(ci): serialize release runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   NPM_CONFIG_PROVENANCE: true
   NX_MAX_WORKERS: 4


### PR DESCRIPTION
## What

Add `concurrency` group to `release.yml` to ensure only one release runs at a time — subsequent triggers queue and wait instead of running in parallel.

## Why

Two PRs merging close together triggered simultaneous release runs. Each resolved the same base tag, produced conflicting versions, and the second push overwrote the first — leaving `0.169.0` orphaned on master.

Closes #949