### PR TITLE
fix(ci): use assemble instead of build for JVM publish targets to skip flaky tests

### DIFF
--- a/tools/plugins/agentos-gradle/src/agentos-gradle.spec.ts
+++ b/tools/plugins/agentos-gradle/src/agentos-gradle.spec.ts
@@ -61,11 +61,12 @@ describe('buildProjectConfig', () => {
   })
 
   describe('nx-release-publish target', () => {
-    it('infers a no-op echo command', () => {
+    it('infers a no-op echo command with assemble dependsOn', () => {
       const result = buildProjectConfig('agentos/agentos-service', 'agentos-service')
       const target = result.projects?.['agentos/agentos-service']?.targets?.['nx-release-publish']
       expect(target).toMatchObject({
         executor: 'nx:run-commands',
+        dependsOn: ['assemble'],
         options: { command: "echo 'agentos-service published via Gradle in CI'" },
       })
     })
@@ -88,7 +89,7 @@ describe('buildProjectConfig', () => {
           command: './gradlew :agentos-service:publish',
           cwd: 'agentos',
         },
-        dependsOn: ['build'],
+        dependsOn: ['assemble'],
       })
     })
 

--- a/tools/plugins/agentos-gradle/src/agentos-gradle.ts
+++ b/tools/plugins/agentos-gradle/src/agentos-gradle.ts
@@ -9,7 +9,13 @@ const GRADLE_INPUTS = [
   '{workspaceRoot}/agentos/settings.gradle.kts',
 ]
 
-const SDK_DEPENDENCY = { target: 'build', projects: ['agentos-sdk'] }
+// For build/test targets: depend on agentos-sdk:build (compile + test) to ensure
+// the SDK is fully verified before downstream compilation or testing.
+const SDK_BUILD_DEPENDENCY = { target: 'build', projects: ['agentos-sdk'] }
+
+// For assemble/publish targets: depend on agentos-sdk:assemble only.
+// SDK tests already ran in validate.yml on every PR — no need to re-run them at publish time.
+const SDK_ASSEMBLE_DEPENDENCY = { target: 'assemble', projects: ['agentos-sdk'] }
 
 // Matches all build.gradle.kts files one level deep under agentos/
 // e.g. agentos/agentos-service/build.gradle.kts
@@ -58,7 +64,7 @@ export function buildProjectConfig(projectDir: string, projectName: string): Cre
               command: `./gradlew :${projectName}:build`,
               cwd: 'agentos',
             },
-            dependsOn: [SDK_DEPENDENCY],
+            dependsOn: [SDK_BUILD_DEPENDENCY],
           },
           assemble: {
             executor: 'nx:run-commands',
@@ -69,7 +75,7 @@ export function buildProjectConfig(projectDir: string, projectName: string): Cre
               command: `./gradlew :${projectName}:assemble`,
               cwd: 'agentos',
             },
-            dependsOn: [SDK_DEPENDENCY],
+            dependsOn: [SDK_ASSEMBLE_DEPENDENCY],
           },
           test: {
             executor: 'nx:run-commands',
@@ -81,7 +87,7 @@ export function buildProjectConfig(projectDir: string, projectName: string): Cre
               cwd: 'agentos',
               passWithNoTests: null,
             },
-            dependsOn: ['build', SDK_DEPENDENCY],
+            dependsOn: ['build', SDK_BUILD_DEPENDENCY],
           },
           clean: {
             executor: 'nx:run-commands',
@@ -93,6 +99,9 @@ export function buildProjectConfig(projectDir: string, projectName: string): Cre
           },
           'nx-release-publish': {
             executor: 'nx:run-commands',
+            // Override targetDefaults["nx-release-publish"].dependsOn which defaults to ["build"].
+            // `assemble` (no tests) is sufficient — tests already ran in validate.yml on every PR.
+            dependsOn: ['assemble'],
             options: {
               command: `echo '${projectName} published via Gradle in CI'`,
             },
@@ -104,7 +113,9 @@ export function buildProjectConfig(projectDir: string, projectName: string): Cre
               command: `./gradlew :${projectName}:publish`,
               cwd: 'agentos',
             },
-            dependsOn: ['build'],
+            // `assemble` (no tests) is sufficient — tests already ran in validate.yml on every PR.
+            // Gradle's own `publish` task already depends on `assemble` internally.
+            dependsOn: ['assemble'],
           },
         },
       },


### PR DESCRIPTION
JVM publish and release targets were depending on `build` (which includes tests), causing flaky `agentos-service` tests to block the release after the tag and npm packages were already published.

Changed `nx-release-publish` and `publish` targets in the Gradle Nx plugin to depend on `assemble` instead — producing the same artifacts without running tests. Tests already run in `validate.yml` on every PR.

Fixes #969