### PR TITLE
fix: #WZ-32236 remove mandatory apiKey validation in ChatModelFactory

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
@@ -31,52 +31,39 @@ class ChatModelFactory(
         maxTokens: Int? = null,
         headers: Map<String, String> = emptyMap(),
     ): ChatModel {
-        val resolvedApiKey =
-            apiKey?.takeIf { it.isNotBlank() }
-                ?: throw IllegalArgumentException("No API key configured for provider (apiType=$apiType).")
-
+        val resolvedApiKey = apiKey ?: ""
         return when (apiType) {
-            AiApiType.OpenAI -> {
-                createOpenAiModel(
-                    baseUrl = baseUrl ?: OPENAI_DEFAULT_BASE_URL,
-                    apiKey = resolvedApiKey,
-                    model = modelName,
-                    temp = temperature ?: DEFAULT_TEMPERATURE,
-                    maxTokens = maxTokens,
-                )
-            }
-
-            AiApiType.vLLM -> {
-                createVllmModel(
-                    baseUrl = baseUrl!!,
-                    apiKey = resolvedApiKey,
-                    model = modelName,
-                    temp = temperature ?: DEFAULT_TEMPERATURE,
-                    maxTokens = maxTokens,
-                    headers = headers,
-                )
-            }
-
-            AiApiType.Anthropic -> {
-                createAnthropicModel(
-                    baseUrl = baseUrl ?: ANTHROPIC_DEFAULT_BASE_URL,
-                    apiKey = resolvedApiKey,
-                    model = modelName,
-                    temp = temperature ?: DEFAULT_TEMPERATURE,
-                    maxTokens = maxTokens,
-                )
-            }
-
-            AiApiType.Gemini -> {
-                createGeminiModel(
-                    apiKey = resolvedApiKey,
-                    model = modelName,
-                    temp = temperature ?: DEFAULT_TEMPERATURE,
-                    maxTokens = maxTokens,
-                )
-            }
+            AiApiType.OpenAI -> createOpenAiModel(
+                baseUrl = baseUrl ?: OPENAI_DEFAULT_BASE_URL,
+                apiKey = resolvedApiKey,
+                model = modelName,
+                temp = temperature ?: DEFAULT_TEMPERATURE,
+                maxTokens = maxTokens,
+            )
+            AiApiType.vLLM -> createVllmModel(
+                baseUrl = baseUrl!!,
+                apiKey = resolvedApiKey,
+                model = modelName,
+                temp = temperature ?: DEFAULT_TEMPERATURE,
+                maxTokens = maxTokens,
+                headers = headers,
+            )
+            AiApiType.Anthropic -> createAnthropicModel(
+                baseUrl = baseUrl ?: ANTHROPIC_DEFAULT_BASE_URL,
+                apiKey = resolvedApiKey,
+                model = modelName,
+                temp = temperature ?: DEFAULT_TEMPERATURE,
+                maxTokens = maxTokens,
+            )
+            AiApiType.Gemini -> createGeminiModel(
+                apiKey = resolvedApiKey,
+                model = modelName,
+                temp = temperature ?: DEFAULT_TEMPERATURE,
+                maxTokens = maxTokens,
+            )
         }
     }
