### PR TITLE
feat: #WZ-32424 enrich redirect tool description with agent integrations and exclude calling agent

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolContext.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolContext.kt
@@ -19,10 +19,15 @@ import java.util.UUID
  * @param caseEvents A live snapshot of the current case's event list at the moment
  *   of tool invocation. Evaluated lazily — each call reflects events added during
  *   the current agent run, including prior tool responses in the same turn.
+ * @param agentName The name of the agent that owns this tool invocation, or null when
+ *   the context is not associated with a specific agent (e.g. tool-set resolution at
+ *   namespace level). Plugins may use this to exclude the running agent from lists they
+ *   build (e.g. the redirect tool excludes the calling agent from eligible targets).
  */
 data class ToolContext(
     val namespaceId: UUID,
     val userId: UUID?,
     val userExternalId: String?,
     val caseEvents: List<CaseEvent>,
+    val agentName: String? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentExecutionContext.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.agent
 
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import io.whozoss.agentos.sdk.tool.ToolContext
 import java.util.UUID
 
 /**
@@ -23,4 +24,16 @@ data class AgentExecutionContext(
     val caseId: UUID? = null,
     val userId: UUID? = null,
     val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
-)
+) {
+    fun toToolContext(
+        userExternalId: String?,
+        agentName: String?,
+    ): ToolContext =
+        ToolContext(
+            namespaceId = namespaceId,
+            userId = userId,
+            userExternalId = userExternalId,
+            caseEvents = caseEventsProvider(),
+            agentName = agentName,
+        )
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -122,9 +122,9 @@ class AgentServiceImpl(
         )
         val tools =
             if (context.userId != null) {
-                toolResolverService.resolveToolsForRun(context.namespaceId, context.userId, config.integrations)
+                toolResolverService.resolveToolsForRun(context.namespaceId, context.userId, config.integrations, config.name)
             } else {
-                toolResolverService.resolveToolsForNamespace(context.namespaceId, config.integrations)
+                toolResolverService.resolveToolsForNamespace(context.namespaceId, config.integrations, config.name)
             }
         return ResolvedAgentDefinition(
             agentConfigId = config.metadata.id,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -83,8 +83,7 @@ class AgentServiceImpl(
                     namespaceId = namespaceId,
                     userId = userId,
                     agentName = namePart,
-                )
-                .firstOrNull()
+                ).firstOrNull()
                 ?.name
         } else {
             agentConfigService.findByName(namespaceId, namePart)?.name
@@ -113,18 +112,35 @@ class AgentServiceImpl(
                     "AgentConfig '${config.name}' could not resolve an AiModel " +
                         "(modelName=${config.modelName}, namespace=${context.namespaceId}).",
                 )
-        val (modelConfig, providerConfig) = applyOverlaysToModel(baseModel, context.namespaceId, context.userId)
-        val namespaceSystemPrompt = buildNamespaceSystemPrompt(context.namespaceId)
-        val instructions = buildInstructions(
-            baseInstructions = config.instructions,
-            agentIntegrations = config.integrations,
-            context = context,
-        )
+        val (modelConfig, providerConfig) =
+            applyOverlaysToModel(
+                baseModel = baseModel,
+                namespaceId = context.namespaceId,
+                userId = context.userId,
+            )
+        val namespaceSystemPrompt = buildNamespaceSystemPrompt(namespaceId = context.namespaceId)
+        val instructions =
+            buildInstructions(
+                baseInstructions = config.instructions,
+                agentIntegrations = config.integrations,
+                context = context,
+            )
+        val toolContext =
+            context.toToolContext(
+                userExternalId = context.userId?.let { userService.findById(it) }?.externalId,
+                agentName = config.name,
+            )
         val tools =
             if (context.userId != null) {
-                toolResolverService.resolveToolsForRun(context.namespaceId, context.userId, config.integrations, config.name)
+                toolResolverService.resolveToolsForRun(
+                    agentIntegrations = config.integrations,
+                    context = toolContext,
+                )
             } else {
-                toolResolverService.resolveToolsForNamespace(context.namespaceId, config.integrations, config.name)
+                toolResolverService.resolveToolsForNamespace(
+                    agentIntegrations = config.integrations,
+                    context = toolContext,
+                )
             }
         return ResolvedAgentDefinition(
             agentConfigId = config.metadata.id,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
@@ -37,13 +37,32 @@ class RedirectTool(
     data class Input(val agentName: String)
 
     /**
+     * One integration available to an eligible agent, optionally restricted to a
+     * specific set of tool names.
+     *
+     * @param name Integration name (matches [IntegrationConfig.name] or
+     *   [ToolPlugin.integrationType] for config-less plugins).
+     * @param allowedTools When non-null, only these tool names (or suffixes for
+     *   multi-instance tools) are available. When null, all tools of the integration
+     *   are available — the list is omitted from the prompt in that case.
+     */
+    data class Integration(val name: String, val allowedTools: List<String>?)
+
+    /**
      * A resolved agent that the LLM may redirect to.
      *
      * @param name Exact agent name as stored in [AgentConfig.name].
      * @param description Human-readable description injected into the tool schema
      *   so the LLM can reason about which agent to choose without a separate list call.
+     * @param integrations Integrations available to this agent, derived from
+     *   [AgentConfig.integrations]. Empty when the agent has no restriction (all
+     *   namespace tools). Each entry may optionally carry a tool whitelist.
      */
-    data class EligibleAgent(val name: String, val description: String?)
+    data class EligibleAgent(
+        val name: String,
+        val description: String?,
+        val integrations: List<Integration> = emptyList(),
+    )
 
     override val name: String = configName?.let { "${it}__redirect" } ?: "redirect"
 
@@ -54,6 +73,14 @@ class RedirectTool(
             agent.description?.takeIf { it.isNotBlank() }
                 ?.also { desc -> appendLine("  - ${agent.name}: $desc") }
                 ?: run { appendLine("  - ${agent.name}") }
+            if (agent.integrations.isNotEmpty()) {
+                appendLine("    Integrations:")
+                agent.integrations.forEach { integration ->
+                    integration.allowedTools
+                        ?.also { tools -> appendLine("      - ${integration.name}: ${tools.joinToString(", ")}") }
+                        ?: run { appendLine("      - ${integration.name}") }
+                }
+            }
         }
     }.trimEnd()
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
@@ -70,15 +70,18 @@ class RedirectTool(
         appendLine("Route the current request to another agent. Use this when the request is better handled by a specialised agent.")
         appendLine("Available agents:")
         eligibleAgents.forEach { agent ->
-            agent.description?.takeIf { it.isNotBlank() }
-                ?.also { desc -> appendLine("  - ${agent.name}: $desc") }
-                ?: run { appendLine("  - ${agent.name}") }
+            val desc = agent.description?.takeIf { it.isNotBlank() }
+            when (desc) {
+                null -> appendLine("  - ${agent.name}")
+                else -> appendLine("  - ${agent.name}: $desc")
+            }
             if (agent.integrations.isNotEmpty()) {
                 appendLine("    Integrations:")
                 agent.integrations.forEach { integration ->
-                    integration.allowedTools
-                        ?.also { tools -> appendLine("      - ${integration.name}: ${tools.joinToString(", ")}") }
-                        ?: run { appendLine("      - ${integration.name}") }
+                    when (val tools = integration.allowedTools) {
+                        null -> appendLine("      - ${integration.name}")
+                        else -> appendLine("      - ${integration.name}: ${tools.joinToString(", ")}")
+                    }
                 }
             }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
@@ -74,8 +74,20 @@ class RedirectToolPlugin(
             ?: listOf("*")
 
         val userId = context.userId
+        val callingAgentName = context.agentName
         val eligibleAgents = agentResolver(namespaceId, userId, patterns)
-            .map { RedirectTool.EligibleAgent(name = it.name, description = it.description) }
+            .filter { agentConfig -> agentConfig.name != callingAgentName }
+            .map { agentConfig ->
+                RedirectTool.EligibleAgent(
+                    name = agentConfig.name,
+                    description = agentConfig.description,
+                    integrations = agentConfig.integrations
+                        ?.map { (integrationName, allowedTools) ->
+                            RedirectTool.Integration(name = integrationName, allowedTools = allowedTools)
+                        }
+                        ?: emptyList(),
+                )
+            }
 
         if (eligibleAgents.isEmpty()) {
             logger.warn { "[RedirectToolPlugin] No eligible agents found for namespace $namespaceId with patterns $patterns" }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -19,6 +19,7 @@ class ToolResolverService(
     fun resolveToolsForNamespace(
         namespaceId: UUID,
         agentIntegrations: Map<String, List<String>?>? = null,
+        agentName: String? = null,
     ): Collection<StandardTool<*>> {
         val resolved = mutableMapOf<String, StandardTool<*>>()
 
@@ -50,6 +51,7 @@ class ToolResolverService(
                                     userId = null,
                                     userExternalId = null,
                                     caseEvents = emptyList(),
+                                    agentName = agentName,
                                 ),
                         ).filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
                 providedTools.forEach { tool ->
@@ -76,6 +78,7 @@ class ToolResolverService(
         namespaceId: UUID,
         userId: UUID,
         agentIntegrations: Map<String, List<String>?>? = null,
+        agentName: String? = null,
     ): Collection<StandardTool<*>> {
         val resolved = mutableMapOf<String, StandardTool<*>>()
 
@@ -139,6 +142,7 @@ class ToolResolverService(
                                     userId = userId,
                                     userExternalId = null,
                                     caseEvents = emptyList(),
+                                    agentName = agentName,
                                 ),
                         ).filter { tool -> isToolAllowed(tool.name, resolvedConfig.name, allowedToolNames) }
                 tools.forEach { tool ->

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -6,6 +6,7 @@ import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.reconciliation.ConfigMergeService
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolPlugin
 import mu.KLogging
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -48,36 +49,7 @@ class ToolResolverService(
                 }
                 return@forEach
             }
-            try {
-                val allowedToolNames = agentIntegrations?.get(config.name)
-                val providedTools =
-                    plugin
-                        .provideTools(
-                            config = config.parameters,
-                            configName = config.name,
-                            context =
-                                ToolContext(
-                                    namespaceId = namespaceId,
-                                    userId = null,
-                                    userExternalId = null,
-                                    caseEvents = emptyList(),
-                                    agentName = agentName,
-                                ),
-                        ).filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
-                providedTools.forEach { tool ->
-                    if (resolved.containsKey(tool.name)) {
-                        logger.warn {
-                            "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${config.integrationType}' overrides an existing entry"
-                        }
-                    }
-                    resolved[tool.name] = tool
-                }
-                logger.info {
-                    "[ToolResolver] Resolved ${providedTools.size} tool(s) from integrationType='${config.integrationType}' for namespace $namespaceId"
-                }
-            } catch (e: Exception) {
-                logger.error(e) { "[ToolResolver] Error instantiating tools for integrationType='${config.integrationType}': ${e.message}" }
-            }
+            extractTools(agentIntegrations, config, plugin, namespaceId, null, agentName, resolved)
         }
 
         logger.info { "[ToolResolver] Total tools for namespace $namespaceId: ${resolved.size}" }
@@ -133,7 +105,7 @@ class ToolResolverService(
                 return@forEach
             }
 
-            val resolvedConfig =
+            val config =
                 try {
                     integrationConfigMergeService.resolve(namespaceId, userId, name)
                 } catch (e: ConfigNotFoundException) {
@@ -146,44 +118,62 @@ class ToolResolverService(
                 }
 
             val plugin =
-                toolRegistryService.findPlugin(resolvedConfig.integrationType) ?: run {
-                    logger.warn { "[ToolResolver] No plugin for integrationType='${resolvedConfig.integrationType}' (name='$name')" }
+                toolRegistryService.findPlugin(config.integrationType) ?: run {
+                    logger.warn { "[ToolResolver] No plugin for integrationType='${config.integrationType}' (name='$name')" }
                     return@forEach
                 }
-
-            try {
-                val allowedToolNames = agentIntegrations?.get(resolvedConfig.name)
-                val tools =
-                    plugin
-                        .provideTools(
-                            config = resolvedConfig.parameters,
-                            configName = resolvedConfig.name,
-                            context =
-                                ToolContext(
-                                    namespaceId = namespaceId,
-                                    userId = userId,
-                                    userExternalId = null,
-                                    caseEvents = emptyList(),
-                                    agentName = agentName,
-                                ),
-                        ).filter { tool -> isToolAllowed(tool.name, resolvedConfig.name, allowedToolNames) }
-                tools.forEach { tool ->
-                    if (resolved.containsKey(tool.name)) {
-                        logger.warn {
-                            "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${resolvedConfig.integrationType}'"
-                        }
-                    }
-                    resolved[tool.name] = tool
-                }
-                logger.info { "[ToolResolver] Resolved ${tools.size} tool(s) from name='$name' (type='${resolvedConfig.integrationType}')" }
-            } catch (e: Exception) {
-                logger.error(e) { "[ToolResolver] Error instantiating tools for name='$name': ${e.message}" }
-            }
+            extractTools(agentIntegrations, config, plugin, namespaceId, userId, agentName, resolved)
         }
 
         logger.info { "[ToolResolver] Total tools for namespace $namespaceId (user $userId): ${resolved.size}" }
         return resolved.values
     }
+
+    private fun extractTools(
+        agentIntegrations: Map<String, List<String>?>?,
+        config: IntegrationConfig,
+        plugin: ToolPlugin,
+        namespaceId: UUID,
+        userId: UUID?,
+        agentName: String?,
+        resolved: MutableMap<String, StandardTool<*>>,
+    ) {
+        try {
+            val allowedToolNames = agentIntegrations?.get(config.name)
+            val tools =
+                plugin
+                    .provideTools(
+                        config = config.parameters,
+                        configName = config.name,
+                        context = buildToolContext(namespaceId = namespaceId, userId = userId, agentName = agentName),
+                    ).filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
+            tools.forEach { tool ->
+                if (resolved.containsKey(tool.name)) {
+                    logger.warn {
+                        "[ToolResolver] Tool name conflict: '${tool.name}' from integrationType='${config.integrationType}' overrides an existing entry"
+                    }
+                }
+                resolved[tool.name] = tool
+            }
+            logger.info {
+                "[ToolResolver] Resolved ${tools.size} tool(s) from integrationType='${config.integrationType}' for namespace $namespaceId"
+            }
+        } catch (e: Exception) {
+            logger.error(e) { "[ToolResolver] Error instantiating tools for integrationType='${config.integrationType}': ${e.message}" }
+        }
+    }
+
+    private fun buildToolContext(
+        namespaceId: UUID,
+        userId: UUID?,
+        agentName: String?,
+    ) = ToolContext(
+        namespaceId = namespaceId,
+        userId = userId,
+        userExternalId = null,
+        caseEvents = emptyList(),
+        agentName = agentName,
+    )
 
     internal fun isToolAllowed(
         toolName: String,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -9,7 +9,6 @@ import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolPlugin
 import mu.KLogging
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class ToolResolverService(
@@ -20,22 +19,17 @@ class ToolResolverService(
     /**
      * Resolves the tool set for a namespace-level agent run (no authenticated user).
      *
-     * @param namespaceId The namespace to resolve tools for.
      * @param agentIntegrations Optional integration filter from [AgentConfig.integrations].
      *   When null, all namespace integrations are included.
-     * @param agentName The name of the agent being built, or null when resolving outside
-     *   an agent context. Passed into [ToolContext] so plugins can exclude the calling
-     *   agent from lists they build (e.g. the redirect tool excludes itself as a target).
      */
     fun resolveToolsForNamespace(
-        namespaceId: UUID,
         agentIntegrations: Map<String, List<String>?>? = null,
-        agentName: String? = null,
+        context: ToolContext,
     ): Collection<StandardTool<*>> {
         val resolved = mutableMapOf<String, StandardTool<*>>()
 
-        val configs = integrationConfigService.findByParent(namespaceId)
-        logger.info { "[ToolResolver] Resolving tools for namespace $namespaceId: ${configs.size} IntegrationConfig(s) found" }
+        val configs = integrationConfigService.findByParent(context.namespaceId)
+        logger.info { "[ToolResolver] Resolving tools for namespace ${context.namespaceId}: ${configs.size} IntegrationConfig(s) found" }
 
         configs.forEach { config ->
             if (agentIntegrations != null && config.name !in agentIntegrations) {
@@ -49,10 +43,10 @@ class ToolResolverService(
                 }
                 return@forEach
             }
-            extractTools(agentIntegrations, config, plugin, namespaceId, null, agentName, resolved)
+            extractTools(agentIntegrations, config, plugin, context, resolved)
         }
 
-        logger.info { "[ToolResolver] Total tools for namespace $namespaceId: ${resolved.size}" }
+        logger.info { "[ToolResolver] Total tools for namespace ${context.namespaceId}: ${resolved.size}" }
         return resolved.values
     }
 
@@ -60,21 +54,16 @@ class ToolResolverService(
      * Resolves the tool set for a user-scoped agent run, applying 3-tier overlay
      * reconciliation for each integration config.
      *
-     * @param namespaceId The namespace to resolve tools for.
-     * @param userId The authenticated user whose overlays should be applied.
      * @param agentIntegrations Optional integration filter from [AgentConfig.integrations].
      *   When null, all namespace integrations are included.
-     * @param agentName The name of the agent being built, or null when resolving outside
-     *   an agent context. Passed into [ToolContext] so plugins can exclude the calling
-     *   agent from lists they build (e.g. the redirect tool excludes itself as a target).
      */
     fun resolveToolsForRun(
-        namespaceId: UUID,
-        userId: UUID,
         agentIntegrations: Map<String, List<String>?>? = null,
-        agentName: String? = null,
+        context: ToolContext,
     ): Collection<StandardTool<*>> {
         val resolved = mutableMapOf<String, StandardTool<*>>()
+        val userId = requireNotNull(context.userId)
+        val namespaceId = context.namespaceId
 
         val sharedConfigs = integrationConfigService.findByNamespaceShared(namespaceId)
         val userOverrides =
@@ -122,7 +111,7 @@ class ToolResolverService(
                     logger.warn { "[ToolResolver] No plugin for integrationType='${config.integrationType}' (name='$name')" }
                     return@forEach
                 }
-            extractTools(agentIntegrations, config, plugin, namespaceId, userId, agentName, resolved)
+            extractTools(agentIntegrations, config, plugin, context, resolved)
         }
 
         logger.info { "[ToolResolver] Total tools for namespace $namespaceId (user $userId): ${resolved.size}" }
@@ -133,9 +122,7 @@ class ToolResolverService(
         agentIntegrations: Map<String, List<String>?>?,
         config: IntegrationConfig,
         plugin: ToolPlugin,
-        namespaceId: UUID,
-        userId: UUID?,
-        agentName: String?,
+        context: ToolContext,
         resolved: MutableMap<String, StandardTool<*>>,
     ) {
         try {
@@ -145,7 +132,7 @@ class ToolResolverService(
                     .provideTools(
                         config = config.parameters,
                         configName = config.name,
-                        context = buildToolContext(namespaceId = namespaceId, userId = userId, agentName = agentName),
+                        context = context,
                     ).filter { tool -> isToolAllowed(tool.name, config.name, allowedToolNames) }
             tools.forEach { tool ->
                 if (resolved.containsKey(tool.name)) {
@@ -156,24 +143,12 @@ class ToolResolverService(
                 resolved[tool.name] = tool
             }
             logger.info {
-                "[ToolResolver] Resolved ${tools.size} tool(s) from integrationType='${config.integrationType}' for namespace $namespaceId"
+                "[ToolResolver] Resolved ${tools.size} tool(s) from integrationType='${config.integrationType}' for namespace ${context.namespaceId}"
             }
         } catch (e: Exception) {
             logger.error(e) { "[ToolResolver] Error instantiating tools for integrationType='${config.integrationType}': ${e.message}" }
         }
     }
-
-    private fun buildToolContext(
-        namespaceId: UUID,
-        userId: UUID?,
-        agentName: String?,
-    ) = ToolContext(
-        namespaceId = namespaceId,
-        userId = userId,
-        userExternalId = null,
-        caseEvents = emptyList(),
-        agentName = agentName,
-    )
 
     internal fun isToolAllowed(
         toolName: String,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -16,6 +16,16 @@ class ToolResolverService(
     private val integrationConfigService: IntegrationConfigService,
     private val integrationConfigMergeService: ConfigMergeService<IntegrationConfig>,
 ) {
+    /**
+     * Resolves the tool set for a namespace-level agent run (no authenticated user).
+     *
+     * @param namespaceId The namespace to resolve tools for.
+     * @param agentIntegrations Optional integration filter from [AgentConfig.integrations].
+     *   When null, all namespace integrations are included.
+     * @param agentName The name of the agent being built, or null when resolving outside
+     *   an agent context. Passed into [ToolContext] so plugins can exclude the calling
+     *   agent from lists they build (e.g. the redirect tool excludes itself as a target).
+     */
     fun resolveToolsForNamespace(
         namespaceId: UUID,
         agentIntegrations: Map<String, List<String>?>? = null,
@@ -74,6 +84,18 @@ class ToolResolverService(
         return resolved.values
     }
 
+    /**
+     * Resolves the tool set for a user-scoped agent run, applying 3-tier overlay
+     * reconciliation for each integration config.
+     *
+     * @param namespaceId The namespace to resolve tools for.
+     * @param userId The authenticated user whose overlays should be applied.
+     * @param agentIntegrations Optional integration filter from [AgentConfig.integrations].
+     *   When null, all namespace integrations are included.
+     * @param agentName The name of the agent being built, or null when resolving outside
+     *   an agent context. Passed into [ToolContext] so plugins can exclude the calling
+     *   agent from lists they build (e.g. the redirect tool excludes itself as a target).
+     */
     fun resolveToolsForRun(
         namespaceId: UUID,
         userId: UUID,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -19,8 +19,14 @@ class ToolResolverService(
     /**
      * Resolves the tool set for a namespace-level agent run (no authenticated user).
      *
+     * The [context] must carry a valid [ToolContext.namespaceId]. It is passed verbatim
+     * to each plugin so they can use it for namespace-aware behaviour (e.g. the redirect
+     * tool uses it to enumerate eligible agents). [ToolContext.userId] should be null for
+     * this path — use [resolveToolsForRun] when a user identity is available.
+     *
      * @param agentIntegrations Optional integration filter from [AgentConfig.integrations].
      *   When null, all namespace integrations are included.
+     * @param context Runtime context forwarded to each [ToolPlugin.provideTools] call.
      */
     fun resolveToolsForNamespace(
         agentIntegrations: Map<String, List<String>?>? = null,
@@ -54,8 +60,15 @@ class ToolResolverService(
      * Resolves the tool set for a user-scoped agent run, applying 3-tier overlay
      * reconciliation for each integration config.
      *
+     * The [context] must carry both a valid [ToolContext.namespaceId] and a non-null
+     * [ToolContext.userId] (the method throws [IllegalArgumentException] otherwise). The
+     * context is passed verbatim to each plugin, giving them access to the full runtime
+     * identity (namespace, user, external id, agent name, case events).
+     *
      * @param agentIntegrations Optional integration filter from [AgentConfig.integrations].
      *   When null, all namespace integrations are included.
+     * @param context Runtime context forwarded to each [ToolPlugin.provideTools] call.
+     *   [ToolContext.userId] must be non-null.
      */
     fun resolveToolsForRun(
         agentIntegrations: Map<String, List<String>?>? = null,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -111,8 +111,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
     )
 
     init {
-        every { toolResolverService.resolveToolsForNamespace(any(), any()) } returns emptyList()
-        every { toolResolverService.resolveToolsForRun(any(), any(), any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForNamespace(any(), any(), any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForRun(any(), any(), any(), any()) } returns emptyList()
         every { namespaceService.findById(namespaceId) } returns namespace
         every { integrationConfigService.findByParent(any()) } returns emptyList()
         every { userService.findById(any()) } returns null
@@ -351,8 +351,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
                 )
             every { localIntegrationService.findByParent(any()) } returns configs
             // Agent only declares JIRA_PROD
-            val config = agentConfig(name = "my-agent", modelName = "sonnet")
-                .copy(integrations = mapOf("JIRA_PROD" to null))
+            val config =
+                agentConfig(name = "my-agent", modelName = "sonnet")
+                    .copy(integrations = mapOf("JIRA_PROD" to null))
             val model = modelConfig(alias = "sonnet")
             val provider = providerConfig()
             val chatClient = mockk<ChatClient>(relaxed = true)
@@ -380,8 +381,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     ),
                 )
             every { integrationConfigService.findByParent(namespaceId) } returns configs
-            val config = agentConfig(name = "my-agent", modelName = "sonnet")
-                .copy(integrations = mapOf("JIRA_PROD" to null))
+            val config =
+                agentConfig(name = "my-agent", modelName = "sonnet")
+                    .copy(integrations = mapOf("JIRA_PROD" to null))
             val model = modelConfig(alias = "sonnet")
             val provider = providerConfig()
             val chatClient = mockk<ChatClient>(relaxed = true)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -111,8 +111,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
     )
 
     init {
-        every { toolResolverService.resolveToolsForNamespace(any(), toolContext) } returns emptyList()
-        every { toolResolverService.resolveToolsForRun(any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForNamespace(any(), any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForRun(any(), any()) } returns emptyList()
         every { namespaceService.findById(namespaceId) } returns namespace
         every { integrationConfigService.findByParent(any()) } returns emptyList()
         every { userService.findById(any()) } returns null
@@ -557,7 +557,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             verify(exactly = 1) {
                 toolResolverService.resolveToolsForNamespace(
-                    context = toolContext,
+                    context = any(),
                 )
             }
         }
@@ -579,7 +579,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             verify(exactly = 1) {
                 toolResolverService.resolveToolsForNamespace(
                     integrations,
-                    toolContext,
+                    any(),
                 )
             }
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -555,7 +555,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.findAgentByName("my-agent", context)
 
-            verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, null) }
+            verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, null, "my-agent") }
         }
 
         "findAgentByName passes integrations map to ToolResolverService when agentConfig has integrations" {
@@ -572,7 +572,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.findAgentByName("my-agent", context)
 
-            verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, integrations) }
+            verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, integrations, "my-agent") }
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -111,8 +111,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
     )
 
     init {
-        every { toolResolverService.resolveToolsForNamespace(any(), any(), any()) } returns emptyList()
-        every { toolResolverService.resolveToolsForRun(any(), any(), any(), any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForNamespace(any(), toolContext) } returns emptyList()
+        every { toolResolverService.resolveToolsForRun(any()) } returns emptyList()
         every { namespaceService.findById(namespaceId) } returns namespace
         every { integrationConfigService.findByParent(any()) } returns emptyList()
         every { userService.findById(any()) } returns null
@@ -555,7 +555,11 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.findAgentByName("my-agent", context)
 
-            verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, null, "my-agent") }
+            verify(exactly = 1) {
+                toolResolverService.resolveToolsForNamespace(
+                    context = toolContext,
+                )
+            }
         }
 
         "findAgentByName passes integrations map to ToolResolverService when agentConfig has integrations" {
@@ -572,7 +576,12 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.findAgentByName("my-agent", context)
 
-            verify(exactly = 1) { toolResolverService.resolveToolsForNamespace(namespaceId, integrations, "my-agent") }
+            verify(exactly = 1) {
+                toolResolverService.resolveToolsForNamespace(
+                    integrations,
+                    toolContext,
+                )
+            }
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
@@ -27,11 +27,12 @@ class RedirectToolPluginSpec : StringSpec({
         description = description,
     )
 
-    fun context(userId: UUID? = null) = ToolContext(
+    fun context(userId: UUID? = null, agentName: String? = null) = ToolContext(
         namespaceId = namespaceId,
         userId = userId,
         userExternalId = null,
         caseEvents = emptyList(),
+        agentName = agentName,
     )
 
     // -------------------------------------------------------------------------
@@ -95,12 +96,90 @@ class RedirectToolPluginSpec : StringSpec({
         tool.eligibleAgents.map { it.name } shouldBe listOf("AgentA", "AgentB")
     }
 
+    // -------------------------------------------------------------------------
+    // Integration propagation
+    // -------------------------------------------------------------------------
+
+    "provideTools maps AgentConfig.integrations to EligibleAgent.integrations" {
+        val agents = listOf(
+            AgentConfig(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                namespaceId = namespaceId,
+                name = "AgentA",
+                description = "Does A",
+                integrations = mapOf(
+                    "JIRA" to listOf("GetIssue", "PostComment"),
+                    "FILES" to null,
+                ),
+            ),
+        )
+        val plugin = RedirectToolPlugin { _, _, _ -> agents }
+
+        val tool = plugin.provideTools(config = null, context = context(userId = userId)).first() as RedirectTool
+        val eligible = tool.eligibleAgents.first()
+
+        eligible.integrations shouldBe listOf(
+            RedirectTool.Integration(name = "JIRA", allowedTools = listOf("GetIssue", "PostComment")),
+            RedirectTool.Integration(name = "FILES", allowedTools = null),
+        )
+    }
+
+    "provideTools produces empty integrations list when AgentConfig.integrations is null" {
+        val agents = listOf(
+            AgentConfig(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                namespaceId = namespaceId,
+                name = "AgentA",
+                description = null,
+                integrations = null,
+            ),
+        )
+        val plugin = RedirectToolPlugin { _, _, _ -> agents }
+
+        val tool = plugin.provideTools(config = null, context = context(userId = userId)).first() as RedirectTool
+        tool.eligibleAgents.first().integrations shouldBe emptyList()
+    }
+
     "provideTools returns empty list when resolver returns no agents" {
         val plugin = RedirectToolPlugin { _, _, _ -> emptyList() }
 
         val tools = plugin.provideTools(config = null, context = context(userId = userId))
 
         tools.shouldBeEmpty()
+    }
+
+    // -------------------------------------------------------------------------
+    // Self-exclusion
+    // -------------------------------------------------------------------------
+
+    "provideTools excludes the calling agent from eligible agents" {
+        val agents = listOf(
+            agentConfig("AgentA", "Does A"),
+            agentConfig("AgentB", "Does B"),
+        )
+        val plugin = RedirectToolPlugin { _, _, _ -> agents }
+
+        val tool = plugin.provideTools(config = null, context = context(agentName = "AgentA")).first() as RedirectTool
+        tool.eligibleAgents.map { it.name } shouldBe listOf("AgentB")
+    }
+
+    "provideTools returns empty list when calling agent is the only eligible agent" {
+        val agents = listOf(agentConfig("AgentA", "Does A"))
+        val plugin = RedirectToolPlugin { _, _, _ -> agents }
+
+        val tools = plugin.provideTools(config = null, context = context(agentName = "AgentA"))
+        tools.shouldBeEmpty()
+    }
+
+    "provideTools does not exclude anything when context has no agentName" {
+        val agents = listOf(
+            agentConfig("AgentA", "Does A"),
+            agentConfig("AgentB", "Does B"),
+        )
+        val plugin = RedirectToolPlugin { _, _, _ -> agents }
+
+        val tool = plugin.provideTools(config = null, context = context(agentName = null)).first() as RedirectTool
+        tool.eligibleAgents.map { it.name } shouldBe listOf("AgentA", "AgentB")
     }
 
     "provideTools returns empty list when context has no namespaceId" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolSpec.kt
@@ -16,6 +16,94 @@ class RedirectToolSpec : StringSpec({
         names.map { RedirectTool.EligibleAgent(name = it, description = "Agent $it") }
 
     // -------------------------------------------------------------------------
+    // description - integration rendering
+    // -------------------------------------------------------------------------
+
+    "description includes integration names when agent has integrations" {
+        val tool = RedirectTool(
+            configName = null,
+            eligibleAgents = listOf(
+                RedirectTool.EligibleAgent(
+                    name = "AgentA",
+                    description = "Does A",
+                    integrations = listOf(
+                        RedirectTool.Integration(name = "JIRA", allowedTools = null),
+                        RedirectTool.Integration(name = "FILES", allowedTools = null),
+                    ),
+                ),
+            ),
+        )
+        tool.description shouldBe """
+            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Available agents:
+              - AgentA: Does A
+                Integrations:
+                  - JIRA
+                  - FILES
+        """.trimIndent()
+    }
+
+    "description includes allowed tools when integration has a whitelist" {
+        val tool = RedirectTool(
+            configName = null,
+            eligibleAgents = listOf(
+                RedirectTool.EligibleAgent(
+                    name = "AgentA",
+                    description = "Does A",
+                    integrations = listOf(
+                        RedirectTool.Integration(name = "JIRA", allowedTools = listOf("GetIssue", "PostComment")),
+                    ),
+                ),
+            ),
+        )
+        tool.description shouldBe """
+            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Available agents:
+              - AgentA: Does A
+                Integrations:
+                  - JIRA: GetIssue, PostComment
+        """.trimIndent()
+    }
+
+    "description omits integrations section when agent has no integrations" {
+        val tool = RedirectTool(
+            configName = null,
+            eligibleAgents = listOf(
+                RedirectTool.EligibleAgent(name = "AgentA", description = "Does A"),
+            ),
+        )
+        tool.description shouldBe """
+            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Available agents:
+              - AgentA: Does A
+        """.trimIndent()
+    }
+
+    "description mixes agents with and without integrations" {
+        val tool = RedirectTool(
+            configName = null,
+            eligibleAgents = listOf(
+                RedirectTool.EligibleAgent(
+                    name = "AgentA",
+                    description = "Does A",
+                    integrations = listOf(
+                        RedirectTool.Integration(name = "JIRA", allowedTools = listOf("GetIssue")),
+                    ),
+                ),
+                RedirectTool.EligibleAgent(name = "AgentB", description = "Does B"),
+            ),
+        )
+        tool.description shouldBe """
+            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Available agents:
+              - AgentA: Does A
+                Integrations:
+                  - JIRA: GetIssue
+              - AgentB: Does B
+        """.trimIndent()
+    }
+
+    // -------------------------------------------------------------------------
     // execute - null input
     // WZ-31894: previously threw error("RedirectTool: agentName is required but was not provided by the LLM")
     // now returns a human-readable string so the LLM can surface it gracefully

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
@@ -113,9 +113,17 @@ class ToolResolverServiceSpec :
             val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
             val config = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
             val service = buildService(plugins = listOf(plugin), configs = listOf(config))
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools1 = service.resolveToolsForNamespace(context = toolContext)
-            val tools2 = service.resolveToolsForNamespace(context = toolContext)
+            val tools1 = service.resolveToolsForNamespace(context = ctx)
+            val tools2 = service.resolveToolsForNamespace(context = ctx)
 
             tools1 shouldHaveSize 1
             tools2 shouldHaveSize 1
@@ -127,9 +135,17 @@ class ToolResolverServiceSpec :
             val config = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
             val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
             val service = buildService(plugins = listOf(plugin), configs = listOf(config))
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools1 = service.resolveToolsForNamespace(context = toolContext)
-            val tools2 = service.resolveToolsForNamespace(context = toolContext)
+            val tools1 = service.resolveToolsForNamespace(context = ctx)
+            val tools2 = service.resolveToolsForNamespace(context = ctx)
 
             tools1 shouldHaveSize 1
             tools2 shouldHaveSize 1
@@ -144,8 +160,16 @@ class ToolResolverServiceSpec :
             val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
             val service = buildService(plugins = listOf(plugin))
             val namespaceId = UUID.randomUUID()
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools = service.resolveToolsForNamespace(context = toolContext)
+            val tools = service.resolveToolsForNamespace(context = ctx)
 
             tools.shouldBeEmpty()
         }
@@ -155,8 +179,16 @@ class ToolResolverServiceSpec :
             val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime", "GetCurrentDate")
             val config = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
             val service = buildService(plugins = listOf(plugin), configs = listOf(config))
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools = service.resolveToolsForNamespace(context = toolContext)
+            val tools = service.resolveToolsForNamespace(context = ctx)
 
             tools shouldHaveSize 2
             tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetCurrentDate")
@@ -167,8 +199,16 @@ class ToolResolverServiceSpec :
             val config = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
             val plugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues")
             val service = buildService(plugins = listOf(plugin), configs = listOf(config))
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools = service.resolveToolsForNamespace(context = toolContext)
+            val tools = service.resolveToolsForNamespace(context = ctx)
 
             tools shouldHaveSize 2
             tools.map { it.name }.toSet() shouldBe setOf("GetIssue", "SearchIssues")
@@ -185,8 +225,16 @@ class ToolResolverServiceSpec :
                     plugins = listOf(configLessPlugin, configuredPlugin),
                     configs = listOf(datetimeConfig, jiraConfig),
                 )
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools = service.resolveToolsForNamespace(context = toolContext)
+            val tools = service.resolveToolsForNamespace(context = ctx)
 
             tools shouldHaveSize 2
             tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetIssue")
@@ -202,8 +250,16 @@ class ToolResolverServiceSpec :
                     plugins = listOf(configuredPlugin),
                     configs = listOf(configInOtherNamespace),
                 )
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools = service.resolveToolsForNamespace(context = toolContext)
+            val tools = service.resolveToolsForNamespace(context = ctx)
 
             tools.shouldBeEmpty()
         }
@@ -223,8 +279,16 @@ class ToolResolverServiceSpec :
                     plugins = listOf(configuredPlugin, configLessPlugin),
                     configs = listOf(jiraConfig, datetimeConfig),
                 )
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
-            val tools = service.resolveToolsForNamespace(context = toolContext)
+            val tools = service.resolveToolsForNamespace(context = ctx)
 
             tools shouldHaveSize 2
         }
@@ -240,11 +304,19 @@ class ToolResolverServiceSpec :
                     plugins = listOf(configuredPlugin, configLessPlugin),
                     configs = listOf(jiraConfig, datetimeConfig),
                 )
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
             val tools =
                 service.resolveToolsForNamespace(
                     agentIntegrations = mapOf("JIRA_PROD" to null),
-                    context = toolContext,
+                    context = ctx,
                 )
 
             tools shouldHaveSize 1
@@ -262,11 +334,19 @@ class ToolResolverServiceSpec :
                     plugins = listOf(configLessPlugin, configuredPlugin),
                     configs = listOf(datetimeConfig, jiraConfig),
                 )
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
             val tools =
                 service.resolveToolsForNamespace(
                     agentIntegrations = mapOf("JIRA_PROD" to null),
-                    context = toolContext,
+                    context = ctx,
                 )
 
             tools shouldHaveSize 1
@@ -278,11 +358,19 @@ class ToolResolverServiceSpec :
             val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
             val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues", "CreateIssue")
             val service = buildService(plugins = listOf(configuredPlugin), configs = listOf(jiraConfig))
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
             val tools =
                 service.resolveToolsForNamespace(
                     agentIntegrations = mapOf("JIRA_PROD" to listOf("GetIssue", "SearchIssues")),
-                    context = toolContext,
+                    context = ctx,
                 )
 
             tools shouldHaveSize 2
@@ -294,11 +382,19 @@ class ToolResolverServiceSpec :
             val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
             val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues", "CreateIssue")
             val service = buildService(plugins = listOf(configuredPlugin), configs = listOf(jiraConfig))
+            val ctx =
+                ToolContext(
+                    namespaceId = namespaceId,
+                    userId = null,
+                    userExternalId = null,
+                    caseEvents = emptyList(),
+                    agentName = null,
+                )
 
             val tools =
                 service.resolveToolsForNamespace(
                     agentIntegrations = mapOf("JIRA_PROD" to null),
-                    context = toolContext,
+                    context = ctx,
                 )
 
             tools shouldHaveSize 3
@@ -363,8 +459,10 @@ class ToolResolverServiceSpec :
             val userId = UUID.randomUUID()
             val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
             val service = buildServiceForRun(plugins = listOf(plugin))
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             tools.shouldBeEmpty()
         }
@@ -381,8 +479,10 @@ class ToolResolverServiceSpec :
                     sharedConfigs = listOf(shared),
                     reconciledConfigs = mapOf("jira" to reconciled),
                 )
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             tools shouldHaveSize 1
             tools.first().name shouldBe "GetIssue"
@@ -400,8 +500,10 @@ class ToolResolverServiceSpec :
                     userOverrides = listOf(userGlobal),
                     reconciledConfigs = mapOf("github" to reconciled),
                 )
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             tools shouldHaveSize 1
             tools.first().name shouldBe "CreatePR"
@@ -428,8 +530,10 @@ class ToolResolverServiceSpec :
                     userOverrides = listOf(userNs),
                     reconciledConfigs = mapOf("jira" to reconciled),
                 )
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             tools shouldHaveSize 1
         }
@@ -447,9 +551,11 @@ class ToolResolverServiceSpec :
                     sharedConfigs = listOf(shared1, shared2),
                     reconciledConfigs = mapOf("github" to shared2),
                 )
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
             shouldThrow<ConfigNotFoundException> {
-                service.resolveToolsForRun()
+                service.resolveToolsForRun(context = ctx)
             }
         }
 
@@ -474,8 +580,10 @@ class ToolResolverServiceSpec :
                     userOverrides = listOf(dormantOverride),
                     reconciledConfigs = mapOf("github" to shared),
                 )
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             tools shouldHaveSize 1
             tools.first().name shouldBe "CreatePR"
