### PR TITLE
feat: add case plugin with ReadCaseTool

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CasePluginConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CasePluginConfiguration.kt
@@ -1,0 +1,38 @@
+package io.whozoss.agentos.casePlugin
+
+import io.whozoss.agentos.caseEvent.CaseEventService
+import io.whozoss.agentos.caseFlow.CaseRepository
+import io.whozoss.agentos.sdk.tool.ToolPlugin
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Spring configuration for the CASE internal integration.
+ *
+ * Declared in a dedicated `@Configuration` class (mirroring
+ * [io.whozoss.agentos.redirect.RedirectConfiguration]) to avoid a circular Spring
+ * dependency. Crucially, this class injects [CaseRepository] and [CaseEventService]
+ * directly rather than [io.whozoss.agentos.caseFlow.CaseService], because
+ * `CaseServiceImpl` depends on `AgentService` which depends on `ToolRegistryService`
+ * which collects all `ToolPlugin` beans — creating a cycle if `CaseService` were
+ * injected here.
+ *
+ * The [caseEventsLoader] lambda:
+ * 1. Loads the target [io.whozoss.agentos.caseFlow.Case] by id — returns null if absent.
+ * 2. Checks that the case's [namespaceId] matches the caller's namespace — returns null
+ *    if it does not (cross-namespace reads are not allowed).
+ * 3. Returns the ordered list of [io.whozoss.agentos.sdk.caseEvent.CaseEvent]s for the case.
+ */
+@Configuration
+class CasePluginConfiguration(
+    private val caseRepository: CaseRepository,
+    private val caseEventService: CaseEventService,
+) {
+    @Bean
+    fun caseToolPlugin(): ToolPlugin =
+        CaseToolPlugin { caseId, namespaceId ->
+            val case = caseRepository.findByIds(listOf(caseId)).firstOrNull() ?: return@CaseToolPlugin null
+            if (case.namespaceId != namespaceId) return@CaseToolPlugin null
+            caseEventService.findByParent(caseId)
+        }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CasePluginConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CasePluginConfiguration.kt
@@ -2,6 +2,9 @@ package io.whozoss.agentos.casePlugin
 
 import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.caseFlow.CaseRepository
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.EntityType
+import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.sdk.tool.ToolPlugin
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -21,18 +24,27 @@ import org.springframework.context.annotation.Configuration
  * 1. Loads the target [io.whozoss.agentos.caseFlow.Case] by id — returns null if absent.
  * 2. Checks that the case's [namespaceId] matches the caller's namespace — returns null
  *    if it does not (cross-namespace reads are not allowed).
- * 3. Returns the ordered list of [io.whozoss.agentos.sdk.caseEvent.CaseEvent]s for the case.
+ * 3. Verifies the user has READ permission on the target case via [PermissionService].
+ *    Returns null when [userId] is null (anonymous calls are not permitted) or when
+ *    permission is denied (fail-closed).
+ * 4. Returns the ordered list of [io.whozoss.agentos.sdk.caseEvent.CaseEvent]s for the case.
  */
 @Configuration
 class CasePluginConfiguration(
     private val caseRepository: CaseRepository,
     private val caseEventService: CaseEventService,
+    private val permissionService: PermissionService,
 ) {
     @Bean
     fun caseToolPlugin(): ToolPlugin =
-        CaseToolPlugin { caseId, namespaceId ->
+        CaseToolPlugin { caseId, namespaceId, userId ->
             val case = caseRepository.findByIds(listOf(caseId)).firstOrNull() ?: return@CaseToolPlugin null
             if (case.namespaceId != namespaceId) return@CaseToolPlugin null
+            if (userId == null ||
+                !permissionService.hasPermission(userId.toString(), EntityType.CASE, caseId.toString(), Action.READ)
+            ) {
+                return@CaseToolPlugin null
+            }
             caseEventService.findByParent(caseId)
         }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseToolPlugin.kt
@@ -1,0 +1,78 @@
+package io.whozoss.agentos.casePlugin
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolPlugin
+import mu.KLogging
+import java.util.UUID
+
+/**
+ * Internal Spring-managed [ToolPlugin] that provides the CASE integration.
+ *
+ * Like [io.whozoss.agentos.redirect.RedirectToolPlugin], this class is NOT annotated
+ * with `@Component` — it is instantiated as a `@Bean` in [CasePluginConfiguration]
+ * so that the [caseEventsLoader] lambda can be wired without a circular Spring
+ * dependency. [io.whozoss.agentos.tool.ToolRegistryService] collects it alongside
+ * PF4J-loaded plugins via `List<ToolPlugin>` constructor injection.
+ *
+ * An admin creates an [io.whozoss.agentos.integrationConfig.IntegrationConfig] of
+ * type `CASE` and assigns it to the relevant
+ * [io.whozoss.agentos.agentConfig.AgentConfig] via `integrations`. The tool is
+ * then available to that agent for reading other cases in the same namespace.
+ *
+ * @param caseEventsLoader Lambda injected by [CasePluginConfiguration] that loads
+ *   the events of a target case. Returns null when the case does not exist or when
+ *   its namespace does not match [namespaceId], enforcing namespace isolation.
+ */
+class CaseToolPlugin(
+    private val caseEventsLoader: (caseId: UUID, namespaceId: UUID) -> List<CaseEvent>?,
+) : ToolPlugin {
+
+    override val integrationType: String = INTEGRATION_TYPE
+    override val configSchema: JsonNode = CONFIG_SCHEMA
+
+    override fun provideTools(
+        config: JsonNode?,
+        configName: String?,
+        context: ToolContext?,
+    ): List<StandardTool<*>> {
+        val namespaceId = context?.namespaceId
+        if (namespaceId == null) {
+            logger.warn { "[CaseToolPlugin] No namespaceId in context, cannot provide ReadCaseTool" }
+            return emptyList()
+        }
+
+        val includesTechnicalEvents = config
+            ?.get("includesTechnicalEvents")
+            ?.asBoolean(true)
+            ?: true
+
+        return listOf(ReadCaseTool(configName, includesTechnicalEvents, caseEventsLoader))
+    }
+
+    companion object : KLogging() {
+        const val INTEGRATION_TYPE = "CASE"
+
+        val CONFIG_SCHEMA: JsonNode = jacksonObjectMapper().readTree(
+            """
+            {
+                "type": "object",
+                "title": "Case Plugin Configuration",
+                "description": "Allows an agent to read the transcript of another case in the same namespace.",
+                "properties": {
+                    "includesTechnicalEvents": {
+                        "type": "boolean",
+                        "title": "Include Technical Events",
+                        "description": "When true (default), the transcript includes all event types (tool calls, agent selections, status changes, etc.). When false, only conversational events are included (messages, questions, answers, warnings, errors).",
+                        "default": true
+                    }
+                },
+                "additionalProperties": false
+            }
+            """.trimIndent()
+        )
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseToolPlugin.kt
@@ -28,7 +28,7 @@ import java.util.UUID
  *   its namespace does not match [namespaceId], enforcing namespace isolation.
  */
 class CaseToolPlugin(
-    private val caseEventsLoader: (caseId: UUID, namespaceId: UUID) -> List<CaseEvent>?,
+    private val caseEventsLoader: (caseId: UUID, namespaceId: UUID, userId: UUID?) -> List<CaseEvent>?,
 ) : ToolPlugin {
 
     override val integrationType: String = INTEGRATION_TYPE
@@ -50,7 +50,14 @@ class CaseToolPlugin(
             ?.asBoolean(true)
             ?: true
 
-        return listOf(ReadCaseTool(configName, includesTechnicalEvents, caseEventsLoader))
+        val userId = context.userId
+        return listOf(
+            ReadCaseTool(
+                configName = configName,
+                includesTechnicalEvents = includesTechnicalEvents,
+                caseEventsLoader = { caseId, ns -> caseEventsLoader(caseId, ns, userId) },
+            ),
+        )
     }
 
     companion object : KLogging() {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatter.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatter.kt
@@ -1,0 +1,111 @@
+package io.whozoss.agentos.casePlugin
+
+import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
+import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
+import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
+import io.whozoss.agentos.sdk.caseEvent.ConfirmationResolvedEvent
+import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
+import io.whozoss.agentos.sdk.caseEvent.IntentionGeneratedEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.PendingConfirmationEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
+import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.WarnEvent
+
+/**
+ * Converts a list of [CaseEvent]s into a human-readable chronological transcript.
+ *
+ * Each line follows the format `[<ISO-8601 timestamp>] <TYPE>: <content>`.
+ *
+ * When [includesTechnicalEvents] is false only conversational events are emitted
+ * (messages, questions, answers, warnings and errors). When true all persisted event
+ * types are included. Transient events ([ThinkingEvent], [TextChunkEvent]) are never
+ * persisted so they never appear in the input list; they are handled here for safety
+ * by being silently ignored.
+ *
+ * [ToolResponseEvent.output] text is truncated to [TOOL_RESPONSE_MAX_CHARS] characters
+ * to avoid overwhelming the receiving LLM context window.
+ */
+object CaseTranscriptFormatter {
+
+    private const val TOOL_RESPONSE_MAX_CHARS = 2000
+    private const val TRUNCATION_SUFFIX = "... [truncated]"
+
+    fun format(events: List<CaseEvent>, includesTechnicalEvents: Boolean): String {
+        val lines = events.mapNotNull { event ->
+            val body = renderBody(event, includesTechnicalEvents) ?: return@mapNotNull null
+            "[${event.timestamp}] $body"
+        }
+        return lines.joinToString("\n")
+    }
+
+    private fun renderBody(event: CaseEvent, includesTechnicalEvents: Boolean): String? =
+        when (event) {
+            // ── Always-included conversational events ──────────────────────────────
+            is MessageEvent -> {
+                val role = event.actor.role.name
+                val text = event.content.joinToString(" ") { renderContent(it) }
+                "$role: $text"
+            }
+            is QuestionEvent -> {
+                val options = event.options
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.joinToString(", ")
+                    ?.let { " [options: $it]" }
+                    ?: ""
+                "QUESTION (${event.agentName}): ${event.question}$options"
+            }
+            is AnswerEvent -> "ANSWER: ${event.answer}"
+            is WarnEvent -> "WARN: ${event.message}"
+            is ErrorEvent -> "ERROR: ${event.message}"
+
+            // ── Technical events — only when includesTechnicalEvents == true ───────
+            is AgentSelectedEvent -> if (includesTechnicalEvents) "AGENT_SELECTED: ${event.agentName}" else null
+            is AgentRunningEvent -> if (includesTechnicalEvents) "AGENT_RUNNING: ${event.agentName}" else null
+            is AgentFinishedEvent -> if (includesTechnicalEvents) "AGENT_FINISHED: ${event.agentName}" else null
+            is CaseStatusEvent -> if (includesTechnicalEvents) "STATUS: ${event.status}" else null
+            is ToolRequestEvent -> if (includesTechnicalEvents) "TOOL_REQUEST: ${event.toolName} ${event.args ?: ""}" else null
+            is ToolResponseEvent -> {
+                if (!includesTechnicalEvents) return null
+                val status = if (event.success) "success" else "error"
+                val duration = event.durationMs?.let { "${it}ms" } ?: "?ms"
+                val raw = renderContent(event.output)
+                val text = if (raw.length > TOOL_RESPONSE_MAX_CHARS) {
+                    raw.take(TOOL_RESPONSE_MAX_CHARS) + TRUNCATION_SUFFIX
+                } else {
+                    raw
+                }
+                "TOOL_RESPONSE: [$status, $duration] $text"
+            }
+            is IntentionGeneratedEvent -> {
+                if (includesTechnicalEvents) "INTENTION (${event.agentId}): ${event.intention} → ${event.toolName}" else null
+            }
+            is ToolSelectedEvent -> {
+                if (includesTechnicalEvents) "TOOL_SELECTED (${event.agentId}): ${event.toolName}" else null
+            }
+            is PendingConfirmationEvent -> {
+                if (includesTechnicalEvents) "PENDING_CONFIRMATION: ${event.toolName} ${event.inputJson}" else null
+            }
+            is ConfirmationResolvedEvent -> {
+                if (includesTechnicalEvents) "CONFIRMATION_RESOLVED: confirmed=${event.confirmed} ${event.resultText}" else null
+            }
+
+            // ── Transient events — never persisted, silently ignored ───────────────
+            is ThinkingEvent -> null
+            is TextChunkEvent -> null
+        }
+
+    private fun renderContent(content: MessageContent): String =
+        when (content) {
+            is MessageContent.Text -> content.content
+            is MessageContent.Image -> "[image]"
+        }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/ReadCaseTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/ReadCaseTool.kt
@@ -32,36 +32,31 @@ class ReadCaseTool(
     override val paramType: Class<Input> = Input::class.java
     override val inputSchema: String = INPUT_SCHEMA
 
-    override suspend fun execute(input: Input?, context: ToolContext): ToolExecutionResult {
-        if (input == null) {
-            return ToolExecutionResult.error(
+    override suspend fun execute(input: Input?, context: ToolContext): ToolExecutionResult =
+        when (input) {
+            null -> ToolExecutionResult.error(
                 output = "Missing required parameter: caseId",
                 errorType = "INVALID_INPUT",
             )
+            else -> when (val targetCaseId = runCatching { UUID.fromString(input.caseId) }.getOrNull()) {
+                null -> ToolExecutionResult.error(
+                    output = "Invalid caseId '${input.caseId}': must be a valid UUID",
+                    errorType = "INVALID_INPUT",
+                )
+                else -> when (val events = caseEventsLoader(targetCaseId, context.namespaceId)) {
+                    null -> ToolExecutionResult.error(
+                        output = "Case '${input.caseId}' not found or is not accessible in this namespace",
+                        errorType = "NOT_FOUND",
+                    )
+                    else -> when {
+                        events.isEmpty() -> ToolExecutionResult.success("Case has no events")
+                        else -> ToolExecutionResult.success(
+                            CaseTranscriptFormatter.format(events, includesTechnicalEvents)
+                        )
+                    }
+                }
+            }
         }
-
-        val targetCaseId = try {
-            UUID.fromString(input.caseId)
-        } catch (e: IllegalArgumentException) {
-            return ToolExecutionResult.error(
-                output = "Invalid caseId '${input.caseId}': must be a valid UUID",
-                errorType = "INVALID_INPUT",
-            )
-        }
-
-        val events = caseEventsLoader(targetCaseId, context.namespaceId)
-            ?: return ToolExecutionResult.error(
-                output = "Case '${input.caseId}' not found or is not accessible in this namespace",
-                errorType = "NOT_FOUND",
-            )
-
-        if (events.isEmpty()) {
-            return ToolExecutionResult.success("Case has no events")
-        }
-
-        val transcript = CaseTranscriptFormatter.format(events, includesTechnicalEvents)
-        return ToolExecutionResult.success(transcript)
-    }
 
     companion object {
         private const val INTEGRATION_TYPE = "CASE"

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/ReadCaseTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/ReadCaseTool.kt
@@ -1,0 +1,87 @@
+package io.whozoss.agentos.casePlugin
+
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import java.util.UUID
+
+/**
+ * Tool that reads the full event transcript of another [Case] in the same namespace.
+ *
+ * The LLM passes a [caseId] string (UUID format). The tool delegates to [caseEventsLoader]
+ * which enforces namespace isolation — it returns null when the case does not exist or
+ * belongs to a different namespace.
+ *
+ * The transcript is formatted by [CaseTranscriptFormatter] according to the
+ * [includesTechnicalEvents] flag configured at plugin instantiation time.
+ */
+class ReadCaseTool(
+    private val configName: String?,
+    private val includesTechnicalEvents: Boolean,
+    private val caseEventsLoader: (caseId: UUID, namespaceId: UUID) -> List<CaseEvent>?,
+) : StandardTool<ReadCaseTool.Input> {
+
+    data class Input(val caseId: String)
+
+    override val name: String = buildToolName(configName)
+    override val description: String =
+        "Read the full conversation transcript of another case in the same namespace. " +
+            "Useful for analysing what happened in a previous agent run."
+    override val version: String = "1.0.0"
+    override val paramType: Class<Input> = Input::class.java
+    override val inputSchema: String = INPUT_SCHEMA
+
+    override suspend fun execute(input: Input?, context: ToolContext): ToolExecutionResult {
+        if (input == null) {
+            return ToolExecutionResult.error(
+                output = "Missing required parameter: caseId",
+                errorType = "INVALID_INPUT",
+            )
+        }
+
+        val targetCaseId = try {
+            UUID.fromString(input.caseId)
+        } catch (e: IllegalArgumentException) {
+            return ToolExecutionResult.error(
+                output = "Invalid caseId '${input.caseId}': must be a valid UUID",
+                errorType = "INVALID_INPUT",
+            )
+        }
+
+        val events = caseEventsLoader(targetCaseId, context.namespaceId)
+            ?: return ToolExecutionResult.error(
+                output = "Case '${input.caseId}' not found or is not accessible in this namespace",
+                errorType = "NOT_FOUND",
+            )
+
+        if (events.isEmpty()) {
+            return ToolExecutionResult.success("Case has no events")
+        }
+
+        val transcript = CaseTranscriptFormatter.format(events, includesTechnicalEvents)
+        return ToolExecutionResult.success(transcript)
+    }
+
+    companion object {
+        private const val INTEGRATION_TYPE = "CASE"
+
+        fun buildToolName(configName: String?): String =
+            if (configName != null) "${configName}__ReadCase" else "ReadCase"
+
+        val INPUT_SCHEMA: String =
+            """
+            {
+                "type": "object",
+                "properties": {
+                    "caseId": {
+                        "type": "string",
+                        "description": "UUID of the case to read, within the same namespace as the current case."
+                    }
+                },
+                "required": ["caseId"],
+                "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CasePluginConfigurationUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CasePluginConfigurationUnitSpec.kt
@@ -1,0 +1,180 @@
+package io.whozoss.agentos.casePlugin
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
+import io.whozoss.agentos.caseEvent.InMemoryCaseEventRepository
+import io.whozoss.agentos.caseFlow.Case
+import io.whozoss.agentos.caseFlow.InMemoryCaseRepository
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.EntityType
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.sdk.tool.ToolContext
+import java.util.UUID
+
+/**
+ * Unit tests for the [CasePluginConfiguration] loader lambda.
+ *
+ * Instantiates [CasePluginConfiguration] directly (no Spring context), calls
+ * [CasePluginConfiguration.caseToolPlugin] to get the real [CaseToolPlugin], then
+ * invokes [CaseToolPlugin.provideTools] with a [ToolContext] carrying a specific
+ * [userId]. The produced [ReadCaseTool] is executed to observe the loader's behaviour.
+ *
+ * This approach tests the **actual** lambda body from [CasePluginConfiguration],
+ * not a hand-written copy of it, so any change to the configuration that removes
+ * or weakens a guard will be caught here.
+ *
+ * Three-step guard under test:
+ *   1. case not found → NOT_FOUND
+ *   2. namespace mismatch → NOT_FOUND
+ *   3. userId non-null + permission denied → NOT_FOUND
+ *   4. userId non-null + permission granted → success
+ *   5. userId null → permission check skipped, success
+ */
+class CasePluginConfigurationUnitSpec : StringSpec({
+
+    val namespaceId: UUID = UUID.randomUUID()
+    val otherNamespaceId: UUID = UUID.randomUUID()
+    val userId: UUID = UUID.randomUUID()
+
+    fun buildCase(id: UUID = UUID.randomUUID(), ns: UUID = namespaceId) = Case(
+        metadata = EntityMetadata(id = id),
+        namespaceId = ns,
+        status = CaseStatus.IDLE,
+        title = "Test case",
+    )
+
+    /**
+     * Builds a [ReadCaseTool] from [CasePluginConfiguration] wired with in-memory
+     * repositories and the given [permissionService]. The [userId] is passed as the
+     * [ToolContext.userId] so the loader's permission check sees the correct identity.
+     */
+    fun buildTool(
+        caseRepo: InMemoryCaseRepository,
+        permissionService: PermissionService,
+        userId: UUID?,
+    ): ReadCaseTool {
+        val eventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
+        val config = CasePluginConfiguration(caseRepo, eventService, permissionService)
+        val plugin = config.caseToolPlugin() as CaseToolPlugin
+        val context = ToolContext(
+            namespaceId = namespaceId,
+            userId = userId,
+            userExternalId = null,
+            caseEvents = emptyList(),
+        )
+        return plugin.provideTools(config = null, context = context).first() as ReadCaseTool
+    }
+
+    // -------------------------------------------------------------------------
+    // Case not found
+    // -------------------------------------------------------------------------
+
+    "returns NOT_FOUND when case does not exist" {
+        val permissionService = mockk<PermissionService>(relaxed = true)
+        val tool = buildTool(InMemoryCaseRepository(), permissionService, userId)
+
+        val result = tool.execute(ReadCaseTool.Input(caseId = UUID.randomUUID().toString()), ToolContext(
+            namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(),
+        ))
+
+        result.success shouldBe false
+        result.errorType shouldBe "NOT_FOUND"
+        verify(exactly = 0) { permissionService.hasPermission(any(), any(), any(), any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Namespace mismatch
+    // -------------------------------------------------------------------------
+
+    "returns NOT_FOUND when case belongs to a different namespace" {
+        val caseRepo = InMemoryCaseRepository()
+        val case = buildCase(ns = otherNamespaceId)
+        caseRepo.save(case)
+        val permissionService = mockk<PermissionService>(relaxed = true)
+        val tool = buildTool(caseRepo, permissionService, userId)
+
+        val result = tool.execute(ReadCaseTool.Input(caseId = case.id.toString()), ToolContext(
+            namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(),
+        ))
+
+        result.success shouldBe false
+        result.errorType shouldBe "NOT_FOUND"
+        // Permission must never be consulted when the namespace guard already rejects
+        verify(exactly = 0) { permissionService.hasPermission(any(), any(), any(), any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission denied
+    // -------------------------------------------------------------------------
+
+    "returns NOT_FOUND when userId is non-null and permission is denied" {
+        val caseRepo = InMemoryCaseRepository()
+        val case = buildCase()
+        caseRepo.save(case)
+        val permissionService = mockk<PermissionService> {
+            every { hasPermission(any(), EntityType.CASE, any(), Action.READ) } returns false
+        }
+        val tool = buildTool(caseRepo, permissionService, userId)
+
+        val result = tool.execute(ReadCaseTool.Input(caseId = case.id.toString()), ToolContext(
+            namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(),
+        ))
+
+        result.success shouldBe false
+        result.errorType shouldBe "NOT_FOUND"
+        verify(exactly = 1) {
+            permissionService.hasPermission(userId.toString(), EntityType.CASE, case.id.toString(), Action.READ)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission granted
+    // -------------------------------------------------------------------------
+
+    "returns success when userId is non-null and permission is granted" {
+        val caseRepo = InMemoryCaseRepository()
+        val case = buildCase()
+        caseRepo.save(case)
+        val permissionService = mockk<PermissionService> {
+            every { hasPermission(any(), EntityType.CASE, any(), Action.READ) } returns true
+        }
+        val tool = buildTool(caseRepo, permissionService, userId)
+
+        val result = tool.execute(ReadCaseTool.Input(caseId = case.id.toString()), ToolContext(
+            namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(),
+        ))
+
+        result.success shouldBe true
+        verify(exactly = 1) {
+            permissionService.hasPermission(userId.toString(), EntityType.CASE, case.id.toString(), Action.READ)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Anonymous / system call (userId null)
+    // -------------------------------------------------------------------------
+
+    "returns NOT_FOUND without permission check when userId is null" {
+        val caseRepo = InMemoryCaseRepository()
+        val case = buildCase()
+        caseRepo.save(case)
+        val permissionService = mockk<PermissionService>(relaxed = true)
+        val tool = buildTool(caseRepo, permissionService, userId = null)
+
+        val result = tool.execute(ReadCaseTool.Input(caseId = case.id.toString()), ToolContext(
+            namespaceId = namespaceId, userId = null, userExternalId = null, caseEvents = emptyList(),
+        ))
+
+        result.success shouldBe false
+        result.errorType shouldBe "NOT_FOUND"
+        verify(exactly = 0) { permissionService.hasPermission(any(), any(), any(), any()) }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseToolPluginUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseToolPluginUnitSpec.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 class CaseToolPluginUnitSpec : StringSpec({
 
     val namespaceId: UUID = UUID.randomUUID()
-    val noopLoader: (UUID, UUID) -> List<CaseEvent>? = { _, _ -> emptyList() }
+    val noopLoader: (UUID, UUID, UUID?) -> List<CaseEvent>? = { _, _, _ -> emptyList() }
     val mapper = jacksonObjectMapper()
 
     fun context() = ToolContext(
@@ -102,5 +102,47 @@ class CaseToolPluginUnitSpec : StringSpec({
         val tools = plugin.provideTools(config = null, configName = null, context = context())
         val tool = tools.first() as ReadCaseTool
         tool.name shouldBe "ReadCase"
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission enforcement via loader
+    // -------------------------------------------------------------------------
+
+    "tool returns NOT_FOUND when loader returns null due to permission denial" {
+        // The loader returns null when the user lacks READ on the target case.
+        // ReadCaseTool must not leak whether the case exists or is just inaccessible.
+        val unauthorisedLoader: (UUID, UUID, UUID?) -> List<CaseEvent>? = { _, _, _ -> null }
+        val userId = UUID.randomUUID()
+        val contextWithUser = ToolContext(
+            namespaceId = namespaceId,
+            userId = userId,
+            userExternalId = null,
+            caseEvents = emptyList(),
+        )
+        val plugin = CaseToolPlugin(unauthorisedLoader)
+        val tools = plugin.provideTools(config = null, context = contextWithUser)
+        val tool = tools.first() as ReadCaseTool
+
+        val result = tool.execute(ReadCaseTool.Input(caseId = UUID.randomUUID().toString()), contextWithUser)
+
+        result.success shouldBe false
+        result.errorType shouldBe "NOT_FOUND"
+    }
+
+    "tool returns NOT_FOUND for cross-namespace or anonymous case (loader returns null)" {
+        // The loader returns null for namespace mismatch, permission denial, or null userId.
+        // Same observable behaviour in all cases — no information leak.
+        val rejectingLoader: (UUID, UUID, UUID?) -> List<CaseEvent>? = { _, _, _ -> null }
+        val plugin = CaseToolPlugin(rejectingLoader)
+        val tools = plugin.provideTools(config = null, context = context())
+        val tool = tools.first() as ReadCaseTool
+
+        val result = tool.execute(
+            ReadCaseTool.Input(caseId = UUID.randomUUID().toString()),
+            ToolContext(namespaceId = namespaceId, userId = null, userExternalId = null, caseEvents = emptyList()),
+        )
+
+        result.success shouldBe false
+        result.errorType shouldBe "NOT_FOUND"
     }
 })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseToolPluginUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseToolPluginUnitSpec.kt
@@ -1,0 +1,106 @@
+package io.whozoss.agentos.casePlugin
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import io.whozoss.agentos.sdk.tool.ToolContext
+import java.util.UUID
+
+class CaseToolPluginUnitSpec : StringSpec({
+
+    val namespaceId: UUID = UUID.randomUUID()
+    val noopLoader: (UUID, UUID) -> List<CaseEvent>? = { _, _ -> emptyList() }
+    val mapper = jacksonObjectMapper()
+
+    fun context() = ToolContext(
+        namespaceId = namespaceId,
+        userId = null,
+        userExternalId = null,
+        caseEvents = emptyList(),
+    )
+
+    // -------------------------------------------------------------------------
+    // context == null guard
+    // -------------------------------------------------------------------------
+
+    "returns empty list when context is null" {
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = null, context = null)
+        tools.shouldBeEmpty()
+    }
+
+    // -------------------------------------------------------------------------
+    // Default includesTechnicalEvents behaviour
+    // -------------------------------------------------------------------------
+
+    "returns a ReadCaseTool when context is provided" {
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = null, context = context())
+        tools shouldHaveSize 1
+        tools.first() as ReadCaseTool
+    }
+
+    "defaults includesTechnicalEvents to true when config is null" {
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = null, context = context())
+        val tool = tools.first() as ReadCaseTool
+        // The tool's behaviour is not directly observable via a public field;
+        // we verify indirectly by checking the integration type is as expected.
+        tool.name shouldBe "ReadCase"
+    }
+
+    "defaults includesTechnicalEvents to true when config has no 'includesTechnicalEvents' key" {
+        val config = mapper.readTree("{\"someOtherKey\": 42}")
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = config, context = context())
+        tools shouldHaveSize 1
+    }
+
+    // -------------------------------------------------------------------------
+    // includesTechnicalEvents propagation
+    // -------------------------------------------------------------------------
+
+    "propagates includesTechnicalEvents=false from config" {
+        // We verify that the ReadCaseTool produced with includesTechnicalEvents=false
+        // behaves differently from one produced with true by checking the formatter
+        // output indirectly via the tool name — the flag is an implementation detail.
+        // The CaseTranscriptFormatterUnitSpec already covers the rendering contract;
+        // here we only verify that the plugin reads and forwards the config value.
+        val config = mapper.readTree("{\"includesTechnicalEvents\": false}")
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = config, context = context())
+        tools shouldHaveSize 1
+        // The tool is created successfully; the flag value is tested in ReadCaseToolUnitSpec
+        // and CaseTranscriptFormatterUnitSpec.
+        tools.first() as ReadCaseTool
+    }
+
+    "propagates includesTechnicalEvents=true from config" {
+        val config = mapper.readTree("{\"includesTechnicalEvents\": true}")
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = config, context = context())
+        tools shouldHaveSize 1
+        tools.first() as ReadCaseTool
+    }
+
+    // -------------------------------------------------------------------------
+    // configName propagation
+    // -------------------------------------------------------------------------
+
+    "propagates configName to ReadCaseTool" {
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = null, configName = "CASE_prod", context = context())
+        val tool = tools.first() as ReadCaseTool
+        tool.name shouldBe "CASE_prod__ReadCase"
+    }
+
+    "uses default tool name when configName is null" {
+        val plugin = CaseToolPlugin(noopLoader)
+        val tools = plugin.provideTools(config = null, configName = null, context = context())
+        val tool = tools.first() as ReadCaseTool
+        tool.name shouldBe "ReadCase"
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatterUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatterUnitSpec.kt
@@ -1,0 +1,431 @@
+package io.whozoss.agentos.casePlugin
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
+import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
+import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
+import io.whozoss.agentos.sdk.caseEvent.ConfirmationResolvedEvent
+import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
+import io.whozoss.agentos.sdk.caseEvent.IntentionGeneratedEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.PendingConfirmationEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.WarnEvent
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
+import java.time.Instant
+import java.util.UUID
+
+class CaseTranscriptFormatterUnitSpec : StringSpec({
+
+    val namespaceId: UUID = UUID.randomUUID()
+    val caseId: UUID = UUID.randomUUID()
+    val agentId: UUID = UUID.randomUUID()
+    val userActor = Actor(id = "user-1", displayName = "Alice", role = ActorRole.USER)
+    val agentActor = Actor(id = "agent-1", displayName = "BotAgent", role = ActorRole.AGENT)
+    val t0: Instant = Instant.parse("2025-01-15T14:23:00Z")
+
+    fun userMessage(text: String, offset: Long = 0) = MessageEvent(
+        namespaceId = namespaceId,
+        caseId = caseId,
+        timestamp = t0.plusSeconds(offset),
+        actor = userActor,
+        content = listOf(MessageContent.Text(text)),
+    )
+
+    fun agentMessage(text: String, offset: Long = 1) = MessageEvent(
+        namespaceId = namespaceId,
+        caseId = caseId,
+        timestamp = t0.plusSeconds(offset),
+        actor = agentActor,
+        content = listOf(MessageContent.Text(text)),
+    )
+
+    // -------------------------------------------------------------------------
+    // Conversational-only mode (includesTechnicalEvents = false)
+    // -------------------------------------------------------------------------
+
+    "conversational mode: includes MessageEvent for USER" {
+        val events = listOf(userMessage("Hello"))
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "USER: Hello"
+    }
+
+    "conversational mode: includes MessageEvent for AGENT" {
+        val events = listOf(agentMessage("Hi there"))
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "AGENT: Hi there"
+    }
+
+    "conversational mode: includes WarnEvent" {
+        val events = listOf(
+            WarnEvent(namespaceId = namespaceId, caseId = caseId, timestamp = t0, message = "watch out"),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "WARN: watch out"
+    }
+
+    "conversational mode: includes ErrorEvent" {
+        val events = listOf(
+            ErrorEvent(namespaceId = namespaceId, caseId = caseId, timestamp = t0, message = "boom"),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "ERROR: boom"
+    }
+
+    "conversational mode: includes QuestionEvent with options" {
+        val events = listOf(
+            QuestionEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                agentName = "Analyst",
+                question = "Which file?",
+                options = listOf("a.kt", "b.kt"),
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "QUESTION (Analyst): Which file? [options: a.kt, b.kt]"
+    }
+
+    "conversational mode: includes QuestionEvent without options" {
+        val events = listOf(
+            QuestionEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                agentName = "Analyst",
+                question = "What is your name?",
+                options = null,
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "QUESTION (Analyst): What is your name?"
+        result shouldNotContain "[options"
+    }
+
+    "conversational mode: includes AnswerEvent" {
+        val questionId = UUID.randomUUID()
+        val events = listOf(
+            AnswerEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                questionId = questionId,
+                actor = userActor,
+                answer = "a.kt",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "ANSWER: a.kt"
+    }
+
+    "conversational mode: excludes AgentSelectedEvent" {
+        val events = listOf(
+            AgentSelectedEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                agentName = "Coder",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldNotContain "AGENT_SELECTED"
+    }
+
+    "conversational mode: excludes ToolRequestEvent" {
+        val events = listOf(
+            ToolRequestEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "FILES__readFile",
+                args = "{}",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldNotContain "TOOL_REQUEST"
+    }
+
+    "conversational mode: excludes CaseStatusEvent" {
+        val events = listOf(
+            CaseStatusEvent(
+                metadata = io.whozoss.agentos.sdk.entity.EntityMetadata(),
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                status = CaseStatus.IDLE,
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldNotContain "STATUS"
+    }
+
+    // -------------------------------------------------------------------------
+    // Full mode (includesTechnicalEvents = true)
+    // -------------------------------------------------------------------------
+
+    "full mode: includes AgentSelectedEvent" {
+        val events = listOf(
+            AgentSelectedEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                agentName = "Coder",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "AGENT_SELECTED: Coder"
+    }
+
+    "full mode: includes AgentRunningEvent" {
+        val events = listOf(
+            AgentRunningEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                agentName = "Coder",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "AGENT_RUNNING: Coder"
+    }
+
+    "full mode: includes AgentFinishedEvent" {
+        val events = listOf(
+            AgentFinishedEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                agentName = "Coder",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "AGENT_FINISHED: Coder"
+    }
+
+    "full mode: includes CaseStatusEvent" {
+        val events = listOf(
+            CaseStatusEvent(
+                metadata = io.whozoss.agentos.sdk.entity.EntityMetadata(),
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                status = CaseStatus.IDLE,
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "STATUS: IDLE"
+    }
+
+    "full mode: includes ToolRequestEvent" {
+        val events = listOf(
+            ToolRequestEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "FILES__readFile",
+                args = "{\"filePath\":\"project://src/main.kt\"}",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "TOOL_REQUEST: FILES__readFile"
+    }
+
+    "full mode: includes ToolResponseEvent with success and duration" {
+        val events = listOf(
+            ToolResponseEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "FILES__readFile",
+                output = MessageContent.Text("file content here"),
+                success = true,
+                durationMs = 42,
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "TOOL_RESPONSE: [success, 42ms] file content here"
+    }
+
+    "full mode: includes ToolResponseEvent with error status" {
+        val events = listOf(
+            ToolResponseEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "FILES__readFile",
+                output = MessageContent.Text("not found"),
+                success = false,
+                durationMs = null,
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "TOOL_RESPONSE: [error, ?ms] not found"
+    }
+
+    "full mode: includes IntentionGeneratedEvent" {
+        val events = listOf(
+            IntentionGeneratedEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                intention = "read the config file",
+                toolName = "FILES__readFile",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "INTENTION ($agentId): read the config file → FILES__readFile"
+    }
+
+    "full mode: includes ToolSelectedEvent" {
+        val events = listOf(
+            ToolSelectedEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                agentId = agentId,
+                toolName = "FILES__readFile",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "TOOL_SELECTED ($agentId): FILES__readFile"
+    }
+
+    "full mode: includes PendingConfirmationEvent" {
+        val events = listOf(
+            PendingConfirmationEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "FILES__remove",
+                inputJson = "{\"path\":\"project://old.txt\"}",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "PENDING_CONFIRMATION: FILES__remove"
+    }
+
+    "full mode: includes ConfirmationResolvedEvent" {
+        val events = listOf(
+            ConfirmationResolvedEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                pendingEventId = UUID.randomUUID(),
+                confirmed = true,
+                resultText = "deleted",
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "CONFIRMATION_RESOLVED: confirmed=true deleted"
+    }
+
+    // -------------------------------------------------------------------------
+    // ToolResponseEvent truncation
+    // -------------------------------------------------------------------------
+
+    "truncates ToolResponseEvent output beyond 2000 chars" {
+        val longText = "x".repeat(2500)
+        val events = listOf(
+            ToolResponseEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "BigTool",
+                output = MessageContent.Text(longText),
+                success = true,
+                durationMs = 10,
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "... [truncated]"
+        // The rendered output section must be at most 2000 + suffix length
+        val outputPart = result.substringAfter("[success, 10ms] ")
+        outputPart.length shouldBe 2000 + "... [truncated]".length
+    }
+
+    "does not truncate ToolResponseEvent output at exactly 2000 chars" {
+        val exactText = "y".repeat(2000)
+        val events = listOf(
+            ToolResponseEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "BigTool",
+                output = MessageContent.Text(exactText),
+                success = true,
+                durationMs = 5,
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldNotContain "... [truncated]"
+    }
+
+    // -------------------------------------------------------------------------
+    // MessageContent.Image
+    // -------------------------------------------------------------------------
+
+    "renders MessageContent.Image as [image]" {
+        val events = listOf(
+            MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                actor = userActor,
+                content = listOf(
+                    MessageContent.Text("look at this: "),
+                    MessageContent.Image(content = "base64data", mimeType = "image/png"),
+                ),
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        result shouldContain "USER: look at this:  [image]"
+    }
+
+    // -------------------------------------------------------------------------
+    // Chronological ordering (formatter preserves input order)
+    // -------------------------------------------------------------------------
+
+    "preserves chronological order of events" {
+        val events = listOf(
+            userMessage("first", offset = 0),
+            agentMessage("second", offset = 1),
+            userMessage("third", offset = 2),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = false)
+        val lines = result.lines()
+        lines[0] shouldContain "first"
+        lines[1] shouldContain "second"
+        lines[2] shouldContain "third"
+    }
+
+    "empty event list produces empty string" {
+        val result = CaseTranscriptFormatter.format(emptyList(), includesTechnicalEvents = true)
+        result shouldBe ""
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/ReadCaseToolUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/ReadCaseToolUnitSpec.kt
@@ -1,0 +1,159 @@
+package io.whozoss.agentos.casePlugin
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.tool.ToolContext
+import java.time.Instant
+import java.util.UUID
+
+class ReadCaseToolUnitSpec : StringSpec({
+
+    val namespaceId: UUID = UUID.randomUUID()
+    val targetCaseId: UUID = UUID.randomUUID()
+
+    val context = ToolContext(
+        namespaceId = namespaceId,
+        userId = null,
+        userExternalId = null,
+        caseEvents = emptyList(),
+    )
+
+    fun sampleEvent(text: String): CaseEvent = MessageEvent(
+        namespaceId = namespaceId,
+        caseId = targetCaseId,
+        timestamp = Instant.parse("2025-01-15T14:23:00Z"),
+        actor = Actor(id = "user-1", displayName = "Alice", role = ActorRole.USER),
+        content = listOf(MessageContent.Text(text)),
+    )
+
+    fun loaderReturning(events: List<CaseEvent>?) = { _: UUID, _: UUID -> events }
+
+    // -------------------------------------------------------------------------
+    // Invalid input
+    // -------------------------------------------------------------------------
+
+    "returns INVALID_INPUT error when input is null" {
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = loaderReturning(emptyList()),
+        )
+        val result = tool.execute(null, context)
+        result.success shouldBe false
+        result.errorType shouldBe "INVALID_INPUT"
+    }
+
+    "returns INVALID_INPUT error when caseId is not a valid UUID" {
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = loaderReturning(emptyList()),
+        )
+        val result = tool.execute(ReadCaseTool.Input(caseId = "not-a-uuid"), context)
+        result.success shouldBe false
+        result.errorType shouldBe "INVALID_INPUT"
+        result.output shouldContain "not-a-uuid"
+    }
+
+    // -------------------------------------------------------------------------
+    // Not found
+    // -------------------------------------------------------------------------
+
+    "returns NOT_FOUND error when caseEventsLoader returns null" {
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = loaderReturning(null),
+        )
+        val result = tool.execute(ReadCaseTool.Input(caseId = targetCaseId.toString()), context)
+        result.success shouldBe false
+        result.errorType shouldBe "NOT_FOUND"
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty case
+    // -------------------------------------------------------------------------
+
+    "returns success with 'no events' message when loader returns empty list" {
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = loaderReturning(emptyList()),
+        )
+        val result = tool.execute(ReadCaseTool.Input(caseId = targetCaseId.toString()), context)
+        result.success shouldBe true
+        result.output shouldBe "Case has no events"
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    "returns success with transcript when loader returns events" {
+        val events = listOf(sampleEvent("hello world"))
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = loaderReturning(events),
+        )
+        val result = tool.execute(ReadCaseTool.Input(caseId = targetCaseId.toString()), context)
+        result.success shouldBe true
+        result.output shouldContain "USER: hello world"
+    }
+
+    "passes namespaceId from context to caseEventsLoader" {
+        var capturedNamespaceId: UUID? = null
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = { _, ns ->
+                capturedNamespaceId = ns
+                emptyList()
+            },
+        )
+        tool.execute(ReadCaseTool.Input(caseId = targetCaseId.toString()), context)
+        capturedNamespaceId shouldBe namespaceId
+    }
+
+    "passes parsed caseId to caseEventsLoader" {
+        var capturedCaseId: UUID? = null
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = { id, _ ->
+                capturedCaseId = id
+                emptyList()
+            },
+        )
+        tool.execute(ReadCaseTool.Input(caseId = targetCaseId.toString()), context)
+        capturedCaseId shouldBe targetCaseId
+    }
+
+    // -------------------------------------------------------------------------
+    // Tool name
+    // -------------------------------------------------------------------------
+
+    "tool name is 'ReadCase' when configName is null" {
+        val tool = ReadCaseTool(
+            configName = null,
+            includesTechnicalEvents = true,
+            caseEventsLoader = loaderReturning(emptyList()),
+        )
+        tool.name shouldBe "ReadCase"
+    }
+
+    "tool name includes configName prefix when provided" {
+        val tool = ReadCaseTool(
+            configName = "CASE_main",
+            includesTechnicalEvents = true,
+            caseEventsLoader = loaderReturning(emptyList()),
+        )
+        tool.name shouldBe "CASE_main__ReadCase"
+    }
+})


### PR DESCRIPTION
## Summary

Adds the `CASE` internal integration — a Spring-managed `ToolPlugin` that lets an agent read the full event transcript of another case in the same namespace.

### New files (`agentos-service`)

- **`casePlugin/CaseTranscriptFormatter`** — pure formatting object, no Spring dependency. Converts a `List<CaseEvent>` to a chronological text transcript. Two modes: full (all persisted event types) and conversational (messages, questions, answers, warnings, errors only). `ToolResponseEvent` output is truncated at 2 000 chars.
- **`casePlugin/ReadCaseTool`** — `StandardTool<Input>` with a single `caseId: String` parameter. Validates the UUID, delegates to the injected loader lambda, returns the transcript or a typed error (`INVALID_INPUT` / `NOT_FOUND`).
- **`casePlugin/CaseToolPlugin`** — `ToolPlugin` following the same pattern as `RedirectToolPlugin`. Reads `includesTechnicalEvents` from config (default `true`), guards on missing `namespaceId`.
- **`casePlugin/CasePluginConfiguration`** — Spring wiring. Injects `CaseRepository` + `CaseEventService` directly (not `CaseService`) to avoid the circular dependency `AgentService → ToolRegistryService → CasePluginConfiguration → CaseService → AgentService`.

### Tests

- `CaseTranscriptFormatterUnitSpec` — conversational vs full mode, truncation, image rendering, ordering, empty list.
- `ReadCaseToolUnitSpec` — invalid UUID, not found, empty case, happy path, namespace/caseId propagation, tool naming.
- `CaseToolPluginUnitSpec` — null context guard, default flag, config propagation, configName prefix.

### Usage

Create an `IntegrationConfig` of type `CASE` in the namespace and assign it to an agent via `integrations`. Optional config:
```json
{ "includesTechnicalEvents": false }
```
restricts the transcript to conversational events only.