+
     private fun createOpenAiModel(
         baseUrl: String,
         apiKey: String,
@@ -84,7 +71,12 @@ class ChatModelFactory(
         temp: Double,
         maxTokens: Int?,
     ): ChatModel {
-        val api = OpenAiApi.Builder().baseUrl(baseUrl).apiKey(apiKey).build()
+        val api =
+            OpenAiApi
+                .Builder()
+                .baseUrl(baseUrl)
+                .apiKey(apiKey)
+                .build()
 
         val optionsBuilder =
             OpenAiChatOptions
@@ -116,9 +108,10 @@ class ChatModelFactory(
     ): ChatModel {
         var builder = OpenAiApi.Builder().baseUrl(baseUrl).apiKey(apiKey)
         if (headers.isNotEmpty()) {
-            val multiValueHeaders = LinkedMultiValueMap<String, String>(
-                headers.mapValues { (_, value) -> listOf(value) }
-            )
+            val multiValueHeaders =
+                LinkedMultiValueMap<String, String>(
+                    headers.mapValues { (_, value) -> listOf(value) },
+                )
             builder = builder.headers(multiValueHeaders)
         }
         val api = builder.build()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiProvider/ChatModelFactoryUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiProvider/ChatModelFactoryUnitSpec.kt
@@ -1,9 +1,7 @@
 package io.whozoss.agentos.aiProvider
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.micrometer.observation.ObservationRegistry
 import io.whozoss.agentos.chat.ChatModelFactory
@@ -24,6 +22,18 @@ class ChatModelFactoryUnitSpec : StringSpec({
             modelName = "gpt-4",
             temperature = 0.7,
             maxTokens = null,
+        )
+
+        model.shouldNotBeNull()
+        model.shouldBeInstanceOf<OpenAiChatModel>()
+    }
+
+    "createChatModel should create OpenAI chat model with null apiKey" {
+        val model = factory.createChatModel(
+            apiType = AiApiType.OpenAI,
+            baseUrl = null,
+            apiKey = null,
+            modelName = "gpt-4",
         )
 
         model.shouldNotBeNull()
@@ -58,16 +68,28 @@ class ChatModelFactoryUnitSpec : StringSpec({
         model.shouldBeInstanceOf<GoogleGenAiChatModel>()
     }
 
-    "createChatModel should throw exception when API key is blank" {
-        val exception = shouldThrow<IllegalArgumentException> {
-            factory.createChatModel(
-                apiType = AiApiType.OpenAI,
-                baseUrl = null,
-                apiKey = null,
-                modelName = "gpt-4",
-            )
-        }
-        exception.message shouldContain "No API key"
+    "createChatModel vLLM with apiKey works normally" {
+        val model = factory.createChatModel(
+            apiType = AiApiType.vLLM,
+            baseUrl = "http://localhost:8000",
+            apiKey = "sk-vllm-key",
+            modelName = "meta-llama/Llama-3-8b-instruct",
+        )
+
+        model.shouldNotBeNull()
+        model.shouldBeInstanceOf<OpenAiChatModel>()
+    }
+
+    "createChatModel vLLM without apiKey does not throw" {
+        val model = factory.createChatModel(
+            apiType = AiApiType.vLLM,
+            baseUrl = "http://localhost:8000",
+            apiKey = null,
+            modelName = "meta-llama/Llama-3-8b-instruct",
+        )
+
+        model.shouldNotBeNull()
+        model.shouldBeInstanceOf<OpenAiChatModel>()
     }
 
     "createChatModel should use null temperature and fall back to default" {


### PR DESCRIPTION
## Problem

vLLM is a self-hosted LLM server that does not require API key authentication. The `ChatModelFactory` was throwing `IllegalArgumentException: No API key configured for provider` unconditionally for all provider types, blocking vLLM usage without a key.

## Fix

Removed the upfront API key validation entirely. The factory now passes `apiKey ?: \"\"` to all provider builders. If a key is missing for a provider that actually requires one (OpenAI, Anthropic, Gemini), the remote provider will respond with a 401 — a cleaner and more honest failure mode than a local guard.

This simplifies `ChatModelFactory` significantly: no more `requireApiKey()` helper, no per-type branching for key resolution, no vLLM-specific placeholder constant.

## Tests

- Removed the test asserting `IllegalArgumentException` on blank key (behaviour no longer exists)
- Added `createChatModel OpenAI with null apiKey` — verifies construction succeeds
- Added `createChatModel vLLM with apiKey` and `vLLM without apiKey` — both verify a valid `OpenAiChatModel` is returned

Closes WZ-32236