### PR TITLE
fix: restore matrix strategy for jvm publish to avoid github packages 409 conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,20 +204,52 @@ jobs:
             echo "Warning: Coday Twin PKG not found"
           fi
 
-  # Job 3: Publish all JVM artifacts to GitHub Packages
-  publish-agentos-artifacts:
-    name: publish jvm artifacts to github packages
+  # Job 3: Resolve the list of JVM projects to publish from the platform:jvm tag
+  compute-jvm-projects:
     runs-on: ubuntu-latest
     needs: release
+    if: needs.release.outputs.new_version
+    outputs:
+      projects: ${{ steps.resolve.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.release_sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve JVM projects from tag
+        id: resolve
+        # --json --quiet mirrors validate.yml to avoid output pollution from the nx daemon/cache
+        run: |
+          PROJECTS=$(npx nx show projects --projects="tag:platform:jvm" --json --quiet | jq -c '.' || echo '[]')
+          echo "projects=$PROJECTS" >> $GITHUB_OUTPUT
+
+  # Job 4: Publish all JVM artifacts to GitHub Packages
+  publish-agentos-artifacts:
+    name: publish ${{ matrix.project }} to github packages
+    runs-on: ubuntu-latest
+    needs: [release, compute-jvm-projects]
     if: needs.release.outputs.new_version
 
     permissions:
       contents: read
       packages: write
 
-    env:
-      # 20 = max concurrent jobs for GitHub Free plan on standard runners
-      NX_PARALLEL: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(needs.compute-jvm-projects.outputs.projects) }}
 
     steps:
       - name: Checkout repository
@@ -252,4 +284,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-        run: pnpm nx run-many -t publish --projects="tag:platform:jvm"
+        run: pnpm nx publish ${{ matrix.project }}

--- a/apps/client/src/app/components/token-usage/token-usage.component.ts
+++ b/apps/client/src/app/components/token-usage/token-usage.component.ts
@@ -116,7 +116,7 @@ export class TokenUsageComponent implements OnInit {
     if (!total) return false
 
     // Token counts may be null for legacy periods where token tracking was disabled,
-    // but cost can still be available. Only consider the period "missing" when both are absent
+    // but cost can still be available. Only consider the period "missing" when both are absent.
     return total.totalTokens === null && (total.cost === null || total.cost === undefined)
   })
 


### PR DESCRIPTION
GitHub Packages has a known reliability issue: under concurrent load, a PUT request 
can succeed server-side but return an error to the client. Gradle then retries the 
upload and gets a 409 Conflict, failing the build even though the artifact was 
successfully published.

Running all JVM projects via `nx run-many` with high parallelism triggers this 
consistently. Restoring the matrix strategy isolates each project into its own job, 
reducing concurrent load on GitHub Packages to a level it handles reliably.