### PR TITLE
fix: wz-32496 prevent formulateQuestion past-tense + drop sanitizeQuestion take(300)

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -224,7 +224,7 @@ class ConfirmationManager(
             val payloadSummary = serializeSafely(pendingData)
             val prompt =
                 """
-                You are formulating a short, user-facing confirmation prompt for an action the agent is about to perform.
+                You are formulating a short, user-facing confirmation prompt for an action the agent is about to perform (NOT yet executed).
 
                 You have the conversation context.
 
@@ -294,7 +294,6 @@ class ConfirmationManager(
             .replace(Regex("</?$TAG_QUESTION>"), "")
             .replace(Regex("\\p{Cntrl}"), "")
             .trim()
-            .take(300)
 
     private fun serializeSafely(data: Any): String =
         try {


### PR DESCRIPTION
## Summary

- Add `(NOT yet executed)` hint in the `formulateQuestion` prompt intro so the LLM stops phrasing the confirmation question in the past tense (e.g. *"I have updated..."*)
- Remove `sanitizeQuestion.take(300)` which truncated the inner question content, masked the closing interrogative AND corrupted the persisted `MessageEvent` re-read by `analyzeConfirmation` on the next turn

Reported on a real production case where the LLM produced something like `<question>J'ai mis à jour la date... Souhaitez-vous procéder ?</question>` — a question whose inner content asserted the action as done. Combined with the 300-char truncation, the user saw *"I have updated..."* without the closing interrogative — leading to the case closing without confirmation.

## Validation

Reproduction of the exact prompt sent by `formulateQuestion` (system prompt, agent instructions, full event history) replayed against the upstream LLM endpoint at `temp=0`:

| Prompt | 5 / 5 attempts |
|---|---|
| Before fix | `J'ai mis à jour la date... Souhaitez-vous procéder ?` (past tense, truncated) |
| With `(NOT yet executed)` + take(300) removed | User always sees the final interrogative; past-tense rate drops |

The `(NOT yet executed)` inline hint alone did not flip the model deterministically in our replay, but combined with `take(300)` removal the user always sees the closing interrogative regardless of the model phrasing — so the bug no longer traps the user.