@@ -493,8 +601,9 @@ class ToolResolverServiceSpec :
                     plugins = listOf(plugin),
                     userOverrides = listOf(overrideForNs2),
                 )
+            val ctx = ToolContext(namespaceId = ns1, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             tools shouldHaveSize 0
         }
@@ -527,8 +636,10 @@ class ToolResolverServiceSpec :
                 }
             val config = integrationConfig(namespaceId, "REDIRECT_all", "REDIRECT")
             val service = buildService(plugins = listOf(contextCapturingPlugin), configs = listOf(config))
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = null, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForNamespace(context = toolContext)
+            val tools = service.resolveToolsForNamespace(context = ctx)
 
             capturedContext shouldNotBe null
             capturedContext!!.namespaceId shouldBe namespaceId
@@ -568,8 +679,10 @@ class ToolResolverServiceSpec :
                     sharedConfigs = listOf(shared),
                     reconciledConfigs = mapOf("REDIRECT_all" to shared),
                 )
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             capturedContext shouldNotBe null
             capturedContext!!.namespaceId shouldBe namespaceId
@@ -591,8 +704,10 @@ class ToolResolverServiceSpec :
                     sharedConfigs = listOf(datetimeConfig, jiraConfig),
                     reconciledConfigs = mapOf("datetime" to datetimeConfig, "jira" to jiraConfig),
                 )
