### PR TITLE
fix: remove redundant build dependsOn from JVM nx-release-publish no-op target

### DIFF
--- a/apps/client/project.json
+++ b/apps/client/project.json
@@ -86,6 +86,7 @@
       }
     },
     "nx-release-publish": {
+      "dependsOn": ["build"],
       "options": {
         "packageRoot": "apps/client/dist"
       }

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -65,6 +65,7 @@
       }
     },
     "nx-release-publish": {
+      "dependsOn": ["build"],
       "options": {
         "packageRoot": "apps/server/dist"
       }

--- a/nx.json
+++ b/nx.json
@@ -24,11 +24,6 @@
         "^default"
       ]
     },
-    "nx-release-publish": {
-      "dependsOn": [
-        "build"
-      ]
-    },
     "lint": {
       "cache": true
     },

--- a/tools/plugins/agentos-gradle/src/agentos-gradle.spec.ts
+++ b/tools/plugins/agentos-gradle/src/agentos-gradle.spec.ts
@@ -61,12 +61,12 @@ describe('buildProjectConfig', () => {
   })
 
   describe('nx-release-publish target', () => {
-    it('infers a no-op echo command with assemble dependsOn', () => {
+    it('infers a no-op echo command with empty dependsOn', () => {
       const result = buildProjectConfig('agentos/agentos-service', 'agentos-service')
       const target = result.projects?.['agentos/agentos-service']?.targets?.['nx-release-publish']
       expect(target).toMatchObject({
         executor: 'nx:run-commands',
-        dependsOn: ['assemble'],
+        dependsOn: [],
         options: { command: "echo 'agentos-service published via Gradle in CI'" },
       })
     })

--- a/tools/plugins/agentos-gradle/src/agentos-gradle.ts
+++ b/tools/plugins/agentos-gradle/src/agentos-gradle.ts
@@ -99,9 +99,8 @@ export function buildProjectConfig(projectDir: string, projectName: string): Cre
           },
           'nx-release-publish': {
             executor: 'nx:run-commands',
-            // Override targetDefaults["nx-release-publish"].dependsOn which defaults to ["build"].
-            // `assemble` (no tests) is sufficient — tests already ran in validate.yml on every PR.
-            dependsOn: ['assemble'],
+            // No-op: real publishing happens via the `publish` target below, called by publish-agentos-artifacts in validate.yml CI workflow.
+            dependsOn: [],
             options: {
               command: `echo '${projectName} published via Gradle in CI'`,
             },


### PR DESCRIPTION
The `nx-release-publish` target for Gradle projects is a no-op echo — real publishing happens via the `publish` target in the `publish-agentos-artifacts` CI job, which has its own `dependsOn: ['assemble']`. The target had `dependsOn: ['assemble']` but was itself overridden by `targetDefaults["nx-release-publish"].dependsOn: ["build"]` in `nx.json`, meaning the full Gradle `build` task (compile + tests) was running before an echo. Removed both the stale default and the explicit `assemble` dep, replacing with `dependsOn: []` to ensure nothing runs before the no-op.