### PR TITLE
fix: #WZ-32024 prevent `@CreatedBy` from being overridden on updates

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/entity/EntityMetadata.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/entity/EntityMetadata.kt
@@ -11,9 +11,14 @@ import java.util.UUID
  * - Identity (id)
  * - Audit trail (created, createdBy, modified, modifiedBy)
  * - Soft delete (removed)
+ * - Optimistic locking version (version)
  *
  * This class will be annotated with Spring Data annotations when we add database persistence.
  * Spring Data will handle automatic timestamp updates on save.
+ *
+ * [version] is used by Spring Data Neo4j for optimistic locking and for the `isNew()` heuristic:
+ * a null version means the entity has never been persisted, so Spring Data treats it as new
+ * (triggering `@CreatedBy`). A non-null version means the entity already exists (update path).
  *
  * @JsonIgnoreProperties(ignoreUnknown = true) allows forward-compatible deserialization
  * when new fields are added to the metadata in future versions.
@@ -26,6 +31,7 @@ data class EntityMetadata(
     val modified: Instant = Instant.now(),
     val modifiedBy: String? = null,
     var removed: Boolean = false,
+    val version: Long? = null,
 ) {
     fun markAsRemoved(): EntityMetadata = copy(removed = true)
 }

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/entity/EntityMetadata.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/entity/EntityMetadata.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.sdk.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.Instant
 import java.util.UUID