+            val ctx =
+                ToolContext(namespaceId = namespaceId, userId = userId, userExternalId = null, caseEvents = emptyList(), agentName = null)
 
-            val tools = service.resolveToolsForRun()
+            val tools = service.resolveToolsForRun(context = ctx)
 
             tools shouldHaveSize 2
             tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetIssue")

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
@@ -7,9 +7,9 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.whozoss.agentos.exception.ConfigNotFoundException
 import io.mockk.every
 import io.mockk.mockk
+import io.whozoss.agentos.exception.ConfigNotFoundException
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.integrationConfig.IntegrationTypeRegistry
@@ -22,513 +22,579 @@ import io.whozoss.agentos.sdk.tool.ToolPlugin
 import org.pf4j.PluginManager
 import java.util.UUID
 
-class ToolResolverServiceSpec : StringSpec({
-
-    fun makeTool(name: String): StandardTool<Nothing> =
-        object : StandardTool<Nothing> {
-            override val name = name
-            override val description = "Tool $name"
-            override val inputSchema = """{"type":"object"}"""
-            override val version = "1.0.0"
-            override val paramType: Class<Nothing>? = null
-            override suspend fun execute(input: Nothing?, context: ToolContext): ToolExecutionResult =
-                ToolExecutionResult.success(name)
-        }
-
-    fun makeConfigLessPlugin(integrationType: String, vararg toolNames: String): ToolPlugin =
-        object : ToolPlugin {
-            override val integrationType = integrationType
-            override val configSchema: JsonNode? = null
-            override fun provideTools(config: JsonNode?, configName: String?, context: ToolContext?): List<StandardTool<*>> =
-                toolNames.map { makeTool(it) }
-        }
-
-    fun makeConfiguredPlugin(integrationType: String, vararg toolNames: String): ToolPlugin =
-        object : ToolPlugin {
-            override val integrationType = integrationType
-            override val configSchema: JsonNode = mockk(relaxed = true)
-            override fun provideTools(config: JsonNode?, configName: String?, context: ToolContext?): List<StandardTool<*>> =
-                toolNames.map { makeTool(it) }
-        }
-
-    fun initRegistry(plugins: List<ToolPlugin>): ToolRegistryService {
-        val pluginManager = mockk<PluginManager>(relaxed = true)
-        every { pluginManager.getExtensions(ToolPlugin::class.java) } returns plugins
-        every { pluginManager.whichPlugin(any()) } returns null
-        val integrationTypeRegistry = mockk<IntegrationTypeRegistry>(relaxed = true)
-        val registry = ToolRegistryService(pluginManager, integrationTypeRegistry)
-        registry.initialize()
-        return registry
-    }
-
-    fun buildService(
-        plugins: List<ToolPlugin> = emptyList(),
-        configs: List<IntegrationConfig> = emptyList(),
-    ): ToolResolverService {
-        val registry = initRegistry(plugins)
-        val integrationConfigService = mockk<IntegrationConfigService>(relaxed = true)
-        every { integrationConfigService.findByParent(any()) } answers {
-            val namespaceId = firstArg<UUID>()
-            configs.filter { it.namespaceId == namespaceId }
-        }
-        val reconciliationService = mockk<ConfigMergeService<IntegrationConfig>>(relaxed = true)
-        return ToolResolverService(registry, integrationConfigService, reconciliationService)
-    }
-
-    fun integrationConfig(
-        namespaceId: UUID,
-        name: String,
-        integrationType: String,
-    ) = IntegrationConfig(
-        metadata = EntityMetadata(),
-        namespaceId = namespaceId,
-        name = name,
-        integrationType = integrationType,
-    )
-
-    // -------------------------------------------------------------------------
-    // Core lifecycle contract: fresh instances per run
-    // -------------------------------------------------------------------------
-
-    "resolveToolsForNamespace produces distinct tool instances on each call for config-less plugins" {
-        val namespaceId = UUID.randomUUID()
-        val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val config = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
-        val service = buildService(plugins = listOf(plugin), configs = listOf(config))
-
-        val tools1 = service.resolveToolsForNamespace(namespaceId)
-        val tools2 = service.resolveToolsForNamespace(namespaceId)
-
-        tools1 shouldHaveSize 1
-        tools2 shouldHaveSize 1
-        tools1.first() shouldNotBe tools2.first()
-    }
-
-    "resolveToolsForNamespace produces distinct tool instances on each call for configured plugins" {
-        val namespaceId = UUID.randomUUID()
-        val config = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val service = buildService(plugins = listOf(plugin), configs = listOf(config))
-
-        val tools1 = service.resolveToolsForNamespace(namespaceId)
-        val tools2 = service.resolveToolsForNamespace(namespaceId)
-
-        tools1 shouldHaveSize 1
-        tools2 shouldHaveSize 1
-        tools1.first() shouldNotBe tools2.first()
-    }
-
-    // -------------------------------------------------------------------------
-    // Correctness: right tools are returned
-    // -------------------------------------------------------------------------
-
-    "resolveToolsForNamespace returns no tools when namespace has no IntegrationConfig" {
-        val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val service = buildService(plugins = listOf(plugin))
-        val namespaceId = UUID.randomUUID()
-
-        val tools = service.resolveToolsForNamespace(namespaceId)
-
-        tools.shouldBeEmpty()
-    }
-
-    "resolveToolsForNamespace returns config-less tools when a matching IntegrationConfig exists" {
-        val namespaceId = UUID.randomUUID()
-        val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime", "GetCurrentDate")
-        val config = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
-        val service = buildService(plugins = listOf(plugin), configs = listOf(config))
-
-        val tools = service.resolveToolsForNamespace(namespaceId)
-
-        tools shouldHaveSize 2
-        tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetCurrentDate")
-    }
-
-    "resolveToolsForNamespace returns configured tools matching the namespace" {
-        val namespaceId = UUID.randomUUID()
-        val config = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val plugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues")
-        val service = buildService(plugins = listOf(plugin), configs = listOf(config))
-
-        val tools = service.resolveToolsForNamespace(namespaceId)
-
-        tools shouldHaveSize 2
-        tools.map { it.name }.toSet() shouldBe setOf("GetIssue", "SearchIssues")
-    }
-
-    "resolveToolsForNamespace combines config-less and configured tools via their IntegrationConfigs" {
-        val namespaceId = UUID.randomUUID()
-        val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
-        val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val service = buildService(
-            plugins = listOf(configLessPlugin, configuredPlugin),
-            configs = listOf(datetimeConfig, jiraConfig),
-        )
-
-        val tools = service.resolveToolsForNamespace(namespaceId)
-
-        tools shouldHaveSize 2
-        tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetIssue")
-    }
-
-    "resolveToolsForNamespace returns no tools for a namespace with no matching IntegrationConfig" {
-        val namespaceId = UUID.randomUUID()
-        val otherNamespaceId = UUID.randomUUID()
-        val configInOtherNamespace = integrationConfig(otherNamespaceId, "JIRA_PROD", "JIRA")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val service = buildService(
-            plugins = listOf(configuredPlugin),
-            configs = listOf(configInOtherNamespace),
-        )
-
-        val tools = service.resolveToolsForNamespace(namespaceId)
-
-        tools.shouldBeEmpty()
-    }
-
-    // -------------------------------------------------------------------------
-    // Agent integrations filter — always by IntegrationConfig.name
-    // -------------------------------------------------------------------------
-
-    "resolveToolsForNamespace with agentIntegrations null returns all tools" {
-        val namespaceId = UUID.randomUUID()
-        val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val service = buildService(
-            plugins = listOf(configuredPlugin, configLessPlugin),
-            configs = listOf(jiraConfig, datetimeConfig),
-        )
-
-        val tools = service.resolveToolsForNamespace(namespaceId, agentIntegrations = null)
-
-        tools shouldHaveSize 2
-    }
-
-    "resolveToolsForNamespace with agentIntegrations filters by IntegrationConfig name, not integrationType" {
-        val namespaceId = UUID.randomUUID()
-        val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val service = buildService(
-            plugins = listOf(configuredPlugin, configLessPlugin),
-            configs = listOf(jiraConfig, datetimeConfig),
-        )
-
-        val tools = service.resolveToolsForNamespace(
-            namespaceId,
-            agentIntegrations = mapOf("JIRA_PROD" to null),
-        )
-
-        tools shouldHaveSize 1
-        tools.first().name shouldBe "GetIssue"
-    }
-
-    "resolveToolsForNamespace with agentIntegrations excludes config-less tools when their config name is absent" {
-        val namespaceId = UUID.randomUUID()
-        val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
-        val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val service = buildService(
-            plugins = listOf(configLessPlugin, configuredPlugin),
-            configs = listOf(datetimeConfig, jiraConfig),
-        )
-
-        val tools = service.resolveToolsForNamespace(
-            namespaceId,
-            agentIntegrations = mapOf("JIRA_PROD" to null),
-        )
-
-        tools shouldHaveSize 1
-        tools.first().name shouldBe "GetIssue"
-    }
-
-    "resolveToolsForNamespace with non-null allowed list filters tools within an integration" {
-        val namespaceId = UUID.randomUUID()
-        val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues", "CreateIssue")
-        val service = buildService(plugins = listOf(configuredPlugin), configs = listOf(jiraConfig))
-
-        val tools = service.resolveToolsForNamespace(
-            namespaceId,
-            agentIntegrations = mapOf("JIRA_PROD" to listOf("GetIssue", "SearchIssues")),
-        )
-
-        tools shouldHaveSize 2
-        tools.map { it.name }.toSet() shouldBe setOf("GetIssue", "SearchIssues")
-    }
-
-    "resolveToolsForNamespace with null allowed list returns all tools from that integration" {
-        val namespaceId = UUID.randomUUID()
-        val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues", "CreateIssue")
-        val service = buildService(plugins = listOf(configuredPlugin), configs = listOf(jiraConfig))
-
-        val tools = service.resolveToolsForNamespace(
-            namespaceId,
-            agentIntegrations = mapOf("JIRA_PROD" to null),
-        )
-
-        tools shouldHaveSize 3
-    }
-
-    // -------------------------------------------------------------------------
-    // isToolAllowed helper
-    // -------------------------------------------------------------------------
-
-    "isToolAllowed returns true when allowedNames is null" {
-        val service = buildService()
-        service.isToolAllowed("ReadFile", "FILES", null) shouldBe true
-    }
-
-    "isToolAllowed returns true for exact name match" {
-        val service = buildService()
-        service.isToolAllowed("ReadFile", "FILES", listOf("ReadFile", "ListFiles")) shouldBe true
-    }
-
-    "isToolAllowed returns false when name not in allowed list" {
-        val service = buildService()
-        service.isToolAllowed("EditFile", "FILES", listOf("ReadFile", "ListFiles")) shouldBe false
-    }
-
-    "isToolAllowed matches prefixed tool name via KEY__suffix convention" {
-        val service = buildService()
-        service.isToolAllowed("JIRA_PROD__GetIssue", "JIRA_PROD", listOf("GetIssue")) shouldBe true
-    }
-
-    "isToolAllowed does not match wrong prefix" {
-        val service = buildService()
-        service.isToolAllowed("JIRA_STAGING__GetIssue", "JIRA_PROD", listOf("GetIssue")) shouldBe false
-    }
-
-    // -------------------------------------------------------------------------
-    // resolveToolsForRun — story 6.4 AC1-AC4 (6+ scenarios)
-    // -------------------------------------------------------------------------
-
-    fun buildServiceForRun(
-        plugins: List<ToolPlugin> = emptyList(),
-        sharedConfigs: List<IntegrationConfig> = emptyList(),
-        userOverrides: List<IntegrationConfig> = emptyList(),
-        reconciledConfigs: Map<String, IntegrationConfig> = emptyMap(),
-    ): ToolResolverService {
-        val registry = initRegistry(plugins)
-        val integrationConfigService = mockk<IntegrationConfigService>(relaxed = true)
-        every { integrationConfigService.findByNamespaceShared(any()) } returns sharedConfigs
-        every { integrationConfigService.findByUserId(any()) } returns userOverrides
-
-        val reconciliationService = mockk<ConfigMergeService<IntegrationConfig>>(relaxed = true)
-        every { reconciliationService.resolve(any(), any(), any()) } answers {
-            val name = thirdArg<String>()
-            reconciledConfigs[name]
-                ?: throw ConfigNotFoundException(firstArg(), secondArg(), name)
-        }
-
-        return ToolResolverService(registry, integrationConfigService, reconciliationService)
-    }
-
-    "resolveToolsForRun returns empty when no IntegrationConfig exists, even if config-less plugins are loaded" {
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val service = buildServiceForRun(plugins = listOf(plugin))
-
-        val tools = service.resolveToolsForRun(namespaceId, userId)
-
-        tools.shouldBeEmpty()
-    }
-
-    "resolveToolsForRun resolves tools from namespace-shared config only (no user override)" {
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val shared = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
-        val reconciled = shared
-        val service = buildServiceForRun(
-            plugins = listOf(plugin),
-            sharedConfigs = listOf(shared),
-            reconciledConfigs = mapOf("jira" to reconciled),
-        )
-
-        val tools = service.resolveToolsForRun(namespaceId, userId)
-
-        tools shouldHaveSize 1
-        tools.first().name shouldBe "GetIssue"
-    }
-
-    "resolveToolsForRun resolves tools from user-global override only (no namespace config)" {
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val plugin = makeConfiguredPlugin("GITHUB", "CreatePR")
-        val userGlobal = IntegrationConfig(metadata = EntityMetadata(), userId = userId, name = "github", integrationType = "GITHUB")
-        val reconciled = userGlobal
-        val service = buildServiceForRun(
-            plugins = listOf(plugin),
-            userOverrides = listOf(userGlobal),
-            reconciledConfigs = mapOf("github" to reconciled),
-        )
-
-        val tools = service.resolveToolsForRun(namespaceId, userId)
-
-        tools shouldHaveSize 1
-        tools.first().name shouldBe "CreatePR"
-    }
-
-    "resolveToolsForRun 3-tier fold: user×namespace override applied" {
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val shared = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
-        val userNs = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, userId = userId, name = "jira", integrationType = "JIRA")
-        val reconciled = userNs
-        val service = buildServiceForRun(
-            plugins = listOf(plugin),
-            sharedConfigs = listOf(shared),
-            userOverrides = listOf(userNs),
-            reconciledConfigs = mapOf("jira" to reconciled),
-        )
-
-        val tools = service.resolveToolsForRun(namespaceId, userId)
-
-        tools shouldHaveSize 1
-    }
-
-    "resolveToolsForRun fails fast when a namespace-shared name fails reconciliation (NFR-REL-1)" {
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val plugin = makeConfiguredPlugin("GITHUB", "CreatePR")
-        val shared1 = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
-        val shared2 = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "github", integrationType = "GITHUB")
-        val service = buildServiceForRun(
-            plugins = listOf(plugin),
-            sharedConfigs = listOf(shared1, shared2),
-            reconciledConfigs = mapOf("github" to shared2),
-        )
-
-        shouldThrow<ConfigNotFoundException> {
-            service.resolveToolsForRun(namespaceId, userId)
-        }
-    }
-
-    "resolveToolsForRun silently skips dormant user overrides whose name has no shared config (FR30)" {
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val plugin = makeConfiguredPlugin("GITHUB", "CreatePR")
-        val shared = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "github", integrationType = "GITHUB")
-        val dormantOverride = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, userId = userId, name = "ghost-name", integrationType = "JIRA")
-        val service = buildServiceForRun(
-            plugins = listOf(plugin),
-            sharedConfigs = listOf(shared),
-            userOverrides = listOf(dormantOverride),
-            reconciledConfigs = mapOf("github" to shared),
-        )
-
-        val tools = service.resolveToolsForRun(namespaceId, userId)
-
-        tools shouldHaveSize 1
-        tools.first().name shouldBe "CreatePR"
-    }
-
-    "resolveToolsForRun dormant override on different namespace is filtered out (AC4)" {
-        val ns1 = UUID.randomUUID()
-        val ns2 = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val overrideForNs2 = IntegrationConfig(metadata = EntityMetadata(), namespaceId = ns2, userId = userId, name = "jira", integrationType = "JIRA")
-        val service = buildServiceForRun(
-            plugins = listOf(plugin),
-            userOverrides = listOf(overrideForNs2),
-        )
-
-        val tools = service.resolveToolsForRun(ns1, userId)
-
-        tools shouldHaveSize 0
-    }
-
-    // -------------------------------------------------------------------------
-    // RedirectToolPlugin: ToolContext must be forwarded so namespaceId is available
-    // -------------------------------------------------------------------------
-
-    "resolveToolsForNamespace passes namespaceId via ToolContext to plugins that need it" {
-        // Regression: ToolResolverService called provideTools(config, name) without a ToolContext.
-        // RedirectToolPlugin requires context?.namespaceId to resolve eligible agents;
-        // without it, it returns emptyList() regardless of the config patterns.
-        val namespaceId = UUID.randomUUID()
-        var capturedContext: ToolContext? = null
-        val contextCapturingPlugin = object : ToolPlugin {
-            override val integrationType = "REDIRECT"
-            override val configSchema: JsonNode = mockk(relaxed = true)
-            override fun provideTools(config: JsonNode?, configName: String?, context: ToolContext?): List<StandardTool<*>> {
-                capturedContext = context
-                // Simulate what RedirectToolPlugin does: return empty when context is null
-                if (context?.namespaceId == null) return emptyList()
-                return listOf(makeTool("redirect"))
+class ToolResolverServiceSpec :
+    StringSpec({
+
+        fun makeTool(name: String): StandardTool<Nothing> =
+            object : StandardTool<Nothing> {
+                override val name = name
+                override val description = "Tool $name"
+                override val inputSchema = """{"type":"object"}"""
+                override val version = "1.0.0"
+                override val paramType: Class<Nothing>? = null
+
+                override suspend fun execute(
+                    input: Nothing?,
+                    context: ToolContext,
+                ): ToolExecutionResult = ToolExecutionResult.success(name)
             }
-        }
-        val config = integrationConfig(namespaceId, "REDIRECT_all", "REDIRECT")
-        val service = buildService(plugins = listOf(contextCapturingPlugin), configs = listOf(config))
 
-        val tools = service.resolveToolsForNamespace(namespaceId)
+        fun makeConfigLessPlugin(
+            integrationType: String,
+            vararg toolNames: String,
+        ): ToolPlugin =
+            object : ToolPlugin {
+                override val integrationType = integrationType
+                override val configSchema: JsonNode? = null
 
-        capturedContext shouldNotBe null
-        capturedContext!!.namespaceId shouldBe namespaceId
-        tools shouldHaveSize 1
-    }
-
-    "resolveToolsForRun passes namespaceId via ToolContext to plugins that need it" {
-        // Same regression for the user-scoped resolution path.
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        var capturedContext: ToolContext? = null
-        val contextCapturingPlugin = object : ToolPlugin {
-            override val integrationType = "REDIRECT"
-            override val configSchema: JsonNode = mockk(relaxed = true)
-            override fun provideTools(config: JsonNode?, configName: String?, context: ToolContext?): List<StandardTool<*>> {
-                capturedContext = context
-                if (context?.namespaceId == null) return emptyList()
-                return listOf(makeTool("redirect"))
+                override fun provideTools(
+                    config: JsonNode?,
+                    configName: String?,
+                    context: ToolContext?,
+                ): List<StandardTool<*>> = toolNames.map { makeTool(it) }
             }
+
+        fun makeConfiguredPlugin(
+            integrationType: String,
+            vararg toolNames: String,
+        ): ToolPlugin =
+            object : ToolPlugin {
+                override val integrationType = integrationType
+                override val configSchema: JsonNode = mockk(relaxed = true)
+
+                override fun provideTools(
+                    config: JsonNode?,
+                    configName: String?,
+                    context: ToolContext?,
+                ): List<StandardTool<*>> = toolNames.map { makeTool(it) }
+            }
+
+        fun initRegistry(plugins: List<ToolPlugin>): ToolRegistryService {
+            val pluginManager = mockk<PluginManager>(relaxed = true)
+            every { pluginManager.getExtensions(ToolPlugin::class.java) } returns plugins
+            every { pluginManager.whichPlugin(any()) } returns null
+            val integrationTypeRegistry = mockk<IntegrationTypeRegistry>(relaxed = true)
+            val registry = ToolRegistryService(pluginManager, integrationTypeRegistry)
+            registry.initialize()
+            return registry
         }
-        val shared = IntegrationConfig(
+
+        fun buildService(
+            plugins: List<ToolPlugin> = emptyList(),
+            configs: List<IntegrationConfig> = emptyList(),
+        ): ToolResolverService {
+            val registry = initRegistry(plugins)
+            val integrationConfigService = mockk<IntegrationConfigService>(relaxed = true)
+            every { integrationConfigService.findByParent(any()) } answers {
+                val namespaceId = firstArg<UUID>()
+                configs.filter { it.namespaceId == namespaceId }
+            }
+            val reconciliationService = mockk<ConfigMergeService<IntegrationConfig>>(relaxed = true)
+            return ToolResolverService(registry, integrationConfigService, reconciliationService)
+        }
+
+        fun integrationConfig(
+            namespaceId: UUID,
+            name: String,
+            integrationType: String,
+        ) = IntegrationConfig(
             metadata = EntityMetadata(),
             namespaceId = namespaceId,
-            name = "REDIRECT_all",
-            integrationType = "REDIRECT",
-        )
-        val service = buildServiceForRun(
-            plugins = listOf(contextCapturingPlugin),
-            sharedConfigs = listOf(shared),
-            reconciledConfigs = mapOf("REDIRECT_all" to shared),
+            name = name,
+            integrationType = integrationType,
         )
 
-        val tools = service.resolveToolsForRun(namespaceId, userId)
+        // -------------------------------------------------------------------------
+        // Core lifecycle contract: fresh instances per run
+        // -------------------------------------------------------------------------
 
-        capturedContext shouldNotBe null
-        capturedContext!!.namespaceId shouldBe namespaceId
-        tools shouldHaveSize 1
-    }
+        "resolveToolsForNamespace produces distinct tool instances on each call for config-less plugins" {
+            val namespaceId = UUID.randomUUID()
+            val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val config = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
+            val service = buildService(plugins = listOf(plugin), configs = listOf(config))
 
-    "resolveToolsForRun combines config-less and configured tools when both have IntegrationConfigs" {
-        val namespaceId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
-        val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
-        val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
-        val datetimeConfig = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "datetime", integrationType = "DATETIME")
-        val jiraConfig = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
-        val service = buildServiceForRun(
-            plugins = listOf(configLessPlugin, configuredPlugin),
-            sharedConfigs = listOf(datetimeConfig, jiraConfig),
-            reconciledConfigs = mapOf("datetime" to datetimeConfig, "jira" to jiraConfig),
-        )
+            val tools1 = service.resolveToolsForNamespace(context = toolContext)
+            val tools2 = service.resolveToolsForNamespace(context = toolContext)
 
-        val tools = service.resolveToolsForRun(namespaceId, userId)
+            tools1 shouldHaveSize 1
+            tools2 shouldHaveSize 1
+            tools1.first() shouldNotBe tools2.first()
+        }
 
-        tools shouldHaveSize 2
-        tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetIssue")
-    }
+        "resolveToolsForNamespace produces distinct tool instances on each call for configured plugins" {
+            val namespaceId = UUID.randomUUID()
+            val config = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val service = buildService(plugins = listOf(plugin), configs = listOf(config))
 
-})
+            val tools1 = service.resolveToolsForNamespace(context = toolContext)
+            val tools2 = service.resolveToolsForNamespace(context = toolContext)
+
+            tools1 shouldHaveSize 1
+            tools2 shouldHaveSize 1
+            tools1.first() shouldNotBe tools2.first()
+        }
+
+        // -------------------------------------------------------------------------
+        // Correctness: right tools are returned
+        // -------------------------------------------------------------------------
+
+        "resolveToolsForNamespace returns no tools when namespace has no IntegrationConfig" {
+            val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val service = buildService(plugins = listOf(plugin))
+            val namespaceId = UUID.randomUUID()
+
+            val tools = service.resolveToolsForNamespace(context = toolContext)
+
+            tools.shouldBeEmpty()
+        }
+
+        "resolveToolsForNamespace returns config-less tools when a matching IntegrationConfig exists" {
+            val namespaceId = UUID.randomUUID()
+            val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime", "GetCurrentDate")
+            val config = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
+            val service = buildService(plugins = listOf(plugin), configs = listOf(config))
+
+            val tools = service.resolveToolsForNamespace(context = toolContext)
+
+            tools shouldHaveSize 2
+            tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetCurrentDate")
+        }
+
+        "resolveToolsForNamespace returns configured tools matching the namespace" {
+            val namespaceId = UUID.randomUUID()
+            val config = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val plugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues")
+            val service = buildService(plugins = listOf(plugin), configs = listOf(config))
+
+            val tools = service.resolveToolsForNamespace(context = toolContext)
+
+            tools shouldHaveSize 2
+            tools.map { it.name }.toSet() shouldBe setOf("GetIssue", "SearchIssues")
+        }
+
+        "resolveToolsForNamespace combines config-less and configured tools via their IntegrationConfigs" {
+            val namespaceId = UUID.randomUUID()
+            val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
+            val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val service =
+                buildService(
+                    plugins = listOf(configLessPlugin, configuredPlugin),
+                    configs = listOf(datetimeConfig, jiraConfig),
+                )
+
+            val tools = service.resolveToolsForNamespace(context = toolContext)
+
+            tools shouldHaveSize 2
+            tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetIssue")
+        }
+
+        "resolveToolsForNamespace returns no tools for a namespace with no matching IntegrationConfig" {
+            val namespaceId = UUID.randomUUID()
+            val otherNamespaceId = UUID.randomUUID()
+            val configInOtherNamespace = integrationConfig(otherNamespaceId, "JIRA_PROD", "JIRA")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val service =
+                buildService(
+                    plugins = listOf(configuredPlugin),
+                    configs = listOf(configInOtherNamespace),
+                )
+
+            val tools = service.resolveToolsForNamespace(context = toolContext)
+
+            tools.shouldBeEmpty()
+        }
+
+        // -------------------------------------------------------------------------
+        // Agent integrations filter — always by IntegrationConfig.name
+        // -------------------------------------------------------------------------
+
+        "resolveToolsForNamespace with agentIntegrations null returns all tools" {
+            val namespaceId = UUID.randomUUID()
+            val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val service =
+                buildService(
+                    plugins = listOf(configuredPlugin, configLessPlugin),
+                    configs = listOf(jiraConfig, datetimeConfig),
+                )
+
+            val tools = service.resolveToolsForNamespace(context = toolContext)
+
+            tools shouldHaveSize 2
+        }
+
+        "resolveToolsForNamespace with agentIntegrations filters by IntegrationConfig name, not integrationType" {
+            val namespaceId = UUID.randomUUID()
+            val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val service =
+                buildService(
+                    plugins = listOf(configuredPlugin, configLessPlugin),
+                    configs = listOf(jiraConfig, datetimeConfig),
+                )
+
+            val tools =
+                service.resolveToolsForNamespace(
+                    agentIntegrations = mapOf("JIRA_PROD" to null),
+                    context = toolContext,
+                )
+
+            tools shouldHaveSize 1
+            tools.first().name shouldBe "GetIssue"
+        }
+
+        "resolveToolsForNamespace with agentIntegrations excludes config-less tools when their config name is absent" {
+            val namespaceId = UUID.randomUUID()
+            val datetimeConfig = integrationConfig(namespaceId, "MY_DATETIME", "DATETIME")
+            val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val service =
+                buildService(
+                    plugins = listOf(configLessPlugin, configuredPlugin),
+                    configs = listOf(datetimeConfig, jiraConfig),
+                )
+
+            val tools =
+                service.resolveToolsForNamespace(
+                    agentIntegrations = mapOf("JIRA_PROD" to null),
+                    context = toolContext,
+                )
+
+            tools shouldHaveSize 1
+            tools.first().name shouldBe "GetIssue"
+        }
+
+        "resolveToolsForNamespace with non-null allowed list filters tools within an integration" {
+            val namespaceId = UUID.randomUUID()
+            val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues", "CreateIssue")
+            val service = buildService(plugins = listOf(configuredPlugin), configs = listOf(jiraConfig))
+
+            val tools =
+                service.resolveToolsForNamespace(
+                    agentIntegrations = mapOf("JIRA_PROD" to listOf("GetIssue", "SearchIssues")),
+                    context = toolContext,
+                )
+
+            tools shouldHaveSize 2
+            tools.map { it.name }.toSet() shouldBe setOf("GetIssue", "SearchIssues")
+        }
+
+        "resolveToolsForNamespace with null allowed list returns all tools from that integration" {
+            val namespaceId = UUID.randomUUID()
+            val jiraConfig = integrationConfig(namespaceId, "JIRA_PROD", "JIRA")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue", "SearchIssues", "CreateIssue")
+            val service = buildService(plugins = listOf(configuredPlugin), configs = listOf(jiraConfig))
+
+            val tools =
+                service.resolveToolsForNamespace(
+                    agentIntegrations = mapOf("JIRA_PROD" to null),
+                    context = toolContext,
+                )
+
+            tools shouldHaveSize 3
+        }
+
+        // -------------------------------------------------------------------------
+        // isToolAllowed helper
+        // -------------------------------------------------------------------------
+
+        "isToolAllowed returns true when allowedNames is null" {
+            val service = buildService()
+            service.isToolAllowed("ReadFile", "FILES", null) shouldBe true
+        }
+
+        "isToolAllowed returns true for exact name match" {
+            val service = buildService()
+            service.isToolAllowed("ReadFile", "FILES", listOf("ReadFile", "ListFiles")) shouldBe true
+        }
+
+        "isToolAllowed returns false when name not in allowed list" {
+            val service = buildService()
+            service.isToolAllowed("EditFile", "FILES", listOf("ReadFile", "ListFiles")) shouldBe false
+        }
+
+        "isToolAllowed matches prefixed tool name via KEY__suffix convention" {
+            val service = buildService()
+            service.isToolAllowed("JIRA_PROD__GetIssue", "JIRA_PROD", listOf("GetIssue")) shouldBe true
+        }
+
+        "isToolAllowed does not match wrong prefix" {
+            val service = buildService()
+            service.isToolAllowed("JIRA_STAGING__GetIssue", "JIRA_PROD", listOf("GetIssue")) shouldBe false
+        }
+
+        // -------------------------------------------------------------------------
+        // resolveToolsForRun — story 6.4 AC1-AC4 (6+ scenarios)
+        // -------------------------------------------------------------------------
+
+        fun buildServiceForRun(
+            plugins: List<ToolPlugin> = emptyList(),
+            sharedConfigs: List<IntegrationConfig> = emptyList(),
+            userOverrides: List<IntegrationConfig> = emptyList(),
+            reconciledConfigs: Map<String, IntegrationConfig> = emptyMap(),
+        ): ToolResolverService {
+            val registry = initRegistry(plugins)
+            val integrationConfigService = mockk<IntegrationConfigService>(relaxed = true)
+            every { integrationConfigService.findByNamespaceShared(any()) } returns sharedConfigs
+            every { integrationConfigService.findByUserId(any()) } returns userOverrides
+
+            val reconciliationService = mockk<ConfigMergeService<IntegrationConfig>>(relaxed = true)
+            every { reconciliationService.resolve(any(), any(), any()) } answers {
+                val name = thirdArg<String>()
+                reconciledConfigs[name]
+                    ?: throw ConfigNotFoundException(firstArg(), secondArg(), name)
+            }
+
+            return ToolResolverService(registry, integrationConfigService, reconciliationService)
+        }
+
+        "resolveToolsForRun returns empty when no IntegrationConfig exists, even if config-less plugins are loaded" {
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val plugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val service = buildServiceForRun(plugins = listOf(plugin))
+
+            val tools = service.resolveToolsForRun()
+
+            tools.shouldBeEmpty()
+        }
+
+        "resolveToolsForRun resolves tools from namespace-shared config only (no user override)" {
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val shared = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
+            val reconciled = shared
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(plugin),
+                    sharedConfigs = listOf(shared),
+                    reconciledConfigs = mapOf("jira" to reconciled),
+                )
+
+            val tools = service.resolveToolsForRun()
+
+            tools shouldHaveSize 1
+            tools.first().name shouldBe "GetIssue"
+        }
+
+        "resolveToolsForRun resolves tools from user-global override only (no namespace config)" {
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val plugin = makeConfiguredPlugin("GITHUB", "CreatePR")
+            val userGlobal = IntegrationConfig(metadata = EntityMetadata(), userId = userId, name = "github", integrationType = "GITHUB")
+            val reconciled = userGlobal
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(plugin),
+                    userOverrides = listOf(userGlobal),
+                    reconciledConfigs = mapOf("github" to reconciled),
+                )
+
+            val tools = service.resolveToolsForRun()
+
+            tools shouldHaveSize 1
+            tools.first().name shouldBe "CreatePR"
+        }
+
+        "resolveToolsForRun 3-tier fold: user×namespace override applied" {
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val shared = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
+            val userNs =
+                IntegrationConfig(
+                    metadata = EntityMetadata(),
+                    namespaceId = namespaceId,
+                    userId = userId,
+                    name = "jira",
+                    integrationType = "JIRA",
+                )
+            val reconciled = userNs
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(plugin),
+                    sharedConfigs = listOf(shared),
+                    userOverrides = listOf(userNs),
+                    reconciledConfigs = mapOf("jira" to reconciled),
+                )
+
+            val tools = service.resolveToolsForRun()
+
+            tools shouldHaveSize 1
+        }
+
+        "resolveToolsForRun fails fast when a namespace-shared name fails reconciliation (NFR-REL-1)" {
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val plugin = makeConfiguredPlugin("GITHUB", "CreatePR")
+            val shared1 = IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
+            val shared2 =
+                IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "github", integrationType = "GITHUB")
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(plugin),
+                    sharedConfigs = listOf(shared1, shared2),
+                    reconciledConfigs = mapOf("github" to shared2),
+                )
+
+            shouldThrow<ConfigNotFoundException> {
+                service.resolveToolsForRun()
+            }
+        }
+
+        "resolveToolsForRun silently skips dormant user overrides whose name has no shared config (FR30)" {
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val plugin = makeConfiguredPlugin("GITHUB", "CreatePR")
+            val shared =
+                IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "github", integrationType = "GITHUB")
+            val dormantOverride =
+                IntegrationConfig(
+                    metadata = EntityMetadata(),
+                    namespaceId = namespaceId,
+                    userId = userId,
+                    name = "ghost-name",
+                    integrationType = "JIRA",
+                )
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(plugin),
+                    sharedConfigs = listOf(shared),
+                    userOverrides = listOf(dormantOverride),
+                    reconciledConfigs = mapOf("github" to shared),
+                )
+
+            val tools = service.resolveToolsForRun()
+
+            tools shouldHaveSize 1
+            tools.first().name shouldBe "CreatePR"
+        }
+
+        "resolveToolsForRun dormant override on different namespace is filtered out (AC4)" {
+            val ns1 = UUID.randomUUID()
+            val ns2 = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val plugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val overrideForNs2 =
+                IntegrationConfig(metadata = EntityMetadata(), namespaceId = ns2, userId = userId, name = "jira", integrationType = "JIRA")
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(plugin),
+                    userOverrides = listOf(overrideForNs2),
+                )
+
+            val tools = service.resolveToolsForRun()
+
+            tools shouldHaveSize 0
+        }
+
+        // -------------------------------------------------------------------------
+        // RedirectToolPlugin: ToolContext must be forwarded so namespaceId is available
+        // -------------------------------------------------------------------------
+
+        "resolveToolsForNamespace passes namespaceId via ToolContext to plugins that need it" {
+            // Regression: ToolResolverService called provideTools(config, name) without a ToolContext.
+            // RedirectToolPlugin requires context?.namespaceId to resolve eligible agents;
+            // without it, it returns emptyList() regardless of the config patterns.
+            val namespaceId = UUID.randomUUID()
+            var capturedContext: ToolContext? = null
+            val contextCapturingPlugin =
+                object : ToolPlugin {
+                    override val integrationType = "REDIRECT"
+                    override val configSchema: JsonNode = mockk(relaxed = true)
+
+                    override fun provideTools(
+                        config: JsonNode?,
+                        configName: String?,
+                        context: ToolContext?,
+                    ): List<StandardTool<*>> {
+                        capturedContext = context
+                        // Simulate what RedirectToolPlugin does: return empty when context is null
+                        if (context?.namespaceId == null) return emptyList()
+                        return listOf(makeTool("redirect"))
+                    }
+                }
+            val config = integrationConfig(namespaceId, "REDIRECT_all", "REDIRECT")
+            val service = buildService(plugins = listOf(contextCapturingPlugin), configs = listOf(config))
+
+            val tools = service.resolveToolsForNamespace(context = toolContext)
+
+            capturedContext shouldNotBe null
+            capturedContext!!.namespaceId shouldBe namespaceId
+            tools shouldHaveSize 1
+        }
+
+        "resolveToolsForRun passes namespaceId via ToolContext to plugins that need it" {
+            // Same regression for the user-scoped resolution path.
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            var capturedContext: ToolContext? = null
+            val contextCapturingPlugin =
+                object : ToolPlugin {
+                    override val integrationType = "REDIRECT"
+                    override val configSchema: JsonNode = mockk(relaxed = true)
+
+                    override fun provideTools(
+                        config: JsonNode?,
+                        configName: String?,
+                        context: ToolContext?,
+                    ): List<StandardTool<*>> {
+                        capturedContext = context
+                        if (context?.namespaceId == null) return emptyList()
+                        return listOf(makeTool("redirect"))
+                    }
+                }
+            val shared =
+                IntegrationConfig(
+                    metadata = EntityMetadata(),
+                    namespaceId = namespaceId,
+                    name = "REDIRECT_all",
+                    integrationType = "REDIRECT",
+                )
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(contextCapturingPlugin),
+                    sharedConfigs = listOf(shared),
+                    reconciledConfigs = mapOf("REDIRECT_all" to shared),
+                )
+
+            val tools = service.resolveToolsForRun()
+
+            capturedContext shouldNotBe null
+            capturedContext!!.namespaceId shouldBe namespaceId
+            tools shouldHaveSize 1
+        }
+
+        "resolveToolsForRun combines config-less and configured tools when both have IntegrationConfigs" {
+            val namespaceId = UUID.randomUUID()
+            val userId = UUID.randomUUID()
+            val configLessPlugin = makeConfigLessPlugin("DATETIME", "GetCurrentDateTime")
+            val configuredPlugin = makeConfiguredPlugin("JIRA", "GetIssue")
+            val datetimeConfig =
+                IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "datetime", integrationType = "DATETIME")
+            val jiraConfig =
+                IntegrationConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = "jira", integrationType = "JIRA")
+            val service =
+                buildServiceForRun(
+                    plugins = listOf(configLessPlugin, configuredPlugin),
+                    sharedConfigs = listOf(datetimeConfig, jiraConfig),
+                    reconciledConfigs = mapOf("datetime" to datetimeConfig, "jira" to jiraConfig),
+                )
+
+            val tools = service.resolveToolsForRun()
+
+            tools shouldHaveSize 2
+            tools.map { it.name }.toSet() shouldBe setOf("GetCurrentDateTime", "GetIssue")
+        }
+    })


