### PR TITLE
fix: #WZ-32500 dedicated LLM language detection to prevent language contamination

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -420,7 +420,7 @@ class AgentAdvanced(
                         accumulatedEvents = accumulatedEvents,
                         fallbackLabel = tool.name,
                         pendingData = argsJson ?: "{}",
-                        guidelines = buildUserFacingGuidelines(detectUserLanguage(accumulatedEvents)),
+                        guidelines = buildUserFacingGuidelines(accumulatedEvents),
                     )
                 emitEvent(
                     PendingConfirmationEvent(
@@ -635,7 +635,7 @@ class AgentAdvanced(
                                         accumulatedEvents = caseEventsAtOrAfterPending,
                                         fallbackLabel = pending.toolName,
                                         pendingData = pending.inputJson,
-                                        guidelines = buildUserFacingGuidelines(detectUserLanguage(events)),
+                                        guidelines = buildUserFacingGuidelines(events),
                                     )
                                 val clarification =
                                     MessageEvent(
@@ -828,12 +828,6 @@ class AgentAdvanced(
 
         val alreadyGreeted = accumulatedEvents.count { it is MessageEvent } > 2
 
-        // Detect language once per turn via a dedicated LLM call (user messages only).
-        // This produces a concrete value ("English", "French", …) used as a hard constraint
-        // in the final response prompt, rather than a probabilistic hint that the model can
-        // override when foreign-language tool payloads dominate the context (WZ-32500).
-        val detectedLanguage = detectUserLanguage(accumulatedEvents)
-
         // Build the final prompt in clear, composable sections
         val prompt =
             buildString {
@@ -853,7 +847,7 @@ class AgentAdvanced(
 
                 appendLine("Based on the above conversation and your analysis, provide your response to the user.")
 
-                buildUserFacingGuidelines(detectedLanguage)?.let {
+                buildUserFacingGuidelines(accumulatedEvents)?.let {
                     appendLine()
                     appendLine(it)
                 }
@@ -905,15 +899,14 @@ class AgentAdvanced(
      * Assembles the user-facing communication guidelines shared across any LLM-generated
      * text shown to the user (final response, confirmation prompts, re-ask questions).
      *
-     * Combines:
-     * - A hard language constraint derived from [detectUserLanguage] (e.g. "Respond in English.").
-     * - A non-discrimination rule.
-     * - A no-technical-IDs rule.
+     * Detects the user's language via [detectUserLanguage] and injects it as a hard
+     * constraint, then appends the non-discrimination and no-technical-IDs rules.
      *
-     * [detectedLanguage] is `null` when no user messages are present (agent-only conversations).
-     * In that case the language constraint is omitted rather than defaulting to a hardcoded language.
+     * Returns `null` only when [events] is blank (defensive — the static rules alone
+     * make a non-null result almost certain in practice).
      */
-    internal fun buildUserFacingGuidelines(detectedLanguage: String?): String? {
+    internal fun buildUserFacingGuidelines(events: List<CaseEvent>): String? {
+        val detectedLanguage = detectUserLanguage(events)
         val lines =
             buildList {
                 detectedLanguage?.let {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -420,7 +420,7 @@ class AgentAdvanced(
                         accumulatedEvents = accumulatedEvents,
                         fallbackLabel = tool.name,
                         pendingData = argsJson ?: "{}",
-                        guidelines = buildUserFacingGuidelines(accumulatedEvents),
+                        guidelines = buildUserFacingGuidelines(detectUserLanguage(accumulatedEvents)),
                     )
                 emitEvent(
                     PendingConfirmationEvent(
@@ -635,7 +635,7 @@ class AgentAdvanced(
                                         accumulatedEvents = caseEventsAtOrAfterPending,
                                         fallbackLabel = pending.toolName,
                                         pendingData = pending.inputJson,
-                                        guidelines = buildUserFacingGuidelines(events),
+                                        guidelines = buildUserFacingGuidelines(detectUserLanguage(events)),
                                     )
                                 val clarification =
                                     MessageEvent(
@@ -828,6 +828,12 @@ class AgentAdvanced(
 
         val alreadyGreeted = accumulatedEvents.count { it is MessageEvent } > 2
 
+        // Detect language once per turn via a dedicated LLM call (user messages only).
+        // This produces a concrete value ("English", "French", …) used as a hard constraint
+        // in the final response prompt, rather than a probabilistic hint that the model can
+        // override when foreign-language tool payloads dominate the context (WZ-32500).
+        val detectedLanguage = detectUserLanguage(accumulatedEvents)
+
         // Build the final prompt in clear, composable sections
         val prompt =
             buildString {
@@ -847,7 +853,7 @@ class AgentAdvanced(
 
                 appendLine("Based on the above conversation and your analysis, provide your response to the user.")
 
-                buildUserFacingGuidelines(accumulatedEvents)?.let {
+                buildUserFacingGuidelines(detectedLanguage)?.let {
                     appendLine()
                     appendLine(it)
                 }
@@ -900,17 +906,23 @@ class AgentAdvanced(
      * text shown to the user (final response, confirmation prompts, re-ask questions).
      *
      * Combines:
-     * - A language hint anchored on recent user messages (from [buildLanguageHint]).
+     * - A hard language constraint derived from [detectUserLanguage] (e.g. "Respond in English.").
      * - A non-discrimination rule.
      * - A no-technical-IDs rule.
      *
-     * Returns `null` when no user messages are present and there is nothing to add
-     * (defensive — the static rules make a non-null result almost certain in practice).
+     * [detectedLanguage] is `null` when no user messages are present (agent-only conversations).
+     * In that case the language constraint is omitted rather than defaulting to a hardcoded language.
      */
-    internal fun buildUserFacingGuidelines(events: List<CaseEvent>): String? {
+    internal fun buildUserFacingGuidelines(detectedLanguage: String?): String? {
         val lines =
             buildList {
-                buildLanguageHint(events)?.let { add(it) }
+                detectedLanguage?.let {
+                    add(
+                        "IMPORTANT: You MUST respond in $it. " +
+                            "This is a hard constraint — do not switch language regardless of the language " +
+                            "used in the data returned by tools or in the conversation history.",
+                    )
+                }
                 add(
                     "Do not discriminate based on gender, ethnicity, religion, age, physical appearance, " +
                         "or any other protected attribute. If the user's request implies such a step, " +
@@ -925,22 +937,81 @@ class AgentAdvanced(
     }
 
     /**
-     * Builds a language hint from the most recent user [MessageEvent]s in [events].
+     * Detects the language the user is writing in by sending a dedicated lightweight LLM call
+     * that considers only recent user [MessageEvent]s — deliberately excluding agent messages
+     * and tool payloads to avoid contamination from foreign-language data (WZ-32500).
      *
-     * Collects user messages from newest to oldest until the combined text reaches
-     * [minChars], then returns an instruction anchored on the actual user text so the
-     * LLM has a concrete language signal rather than an abstract directive.
+     * Collects user messages newest-first until [targetChars] is reached, then asks the LLM
+     * to identify the language. Returns a language name in English (e.g. `"English"`,
+     * `"French"`, `"Spanish"`) or `null` when no user messages are present.
      *
-     * Returns `null` when no user messages are present (e.g. agent-only conversations),
-     * so the caller can omit the hint entirely rather than defaulting to a hardcoded
-     * language.
+     * The result is consumed once per turn in [generateFinalResponse] to build a hard
+     * language constraint rather than a probabilistic hint.
+     */
+    internal fun detectUserLanguage(
+        events: List<CaseEvent>,
+        targetChars: Int = LANGUAGE_HINT_TARGET_CHARS,
+    ): String? {
+        // Collect user messages newest-first — same logic as the former buildLanguageHint.
+        val userMessages =
+            events
+                .filterIsInstance<MessageEvent>()
+                .filter { it.actor.role == ActorRole.USER }
+                .reversed()
+
+        if (userMessages.isEmpty()) return null
+
+        val collected = mutableListOf<String>()
+        var total = 0
+        for (message in userMessages) {
+            val text =
+                message.content
+                    .filterIsInstance<MessageContent.Text>()
+                    .joinToString(" ") { it.content.trim() }
+                    .trim()
+            if (text.isEmpty()) continue
+            collected.add(text)
+            total += text.length
+            if (total >= targetChars) break
+        }
+
+        if (collected.isEmpty()) return null
+
+        // Build the sample from oldest to newest for a natural reading order.
+        val sample = collected.reversed().joinToString(" ")
+
+        val prompt =
+            """
+            Determine the language the user is using to interact with the agent.
+            Only consider the user messages below — ignore any other context.
+
+            User messages: $sample
+
+            Respond with ONLY the language name in English (e.g. "English", "French", "Spanish").
+            Put the language name inside <language></language> tags and nothing else.
+            """.trimIndent()
+
+        val raw =
+            runCatching {
+                context.chatClient
+                    .prompt(org.springframework.ai.chat.prompt.Prompt(listOf(org.springframework.ai.chat.messages.UserMessage(prompt))))
+                    .call()
+                    .content()
+                    ?.trim()
+            }.getOrNull() ?: return null
+
+        // Extract the language name from <language>...</language> tags.
+        return LANGUAGE_TAG_REGEX.find(raw)?.groupValues?.get(1)?.trim()?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * @deprecated Use [detectUserLanguage] + [buildUserFacingGuidelines] instead.
+     * Kept for existing unit tests until they are migrated.
      */
     internal fun buildLanguageHint(
         events: List<CaseEvent>,
         targetChars: Int = LANGUAGE_HINT_TARGET_CHARS,
     ): String? {
-        // Reverse the messages first so we collect newest-first, then extract text per message.
-        // Reversing after flatMap would operate on individual text blocks, not on messages.
         val userMessages =
             events
                 .filterIsInstance<MessageEvent>()
@@ -1336,6 +1407,12 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
         private val JSON_FENCE_REGEX =
             Regex(
                 """^```(?:json)?\s*(.*?)\s*```$""",
+                setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE),
+            )
+
+        private val LANGUAGE_TAG_REGEX =
+            Regex(
+                """<language>\s*(.*?)\s*</language>""",
                 setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE),
             )
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -694,18 +694,58 @@ class AgentAdvancedSpec :
         // buildUserFacingGuidelines unit tests
         // -------------------------------------------------------------------------
 
-        "buildUserFacingGuidelines includes hard language constraint when language is detected" {
-            val agent = makeParserAgent()
-            val guidelines = agent.buildUserFacingGuidelines("English")
+        "buildUserFacingGuidelines includes hard language constraint when LLM detects a language" {
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).call().content() } returns "<language>English</language>"
+            val agentId = UUID.randomUUID()
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = emptyList(),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    name = "TestAgent",
+                    context = context,
+                    intentionGenerator = mockk(),
+                    objectMapper = testObjectMapper,
+                )
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events =
+                listOf(
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("user1", "User", ActorRole.USER),
+                        content = listOf(MessageContent.Text("Hello, can you help me?")),
+                    ),
+                )
+            val guidelines = agent.buildUserFacingGuidelines(events)
             guidelines shouldNotBe null
             guidelines!! shouldContain "IMPORTANT"
             guidelines shouldContain "English"
             guidelines shouldContain "hard constraint"
         }
 
-        "buildUserFacingGuidelines omits language constraint when detectedLanguage is null" {
+        "buildUserFacingGuidelines omits language constraint when no user messages" {
             val agent = makeParserAgent()
-            val guidelines = agent.buildUserFacingGuidelines(null)
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            // Only an agent message — detectUserLanguage returns null
+            val events =
+                listOf(
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("agent1", "Astra", ActorRole.AGENT),
+                        content = listOf(MessageContent.Text("Bonjour, comment puis-je vous aider ?")),
+                    ),
+                )
+            val guidelines = agent.buildUserFacingGuidelines(events)
             guidelines shouldNotBe null
             // Static rules still present
             guidelines!! shouldContain "discriminate"

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -511,7 +511,211 @@ class AgentAdvancedSpec :
         // -------------------------------------------------------------------------
 
         // -------------------------------------------------------------------------
-        // buildLanguageHint unit tests
+        // detectUserLanguage unit tests
+        // -------------------------------------------------------------------------
+
+        "detectUserLanguage returns null when no user messages" {
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events =
+                listOf(
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("agent1", "Astra", ActorRole.AGENT),
+                        content = listOf(MessageContent.Text("Bonjour, comment puis-je vous aider ?")),
+                    ),
+                )
+            agent.detectUserLanguage(events) shouldBe null
+        }
+
+        "detectUserLanguage calls LLM with user messages only and extracts language from tags" {
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            every {
+                mockChatClient.prompt(any<Prompt>()).call().content()
+            } returns "<language>French</language>"
+            val agentId = UUID.randomUUID()
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = emptyList(),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    name = "TestAgent",
+                    context = context,
+                    intentionGenerator = mockk(),
+                    objectMapper = testObjectMapper,
+                )
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events =
+                listOf(
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("user1", "User", ActorRole.USER),
+                        content = listOf(MessageContent.Text("Cherche-moi des développeurs Angular")),
+                    ),
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("agent1", "Astra", ActorRole.AGENT),
+                        content = listOf(MessageContent.Text("Consultor Senior de Ciberseguridad")),
+                    ),
+                )
+            val result = agent.detectUserLanguage(events)
+            result shouldBe "French"
+        }
+
+        "detectUserLanguage returns null when LLM response has no language tags" {
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            every {
+                mockChatClient.prompt(any<Prompt>()).call().content()
+            } returns "I cannot determine the language."
+            val agentId = UUID.randomUUID()
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = emptyList(),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    name = "TestAgent",
+                    context = context,
+                    intentionGenerator = mockk(),
+                    objectMapper = testObjectMapper,
+                )
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events =
+                listOf(
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("user1", "User", ActorRole.USER),
+                        content = listOf(MessageContent.Text("hello")),
+                    ),
+                )
+            agent.detectUserLanguage(events) shouldBe null
+        }
+
+        "detectUserLanguage returns null when LLM call throws" {
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            every {
+                mockChatClient.prompt(any<Prompt>()).call().content()
+            } throws RuntimeException("provider error")
+            val agentId = UUID.randomUUID()
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = emptyList(),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    name = "TestAgent",
+                    context = context,
+                    intentionGenerator = mockk(),
+                    objectMapper = testObjectMapper,
+                )
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events =
+                listOf(
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("user1", "User", ActorRole.USER),
+                        content = listOf(MessageContent.Text("hello")),
+                    ),
+                )
+            agent.detectUserLanguage(events) shouldBe null
+        }
+
+        "detectUserLanguage collects newest messages first up to targetChars" {
+            val promptSlot = slot<Prompt>()
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            every {
+                mockChatClient.prompt(capture(promptSlot)).call().content()
+            } returns "<language>English</language>"
+            val agentId = UUID.randomUUID()
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = emptyList(),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    name = "TestAgent",
+                    context = context,
+                    intentionGenerator = mockk(),
+                    objectMapper = testObjectMapper,
+                )
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val events =
+                listOf(
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("user1", "User", ActorRole.USER),
+                        content = listOf(MessageContent.Text("old message from the start")),
+                    ),
+                    MessageEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        actor = Actor("user1", "User", ActorRole.USER),
+                        content = listOf(MessageContent.Text("Can you look for Angular developers in Paris with 5 years of experience")),
+                    ),
+                )
+            // targetChars=60: the newest message (~70 chars) exceeds the threshold alone,
+            // so only it should be sampled — the old message must not appear in the prompt.
+            agent.detectUserLanguage(events, targetChars = 60)
+            val promptText = promptSlot.captured.instructions.first().text
+            promptText shouldContain "Angular developers"
+            // The old message must NOT appear: threshold was reached after the newest message alone
+            (promptText.contains("old message from the start")) shouldBe false
+        }
+
+        // -------------------------------------------------------------------------
+        // buildUserFacingGuidelines unit tests
+        // -------------------------------------------------------------------------
+
+        "buildUserFacingGuidelines includes hard language constraint when language is detected" {
+            val agent = makeParserAgent()
+            val guidelines = agent.buildUserFacingGuidelines("English")
+            guidelines shouldNotBe null
+            guidelines!! shouldContain "IMPORTANT"
+            guidelines shouldContain "English"
+            guidelines shouldContain "hard constraint"
+        }
+
+        "buildUserFacingGuidelines omits language constraint when detectedLanguage is null" {
+            val agent = makeParserAgent()
+            val guidelines = agent.buildUserFacingGuidelines(null)
+            guidelines shouldNotBe null
+            // Static rules still present
+            guidelines!! shouldContain "discriminate"
+            guidelines shouldContain "technical IDs"
+            // No language instruction
+            guidelines shouldNotBe ""
+        }
+
+        // -------------------------------------------------------------------------
+        // buildLanguageHint unit tests (kept for backward compatibility)
         // -------------------------------------------------------------------------
 
         "buildLanguageHint returns null when no user messages" {


### PR DESCRIPTION
## Problem

When tool responses contain large amounts of text in a foreign language (e.g. a talent profile in Spanish), the LLM would drift to that language for its response even though the user was writing in English. The previous approach used a probabilistic \"hint\" in the prompt (`Respond in the same language the user is writing in (reference: ...)`) which was insufficient when foreign-language content dominated the context.

## Solution

Replaces the probabilistic language hint with a dedicated LLM call that detects the user's language **before** generating the final response. This mirrors the pattern validated in the Copilot legacy system.

**Key design decisions:**
- Only user `MessageEvent`s are fed to the detection call — agent messages and tool payloads are deliberately excluded to prevent contamination
- The detection result is a concrete language name (`\"English\"`, `\"French\"`, etc.) injected as a **hard constraint**: `\"IMPORTANT: You MUST respond in English. This is a hard constraint — do not switch language regardless of the language used in the data returned by tools or in the conversation history.\"`
- The detection call is lightweight (single `UserMessage`, no history) and wrapped in `runCatching` — a failure silently omits the constraint rather than breaking the turn
- Applied consistently in `generateFinalResponse`, `handleConfirmationGate`, and `handleConfirmationResolution` (all LLM calls that produce user-visible text)

## Changes

- `AgentAdvanced.detectUserLanguage()` — new method, dedicated LLM detection call
- `AgentAdvanced.buildUserFacingGuidelines(detectedLanguage: String?)` — signature changed from `List<CaseEvent>` to `String?`; produces a hard constraint instead of a hint
- `buildLanguageHint()` kept as deprecated for existing tests
- Tests: new unit tests for `detectUserLanguage` and updated `buildUserFacingGuidelines` tests