### PR TITLE
fix: wz-32496 streamline analyzeConfirmation prompt

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -153,7 +153,7 @@ class ConfirmationManager(
         val prompt =
             """
             Classify the user's MOST RECENT message. The user may reply in any language;
-            reason about semantic intent, examples below are illustrative only.
+            reason about semantic intent.
 
             Pending action (NOT yet executed):
             $payloadSummary
@@ -171,7 +171,6 @@ class ConfirmationManager(
               or a clarification question about the pending action.
 
             First give your reasoning between <$TAG_REASONING></$TAG_REASONING>, then the decision.
-            <$TAG_DECISION>
             """.trimIndent()
 
         val decision =

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -87,9 +87,9 @@ class ConfirmationManager(
 
                 Task:
                 Analyze the end of the conversation. Has the user *already* explicitly agreed to or requested this specific action/update?
-                Take the following conversation history: 
+                Take the following conversation history:
                 <conversationHistory>
-                $firstLevelHistory
+                ${historyToString(firstLevelHistory)}
                 </conversationHistory>
 
                 Return "$CHOICE_NO" if ANY of the following are true:
@@ -160,16 +160,17 @@ class ConfirmationManager(
             $toolGuidanceSection
 
             <conversationHistory>
-            $firstLevelHistory
+            ${historyToString(firstLevelHistory)}
             </conversationHistory>
 
             Put exactly one of "$CHOICE_YES", "$CHOICE_NO", "$CHOICE_UNCLEAR" between
             <$TAG_DECISION></$TAG_DECISION> tags:
             - "$CHOICE_YES" — clear, explicit affirmation (e.g. "yes", "go ahead", "confirmed").
             - "$CHOICE_NO" — clear refusal, cancellation, OR topic shift to something unrelated.
-            - "$CHOICE_UNCLEAR" — hesitant, non-committal, or a clarification question about the
-              pending action.
+            - "$CHOICE_UNCLEAR" — hesitant, non-committal (e.g. "why not", "I guess", "as you wish"),
+              or a clarification question about the pending action.
 
+            First give your reasoning between <$TAG_REASONING></$TAG_REASONING>, then the decision.
             <$TAG_DECISION>
             """.trimIndent()
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationManager.kt
@@ -152,23 +152,23 @@ class ConfirmationManager(
 
         val prompt =
             """
-            Based on the given conversation.
+            Classify the user's MOST RECENT message. The user may reply in any language;
+            reason about semantic intent, examples below are illustrative only.
 
-            The agent was awaiting confirmation for this pending action:
+            Pending action (NOT yet executed):
             $payloadSummary
-
-            Using following conversation history: 
-                <conversationHistory>
-                $firstLevelHistory
-                </conversationHistory>
-                
-            And especially based on the last user message, I need to identify if the user confirms the validation (without any modification) or not.
             $toolGuidanceSection
 
-            Decide between three outcomes and put exactly one of "$CHOICE_YES", "$CHOICE_NO", "$CHOICE_UNCLEAR" between <$TAG_DECISION></$TAG_DECISION> tags:
-            - "$CHOICE_YES" — the user clearly confirms the validation without modification.
-            - "$CHOICE_NO" — the user clearly refuses.
-            - "$CHOICE_UNCLEAR" — the reply is genuinely ambiguous (off-topic, sarcastic, evasive, or an idiomatic expression that could plausibly be read as either yes or no). Use this when you have to guess.
+            <conversationHistory>
+            $firstLevelHistory
+            </conversationHistory>
+
+            Put exactly one of "$CHOICE_YES", "$CHOICE_NO", "$CHOICE_UNCLEAR" between
+            <$TAG_DECISION></$TAG_DECISION> tags:
+            - "$CHOICE_YES" — clear, explicit affirmation (e.g. "yes", "go ahead", "confirmed").
+            - "$CHOICE_NO" — clear refusal, cancellation, OR topic shift to something unrelated.
+            - "$CHOICE_UNCLEAR" — hesitant, non-committal, or a clarification question about the
+              pending action.
 
             <$TAG_DECISION>
             """.trimIndent()
@@ -292,7 +292,6 @@ class ConfirmationManager(
         s
             // Strip orphan opening / closing question tags that leak when the LLM omits one side.
             .replace(Regex("</?$TAG_QUESTION>"), "")
-            .replace(Regex("\\p{Cntrl}"), "")
             .trim()
 
     private fun serializeSafely(data: Any): String =


### PR DESCRIPTION
## Summary

Streamline the LLM-judge prompt used in `ConfirmationManager.analyzeConfirmation` to fix two issues observed on real cases:

1. **False negatives on legitimate "yes"**: the prior over-specified prompt (multiple example lists per category, explicit "default to UNCLEAR" asymmetry) was pushing the judge toward UNCLEAR/NO on simple affirmations, observed in local repro cases.
2. **Re-ask loops on topic shift**: when the user moves on to an unrelated topic mid-confirmation (e.g. asks an off-topic question), the judge previously returned UNCLEAR, leading to indefinite re-asks. Now classified as NO (implicit cancellation).

## Changes

`ConfirmationManager.analyzeConfirmation` prompt rewritten to ~17 lines (was ~30) with:
- Clear, one-line definition per outcome (YES / NO / UNCLEAR).
- NO now explicitly covers refusal, cancellation, AND topic shift to something unrelated.
- Explicit multilingual reasoning ("user may reply in any language, examples are illustrative only") — the categories apply to equivalents in any language.

## Validation

Manual replay on local AgentOS:
- "oui" / "yes" after a single confirmation → CONFIRMED ✅
- "pourquoi pas" / "why not" / "I guess" → UNCLEAR → re-ask ✅
- Off-topic question mid-confirmation → NO (cancel), no more infinite re-ask loop ✅
- Emphatic "NON" → NO ✅