### PR TITLE
feat(entity): expose withRemoved on POST /by-ids and removed field on CaseResource

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/aiProvider/AiProviderController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/aiProvider/AiProviderController.kt
@@ -3,6 +3,7 @@ package io.whozoss.agentos.aiProvider
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.whozoss.agentos.entity.EntityController
+import io.whozoss.agentos.entity.GetByIdsRequest
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.permissions.Action
@@ -167,8 +168,8 @@ class AiProviderController(
         produces = [MediaType.APPLICATION_JSON_VALUE],
     )
     @PreAuthorize("isAuthenticated()")
-    override fun getByIds(@RequestBody ids: List<UUID>): List<AiProviderResource> {
-
+    override fun getByIds(@RequestBody request: GetByIdsRequest): List<AiProviderResource> {
+        val ids = request.ids
         if (ids.isEmpty()) return emptyList()
 
         val currentUser = userService.getCurrentUser()
@@ -187,7 +188,7 @@ class AiProviderController(
         // Single DB fetch for all candidate rows ; filter for visibility via membership OR ownership.
         // Bounded by input size so the cost stays O(ids.size), not O(user's overlays).
         val callerId = currentUser.id
-        val rows = aiProviderService.findByIds(ids)
+        val rows = aiProviderService.findByIds(ids, request.withRemoved)
         val byId: Map<UUID, AiProvider> = rows
             .filter { it.metadata.id in membershipVisibleIds || it.userId == callerId }
             .associateBy { it.metadata.id }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -60,6 +60,7 @@ class CaseController(
             status = entity.status,
             title = entity.title,
             created = entity.metadata.created,
+            removed = entity.metadata.removed,
         )
 
     override fun toDomain(resource: CaseResource): Case {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseResource.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseResource.kt
@@ -20,4 +20,5 @@ data class CaseResource(
     val status: CaseStatus = CaseStatus.PENDING,
     val title: String? = null,
     val created: Instant? = null,
+    val removed: Boolean = false,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/entity/EntityController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/entity/EntityController.kt
@@ -110,6 +110,9 @@ abstract class EntityController<E : Entity, ParentIdentifier, ResourceType>(
      * the input order and duplicates so clients that index on request position keep working.
      *
      * Capped at [MAX_BATCH_SIZE] ids to prevent DoS via unbounded requests.
+     *
+     * @param request Wrapper containing the list of IDs and an optional [GetByIdsRequest.withRemoved]
+     *   flag. When false (default), soft-deleted entities are excluded from the result.
      */
     @PostMapping(
         "/by-ids",
@@ -118,8 +121,9 @@ abstract class EntityController<E : Entity, ParentIdentifier, ResourceType>(
     )
     @PreAuthorize("isAuthenticated()")
     open fun getByIds(
-        @RequestBody ids: List<UUID>,
+        @RequestBody request: GetByIdsRequest,
     ): List<ResourceType> {
+        val ids = request.ids
         // Runtime size cap. We deliberately do NOT use Bean Validation `@Size` here :
         // `@Size` on a `@RequestBody` parameter only fires when the controller class
         // is annotated `@Validated` (Spring), and its violation maps by default to
@@ -155,7 +159,7 @@ abstract class EntityController<E : Entity, ParentIdentifier, ResourceType>(
         if (visibleIds.isEmpty()) return emptyList()
 
         // Preserve input order and duplicates : look up each input id in the entity map.
-        val entityById = service.findByIds(visibleIds).associateBy { it.metadata.id }
+        val entityById = service.findByIds(visibleIds, request.withRemoved).associateBy { it.metadata.id }
         return ids.mapNotNull { id -> entityById[id]?.let(::toResource) }
     }
 
@@ -224,3 +228,14 @@ abstract class EntityController<E : Entity, ParentIdentifier, ResourceType>(
         const val MAX_BATCH_SIZE = 1000
     }
 }
+
+/**
+ * Request body for `POST /by-ids`.
+ *
+ * @param ids List of entity UUIDs to fetch.
+ * @param withRemoved when true, soft-deleted entities are included in the result.
+ */
+data class GetByIdsRequest(
+    val ids: List<UUID>,
+    val withRemoved: Boolean = false,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
@@ -3,6 +3,7 @@ package io.whozoss.agentos.integrationConfig
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.whozoss.agentos.entity.EntityController
+import io.whozoss.agentos.entity.GetByIdsRequest
 import io.whozoss.agentos.exception.BadRequestException
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.namespace.NamespaceService
@@ -150,7 +151,8 @@ class IntegrationConfigController(
         produces = [MediaType.APPLICATION_JSON_VALUE],
     )
     @PreAuthorize("isAuthenticated()")
-    override fun getByIds(@RequestBody ids: List<UUID>): List<IntegrationConfigResource> {
+    override fun getByIds(@RequestBody request: GetByIdsRequest): List<IntegrationConfigResource> {
+        val ids = request.ids
         if (ids.isEmpty()) return emptyList()
 
         val currentUser = userService.getCurrentUser()
@@ -167,7 +169,7 @@ class IntegrationConfigController(
         }
 
         val callerId = currentUser.id
-        val rows = integrationConfigService.findByIds(ids)
+        val rows = integrationConfigService.findByIds(ids, request.withRemoved)
         val byId: Map<UUID, IntegrationConfig> = rows
             .filter { it.id in membershipVisibleIds || it.userId == callerId }
             .associateBy { it.id }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.user
 
 import io.swagger.v3.oas.annotations.Operation
 import io.whozoss.agentos.entity.EntityController
+import io.whozoss.agentos.entity.GetByIdsRequest
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.permissions.Action
 import io.whozoss.agentos.permissions.EntityType
@@ -101,8 +102,9 @@ class UserController(
     @PostMapping("/by-ids")
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     override fun getByIds(
-        @RequestBody ids: List<UUID>,
+        @RequestBody request: GetByIdsRequest,
     ): List<UserResource> {
+        val ids = request.ids
         if (ids.size > EntityController.MAX_BATCH_SIZE) {
             throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
@@ -110,7 +112,7 @@ class UserController(
             )
         }
         if (ids.isEmpty()) return emptyList()
-        return userService.findByIds(ids).map(::toResource)
+        return userService.findByIds(ids, request.withRemoved).map(::toResource)
     }
 
     @PostMapping

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerIntegrationSpec.kt
@@ -222,7 +222,7 @@ class AgentConfigControllerIntegrationSpec : StringSpec() {
             mockMvc.perform(
                 post("/api/agent-configs/by-ids")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""["${a.id}", "${b.id}"]"""),
+                    .content("""{ "ids": ["${a.id}", "${b.id}"] }"""),
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize<Any>(2)))
@@ -232,7 +232,7 @@ class AgentConfigControllerIntegrationSpec : StringSpec() {
             mockMvc.perform(
                 post("/api/agent-configs/by-ids")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""[]"""),
+                    .content("""{ "ids": [] }"""),
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize<Any>(0)))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerUnitSpec.kt
@@ -19,6 +19,7 @@ import io.whozoss.agentos.sdk.aiProvider.AiProvider
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.user.User
+import io.whozoss.agentos.entity.GetByIdsRequest
 import io.whozoss.agentos.user.UserService
 import java.util.UUID
 
@@ -310,9 +311,9 @@ class AgentConfigControllerUnitSpec : StringSpec({
         val c1 = config(name = "agent-a")
         val c2 = config(name = "agent-b")
         every { userService.getCurrentUser() } returns superAdmin
-        every { service.findByIds(setOf(c1.id, c2.id)) } returns listOf(c1, c2)
+        every { service.findByIds(setOf(c1.id, c2.id), false) } returns listOf(c1, c2)
 
-        val result = controller.getByIds(listOf(c1.id, c2.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(c1.id, c2.id)))
 
         result shouldBe listOf(controller.toResource(c1), controller.toResource(c2))
     }
@@ -326,9 +327,9 @@ class AgentConfigControllerUnitSpec : StringSpec({
                 callerId.toString(), EntityType.AGENT_CONFIG, listOf(c1.id.toString(), c2.id.toString()), Action.READ,
             )
         } returns setOf(c1.id.toString())
-        every { service.findByIds(setOf(c1.id)) } returns listOf(c1)
+        every { service.findByIds(setOf(c1.id), false) } returns listOf(c1)
 
-        val result = controller.getByIds(listOf(c1.id, c2.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(c1.id, c2.id)))
 
         result shouldBe listOf(controller.toResource(c1))
     }
@@ -340,11 +341,11 @@ class AgentConfigControllerUnitSpec : StringSpec({
             permissionService.filterVisibleIds(any(), any(), any(), any())
         } returns emptySet()
 
-        controller.getByIds(listOf(c1.id)) shouldBe emptyList()
+        controller.getByIds(GetByIdsRequest(ids = listOf(c1.id))) shouldBe emptyList()
     }
 
     "getByIds short-circuits to empty list on empty input WITHOUT touching userService or permissionService" {
-        controller.getByIds(emptyList()) shouldBe emptyList()
+        controller.getByIds(GetByIdsRequest(ids = emptyList())) shouldBe emptyList()
         verify(exactly = 0) { userService.getCurrentUser() }
         verify(exactly = 0) { permissionService.filterVisibleIds(any(), any(), any(), any()) }
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/entity/EntityControllerBatchSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/entity/EntityControllerBatchSpec.kt
@@ -59,19 +59,19 @@ class EntityControllerBatchSpec : StringSpec({
     beforeTest { clearAllMocks() }
 
     "getByIds short-circuits to empty list on empty input WITHOUT calling userService or permissionService" {
-        controller.getByIds(emptyList()) shouldBe emptyList()
+        controller.getByIds(GetByIdsRequest(ids = emptyList())) shouldBe emptyList()
         verify(exactly = 0) { userService.getCurrentUser() }
         verify(exactly = 0) { permissionService.filterVisibleIds(any(), any(), any(), any()) }
-        verify(exactly = 0) { service.findByIds(any()) }
+        verify(exactly = 0) { service.findByIds(any(), any()) }
     }
 
     "getByIds returns all matching entities for a super-admin caller (admin bypass — no permissionService call)" {
         val a = entity(tag = "alpha")
         val b = entity(tag = "beta")
         every { userService.getCurrentUser() } returns superAdmin
-        every { service.findByIds(setOf(a.id, b.id)) } returns listOf(a, b)
+        every { service.findByIds(setOf(a.id, b.id), false) } returns listOf(a, b)
 
-        val result = controller.getByIds(listOf(a.id, b.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(a.id, b.id)))
 
         result.map { it.tag } shouldContainExactly listOf("alpha", "beta")
         verify(exactly = 0) { permissionService.filterVisibleIds(any(), any(), any(), any()) }
@@ -86,9 +86,9 @@ class EntityControllerBatchSpec : StringSpec({
                 callerId.toString(), EntityType.AGENT_CONFIG, listOf(a.id.toString(), b.id.toString()), Action.READ,
             )
         } returns setOf(a.id.toString())
-        every { service.findByIds(setOf(a.id)) } returns listOf(a)
+        every { service.findByIds(setOf(a.id), false) } returns listOf(a)
 
-        val result = controller.getByIds(listOf(a.id, b.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(a.id, b.id)))
 
         result.map { it.tag } shouldContainExactly listOf("visible")
     }
@@ -100,16 +100,16 @@ class EntityControllerBatchSpec : StringSpec({
             permissionService.filterVisibleIds(any(), any(), any(), any())
         } returns emptySet()
 
-        controller.getByIds(listOf(a.id)) shouldBe emptyList()
-        verify(exactly = 0) { service.findByIds(any()) }
+        controller.getByIds(GetByIdsRequest(ids = listOf(a.id))) shouldBe emptyList()
+        verify(exactly = 0) { service.findByIds(any(), any()) }
     }
 
     "getByIds returns empty list when admin sees no matching entity (findByIds returns empty)" {
         val a = entity()
         every { userService.getCurrentUser() } returns superAdmin
-        every { service.findByIds(setOf(a.id)) } returns emptyList()
+        every { service.findByIds(setOf(a.id), false) } returns emptyList()
 
-        controller.getByIds(listOf(a.id)) shouldBe emptyList()
+        controller.getByIds(GetByIdsRequest(ids = listOf(a.id))) shouldBe emptyList()
     }
 
     "getByIds preserves input order" {
@@ -118,9 +118,9 @@ class EntityControllerBatchSpec : StringSpec({
         val c = entity(tag = "third")
         every { userService.getCurrentUser() } returns superAdmin
         // Service may return in any order — controller must reorder to match input.
-        every { service.findByIds(setOf(a.id, b.id, c.id)) } returns listOf(c, a, b)
+        every { service.findByIds(setOf(a.id, b.id, c.id), false) } returns listOf(c, a, b)
 
-        val result = controller.getByIds(listOf(a.id, b.id, c.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(a.id, b.id, c.id)))
 
         result.map { it.tag } shouldContainExactly listOf("first", "second", "third")
     }
@@ -128,10 +128,10 @@ class EntityControllerBatchSpec : StringSpec({
     "getByIds preserves duplicate input ids in the response" {
         val a = entity(tag = "dup")
         every { userService.getCurrentUser() } returns superAdmin
-        every { service.findByIds(setOf(a.id)) } returns listOf(a)
+        every { service.findByIds(setOf(a.id), false) } returns listOf(a)
 
         // Input has 3 copies of the same id ; output also has 3 copies.
-        val result = controller.getByIds(listOf(a.id, a.id, a.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(a.id, a.id, a.id)))
 
         result.size shouldBe 3
         result.all { it.tag == "dup" } shouldBe true
@@ -141,9 +141,9 @@ class EntityControllerBatchSpec : StringSpec({
         val a = entity(tag = "found")
         val missingId = UUID.randomUUID()
         every { userService.getCurrentUser() } returns superAdmin
-        every { service.findByIds(setOf(a.id, missingId)) } returns listOf(a)
+        every { service.findByIds(setOf(a.id, missingId), false) } returns listOf(a)
 
-        val result = controller.getByIds(listOf(a.id, missingId))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(a.id, missingId)))
 
         result.map { it.tag } shouldContainExactly listOf("found")
     }
@@ -151,20 +151,20 @@ class EntityControllerBatchSpec : StringSpec({
     "getByIds rejects oversized input batches with HTTP 400 (DoS protection)" {
         val oversizedIds = List(EntityController.MAX_BATCH_SIZE + 1) { UUID.randomUUID() }
 
-        val ex = shouldThrow<ResponseStatusException> { controller.getByIds(oversizedIds) }
+        val ex = shouldThrow<ResponseStatusException> { controller.getByIds(GetByIdsRequest(ids = oversizedIds)) }
 
         ex.statusCode shouldBe HttpStatus.BAD_REQUEST
         verify(exactly = 0) { userService.getCurrentUser() }
-        verify(exactly = 0) { service.findByIds(any()) }
+        verify(exactly = 0) { service.findByIds(any(), any()) }
     }
 
     "getByIds accepts exactly MAX_BATCH_SIZE input ids (boundary)" {
         val ids = List(EntityController.MAX_BATCH_SIZE) { UUID.randomUUID() }
         every { userService.getCurrentUser() } returns superAdmin
-        every { service.findByIds(ids.toSet()) } returns emptyList()
+        every { service.findByIds(ids.toSet(), false) } returns emptyList()
 
         // Should not throw — exactly at the cap is allowed.
-        controller.getByIds(ids) shouldBe emptyList()
+        controller.getByIds(GetByIdsRequest(ids = ids)) shouldBe emptyList()
     }
 
     "getByIds tolerates malformed UUIDs returned by permissionService (silent drop, fail-closed)" {
@@ -176,9 +176,9 @@ class EntityControllerBatchSpec : StringSpec({
         every {
             permissionService.filterVisibleIds(any(), any(), any(), any())
         } returns setOf(a.id.toString(), "not-a-uuid")
-        every { service.findByIds(setOf(a.id)) } returns listOf(a)
+        every { service.findByIds(setOf(a.id), false) } returns listOf(a)
 
-        val result = controller.getByIds(listOf(a.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(a.id)))
 
         result.map { it.tag } shouldContainExactly listOf("ok")
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/namespace/NamespaceControllerMvcIntegrationSpec.kt
@@ -214,7 +214,7 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
             mockMvc.perform(
                 post("/api/namespaces/by-ids")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""["${a.id}", "${b.id}"]"""),
+                    .content("""{ "ids": ["${a.id}", "${b.id}"] }"""),
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize<Any>(2)))
@@ -224,7 +224,7 @@ class NamespaceControllerMvcIntegrationSpec : StringSpec() {
             mockMvc.perform(
                 post("/api/namespaces/by-ids")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""[]"""),
+                    .content("""{ "ids": [] }"""),
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize<Any>(0)))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/user/UserControllerSpec.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.whozoss.agentos.entity.GetByIdsRequest
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.sdk.entity.EntityMetadata
@@ -204,9 +205,9 @@ class UserControllerSpec : StringSpec({
         val u1 = user(email = "a@x.com")
         val u2 = user(email = "b@x.com")
         every { userService.getCurrentUser() } returns adminUser
-        every { userService.findByIds(listOf(u1.id, u2.id)) } returns listOf(u1, u2)
+        every { userService.findByIds(listOf(u1.id, u2.id), false) } returns listOf(u1, u2)
 
-        val result = controller.getByIds(listOf(u1.id, u2.id))
+        val result = controller.getByIds(GetByIdsRequest(ids = listOf(u1.id, u2.id)))
 
         result shouldBe listOf(controller.toResource(u1), controller.toResource(u2))
     }

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -555,10 +555,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
-                format: uuid
+              $ref: "#/components/schemas/GetByIdsRequest"
         required: true
       responses:
         "200":
@@ -871,10 +868,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
-                format: uuid
+              $ref: "#/components/schemas/GetByIdsRequest"
         required: true
       responses:
         "200":
@@ -982,10 +976,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
-                format: uuid
+              $ref: "#/components/schemas/GetByIdsRequest"
         required: true
       responses:
         "200":
@@ -1094,10 +1085,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
-                format: uuid
+              $ref: "#/components/schemas/GetByIdsRequest"
         required: true
       responses:
         "200":
@@ -1223,10 +1211,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
-                format: uuid
+              $ref: "#/components/schemas/GetByIdsRequest"
         required: true
       responses:
         "200":
@@ -1264,10 +1249,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
-                format: uuid
+              $ref: "#/components/schemas/GetByIdsRequest"
         required: true
       responses:
         "200":
@@ -1325,10 +1307,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
-                format: uuid
+              $ref: "#/components/schemas/GetByIdsRequest"
         required: true
       responses:
         "200":
@@ -1883,8 +1862,11 @@ components:
         created:
           type: string
           format: date-time
+        removed:
+          type: boolean
       required:
       - namespaceId
+      - removed
       - status
     AiProvider:
       type: object
@@ -2003,6 +1985,19 @@ components:
       required:
       - id
       - name
+    GetByIdsRequest:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        withRemoved:
+          type: boolean
+      required:
+      - ids
+      - withRemoved
     UserGroupCreateRequest:
       type: object
       properties:


### PR DESCRIPTION
Exposes `withRemoved` filtering on `POST /by-ids` for all entity controllers and adds the `removed` field to `CaseResource`.

Closes #959