### PR TITLE
fix(agentos-service): fix MockK ClassCastException by passing withRemoved=false in findById stubs

### DIFF
--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -244,7 +244,10 @@ tasks.withType<Test> {
     // rejected with HTTP 400. Force a supported version until Testcontainers
     // is upgraded to 2.x (which ships docker-java 3.7+ defaulting to 1.44).
     systemProperty("api.version", "1.44")
-    // Emit full exception details for MockK/classloader failures in CI.
+    // Disable JVM fast-throw optimisation so MockK can read the ClassCastException
+    // message and auto-hint the correct type for mocked calls.
+    jvmArgs("-XX:-OmitStackTraceInFastThrow")
+    // Emit full exception details in CI logs.
     // Remove once the root cause of ClassCastException is confirmed.
     testLogging {
         showExceptions = true

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -247,14 +247,6 @@ tasks.withType<Test> {
     // Disable JVM fast-throw optimisation so MockK can read the ClassCastException
     // message and auto-hint the correct type for mocked calls.
     jvmArgs("-XX:-OmitStackTraceInFastThrow")
-    // Emit full exception details in CI logs.
-    // Remove once the root cause of ClassCastException is confirmed.
-    testLogging {
-        showExceptions = true
-        showCauses = true
-        showStackTraces = true
-        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-    }
 }
 
 // Neo4j 2026.x ships org.neo4j:neo4j-slf4j-provider which registers SLF4JLogBridge

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -244,6 +244,14 @@ tasks.withType<Test> {
     // rejected with HTTP 400. Force a supported version until Testcontainers
     // is upgraded to 2.x (which ships docker-java 3.7+ defaulting to 1.44).
     systemProperty("api.version", "1.44")
+    // Emit full exception details for MockK/classloader failures in CI.
+    // Remove once the root cause of ClassCastException is confirmed.
+    testLogging {
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
 }
 
 // Neo4j 2026.x ships org.neo4j:neo4j-slf4j-provider which registers SLF4JLogBridge

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpointsSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespacePermissionEndpointsSpec.kt
@@ -67,8 +67,8 @@ class NamespacePermissionEndpointsSpec :
             )
 
         fun stubExistence() {
-            every { namespaceService.findById(namespaceId) } returns namespace
-            every { userService.findById(targetUserId) } returns target
+            every { namespaceService.findById(namespaceId, false) } returns namespace
+            every { userService.findById(targetUserId, false) } returns target
             every { userService.getCurrentUser() } returns caller
         }
 
@@ -95,15 +95,15 @@ class NamespacePermissionEndpointsSpec :
         }
 
         "grantAdmin returns 404 when namespace not found" {
-            every { namespaceService.findById(namespaceId) } returns null
+            every { namespaceService.findById(namespaceId, false) } returns null
 
             shouldThrow<ResourceNotFoundException> { controller.grantAdmin(namespaceId, targetUserId) }
             verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
         }
 
         "grantAdmin returns 404 when target user not found" {
-            every { namespaceService.findById(namespaceId) } returns namespace
-            every { userService.findById(targetUserId) } returns null
+            every { namespaceService.findById(namespaceId, false) } returns namespace
+            every { userService.findById(targetUserId, false) } returns null
 
             shouldThrow<ResourceNotFoundException> { controller.grantAdmin(namespaceId, targetUserId) }
             verify(exactly = 0) { permissionService.grantPermission(any(), any(), any(), any()) }
@@ -140,7 +140,7 @@ class NamespacePermissionEndpointsSpec :
         }
 
         "revokeAdmin returns 404 when namespace not found" {
-            every { namespaceService.findById(namespaceId) } returns null
+            every { namespaceService.findById(namespaceId, false) } returns null
 
             shouldThrow<ResourceNotFoundException> { controller.revokeAdmin(namespaceId, targetUserId) }
         }
@@ -175,8 +175,8 @@ class NamespacePermissionEndpointsSpec :
         }
 
         "grantMember returns 404 when target user not found" {
-            every { namespaceService.findById(namespaceId) } returns namespace
-            every { userService.findById(targetUserId) } returns null
+            every { namespaceService.findById(namespaceId, false) } returns namespace
+            every { userService.findById(targetUserId, false) } returns null
 
             shouldThrow<ResourceNotFoundException> { controller.grantMember(namespaceId, targetUserId) }
         }
@@ -224,7 +224,7 @@ class NamespacePermissionEndpointsSpec :
         // -------------------------------------------------------------------------
 
         "listNamespaceUsers returns list with ADMIN/MEMBER roles" {
-            every { namespaceService.findById(namespaceId) } returns namespace
+            every { namespaceService.findById(namespaceId, false) } returns namespace
             val adminId = UUID.randomUUID()
             val memberId = UUID.randomUUID()
             val adminUser = User(metadata = EntityMetadata(id = adminId), externalId = "a", email = "a")
@@ -252,7 +252,7 @@ class NamespacePermissionEndpointsSpec :
         }
 
         "listNamespaceUsers deduplicates users with both ADMIN and MEMBER (role=ADMIN)" {
-            every { namespaceService.findById(namespaceId) } returns namespace
+            every { namespaceService.findById(namespaceId, false) } returns namespace
             val dualId = UUID.randomUUID()
             val dualUser = User(metadata = EntityMetadata(id = dualId), externalId = "d", email = "d")
             every {
@@ -279,7 +279,7 @@ class NamespacePermissionEndpointsSpec :
         }
 
         "listNamespaceUsers returns empty list when no user has a direct relation" {
-            every { namespaceService.findById(namespaceId) } returns namespace
+            every { namespaceService.findById(namespaceId, false) } returns namespace
             every {
                 permissionService.listUsersWithPermission(
                     EntityType.NAMESPACE,
@@ -299,7 +299,7 @@ class NamespacePermissionEndpointsSpec :
         }
 
         "listNamespaceUsers returns 404 when namespace not found" {
-            every { namespaceService.findById(namespaceId) } returns null
+            every { namespaceService.findById(namespaceId, false) } returns null
 
             shouldThrow<ResourceNotFoundException> { controller.listNamespaceUsers(namespaceId) }
         }


### PR DESCRIPTION
Fix MockK ClassCastException in NamespacePermissionEndpointsSpec

`EntityService.findById` has a default parameter (`withRemoved: Boolean = false`).
MockK's proxy intercepts the wrong JVM method when the single-arg form is used,
causing `ClassCastException` at stub setup time.

Fix: pass `false` explicitly in all `findById` stubs in the test.