### PR TITLE
fix: #32491 detect redirect loop in RedirectTool

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
@@ -1,6 +1,9 @@
 package io.whozoss.agentos.redirect
 
 import io.whozoss.agentos.agent.AgentInterrupt
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
@@ -96,7 +99,36 @@ class RedirectTool(
         return when {
             target == null -> ToolExecutionResult.error("Agent name is required.", errorType = "MISSING_INPUT")
             eligibleAgents.none { it.name == target } -> ToolExecutionResult.error("Agent does not exist.", errorType = "NOT_FOUND")
+            detectRedirectLoop(target, context) -> ToolExecutionResult.error(
+                "Redirect loop detected: '$target' has already been invoked during this turn. " +
+                    "Stop redirecting and answer the user directly.",
+                errorType = "REDIRECT_LOOP",
+            )
             else -> throw AgentInterrupt.Redirect(target)
         }
+    }
+
+    /**
+     * Returns `true` when a redirect loop is detected.
+     *
+     * A loop is detected when the same agent appears at least [REDIRECT_LOOP_THRESHOLD] times
+     * within the last [REDIRECT_LOOP_WINDOW] [AgentSelectedEvent]s since the last user
+     * [MessageEvent] (exclusive). The window cap prevents false positives on long but
+     * legitimate linear chains while still catching ping-pong and triangular cycles.
+     */
+    internal fun detectRedirectLoop(target: String, context: ToolContext): Boolean {
+        val events = context.caseEvents
+        val lastUserMessageIndex = events.indexOfLast { it is MessageEvent && it.actor.role == ActorRole.USER }
+        val eventsThisTurn = if (lastUserMessageIndex >= 0) events.drop(lastUserMessageIndex + 1) else events
+        val window = eventsThisTurn.filterIsInstance<AgentSelectedEvent>().takeLast(REDIRECT_LOOP_WINDOW)
+        return window.count { it.agentName == target } >= REDIRECT_LOOP_THRESHOLD
+    }
+
+    companion object {
+        /** How many recent agent selections to inspect for a redirect loop. */
+        internal const val REDIRECT_LOOP_WINDOW = 10
+
+        /** How many times the same agent must appear in the window to trigger loop detection. */
+        internal const val REDIRECT_LOOP_THRESHOLD = 2
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolSpec.kt
@@ -3,10 +3,18 @@ package io.whozoss.agentos.redirect
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import io.whozoss.agentos.agent.AgentInterrupt
+import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+import java.util.UUID
+
+private val NAMESPACE_ID: UUID = UUID.randomUUID()
+private val CASE_ID: UUID = UUID.randomUUID()
 
 private val CONTEXT = mockk<ToolContext>(relaxed = true)
 
@@ -73,6 +81,125 @@ class RedirectToolSpec : StringSpec({
         )
         val ex = shouldThrow<AgentInterrupt.Redirect> {
             tool.execute(RedirectTool.Input("AgentA"), CONTEXT)
+        }
+        ex.targetAgentName shouldBe "AgentA"
+    }
+
+    // -------------------------------------------------------------------------
+    // Redirect loop detection
+    // -------------------------------------------------------------------------
+
+    "detectRedirectLoop returns true when target appears REDIRECT_LOOP_THRESHOLD times in the window" {
+        // caseEvents already contains THRESHOLD occurrences of AgentA this turn → loop detected.
+        val tool = RedirectTool(configName = null, eligibleAgents = makeEligible("AgentA", "AgentB"))
+        val context = mockk<ToolContext>(relaxed = true)
+        val agentAId = UUID.nameUUIDFromBytes("AgentA".toByteArray())
+        every { context.caseEvents } returns List(RedirectTool.REDIRECT_LOOP_THRESHOLD) {
+            AgentSelectedEvent(
+                metadata = EntityMetadata(),
+                namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID,
+                agentId = agentAId,
+                agentName = "AgentA",
+            )
+        }
+
+        val result = tool.execute(RedirectTool.Input("AgentA"), context)
+
+        result.success shouldBe false
+        result.output shouldBe "Redirect loop detected: 'AgentA' has already been invoked during this turn. " +
+            "Stop redirecting and answer the user directly."
+    }
+
+    "detectRedirectLoop returns false when target appears fewer than REDIRECT_LOOP_THRESHOLD times" {
+        // caseEvents contains THRESHOLD-1 occurrences of AgentA → one more redirect is still allowed.
+        val tool = RedirectTool(configName = null, eligibleAgents = makeEligible("AgentA"))
+        val context = mockk<ToolContext>(relaxed = true)
+        val agentAId = UUID.nameUUIDFromBytes("AgentA".toByteArray())
+        every { context.caseEvents } returns List(RedirectTool.REDIRECT_LOOP_THRESHOLD - 1) {
+            AgentSelectedEvent(
+                metadata = EntityMetadata(),
+                namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID,
+                agentId = agentAId,
+                agentName = "AgentA",
+            )
+        }
+
+        val ex = shouldThrow<AgentInterrupt.Redirect> {
+            tool.execute(RedirectTool.Input("AgentA"), context)
+        }
+        ex.targetAgentName shouldBe "AgentA"
+    }
+
+    "detectRedirectLoop ignores selections outside the REDIRECT_LOOP_WINDOW" {
+        // REDIRECT_LOOP_WINDOW selections of AgentA, but they are pushed outside the window
+        // by REDIRECT_LOOP_WINDOW intervening selections of other agents.
+        // Only the last REDIRECT_LOOP_WINDOW events are inspected, so AgentA count = 0 there.
+        val tool = RedirectTool(configName = null, eligibleAgents = makeEligible("AgentA", "AgentB"))
+        val context = mockk<ToolContext>(relaxed = true)
+        val agentAId = UUID.nameUUIDFromBytes("AgentA".toByteArray())
+        val agentBId = UUID.nameUUIDFromBytes("AgentB".toByteArray())
+        val oldAgentASelections = List(RedirectTool.REDIRECT_LOOP_THRESHOLD) {
+            AgentSelectedEvent(metadata = EntityMetadata(), namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID, agentId = agentAId, agentName = "AgentA")
+        }
+        val interveningBSelections = List(RedirectTool.REDIRECT_LOOP_WINDOW) {
+            AgentSelectedEvent(metadata = EntityMetadata(), namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID, agentId = agentBId, agentName = "AgentB")
+        }
+        every { context.caseEvents } returns oldAgentASelections + interveningBSelections
+
+        val ex = shouldThrow<AgentInterrupt.Redirect> {
+            tool.execute(RedirectTool.Input("AgentA"), context)
+        }
+        ex.targetAgentName shouldBe "AgentA"
+    }
+
+    "detectRedirectLoop is not reset by an agent MessageEvent between selections" {
+        // An agent MessageEvent (ActorRole.AGENT) must NOT reset the turn window.
+        // AgentA selected THRESHOLD times, separated by an agent message — still a loop.
+        val tool = RedirectTool(configName = null, eligibleAgents = makeEligible("AgentA"))
+        val context = mockk<ToolContext>(relaxed = true)
+        val agentAId = UUID.nameUUIDFromBytes("AgentA".toByteArray())
+        every { context.caseEvents } returns listOf(
+            AgentSelectedEvent(metadata = EntityMetadata(), namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID, agentId = agentAId, agentName = "AgentA"),
+            MessageEvent(
+                metadata = EntityMetadata(), namespaceId = NAMESPACE_ID, caseId = CASE_ID,
+                actor = io.whozoss.agentos.sdk.actor.Actor("agent-1", "Agent", io.whozoss.agentos.sdk.actor.ActorRole.AGENT),
+                content = listOf(io.whozoss.agentos.sdk.caseEvent.MessageContent.Text("here is my answer")),
+            ),
+            AgentSelectedEvent(metadata = EntityMetadata(), namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID, agentId = agentAId, agentName = "AgentA"),
+        )
+
+        val result = tool.execute(RedirectTool.Input("AgentA"), context)
+
+        result.success shouldBe false
+    }
+
+    "detectRedirectLoop does not flag loop when AgentSelectedEvent for target precedes last user MessageEvent" {
+        // AgentA was selected THRESHOLD times in a *previous* turn (before the last user message).
+        // The current turn has no redirect to AgentA yet, so this must not be flagged.
+        val tool = RedirectTool(configName = null, eligibleAgents = makeEligible("AgentA"))
+        val context = mockk<ToolContext>(relaxed = true)
+        val agentAId = UUID.nameUUIDFromBytes("AgentA".toByteArray())
+        every { context.caseEvents } returns List(RedirectTool.REDIRECT_LOOP_THRESHOLD) {
+            AgentSelectedEvent(metadata = EntityMetadata(), namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID, agentId = agentAId, agentName = "AgentA")
+        } + listOf(
+            MessageEvent(
+                metadata = EntityMetadata(),
+                namespaceId = NAMESPACE_ID,
+                caseId = CASE_ID,
+                actor = io.whozoss.agentos.sdk.actor.Actor("user-1", "User", io.whozoss.agentos.sdk.actor.ActorRole.USER),
+                content = listOf(io.whozoss.agentos.sdk.caseEvent.MessageContent.Text("new message")),
+            ),
+        )
+
+        val ex = shouldThrow<AgentInterrupt.Redirect> {
+            tool.execute(RedirectTool.Input("AgentA"), context)
         }
         ex.targetAgentName shouldBe "AgentA"
     }


### PR DESCRIPTION
## Problem

Two agents (PCT and DB) were ping-ponging indefinitely via the redirect tool — each delegating to the other without making progress, resulting in 50+ tool calls before hitting the max-iterations limit.

The existing repetition detection in `AgentAdvanced` only looks at `ToolResponseEvent`s within a single agent run. Since each redirect starts a fresh agent run, the loop was invisible to that mechanism.

## Solution

`RedirectTool.execute` now inspects `ToolContext.caseEvents` before throwing `AgentInterrupt.Redirect`. The `detectRedirectLoop` method scans the last `REDIRECT_LOOP_WINDOW = 10` `AgentSelectedEvent`s since the last **user** `MessageEvent` (agent `MessageEvent`s are correctly excluded). If the target agent appears `REDIRECT_LOOP_THRESHOLD = 2` or more times in that window, the tool returns a clear error instead of redirecting:

> "Redirect loop detected: 'X' has already been invoked during this turn. Stop redirecting and answer the user directly."

The LLM receives this as a tool response and can answer the user directly.

## Test coverage

- Loop detected when target reaches threshold in window
- No false positive below threshold
- Selections outside the window are ignored
- Agent `MessageEvent` between selections does not reset the window
- Selections from a previous turn (before last user message) do not count"