### PR TITLE
fix(agentos): repetition detection scoped to current turn only

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -240,30 +240,38 @@ class AgentAdvanced(
 
     /**
      * Counts the maximum repetition of any (toolName, args) pair within the last
-     * [REPETITION_WINDOW] tool responses.
+     * [REPETITION_WINDOW] tool responses **of the current turn**.
      *
-     * Returns `null` when the window is not yet full or when it contains a synthetic
-     * [ToolResponseEvent] from a confirmation resolution (user-validated, not a loop).
-     * No threshold comparison is done here — that is [handleRepetition]'s job.
+     * "Current turn" means events strictly after the last user [MessageEvent] in the
+     * history. This prevents tool calls from previous conversation turns from being
+     * mistaken for an ongoing loop when the agent is reloaded with full case history.
+     *
+     * Returns `null` when the current-turn window is not yet full or when it contains
+     * a synthetic [ToolResponseEvent] from a confirmation resolution (user-validated,
+     * not a loop). No threshold comparison is done here — that is [handleRepetition]'s job.
      */
     internal fun detectToolRepetition(events: List<CaseEvent>): ToolRepetition? {
+        // Scope detection to the current turn only: events after the last user message.
+        val lastUserMessageIndex = events.indexOfLast { it is MessageEvent && it.actor.role == ActorRole.USER }
+        val currentTurnEvents = if (lastUserMessageIndex >= 0) events.drop(lastUserMessageIndex + 1) else events
+
         val resolvedPendingIds =
-            events
+            currentTurnEvents
                 .filterIsInstance<ConfirmationResolvedEvent>()
                 .mapTo(mutableSetOf()) { it.pendingEventId }
         val syntheticToolRequestIds =
-            events
+            currentTurnEvents
                 .filterIsInstance<PendingConfirmationEvent>()
                 .filter { it.metadata.id in resolvedPendingIds }
                 .mapTo(mutableSetOf()) { it.toolRequestId }
 
         val argsByRequestId =
-            events
+            currentTurnEvents
                 .filterIsInstance<ToolRequestEvent>()
                 .associate { it.toolRequestId to (it.args?.trim() ?: "") }
 
         val window =
-            events
+            currentTurnEvents
                 .filterIsInstance<ToolResponseEvent>()
                 .takeLast(REPETITION_WINDOW)
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -2844,6 +2844,56 @@ class AgentAdvancedSpec :
             outcome shouldBe null
         }
 
+        "detectToolRepetition returns null when tool responses from a previous turn fill the window (cross-turn false positive)" {
+            // Regression: before the fix, tool calls from a previous conversation turn
+            // were included in the window, causing a false repetition detection at the
+            // start of the next turn — even before the agent had called anything.
+            // The fix scopes detection to events after the last user MessageEvent.
+            val agent = makeParserAgent()
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val sameArgs = """{"profile":"A"}"""
+
+            // Previous turn: user message + REPETITION_WINDOW calls to the same tool
+            val previousUserMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = Actor("user1", "User", ActorRole.USER),
+                content = listOf(MessageContent.Text("first turn")),
+            )
+            val previousTurnEvents = (1..AgentAdvanced.REPETITION_WINDOW).flatMap { i ->
+                listOf(
+                    ToolRequestEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        toolRequestId = "prev-req-$i",
+                        toolName = "SelectActiveProfile",
+                        args = sameArgs,
+                    ),
+                    ToolResponseEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        toolRequestId = "prev-req-$i",
+                        toolName = "SelectActiveProfile",
+                        output = MessageContent.Text("profile A selected"),
+                    ),
+                )
+            }
+
+            // New turn: new user message, no tool calls yet
+            val newUserMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = Actor("user1", "User", ActorRole.USER),
+                content = listOf(MessageContent.Text("second turn")),
+            )
+
+            val events = listOf(previousUserMsg) + previousTurnEvents + listOf(newUserMsg)
+
+            // The window from the previous turn should NOT trigger detection in the new turn.
+            agent.detectToolRepetition(events) shouldBe null
+        }
+
         "detectToolRepetition returns null when window contains a synthetic ToolResponseEvent" {
             val agent = makeParserAgent()
             val namespaceId = UUID.randomUUID()


### PR DESCRIPTION
Fix repetition detection false positives across conversation turns.

detectToolRepetition was scanning the full case history when looking for repeated tool calls, so tool responses from previous turns would fill the sliding window and trigger a warning at the very start of the next turn — before the agent had called anything. This caused legitimate tools like SelectActiveProfile to be flagged as a loop simply because they had been used in an earlier turn.

The fix scopes detection to events after the last user MessageEvent, restricting the window to the current turn only. A new unit test covers the cross-turn false positive scenario directly.