@@ -31,7 +32,7 @@ data class EntityMetadata(
     val modified: Instant = Instant.now(),
     val modifiedBy: String? = null,
     var removed: Boolean = false,
-    val version: Long? = null,
+    @JsonIgnore val version: Long? = null,
 ) {
     fun markAsRemoved(): EntityMetadata = copy(removed = true)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNode.kt
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.annotation.Version
 import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
 import org.springframework.data.neo4j.core.schema.Relationship
@@ -40,6 +41,7 @@ data class AgentConfigNode(
     val externalMetadataJson: String? = null,
     val advancedExecution: Boolean = false,
     // EntityMetadata fields
+    @Version val version: Long? = null,
     @CreatedDate val created: Instant = Instant.now(),
     @CreatedBy val createdBy: String? = null,
     @LastModifiedDate val modified: Instant = Instant.now(),
@@ -58,6 +60,7 @@ data class AgentConfigNode(
                     modified = modified,
                     modifiedBy = modifiedBy,
                     removed = removed ?: false,
+                    version = version,
                 ),
             namespaceId = UUID.fromString(namespaceId),
             name = name,
@@ -85,6 +88,7 @@ data class AgentConfigNode(
                 integrationsJson = config.integrations?.let { MAPPER.writeValueAsString(it) },
                 externalMetadataJson = config.externalMetadata?.let { MAPPER.writeValueAsString(it) },
                 advancedExecution = config.advancedExecution,
+                version = config.metadata.version,
                 created = config.metadata.created,
                 createdBy = config.metadata.createdBy,
                 modified = config.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializer.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializer.kt
@@ -34,6 +34,20 @@ class Neo4jSchemaInitializer(
                 "FOR (u:ActiveUser) REQUIRE u.externalId IS UNIQUE",
         ).run()
         logger.info { "[Neo4jSchemaInitializer] Constraint user_external_id_unique ensured" }
+
+        // Backfill @Version on AgentConfig nodes created before the version field was introduced.
+        // Spring Data Neo4j's optimistic-locking check generates MATCH WHERE version = ?
+        // which fails if the property is absent. Setting version = 0 makes existing nodes
+        // compatible without affecting any application logic.
+        val backfilled = neo4jClient.query(
+            "MATCH (a:AgentConfig) WHERE a.version IS NULL SET a.version = 0 RETURN count(a) AS count",
+        ).fetchAs(Long::class.java)
+            .mappedBy { _, record -> record["count"].asLong() }
+            .one()
+            .orElse(0L)
+        if (backfilled > 0L) {
+            logger.info { "[Neo4jSchemaInitializer] Backfilled version=0 on $backfilled AgentConfig node(s)" }
+        }
     }
 
     companion object : KLogging()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializerSpec.kt
@@ -1,0 +1,80 @@
+package io.whozoss.agentos.config
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.agentConfig.AgentConfig
+import io.whozoss.agentos.agentConfig.AgentConfigRepository
+import io.whozoss.agentos.persistence.neo4j.EmbeddedNeo4jTestConfiguration
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.neo4j.core.Neo4jClient
+import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
+
+/**
+ * Integration test for [Neo4jSchemaInitializer].
+ *
+ * Verifies that AgentConfig nodes without a version property (created before @Version
+ * was introduced) are backfilled with version=0 on startup, so that Spring Data Neo4j's
+ * optimistic-locking check does not fail on the first update.
+ */
+@SpringBootTest
+@ActiveProfiles("test", "embedded-neo4j")
+@Import(EmbeddedNeo4jTestConfiguration::class)
+class Neo4jSchemaInitializerSpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var neo4jClient: Neo4jClient
+    @Autowired lateinit var agentConfigRepository: AgentConfigRepository
+
+    init {
+        "backfill allows update on legacy AgentConfig node without version property" {
+            val namespaceId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            // Simulate a legacy node: insert via raw Cypher without version property
+            neo4jClient.query(
+                "CREATE (a:AgentConfig {id: \$id, namespaceId: \$namespaceId, name: 'legacy-agent', removed: false})"
+            ).bindAll(mapOf("id" to agentId.toString(), "namespaceId" to namespaceId.toString())).run()
+
+            // Verify node exists without version
+            val hasVersion = neo4jClient.query(
+                "MATCH (a:AgentConfig {id: \$id}) RETURN a.version IS NOT NULL AS hasVersion"
+            ).bindAll(mapOf("id" to agentId.toString()))
+                .fetchAs(Boolean::class.java)
+                .mappedBy { _, record -> record["hasVersion"].asBoolean() }
+                .one().orElse(false)
+            hasVersion shouldBe false
+
+            // Run the backfill
+            val initializer = Neo4jSchemaInitializer(neo4jClient)
+            initializer.run(object : org.springframework.boot.ApplicationArguments {
+                override fun getSourceArgs() = emptyArray<String>()
+                override fun getNonOptionArgs() = emptyList<String>()
+                override fun getOptionNames() = emptySet<String>()
+                override fun containsOption(name: String) = false
+                override fun getOptionValues(name: String) = emptyList<String>()
+            })
+
+            // Verify version is now 0 after backfill
+            val versionAfterBackfill = neo4jClient.query(
+                "MATCH (a:AgentConfig {id: \$id}) RETURN a.version AS version"
+            ).bindAll(mapOf("id" to agentId.toString()))
+                .fetchAs(Long::class.java)
+                .mappedBy { _, record -> record["version"].asLong() }
+                .one().orElse(null)
+            versionAfterBackfill shouldBe 0L
+
+            // Load via repository and update — should not throw OptimisticLockingFailureException
+            val loaded = agentConfigRepository.findByIds(listOf(agentId)).first()
+            loaded.metadata.version shouldBe 0L
+
+            val saved = agentConfigRepository.save(loaded.copy(name = "updated-agent"))
+            saved.name shouldBe "updated-agent"
+            saved.metadata.version shouldBe 1L
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/config/TestAuditConfiguration.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/config/TestAuditConfiguration.kt
@@ -12,15 +12,25 @@ import java.util.Optional
  * The production [AgentOsAuditorAware] relies on [org.springframework.web.context.request.RequestContextHolder]
  * which is unavailable in persistence tests (no HTTP request). This bean provides a
  * deterministic auditor UUID so that @CreatedBy / @LastModifiedBy annotations are exercised.
+ *
+ * [currentAuditorId] is mutable so that individual tests can simulate an auditor switch
+ * between create and update operations. Always reset it in `afterEach` / `beforeEach`.
  */
 @TestConfiguration
 class TestAuditConfiguration {
     @Bean
     @Primary
     fun testAuditorAware(): AuditorAware<String> =
-        AuditorAware { Optional.of(TEST_AUDITOR_ID) }
+        AuditorAware { Optional.of(currentAuditorId) }
 
     companion object {
         const val TEST_AUDITOR_ID = "00000000-0000-0000-0000-000000000042"
+        const val SECOND_AUDITOR_ID = "00000000-0000-0000-0000-000000000099"
+
+        /**
+         * Mutable auditor identity for tests that need to simulate a user switch
+         * between create and update operations. Reset to [TEST_AUDITOR_ID] in beforeEach.
+         */
+        var currentAuditorId: String = TEST_AUDITOR_ID
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
@@ -67,7 +67,10 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         }
 
     init {
-        beforeEach { Neo4jContainerSupport.clearDatabase(driver) }
+        beforeEach {
+            Neo4jContainerSupport.clearDatabase(driver)
+            TestAuditConfiguration.currentAuditorId = TestAuditConfiguration.TEST_AUDITOR_ID
+        }
 
         // -------------------------------------------------------------------------
         // No membership — empty result
@@ -393,6 +396,25 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
             updated.metadata.createdBy shouldBe TestAuditConfiguration.TEST_AUDITOR_ID
             updated.metadata.modifiedBy shouldBe TestAuditConfiguration.TEST_AUDITOR_ID
+        }
+
+        "save on update preserves original createdBy when auditor changes" {
+            val ns = namespaceRepo.save(namespace())
+
+            // Create with auditor A
+            TestAuditConfiguration.currentAuditorId = TestAuditConfiguration.TEST_AUDITOR_ID
+            val created = agentConfigRepo.save(agentConfig(ns.id, "multi-auditor-agent"))
+            created.metadata.createdBy shouldBe TestAuditConfiguration.TEST_AUDITOR_ID
+            created.metadata.modifiedBy shouldBe TestAuditConfiguration.TEST_AUDITOR_ID
+
+            // Update with auditor B
+            TestAuditConfiguration.currentAuditorId = TestAuditConfiguration.SECOND_AUDITOR_ID
+            val updated = agentConfigRepo.save(created.copy(name = "renamed-by-other-user"))
+
+            // createdBy MUST remain auditor A
+            updated.metadata.createdBy shouldBe TestAuditConfiguration.TEST_AUDITOR_ID
+            // modifiedBy MUST be auditor B
+            updated.metadata.modifiedBy shouldBe TestAuditConfiguration.SECOND_AUDITOR_ID
         }
 
         "soft delete stamps lastModifiedDate" {

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -2384,9 +2384,6 @@ components:
           type: string
         removed:
           type: boolean
-        version:
-          type: integer
-          format: int64
       required:
       - created
       - id

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -2384,6 +2384,9 @@ components:
           type: string
         removed:
           type: boolean
+        version:
+          type: integer
+          format: int64
       required:
       - created
       - id


### PR DESCRIPTION
### Problem
On `AgentConfigNode`, `@CreatedBy` was being overridden on every update instead of only on creation, causing the creator field to be incorrectly changed each time the entity was saved.

### Root cause
The `AgentConfigNode` ID is an application-generated UUID. Spring Data's default `isNew()` logic assumes that an entity is new when its ID is `null` or database-generated. With an application-assigned UUID, the entity always appears as "already existing" to `isNew()`, so the auditing mechanism cannot distinguish creation from update. As a result, `@CreatedBy` is treated the same way on every `save()` operation and gets overwritten on each update.

### Fix
Because `isNew()` cannot be used reliably with an application-generated UUID, a version-based condition is used instead to detect initial creation. The version field (managed by Spring Data Neo4j for optimistic locking) is null on first save and non-null on subsequent updates, allowing @CreatedBy to be set only once. This field is kept internal and excluded from API serialization via @JsonIgnore.

The test *"save on update preserves original createdBy when auditor changes"* was written first to reproduce and prove the bug, no existing test covered this case. The test was failing initially, confirming the incorrect behaviour. After implementing the fix, the test passes, ensuring `@CreatedBy` is only set on creation and remains unchanged on subsequent updates even when the auditor changes.