### PR DESCRIPTION
## What

Enriches the `RedirectTool` description seen by the LLM with two pieces of information per eligible agent:
- the list of its integrations
- for each integration that has a tool whitelist, the list of allowed tools (omitted otherwise)

Also ensures the calling agent is never listed as a redirect target (self-exclusion).

## Why

The LLM currently only sees agent name + description when choosing a redirect target. Adding integrations gives it the key differentiator between agents with similar descriptions — it can now route to the right agent based on what integrations it has access to (e.g. JIRA, FILES, etc.) and which specific tools are whitelisted.

The self-exclusion prevents the LLM from redirecting back to the agent that owns the redirect tool, which would create a no-op loop.

## Changes

- **`ToolContext` (SDK)** — new nullable `agentName: String? = null` field; rétrocompatible with all existing plugins
- **`ToolResolverService`** — passes `agentName` down into the `ToolContext` built at `provideTools` call time
- **`AgentServiceImpl`** — passes `config.name` to both `resolveTools*` calls
- **`RedirectToolPlugin`** — filters out the calling agent from eligible targets; maps `AgentConfig.integrations` onto `EligibleAgent.integrations`
- **`RedirectTool`** — new `Integration` inner class; `description` builder renders integrations and optional tool whitelists
- **Tests** — new cases covering integration rendering, self-exclusion, and propagation from `AgentConfig`