### PR TITLE
feat: #WZ-31935 enable agent config runtime filter

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
@@ -68,8 +68,8 @@ data class AgentConfig(
      * Defaults to `false` — newly created agents are unpublished and must be
      * explicitly published via the publish endpoint before they are accessible.
      *
-     * Backward-compat: existing agents stored in Neo4j without this field are
-     * treated as disabled (`COALESCE(a.enabled, false)` in Cypher queries).
+     * Backward-compat: existing nodes without this field are backfilled to `false`
+     * at startup by [io.whozoss.agentos.config.Neo4jSchemaInitializer].
      */
     val enabled: Boolean = false,
 ) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
@@ -111,36 +111,36 @@ class AgentConfigController(
     // story 5-4 factorisation of the pattern introduced by 5-3).
 
     /**
-     * GET /api/agent-configs/by-parentId/{parentId} (no enabledOnly param)
+     * GET /api/agent-configs/by-parentId/{parentId} (no withDisabled param)
      *
-     * Matched by Spring MVC when `enabledOnly` is absent from the query string.
-     * The `params = ["!enabledOnly"]` selector makes this mutually exclusive with
+     * Matched by Spring MVC when `withDisabled` is absent from the query string.
+     * The `params = ["!withDisabled"]` selector makes this mutually exclusive with
      * [listByNamespace], resolving the ambiguous-mapping conflict that arises from
      * the inherited [EntityController.listByParent] `@GetMapping`.
      *
-     * Delegates to [listByNamespace] with `enabledOnly = false`.
+     * Delegates to [listByNamespace] with `withDisabled = true`.
      */
     @GetMapping("/by-parentId/{parentId}")
     @PreAuthorize("hasPermission(#parentId, 'Namespace', 'READ')")
     override fun listByParent(@PathVariable parentId: UUID): List<AgentConfigResource> =
-        listByNamespace(parentId, enabledOnly = false)
+        listByNamespace(parentId, withDisabled = true)
 
     /**
-     * GET /api/agent-configs/by-parentId/{parentId}?enabledOnly=...
+     * GET /api/agent-configs/by-parentId/{parentId}?withDisabled=...
      *
-     * Matched by Spring MVC when `enabledOnly` is present in the query string.
-     * When `true`, only published agents are returned (end-user contexts like Copilot).
-     * When `false`, all agents visible to namespace members/admins are returned.
+     * Matched by Spring MVC when `withDisabled` is present in the query string.
+     * When `true` (the default), all agents visible to namespace members/admins are returned.
+     * When `false`, only published (enabled) agents are returned (end-user contexts like Copilot).
      * Spring's `DefaultConversionService` handles `Boolean` binding — invalid values
      * (neither `"true"` nor `"false"`) produce a 400.
      */
-    @GetMapping("/by-parentId/{parentId}", params = ["enabledOnly"])
+    @GetMapping("/by-parentId/{parentId}", params = ["withDisabled"])
     @PreAuthorize("hasPermission(#parentId, 'Namespace', 'READ')")
     fun listByNamespace(
         @PathVariable parentId: UUID,
-        @RequestParam(required = false, defaultValue = "false") enabledOnly: Boolean,
+        @RequestParam(required = false, defaultValue = "true") withDisabled: Boolean,
     ): List<AgentConfigResource> =
-        agentConfigService.findByNamespace(parentId, enabledOnly).map { toResource(it) }
+        agentConfigService.findByNamespace(parentId, withDisabled = withDisabled).map { toResource(it) }
 
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("hasPermission(#resource.namespaceId, 'Namespace', 'WRITE')")

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNode.kt
@@ -40,7 +40,7 @@ data class AgentConfigNode(
     val integrationsJson: String? = null,
     val externalMetadataJson: String? = null,
     val advancedExecution: Boolean = false,
-    val enabled: Boolean = false,
+    val enabled: Boolean,
     // EntityMetadata fields
     @Version val version: Long? = null,
     @CreatedDate val created: Instant = Instant.now(),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -31,6 +31,10 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
      * - agents deployed on a [io.whozoss.agentos.userGroup.UserGroup] the user is a member of (within the namespace)
      * - agents deployed directly on the namespace, for a user holding MEMBER or ADMIN
      *
+     * Only enabled (published) agents are returned — disabled agents are never surfaced at runtime.
+     * Agents stored before the `enabled` field was introduced are treated as disabled
+     * (`COALESCE(a.enabled, false)`).
+     *
      * When [agentName] is non-null, the result is filtered to configs whose name
      * matches case-insensitively. When null, all accessible configs are returned.
      */
@@ -44,6 +48,7 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
               WHERE NOT COALESCE(g.removed, false)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
               WHERE NOT COALESCE(a.removed, false)
+                AND COALESCE(a.enabled, false)
                 AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
             RETURN DISTINCT a
             UNION
@@ -54,6 +59,7 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
             MATCH (u)-[:MEMBER|ADMIN]->(ns)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
               WHERE NOT COALESCE(a.removed, false)
+                AND COALESCE(a.enabled, false)
                 AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
             RETURN DISTINCT a
             """,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -10,18 +10,19 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
     /**
      * Find non-removed agent configs belonging to a namespace, ordered by name.
      *
-     * When [enabledOnly] is true, only published agents are returned.
+     * When [withDisabled] is `true` (the default), all active configs are returned.
+     * When [withDisabled] is `false`, only published (enabled) agents are returned.
      */
     @Query(
         $$"""
             MATCH (a:AgentConfig)
             WHERE a.namespaceId = $namespaceId
               AND NOT COALESCE(a.removed, false)
-              AND (NOT $enabledOnly OR a.enabled)
+              AND ($withDisabled OR a.enabled)
             RETURN a ORDER BY a.name ASC
             """,
     )
-    fun findActiveByNamespaceId(namespaceId: String, enabledOnly: Boolean = false): List<AgentConfigNode>
+    fun findActiveByNamespaceId(namespaceId: String, withDisabled: Boolean = true): List<AgentConfigNode>
 
 
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigNodeNeo4jRepository.kt
@@ -11,15 +11,13 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
      * Find non-removed agent configs belonging to a namespace, ordered by name.
      *
      * When [enabledOnly] is true, only published agents are returned.
-     * Agents stored before the `enabled` field was introduced are treated as
-     * disabled (`COALESCE(a.enabled, false)`).
      */
     @Query(
         $$"""
             MATCH (a:AgentConfig)
             WHERE a.namespaceId = $namespaceId
               AND NOT COALESCE(a.removed, false)
-              AND (NOT $enabledOnly OR COALESCE(a.enabled, false))
+              AND (NOT $enabledOnly OR a.enabled)
             RETURN a ORDER BY a.name ASC
             """,
     )
@@ -32,8 +30,6 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
      * - agents deployed directly on the namespace, for a user holding MEMBER or ADMIN
      *
      * Only enabled (published) agents are returned — disabled agents are never surfaced at runtime.
-     * Agents stored before the `enabled` field was introduced are treated as disabled
-     * (`COALESCE(a.enabled, false)`).
      *
      * When [agentName] is non-null, the result is filtered to configs whose name
      * matches case-insensitively. When null, all accessible configs are returned.
@@ -48,7 +44,7 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
               WHERE NOT COALESCE(g.removed, false)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
               WHERE NOT COALESCE(a.removed, false)
-                AND COALESCE(a.enabled, false)
+                AND a.enabled
                 AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
             RETURN DISTINCT a
             UNION
@@ -59,7 +55,7 @@ interface AgentConfigNodeNeo4jRepository : Neo4jRepository<AgentConfigNode, Stri
             MATCH (u)-[:MEMBER|ADMIN]->(ns)
             MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(ns)
               WHERE NOT COALESCE(a.removed, false)
-                AND COALESCE(a.enabled, false)
+                AND a.enabled
                 AND (toLower(a.name) = toLower(COALESCE($agentName, a.name)))
             RETURN DISTINCT a
             """,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -20,11 +20,11 @@ interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
     /**
      * Returns [AgentConfig]s belonging to [parentId], optionally filtered to published ones.
      *
-     * When [enabledOnly] is `true`, only enabled (published) configs are returned.
-     * When [enabledOnly] is `false`, all active (non-removed) configs are returned.
+     * When [withDisabled] is `true` (the default), all active (non-removed) configs are returned.
+     * When [withDisabled] is `false`, only enabled (published) configs are returned.
      *
      * @param parentId The namespace UUID
-     * @param enabledOnly When `true`, restricts results to published configs only
+     * @param withDisabled When `false`, restricts results to published configs only
      */
-    fun findByParent(parentId: UUID, enabledOnly: Boolean): List<AgentConfig>
+    fun findByParent(parentId: UUID, withDisabled: Boolean): List<AgentConfig>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigRepository.kt
@@ -22,8 +22,6 @@ interface AgentConfigRepository : EntityRepository<AgentConfig, UUID> {
      *
      * When [enabledOnly] is `true`, only enabled (published) configs are returned.
      * When [enabledOnly] is `false`, all active (non-removed) configs are returned.
-     * Agents stored before the `enabled` field was introduced are treated as
-     * published for backward-compatibility.
      *
      * @param parentId The namespace UUID
      * @param enabledOnly When `true`, restricts results to published configs only

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigService.kt
@@ -39,9 +39,9 @@ interface AgentConfigService : EntityService<AgentConfig, UUID> {
      * (enabled) agents only.
      *
      * @param namespaceId The namespace to list agents for
-     * @param enabledOnly When true, only published agents are returned
+     * @param withDisabled When `true` (the default), all configs are returned; when `false`, only published agents are returned
      */
-    fun findByNamespace(namespaceId: UUID, enabledOnly: Boolean = false): List<AgentConfig>
+    fun findByNamespace(namespaceId: UUID, withDisabled: Boolean = true): List<AgentConfig>
 
     /**
      * Enables an agent config, making it active.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImpl.kt
@@ -50,8 +50,8 @@ class AgentConfigServiceImpl(
     override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
         agentConfigRepository.findAvailableByNamespaceIdAndUserId(namespaceId = namespaceId, userId = userId, agentName = agentName)
 
-    override fun findByNamespace(namespaceId: UUID, enabledOnly: Boolean): List<AgentConfig> =
-        agentConfigRepository.findByParent(namespaceId, enabledOnly)
+    override fun findByNamespace(namespaceId: UUID, withDisabled: Boolean): List<AgentConfig> =
+        agentConfigRepository.findByParent(namespaceId, withDisabled)
 
     override fun enable(id: UUID): AgentConfig {
         val existing = agentConfigRepository.findById(id)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -54,11 +54,11 @@ class FilesystemAgentConfigRepository(
     /**
      * Returns agents for [parentId], optionally filtered to published ones.
      *
-     * Delegates to the underlying repository with [enabledOnly], then merges
+     * Delegates to the underlying repository with [withDisabled], then merges
      * filesystem agents (which are always published by definition).
      */
-    override fun findByParent(parentId: UUID, enabledOnly: Boolean): List<AgentConfig> {
-        val persisted = delegate.findByParent(parentId, enabledOnly)
+    override fun findByParent(parentId: UUID, withDisabled: Boolean): List<AgentConfig> {
+        val persisted = delegate.findByParent(parentId, withDisabled)
         val fromFilesystem = filesystemAgents(parentId, excludeNames = persisted.mapTo(HashSet()) { it.name.lowercase() })
         val merged = persisted + fromFilesystem
         logger.debug { "[FilesystemAgentConfigRepository] namespace=$parentId: ${persisted.size} persisted + ${fromFilesystem.size} filesystem = ${merged.size} total" }
@@ -66,7 +66,7 @@ class FilesystemAgentConfigRepository(
     }
 
     override fun findByParent(parentId: UUID): List<AgentConfig> =
-        findByParent(parentId, enabledOnly = false)
+        findByParent(parentId, withDisabled = true)
 
     /**
      * Loads and returns agent configs from the filesystem for [parentId].

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/Neo4jAgentConfigRepository.kt
@@ -34,9 +34,9 @@ open class Neo4jAgentConfigRepository(
             .findActiveByNamespaceId(parentId.toString())
             .map { it.toDomain() }
 
-    override fun findByParent(parentId: UUID, enabledOnly: Boolean): List<AgentConfig> =
+    override fun findByParent(parentId: UUID, withDisabled: Boolean): List<AgentConfig> =
         neo4jRepository
-            .findActiveByNamespaceId(parentId.toString(), enabledOnly = enabledOnly)
+            .findActiveByNamespaceId(parentId.toString(), withDisabled = withDisabled)
             .map { it.toDomain() }
 
     override fun delete(id: UUID): Boolean =

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializer.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializer.kt
@@ -48,6 +48,19 @@ class Neo4jSchemaInitializer(
         if (backfilled > 0L) {
             logger.info { "[Neo4jSchemaInitializer] Backfilled version=0 on $backfilled AgentConfig node(s)" }
         }
+
+        // Backfill enabled=false on AgentConfig nodes created before the enabled field was introduced.
+        // Once all nodes have the property set, Cypher queries can use a.enabled directly
+        // without COALESCE(a.enabled, false).
+        val backfilledEnabled = neo4jClient.query(
+            "MATCH (a:AgentConfig) WHERE a.enabled IS NULL SET a.enabled = false RETURN count(a) AS count",
+        ).fetchAs(Long::class.java)
+            .mappedBy { _, record -> record["count"].asLong() }
+            .one()
+            .orElse(0L)
+        if (backfilledEnabled > 0L) {
+            logger.info { "[Neo4jSchemaInitializer] Backfilled enabled=false on $backfilledEnabled AgentConfig node(s)" }
+        }
     }
 
     companion object : KLogging()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerUnitSpec.kt
@@ -392,22 +392,22 @@ class AgentConfigControllerUnitSpec : StringSpec({
     "listByParent returns configs for the given namespaceId" {
         val c1 = config(name = "alpha")
         val c2 = config(name = "beta")
-        every { service.findByNamespace(namespaceId, false) } returns listOf(c1, c2)
+        every { service.findByNamespace(namespaceId, withDisabled = true) } returns listOf(c1, c2)
 
         val result = controller.listByParent(namespaceId)
 
         result shouldBe listOf(controller.toResource(c1), controller.toResource(c2))
-        verify(exactly = 1) { service.findByNamespace(namespaceId, false) }
+        verify(exactly = 1) { service.findByNamespace(namespaceId, withDisabled = true) }
     }
 
-    "listByNamespace with enabledOnly=true returns only enabled configs" {
+    "listByNamespace with withDisabled=false returns only enabled configs" {
         val c1 = config(name = "published").copy(enabled = true)
-        every { service.findByNamespace(namespaceId, true) } returns listOf(c1)
+        every { service.findByNamespace(namespaceId, withDisabled = false) } returns listOf(c1)
 
-        val result = controller.listByNamespace(namespaceId, enabledOnly = true)
+        val result = controller.listByNamespace(namespaceId, withDisabled = false)
 
         result shouldBe listOf(controller.toResource(c1))
-        verify(exactly = 1) { service.findByNamespace(namespaceId, true) }
+        verify(exactly = 1) { service.findByNamespace(namespaceId, withDisabled = false) }
     }
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigServiceImplUnitSpec.kt
@@ -26,10 +26,10 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
             override fun findAvailableByNamespaceIdAndUserId(namespaceId: UUID, userId: UUID, agentName: String?): List<AgentConfig> =
                 throw UnsupportedOperationException("Not available in InMemoryEntityRepository")
 
-            // Returns configs from the in-memory store, filtered by enabledOnly.
-            override fun findByParent(parentId: UUID, enabledOnly: Boolean): List<AgentConfig> =
-                if (enabledOnly) inMemory.findByParent(parentId).filter { it.enabled }
-                else inMemory.findByParent(parentId)
+            // Returns configs from the in-memory store, filtered by withDisabled.
+            override fun findByParent(parentId: UUID, withDisabled: Boolean): List<AgentConfig> =
+                if (withDisabled) inMemory.findByParent(parentId)
+                else inMemory.findByParent(parentId).filter { it.enabled }
         }
     }
 
@@ -103,27 +103,27 @@ class AgentConfigServiceImplUnitSpec : StringSpec({
     // findByNamespace
     // -------------------------------------------------------------------------
 
-    "findByNamespace with enabledOnly=false returns all configs" {
+    "findByNamespace with withDisabled=true returns all configs" {
         val repo = repository()
         val svc = service(repo)
         repo.save(config("Published").copy(enabled = true))
         repo.save(config("Unpublished").copy(enabled = false))
 
-        val result = svc.findByNamespace(namespaceId, enabledOnly = false)
+        val result = svc.findByNamespace(namespaceId, withDisabled = true)
         result.map { it.name }.toSet() shouldBe setOf("Published", "Unpublished")
     }
 
-    "findByNamespace with enabledOnly=true returns only enabled configs" {
+    "findByNamespace with withDisabled=false returns only enabled configs" {
         val repo = repository()
         val svc = service(repo)
         repo.save(config("Published").copy(enabled = true))
         repo.save(config("Unpublished").copy(enabled = false))
 
-        val result = svc.findByNamespace(namespaceId, enabledOnly = true)
+        val result = svc.findByNamespace(namespaceId, withDisabled = false)
         result.map { it.name } shouldBe listOf("Published")
     }
 
-    "findByNamespace defaults to enabledOnly=false" {
+    "findByNamespace defaults to withDisabled=true" {
         val repo = repository()
         val svc = service(repo)
         repo.save(config("Alpha").copy(enabled = false))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepositoryUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepositoryUnitSpec.kt
@@ -86,12 +86,12 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
         val nsRepo = nsRepoWith(namespaceId, configPath = null)
         val persisted = listOf(persistedConfig(namespaceId, "Alpha"))
 
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns persisted
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
         result shouldBe persisted
-        verify(exactly = 1) { delegate.findByParent(namespaceId, enabledOnly = false) }
+        verify(exactly = 1) { delegate.findByParent(namespaceId, withDisabled = true) }
     }
 
     "findByParent delegates to underlying repository when namespace is not found" {
@@ -99,7 +99,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
         val nsRepo = mockk<NamespaceRepository>()
         val persisted = listOf(persistedConfig(namespaceId, "Alpha"))
 
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns persisted
         every { nsRepo.findByIds(listOf(namespaceId)) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
@@ -119,7 +119,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
@@ -133,7 +133,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
@@ -149,7 +149,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId).single()
 
@@ -164,13 +164,13 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val repo = buildRepo(delegate, nsRepo)
         val id1 = repo.findByParent(namespaceId).single().id
         // force TTL expiry by using a zero-TTL repo on the same directory
         val nsRepo2 = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
         val repo2 = FilesystemAgentConfigRepository(delegate, nsRepo2, ttl = Duration.ZERO)
         val id2 = repo2.findByParent(namespaceId).single().id
 
@@ -189,7 +189,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
         val persisted = listOf(persistedConfig(namespaceId, "Gamma"))
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns persisted
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
@@ -206,7 +206,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
         val persisted = listOf(persistedConfig(namespaceId, "dev", modelName = "BIG"))
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns persisted
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
@@ -220,7 +220,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
         val persisted = listOf(persistedConfig(namespaceId, "Alpha"))
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns persisted
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
@@ -239,7 +239,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
@@ -266,7 +266,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId)
 
@@ -293,7 +293,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId).single()
 
@@ -317,7 +317,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId).single()
 
@@ -332,7 +332,7 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = false) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = true) } returns emptyList()
 
         val result = buildRepo(delegate, nsRepo).findByParent(namespaceId).single()
 
@@ -379,52 +379,52 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
     }
 
     // -------------------------------------------------------------------------
-    // findByParent with enabledOnly=true
+    // findByParent with withDisabled=false (enabled-only)
     // -------------------------------------------------------------------------
 
-    "findByParent with enabledOnly=true forwards enabledOnly to delegate" {
+    "findByParent with withDisabled=false forwards withDisabled to delegate" {
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, configPath = null)
         val persisted = listOf(persistedConfig(namespaceId, "Alpha"))
 
-        every { delegate.findByParent(namespaceId, enabledOnly = true) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = false) } returns persisted
 
-        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, enabledOnly = true)
+        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, withDisabled = false)
 
         result shouldBe persisted
-        verify(exactly = 1) { delegate.findByParent(namespaceId, enabledOnly = true) }
+        verify(exactly = 1) { delegate.findByParent(namespaceId, withDisabled = false) }
     }
 
-    "findByParent with enabledOnly=true still merges filesystem agents" {
+    "findByParent with withDisabled=false still merges filesystem agents" {
         val root = tempDir()
         writeYaml(agentsDir(root), "dev.yaml", agentYaml("Dev", modelName = "BIG"))
 
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = true) } returns emptyList()
+        every { delegate.findByParent(namespaceId, withDisabled = false) } returns emptyList()
 
-        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, enabledOnly = true)
+        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, withDisabled = false)
 
         result shouldHaveSize 1
         result.single().name shouldBe "Dev"
     }
 
-    "findByParent with enabledOnly=true drops filesystem config when persisted has same name" {
+    "findByParent with withDisabled=false drops filesystem config when persisted has same name" {
         val root = tempDir()
         writeYaml(agentsDir(root), "dev.yaml", agentYaml("Dev", modelName = "SMALL"))
 
         val persisted = listOf(persistedConfig(namespaceId, "dev", modelName = "BIG"))
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = true) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = false) } returns persisted
 
-        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, enabledOnly = true)
+        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, withDisabled = false)
 
         result shouldHaveSize 1
         result.single().modelName shouldBe "BIG"
     }
 
-    "findByParent with enabledOnly=true places persisted first then filesystem" {
+    "findByParent with withDisabled=false places persisted first then filesystem" {
         val root = tempDir()
         writeYaml(agentsDir(root), "alpha.yaml", agentYaml("Alpha"))
         writeYaml(agentsDir(root), "beta.yaml", agentYaml("Beta"))
@@ -432,9 +432,9 @@ class FilesystemAgentConfigRepositoryUnitSpec : StringSpec({
         val persisted = listOf(persistedConfig(namespaceId, "Gamma"))
         val delegate = mockk<AgentConfigRepository>()
         val nsRepo = nsRepoWith(namespaceId, root.toString())
-        every { delegate.findByParent(namespaceId, enabledOnly = true) } returns persisted
+        every { delegate.findByParent(namespaceId, withDisabled = false) } returns persisted
 
-        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, enabledOnly = true)
+        val result = buildRepo(delegate, nsRepo).findByParent(namespaceId, withDisabled = false)
 
         result shouldHaveSize 3
         result.first().name shouldBe "Gamma"

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/config/Neo4jSchemaInitializerSpec.kt
@@ -3,10 +3,8 @@ package io.whozoss.agentos.config
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
-import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigRepository
 import io.whozoss.agentos.persistence.neo4j.EmbeddedNeo4jTestConfiguration
-import io.whozoss.agentos.sdk.entity.EntityMetadata
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
@@ -17,9 +15,10 @@ import java.util.UUID
 /**
  * Integration test for [Neo4jSchemaInitializer].
  *
- * Verifies that AgentConfig nodes without a version property (created before @Version
- * was introduced) are backfilled with version=0 on startup, so that Spring Data Neo4j's
- * optimistic-locking check does not fail on the first update.
+ * Verifies that AgentConfig nodes without `version` or `enabled` properties
+ * (created before those fields were introduced) are backfilled at startup:
+ * - `version = 0`  so Spring Data Neo4j's optimistic-locking check does not fail
+ * - `enabled = false` so Cypher queries can use `a.enabled` directly without COALESCE
  */
 @SpringBootTest
 @ActiveProfiles("test", "embedded-neo4j")
@@ -30,43 +29,61 @@ class Neo4jSchemaInitializerSpec : StringSpec() {
     @Autowired lateinit var neo4jClient: Neo4jClient
     @Autowired lateinit var agentConfigRepository: AgentConfigRepository
 
+    private fun runInitializer() {
+        Neo4jSchemaInitializer(neo4jClient).run(object : org.springframework.boot.ApplicationArguments {
+            override fun getSourceArgs() = emptyArray<String>()
+            override fun getNonOptionArgs() = emptyList<String>()
+            override fun getOptionNames() = emptySet<String>()
+            override fun containsOption(name: String) = false
+            override fun getOptionValues(name: String) = emptyList<String>()
+        })
+    }
+
+    private fun createLegacyNode(agentId: UUID, namespaceId: UUID) {
+        neo4jClient.query(
+            "CREATE (a:AgentConfig {id: \$id, namespaceId: \$namespaceId, name: 'legacy-agent', removed: false})"
+        ).bindAll(mapOf("id" to agentId.toString(), "namespaceId" to namespaceId.toString())).run()
+    }
+
     init {
-        "backfill allows update on legacy AgentConfig node without version property" {
+        "backfill sets version=0 and enabled=false on legacy AgentConfig node" {
             val namespaceId = UUID.randomUUID()
             val agentId = UUID.randomUUID()
 
-            // Simulate a legacy node: insert via raw Cypher without version property
-            neo4jClient.query(
-                "CREATE (a:AgentConfig {id: \$id, namespaceId: \$namespaceId, name: 'legacy-agent', removed: false})"
-            ).bindAll(mapOf("id" to agentId.toString(), "namespaceId" to namespaceId.toString())).run()
+            createLegacyNode(agentId, namespaceId)
 
-            // Verify node exists without version
-            val hasVersion = neo4jClient.query(
+            // Verify node has neither version nor enabled before backfill
+            neo4jClient.query(
                 "MATCH (a:AgentConfig {id: \$id}) RETURN a.version IS NOT NULL AS hasVersion"
             ).bindAll(mapOf("id" to agentId.toString()))
                 .fetchAs(Boolean::class.java)
                 .mappedBy { _, record -> record["hasVersion"].asBoolean() }
-                .one().orElse(false)
-            hasVersion shouldBe false
+                .one().orElse(false) shouldBe false
 
-            // Run the backfill
-            val initializer = Neo4jSchemaInitializer(neo4jClient)
-            initializer.run(object : org.springframework.boot.ApplicationArguments {
-                override fun getSourceArgs() = emptyArray<String>()
-                override fun getNonOptionArgs() = emptyList<String>()
-                override fun getOptionNames() = emptySet<String>()
-                override fun containsOption(name: String) = false
-                override fun getOptionValues(name: String) = emptyList<String>()
-            })
+            neo4jClient.query(
+                "MATCH (a:AgentConfig {id: \$id}) RETURN a.enabled IS NOT NULL AS hasEnabled"
+            ).bindAll(mapOf("id" to agentId.toString()))
+                .fetchAs(Boolean::class.java)
+                .mappedBy { _, record -> record["hasEnabled"].asBoolean() }
+                .one().orElse(false) shouldBe false
 
-            // Verify version is now 0 after backfill
-            val versionAfterBackfill = neo4jClient.query(
+            runInitializer()
+
+            // version backfilled to 0
+            neo4jClient.query(
                 "MATCH (a:AgentConfig {id: \$id}) RETURN a.version AS version"
             ).bindAll(mapOf("id" to agentId.toString()))
                 .fetchAs(Long::class.java)
                 .mappedBy { _, record -> record["version"].asLong() }
-                .one().orElse(null)
-            versionAfterBackfill shouldBe 0L
+                .one().orElse(null) shouldBe 0L
+
+            // enabled backfilled to false
+            neo4jClient.query(
+                "MATCH (a:AgentConfig {id: \$id}) RETURN a.enabled AS enabled"
+            ).bindAll(mapOf("id" to agentId.toString()))
+                .fetchAs(Boolean::class.java)
+                .mappedBy { _, record -> record["enabled"].asBoolean() }
+                .one().orElse(null) shouldBe false
 
             // Load via repository and update — should not throw OptimisticLockingFailureException
             val loaded = agentConfigRepository.findByIds(listOf(agentId)).first()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
@@ -39,6 +39,10 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
     @Autowired lateinit var userRepo: UserRepository
     @Autowired lateinit var driver: Driver
 
+    // ---------------------------------------------------------------------------
+    // Entity builders
+    // ---------------------------------------------------------------------------
+
     private fun namespace(externalId: String = "ext-${UUID.randomUUID()}") =
         Namespace(metadata = EntityMetadata(), name = "ns-$externalId", externalId = externalId)
 
@@ -50,6 +54,10 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
     private fun userGroup(namespaceId: UUID, name: String = "group-${UUID.randomUUID()}") =
         UserGroup(metadata = EntityMetadata(), namespaceId = namespaceId, name = name)
+
+    // ---------------------------------------------------------------------------
+    // Graph helpers
+    // ---------------------------------------------------------------------------
 
     private fun grantMember(userExternalId: String, namespaceId: String) =
         driver.session().use { session ->
@@ -66,6 +74,61 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
                 mapOf("userId" to userExternalId, "nsId" to namespaceId),
             )
         }
+
+    private fun removeEnabledProperty(agentId: UUID) =
+        driver.session().use { session ->
+            session.run(
+                "MATCH (a:AgentConfig {id: \$id}) REMOVE a.enabled",
+                mapOf("id" to agentId.toString()),
+            )
+        }
+
+    // ---------------------------------------------------------------------------
+    // Setup helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Saves a namespace, one or more agents, a user group, and a user — wiring the user
+     * into the group and deploying the agents onto it.
+     *
+     * @param agentNames Names of the agents to create
+     * @param enabled Whether the agents should be enabled (default: true)
+     * @param userEmail Email / externalId of the user (default: alice@example.com)
+     */
+    private fun setupGroupAccess(
+        agentNames: List<String>,
+        enabled: Boolean = true,
+        userEmail: String = "alice@example.com",
+    ): Triple<Namespace, List<AgentConfig>, User> {
+        val ns = namespaceRepo.save(namespace())
+        val agents = agentNames.map { agentConfigRepo.save(agentConfig(ns.id, it).copy(enabled = enabled)) }
+        val group = userGroupRepo.save(userGroup(ns.id))
+        val savedUser = userRepo.save(user(userEmail))
+        userGroupRepo.addAgents(group.id, agents.map { it.id })
+        userGroupRepo.addUsers(group.id, listOf(userEmail))
+        return Triple(ns, agents, savedUser)
+    }
+
+    /**
+     * Saves a namespace, one or more agents, and a user — deploying the agents directly
+     * onto the namespace and granting the user a MEMBER relation.
+     *
+     * @param agentNames Names of the agents to create
+     * @param enabled Whether the agents should be enabled (default: true)
+     * @param userEmail Email / externalId of the user (default: alice@example.com)
+     */
+    private fun setupNamespaceAccess(
+        agentNames: List<String>,
+        enabled: Boolean = true,
+        userEmail: String = "alice@example.com",
+    ): Triple<Namespace, List<AgentConfig>, User> {
+        val ns = namespaceRepo.save(namespace())
+        val agents = agentNames.map { agentConfigRepo.save(agentConfig(ns.id, it).copy(enabled = enabled)) }
+        val savedUser = userRepo.save(user(userEmail))
+        namespaceRepo.deployAgents(ns.id, agents.map { it.id })
+        grantMember(userEmail, ns.id.toString())
+        return Triple(ns, agents, savedUser)
+    }
 
     init {
         beforeEach {
@@ -87,7 +150,6 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val ns = namespaceRepo.save(namespace())
             val alice = userRepo.save(user("alice@example.com"))
             agentConfigRepo.save(agentConfig(ns.id, "agent-a"))
-            // no DEPLOYED_TO, no group, no namespace relation
 
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
@@ -97,12 +159,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "returns agents deployed on user group the user is a member of" {
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "group-agent").copy(enabled = true))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            val alice = userRepo.save(user("alice@example.com"))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            val (ns, _, alice) = setupGroupAccess(listOf("group-agent"))
 
             val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
@@ -124,14 +181,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "does not return agents from a group belonging to a different namespace" {
             val ns = namespaceRepo.save(namespace())
-            val otherNs = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(otherNs.id, "other-ns-group-agent"))
-            val group = userGroupRepo.save(userGroup(otherNs.id))
-            val alice = userRepo.save(user("alice@example.com"))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
-
-            // alice is in a group with an agent, but that group belongs to otherNs, not ns
+            val (_, agents, alice) = setupGroupAccess(listOf("other-ns-group-agent"))
+            // alice's group and agent belong to a different namespace — query uses ns
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
@@ -140,11 +191,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "returns agents deployed on a namespace the user has MEMBER relation on" {
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent").copy(enabled = true))
-            val alice = userRepo.save(user("alice@example.com"))
-            namespaceRepo.deployAgents(ns.id, listOf(agent.id))
-            grantMember("alice@example.com", ns.id.toString())
+            val (ns, _, alice) = setupNamespaceAccess(listOf("ns-agent"))
 
             val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
@@ -169,20 +216,14 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val ns = namespaceRepo.save(namespace())
             agentConfigRepo.save(agentConfig(ns.id, "unreachable-agent"))
             val alice = userRepo.save(user("alice@example.com"))
-            // alice has no MEMBER/ADMIN on ns
 
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         "does not return agents deployed on a different namespace" {
             val ns = namespaceRepo.save(namespace())
-            val otherNs = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(otherNs.id, "other-ns-agent"))
-            val alice = userRepo.save(user("alice@example.com"))
-            namespaceRepo.deployAgents(otherNs.id, listOf(agent.id))
-            grantMember("alice@example.com", otherNs.id.toString())
-
-            // querying ns, not otherNs
+            val (otherNs, agents, alice) = setupNamespaceAccess(listOf("other-ns-agent"))
+            // alice has access in otherNs, but we query ns
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
@@ -244,13 +285,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "does not return soft-deleted agents" {
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "deleted-agent"))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            val alice = userRepo.save(user("alice@example.com"))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
-            agentConfigRepo.delete(agent.id)
+            val (ns, agents, alice) = setupGroupAccess(listOf("deleted-agent"))
+            agentConfigRepo.delete(agents.first().id)
 
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
@@ -283,16 +319,9 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "findByParent with enabledOnly=true treats null enabled as disabled" {
             val ns = namespaceRepo.save(namespace())
             val saved = agentConfigRepo.save(agentConfig(ns.id, "legacy-agent"))
-            driver.session().use { session ->
-                session.run(
-                    "MATCH (a:AgentConfig {id: \$id}) REMOVE a.enabled",
-                    mapOf("id" to saved.id.toString()),
-                )
-            }
+            removeEnabledProperty(saved.id)
 
-            val result = agentConfigRepo.findByParent(ns.id, enabledOnly = true)
-
-            result.shouldBeEmpty()
+            agentConfigRepo.findByParent(ns.id, enabledOnly = true).shouldBeEmpty()
         }
 
         "findByParent excludes soft-deleted configs" {
@@ -312,9 +341,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val agent = agentConfigRepo.save(agentConfig(ns.id, "enabled-then-deleted").copy(enabled = true))
             agentConfigRepo.delete(agent.id)
 
-            val result = agentConfigRepo.findByParent(ns.id, enabledOnly = true)
-
-            result.shouldBeEmpty()
+            agentConfigRepo.findByParent(ns.id, enabledOnly = true).shouldBeEmpty()
         }
 
         "findByParent returns configs scoped to the given namespace only" {
@@ -334,44 +361,33 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "findAvailableByNamespaceIdAndUserId with null agentName returns all accessible agents via group path" {
-            val ns = namespaceRepo.save(namespace())
-            val user = userRepo.save(user("alice@example.com"))
-            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a").copy(enabled = true))
-            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b").copy(enabled = true))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            userGroupRepo.addAgents(group.id, listOf(agentA.id, agentB.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            val (ns, _, alice) = setupGroupAccess(listOf("agent-a", "agent-b"))
 
-            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, null)
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result.map { it.name } shouldContainExactlyInAnyOrder listOf("agent-a", "agent-b")
         }
 
         "findAvailableByNamespaceIdAndUserId with null agentName returns all accessible agents via namespace path" {
-            val ns = namespaceRepo.save(namespace())
-            val user = userRepo.save(user("alice@example.com"))
-            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a").copy(enabled = true))
-            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b").copy(enabled = true))
-            namespaceRepo.deployAgents(ns.id, listOf(agentA.id, agentB.id))
-            grantMember("alice@example.com", ns.id.toString())
+            val (ns, _, alice) = setupNamespaceAccess(listOf("agent-a", "agent-b"))
 
-            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, null)
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result.map { it.name } shouldContainExactlyInAnyOrder listOf("agent-a", "agent-b")
         }
 
         "findAvailableByNamespaceIdAndUserId with null agentName returns union of group and namespace paths" {
             val ns = namespaceRepo.save(namespace())
-            val user = userRepo.save(user("alice@example.com"))
             val groupAgent = agentConfigRepo.save(agentConfig(ns.id, "group-agent").copy(enabled = true))
             val nsAgent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(groupAgent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(nsAgent.id))
             grantMember("alice@example.com", ns.id.toString())
 
-            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, null)
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
 
             result.map { it.name } shouldContainExactlyInAnyOrder listOf("group-agent", "ns-agent")
         }
@@ -381,60 +397,41 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "findAvailableByNamespaceIdAndUserId with agentName returns only the matching agent" {
-            val ns = namespaceRepo.save(namespace())
-            val user = userRepo.save(user("alice@example.com"))
-            val agentA = agentConfigRepo.save(agentConfig(ns.id, "my-agent").copy(enabled = true))
-            val agentB = agentConfigRepo.save(agentConfig(ns.id, "other-agent").copy(enabled = true))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            userGroupRepo.addAgents(group.id, listOf(agentA.id, agentB.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            val (ns, _, alice) = setupGroupAccess(listOf("my-agent", "other-agent"))
 
-            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "my-agent")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, "my-agent")
 
             result shouldHaveSize 1
             result.first().name shouldBe "my-agent"
         }
 
         "findAvailableByNamespaceIdAndUserId with agentName is case-insensitive" {
-            val ns = namespaceRepo.save(namespace())
-            val user = userRepo.save(user("alice@example.com"))
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "My-Agent").copy(enabled = true))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            val (ns, _, alice) = setupGroupAccess(listOf("My-Agent"))
 
-            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "MY-AGENT")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, "MY-AGENT")
 
             result shouldHaveSize 1
             result.first().name shouldBe "My-Agent"
         }
 
         "findAvailableByNamespaceIdAndUserId with nonexistent agentName returns empty list" {
-            val ns = namespaceRepo.save(namespace())
-            val user = userRepo.save(user("alice@example.com"))
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "real-agent"))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            val (ns, _, alice) = setupGroupAccess(listOf("real-agent"), enabled = false)
 
-            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "nonexistent")
-
-            result.shouldBeEmpty()
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, "nonexistent").shouldBeEmpty()
         }
 
         "findAvailableByNamespaceIdAndUserId with agentName matches across both group and namespace paths" {
             val ns = namespaceRepo.save(namespace())
-            val user = userRepo.save(user("alice@example.com"))
             val targetAgent = agentConfigRepo.save(agentConfig(ns.id, "target-agent").copy(enabled = true))
             val otherAgent = agentConfigRepo.save(agentConfig(ns.id, "other-agent").copy(enabled = true))
-            // target-agent reachable via group; other-agent reachable via namespace
             val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(targetAgent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(otherAgent.id))
             grantMember("alice@example.com", ns.id.toString())
 
-            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, user.id, "target-agent")
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, "target-agent")
 
             result shouldHaveSize 1
             result.first().name shouldBe "target-agent"
@@ -445,40 +442,20 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "findAvailableByNamespaceIdAndUserId excludes disabled agents via group path" {
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "disabled-group-agent").copy(enabled = false))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            val alice = userRepo.save(user("alice@example.com"))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            val (ns, _, alice) = setupGroupAccess(listOf("disabled-group-agent"), enabled = false)
 
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         "findAvailableByNamespaceIdAndUserId excludes disabled agents via namespace path" {
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "disabled-ns-agent").copy(enabled = false))
-            val alice = userRepo.save(user("alice@example.com"))
-            namespaceRepo.deployAgents(ns.id, listOf(agent.id))
-            grantMember("alice@example.com", ns.id.toString())
+            val (ns, _, alice) = setupNamespaceAccess(listOf("disabled-ns-agent"), enabled = false)
 
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }
 
         "findAvailableByNamespaceIdAndUserId treats null enabled as disabled" {
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "legacy-agent"))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            val alice = userRepo.save(user("alice@example.com"))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
-            // Remove the enabled property to simulate a legacy node
-            driver.session().use { session ->
-                session.run(
-                    "MATCH (a:AgentConfig {id: \$id}) REMOVE a.enabled",
-                    mapOf("id" to agent.id.toString()),
-                )
-            }
+            val (ns, agents, alice) = setupGroupAccess(listOf("legacy-agent"))
+            removeEnabledProperty(agents.first().id)
 
             agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
