### PR TITLE
fix: #wz-32400 tool parameter generation output in XML

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -280,6 +280,7 @@ class AgentAdvanced(
                 namespaceId = namespaceId,
                 caseId = caseId,
                 toolRequestId = toolRequestId,
+                emitEvent = emitEvent,
             )
         emitEvent(parameters)
         accumulatedEvents.add(parameters)
@@ -913,6 +914,7 @@ class AgentAdvanced(
         namespaceId: UUID,
         caseId: UUID,
         toolRequestId: String,
+        emitEvent: suspend (CaseEvent) -> Unit,
     ): ToolRequestEvent {
         val tool =
             context.tools.firstOrNull { it.name == intentionEvent.toolName }
@@ -937,32 +939,42 @@ Generate the parameters for the tool call below. You must generate a JSON object
 
 Tool: ${tool.name}
 Description: ${tool.description}
-Input JSON Schema: 
+Input JSON Schema:
 ```
 ${tool.inputSchema}
 ```
 
 Intention: ${intentionEvent.intention}$enrichmentBlock
 
-**Generate ONLY the JSON object matching the input schema above. No explanation, no markdown fences.**
+Output requirements:
+- Wrap the JSON object in <parameter> tags: <parameter>{ ... }</parameter>
+- Inside the tags, start your response with `{` and end it with `}`.
+- Do not emit any text, whitespace, or tokens before `{` or after `}` inside the tags.
+- Do not use XML, tool-call wrappers, function tags, markdown, code fences, or any structural syntax other than JSON.
+- Do not include comments, explanations, or reasoning.
+- Only include properties defined in the schema.
             """.trimIndent()
         val accumulatedEventsWithoutCurrentToolCall = accumulatedEvents.dropLast(1)
 
         logger.debug { "[$name] generateParameters for '${tool.name}'" }
         logger.trace { "[$name] generateParameters prompt:\n$basePrompt" }
 
-        return retryWithFallback<String, ToolRequestEvent>(
+        val result = retryWithFallback<String, ToolRequestEvent>(
             maxAttempts = MAX_PARAMETER_ATTEMPTS,
             fallback = { lastRaw ->
                 logger.error {
-                    "[$name] generateParameters: all $MAX_PARAMETER_ATTEMPTS attempts produced invalid JSON for '${tool.name}'. Falling back to last raw result."
+                    "[$name] generateParameters: all $MAX_PARAMETER_ATTEMPTS attempts produced invalid JSON for '${tool.name}'. Last raw: $lastRaw"
                 }
+                // Do NOT pass the invalid output to the tool — it would cause a server-side
+                // error (e.g. HTTP 500) instead of a clean failure the agent can reason about.
+                // args=null signals the failure; the WarnEvent is emitted below after returning
+                // from retryWithFallback (fallback lambda is not suspend).
                 ToolRequestEvent(
                     namespaceId = namespaceId,
                     caseId = caseId,
                     toolRequestId = toolRequestId,
                     toolName = tool.name,
-                    args = lastRaw,
+                    args = null,
                 )
             },
         ) { previousRaw ->
@@ -976,6 +988,15 @@ Intention: ${intentionEvent.intention}$enrichmentBlock
                 previousRaw = previousRaw,
             )
         }
+
+        // args=null means all retries were exhausted — emit a WarnEvent so the failure
+        // is visible in the case event stream (cannot be done inside the non-suspend fallback).
+        if (result.args == null) {
+            val message = "Failed to generate valid JSON parameters for '${tool.name}' after $MAX_PARAMETER_ATTEMPTS attempts."
+            emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = message))
+        }
+
+        return result
     }
 
     private fun attemptParameterGeneration(
@@ -1092,12 +1113,22 @@ Intention: ${intentionEvent.intention}
         return previousContent
     }
 
+    /**
+     * Strips formatting wrappers around a JSON payload, in priority order:
+     * 1. `<parameter>...</parameter>` tags — the canonical format requested in the prompt
+     * 2. Markdown code fences ` ```json ... ``` ` — tolerated as a fallback
+     * 3. Raw string — last resort if neither wrapper is present
+     */
     private fun stripJsonFence(raw: String): String =
-        JSON_FENCE_REGEX
-            .matchEntire(raw)
+        PARAMETER_TAG_REGEX.find(raw)
             ?.groupValues
             ?.get(1)
-            ?.trim() ?: raw
+            ?.trim()
+            ?: JSON_FENCE_REGEX.matchEntire(raw)
+                ?.groupValues
+                ?.get(1)
+                ?.trim()
+            ?: raw
 
     private suspend fun executeTool(
         toolRequest: ToolRequestEvent,
@@ -1174,6 +1205,16 @@ Intention: ${intentionEvent.intention}
         /** How many identical (toolName, args) calls within the window trigger a warning. */
         internal const val REPETITION_THRESHOLD = 3
         internal const val MAX_PARAMETER_ATTEMPTS = 3
+
+        /**
+         * Matches JSON content inside `<parameter>...</parameter>` tags.
+         * This is the canonical output format requested in the parameter generation prompt.
+         */
+        private val PARAMETER_TAG_REGEX =
+            Regex(
+                """<parameter>\s*(.*?)\s*</parameter>""",
+                setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE),
+            )
 
         private val JSON_FENCE_REGEX =
             Regex(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -1529,7 +1529,80 @@ class AgentAdvancedSpec :
             events.filterIsInstance<WarnEvent>().filter { it.message.contains("all") && it.message.contains("attempts") } shouldHaveSize 0
         }
 
-        "generateParameters: falls back to last raw result when all retries fail" {
+        "generateParameters: extracts JSON from canonical <parameter> tags on first attempt" {
+            // The prompt now asks the LLM to wrap its output in <parameter>...</parameter>.
+            // stripJsonFence must extract the content on the first attempt with no retry.
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            val mockTool = mockk<StandardTool<String>>(relaxed = true)
+            every { mockTool.name } returns "ReadEntities"
+            every { mockTool.description } returns "Read entities by id"
+            every { mockTool.inputSchema } returns """{"type":"object","properties":{"entitiesId":{"type":"array","items":{"type":"string"}}}}"""
+            every { mockTool.paramType } returns String::class.java
+            every { mockTool.confirmationMode } returns ConfirmationMode.NONE
+            coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("entity data")
+
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            every { mockStreamSpec.content() } returns Flux.just("done")
+
+            // LLM correctly wraps JSON in <parameter> tags as instructed
+            val response = """<parameter>{"entitiesId":["6790ca2213906f27c141a80b","698c66db04182c7fb1dbd119"]}</parameter>"""
+            every { mockChatClient.prompt(any<Prompt>()).call().content() } returns response
+
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every { mockGenerator.generate(any(), any(), any(), any(), any()) } returnsMany
+                listOf(
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "Read the entity profiles.",
+                        toolName = "ReadEntities",
+                    ),
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "Done.",
+                        toolName = "Answer",
+                    ),
+                )
+
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = listOf(mockTool),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "TestAgent",
+                    context = context,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 5,
+                )
+
+            val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
+
+            // JSON was extracted from the <parameter> tags and passed to the tool
+            val toolRequests = events.filterIsInstance<ToolRequestEvent>()
+            toolRequests shouldHaveSize 1
+            toolRequests[0].args shouldContain "6790ca2213906f27c141a80b"
+            toolRequests[0].args shouldContain "698c66db04182c7fb1dbd119"
+            // No retry: extraction succeeded on the first attempt
+            events.filterIsInstance<WarnEvent>().filter { it.message.contains("invalid JSON") } shouldHaveSize 0
+            events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
+        }
+
+        "generateParameters: falls back to null args when all retries produce invalid JSON" {
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
             val agentId = UUID.randomUUID()
@@ -1590,12 +1663,16 @@ class AgentAdvancedSpec :
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
-            // Tool was still called with the last (invalid) raw result — degraded but non-blocking
+            // args must be null — passing invalid output to the tool would cause a server-side
+            // error (HTTP 500) instead of a clean failure the LLM can reason about.
             val toolRequests = events.filterIsInstance<ToolRequestEvent>()
             toolRequests shouldHaveSize 1
-            // The args should be the last raw value returned by the LLM
-            toolRequests[0].args shouldBe "not json attempt ${AgentAdvanced.MAX_PARAMETER_ATTEMPTS}"
-            // Agent completed its run (no crash)
+            toolRequests[0].args shouldBe null
+            // A WarnEvent must be emitted so the failure is visible in the case event stream
+            val warns = events.filterIsInstance<WarnEvent>().filter { it.message.contains("TEST__tool") }
+            warns shouldHaveSize 1
+            warns[0].message shouldContain "Failed to generate valid JSON parameters"
+            // The loop continues — the LLM sees the failure and can adapt
             events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
         }
 


### PR DESCRIPTION
## Problem

Some LLMs produce XML tool-call wrappers (`<tool_call><function=...><parameter=...>`) instead of raw JSON when asked to generate tool parameters. The previous fallback passed the invalid output directly to `tool.executeWithJson()`, causing HTTP 500 errors server-side.

## Changes

**Prompt improvement** (`generateParameters`):
- Switched from a negative instruction ("no markdown fences") to a positive format: the LLM is asked to wrap its JSON in `<parameter>...</parameter>` tags
- Added explicit output rules forbidding XML, tool-call wrappers, markdown fences, and extra text

**`stripJsonFence` extraction order:**
1. `<parameter>...</parameter>` — canonical format requested by the prompt
2. Markdown code fences ` ```json...``` ` — tolerated fallback
3. Raw string — last resort

**Fallback behaviour when all retries produce invalid JSON:**
- `args = null` instead of passing the invalid blob to the tool (avoids HTTP 500)
- `WarnEvent` emitted so the failure is visible in the case event stream
- Loop continues — the LLM sees `ToolResponseEvent(success=false)` and can adapt

**Tests added:**
- `<parameter>` tag extraction succeeds on first attempt
- XML tool-call output falls through retries → `args=null` + `WarnEvent`
- All retries exhausted → `args=null` + `WarnEvent`