@@ -98,7 +98,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "returns agents deployed on user group the user is a member of" {
             val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "group-agent"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "group-agent").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
             val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
@@ -141,7 +141,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "returns agents deployed on a namespace the user has MEMBER relation on" {
             val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent").copy(enabled = true))
             val alice = userRepo.save(user("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(agent.id))
             grantMember("alice@example.com", ns.id.toString())
@@ -154,7 +154,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "returns agents deployed on a namespace the user has ADMIN relation on" {
             val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "admin-ns-agent"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "admin-ns-agent").copy(enabled = true))
             val alice = userRepo.save(user("alice@example.com"))
             namespaceRepo.deployAgents(ns.id, listOf(agent.id))
             grantAdmin("alice@example.com", ns.id.toString())
@@ -192,7 +192,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "deduplicates agent deployed on two groups the user is a member of" {
             val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "shared-agent"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "shared-agent").copy(enabled = true))
             val group1 = userGroupRepo.save(userGroup(ns.id))
             val group2 = userGroupRepo.save(userGroup(ns.id))
             val alice = userRepo.save(user("alice@example.com"))
@@ -209,7 +209,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "deduplicates agents reachable via both group and namespace paths" {
             val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "shared-agent"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "shared-agent").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
             val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
@@ -225,8 +225,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
         "returns union of agents from group and namespace deployments" {
             val ns = namespaceRepo.save(namespace())
-            val groupAgent = agentConfigRepo.save(agentConfig(ns.id, "group-agent"))
-            val nsAgent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent"))
+            val groupAgent = agentConfigRepo.save(agentConfig(ns.id, "group-agent").copy(enabled = true))
+            val nsAgent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
             val alice = userRepo.save(user("alice@example.com"))
             userGroupRepo.addAgents(group.id, listOf(groupAgent.id))
@@ -336,8 +336,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "findAvailableByNamespaceIdAndUserId with null agentName returns all accessible agents via group path" {
             val ns = namespaceRepo.save(namespace())
             val user = userRepo.save(user("alice@example.com"))
-            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a"))
-            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b"))
+            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a").copy(enabled = true))
+            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
             userGroupRepo.addAgents(group.id, listOf(agentA.id, agentB.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
@@ -350,8 +350,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "findAvailableByNamespaceIdAndUserId with null agentName returns all accessible agents via namespace path" {
             val ns = namespaceRepo.save(namespace())
             val user = userRepo.save(user("alice@example.com"))
-            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a"))
-            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b"))
+            val agentA = agentConfigRepo.save(agentConfig(ns.id, "agent-a").copy(enabled = true))
+            val agentB = agentConfigRepo.save(agentConfig(ns.id, "agent-b").copy(enabled = true))
             namespaceRepo.deployAgents(ns.id, listOf(agentA.id, agentB.id))
             grantMember("alice@example.com", ns.id.toString())
 
@@ -363,8 +363,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "findAvailableByNamespaceIdAndUserId with null agentName returns union of group and namespace paths" {
             val ns = namespaceRepo.save(namespace())
             val user = userRepo.save(user("alice@example.com"))
-            val groupAgent = agentConfigRepo.save(agentConfig(ns.id, "group-agent"))
-            val nsAgent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent"))
+            val groupAgent = agentConfigRepo.save(agentConfig(ns.id, "group-agent").copy(enabled = true))
+            val nsAgent = agentConfigRepo.save(agentConfig(ns.id, "ns-agent").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
             userGroupRepo.addAgents(group.id, listOf(groupAgent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
@@ -383,8 +383,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "findAvailableByNamespaceIdAndUserId with agentName returns only the matching agent" {
             val ns = namespaceRepo.save(namespace())
             val user = userRepo.save(user("alice@example.com"))
-            val agentA = agentConfigRepo.save(agentConfig(ns.id, "my-agent"))
-            val agentB = agentConfigRepo.save(agentConfig(ns.id, "other-agent"))
+            val agentA = agentConfigRepo.save(agentConfig(ns.id, "my-agent").copy(enabled = true))
+            val agentB = agentConfigRepo.save(agentConfig(ns.id, "other-agent").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
             userGroupRepo.addAgents(group.id, listOf(agentA.id, agentB.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
@@ -398,7 +398,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "findAvailableByNamespaceIdAndUserId with agentName is case-insensitive" {
             val ns = namespaceRepo.save(namespace())
             val user = userRepo.save(user("alice@example.com"))
-            val agent = agentConfigRepo.save(agentConfig(ns.id, "My-Agent"))
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "My-Agent").copy(enabled = true))
             val group = userGroupRepo.save(userGroup(ns.id))
             userGroupRepo.addAgents(group.id, listOf(agent.id))
             userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
@@ -425,8 +425,8 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         "findAvailableByNamespaceIdAndUserId with agentName matches across both group and namespace paths" {
             val ns = namespaceRepo.save(namespace())
             val user = userRepo.save(user("alice@example.com"))
-            val targetAgent = agentConfigRepo.save(agentConfig(ns.id, "target-agent"))
-            val otherAgent = agentConfigRepo.save(agentConfig(ns.id, "other-agent"))
+            val targetAgent = agentConfigRepo.save(agentConfig(ns.id, "target-agent").copy(enabled = true))
+            val otherAgent = agentConfigRepo.save(agentConfig(ns.id, "other-agent").copy(enabled = true))
             // target-agent reachable via group; other-agent reachable via namespace
             val group = userGroupRepo.save(userGroup(ns.id))
             userGroupRepo.addAgents(group.id, listOf(targetAgent.id))
@@ -438,6 +438,82 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
 
             result shouldHaveSize 1
             result.first().name shouldBe "target-agent"
+        }
+
+        // -------------------------------------------------------------------------
+        // findAvailableByNamespaceIdAndUserId — enabled filtering
+        // -------------------------------------------------------------------------
+
+        "findAvailableByNamespaceIdAndUserId excludes disabled agents via group path" {
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "disabled-group-agent").copy(enabled = false))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
+        }
+
+        "findAvailableByNamespaceIdAndUserId excludes disabled agents via namespace path" {
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "disabled-ns-agent").copy(enabled = false))
+            val alice = userRepo.save(user("alice@example.com"))
+            namespaceRepo.deployAgents(ns.id, listOf(agent.id))
+            grantMember("alice@example.com", ns.id.toString())
+
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
+        }
+
+        "findAvailableByNamespaceIdAndUserId treats null enabled as disabled" {
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id, "legacy-agent"))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            // Remove the enabled property to simulate a legacy node
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (a:AgentConfig {id: \$id}) REMOVE a.enabled",
+                    mapOf("id" to agent.id.toString()),
+                )
+            }
+
+            agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null).shouldBeEmpty()
+        }
+
+        "findAvailableByNamespaceIdAndUserId returns only enabled agents from mixed set" {
+            val ns = namespaceRepo.save(namespace())
+            val enabled = agentConfigRepo.save(agentConfig(ns.id, "enabled-agent").copy(enabled = true))
+            val disabled = agentConfigRepo.save(agentConfig(ns.id, "disabled-agent").copy(enabled = false))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(enabled.id, disabled.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
+
+            result shouldHaveSize 1
+            result.first().name shouldBe "enabled-agent"
+        }
+
+        "findAvailableByNamespaceIdAndUserId filters by enabled across both group and namespace paths" {
+            val ns = namespaceRepo.save(namespace())
+            val enabledGroupAgent = agentConfigRepo.save(agentConfig(ns.id, "enabled-group").copy(enabled = true))
+            val disabledGroupAgent = agentConfigRepo.save(agentConfig(ns.id, "disabled-group").copy(enabled = false))
+            val enabledNsAgent = agentConfigRepo.save(agentConfig(ns.id, "enabled-ns").copy(enabled = true))
+            val disabledNsAgent = agentConfigRepo.save(agentConfig(ns.id, "disabled-ns").copy(enabled = false))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(enabledGroupAgent.id, disabledGroupAgent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            namespaceRepo.deployAgents(ns.id, listOf(enabledNsAgent.id, disabledNsAgent.id))
+            grantMember("alice@example.com", ns.id.toString())
+
+            val result = agentConfigRepo.findAvailableByNamespaceIdAndUserId(ns.id, alice.id, null)
+
+            result.map { it.name } shouldContainExactlyInAnyOrder listOf("enabled-group", "enabled-ns")
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
@@ -25,7 +25,7 @@ import java.util.UUID
  * Persistence contract tests for [AgentConfigRepository] Cypher queries.
  *
  * Covers:
- * - [AgentConfigRepository.findByParent] with `enabledOnly` filter (enabled/disabled,
+ * - [AgentConfigRepository.findByParent] with `withDisabled` filter (enabled/disabled,
  *   backward compatibility with null enabled, soft-delete, namespace scoping)
  * - [AgentConfigRepository.findAvailableByNamespaceIdAndUserId] (user group membership,
  *   namespace membership, union/deduplication, agent name filtering)
@@ -292,36 +292,36 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
-        // findByParent with enabledOnly filter
+        // findByParent with withDisabled filter
         // -------------------------------------------------------------------------
 
-        "findByParent with enabledOnly=false returns all active configs regardless of enabled status" {
+        "findByParent with withDisabled=true returns all active configs regardless of enabled status" {
             val ns = namespaceRepo.save(namespace())
             val enabled = agentConfigRepo.save(agentConfig(ns.id, "enabled-agent").copy(enabled = true))
             val disabled = agentConfigRepo.save(agentConfig(ns.id, "disabled-agent").copy(enabled = false))
 
-            val result = agentConfigRepo.findByParent(ns.id, enabledOnly = false)
+            val result = agentConfigRepo.findByParent(ns.id, withDisabled = true)
 
             result.map { it.id } shouldContainExactlyInAnyOrder listOf(enabled.id, disabled.id)
         }
 
-        "findByParent with enabledOnly=true returns only enabled configs" {
+        "findByParent with withDisabled=false returns only enabled configs" {
             val ns = namespaceRepo.save(namespace())
             val enabled = agentConfigRepo.save(agentConfig(ns.id, "enabled-agent").copy(enabled = true))
             agentConfigRepo.save(agentConfig(ns.id, "disabled-agent").copy(enabled = false))
 
-            val result = agentConfigRepo.findByParent(ns.id, enabledOnly = true)
+            val result = agentConfigRepo.findByParent(ns.id, withDisabled = false)
 
             result shouldHaveSize 1
             result.first().id shouldBe enabled.id
         }
 
-        "findByParent with enabledOnly=true treats null enabled as disabled" {
+        "findByParent with withDisabled=false treats null enabled as disabled" {
             val ns = namespaceRepo.save(namespace())
             val saved = agentConfigRepo.save(agentConfig(ns.id, "legacy-agent"))
             removeEnabledProperty(saved.id)
 
-            agentConfigRepo.findByParent(ns.id, enabledOnly = true).shouldBeEmpty()
+            agentConfigRepo.findByParent(ns.id, withDisabled = false).shouldBeEmpty()
         }
 
         "findByParent excludes soft-deleted configs" {
@@ -330,18 +330,18 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val toDelete = agentConfigRepo.save(agentConfig(ns.id, "deleted-agent"))
             agentConfigRepo.delete(toDelete.id)
 
-            val result = agentConfigRepo.findByParent(ns.id, enabledOnly = false)
+            val result = agentConfigRepo.findByParent(ns.id, withDisabled = true)
 
             result shouldHaveSize 1
             result.first().id shouldBe active.id
         }
 
-        "findByParent with enabledOnly=true excludes soft-deleted enabled configs" {
+        "findByParent with withDisabled=false excludes soft-deleted enabled configs" {
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id, "enabled-then-deleted").copy(enabled = true))
             agentConfigRepo.delete(agent.id)
 
-            agentConfigRepo.findByParent(ns.id, enabledOnly = true).shouldBeEmpty()
+            agentConfigRepo.findByParent(ns.id, withDisabled = false).shouldBeEmpty()
         }
 
         "findByParent returns configs scoped to the given namespace only" {
@@ -350,7 +350,7 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             val agentInNs1 = agentConfigRepo.save(agentConfig(ns1.id, "ns1-agent"))
             agentConfigRepo.save(agentConfig(ns2.id, "ns2-agent"))
 
-            val result = agentConfigRepo.findByParent(ns1.id, enabledOnly = false)
+            val result = agentConfigRepo.findByParent(ns1.id, withDisabled = true)
 
             result shouldHaveSize 1
             result.first().id shouldBe agentInNs1.id

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -1849,12 +1849,12 @@ paths:
         schema:
           type: string
           format: uuid
-      - name: enabledOnly
+      - name: withDisabled
         in: query
         required: false
         schema:
           type: boolean
-          default: false
+          default: true
       responses:
         "200":
           description: OK


### PR DESCRIPTION
Main : agent runtime filtering by `enabled` property

Bonus :

Rename enabledOnly to withDisabled across all layers (repository, service, controller) for consistency with the existing withRemoved convention.
`withDisabled` defaults to true (include everything), aligning with the previous `enabledOnly = false` default.

Simplified `AbstractAgentConfigPersistenceSpec` by introducing `setupGroupAccess`, `setupNamespaceAccess` and `removeEnabledProperty` setup helpers, reducing boilerplate across persistence tests.

A startup backfill in `Neo4jSchemaInitializer` sets `enabled = false` on legacy nodes, allowing `COALESCE(a.enabled, false)` to be dropped from Cypher queries in favour of a direct` a.enabled` check.