### PR TITLE
feat: wz-31566 Add dynamic namespace description via integration plugin

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolPlugin.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolPlugin.kt
@@ -104,32 +104,30 @@ interface ToolPlugin : ExtensionPoint {
     ): List<StandardTool<*>>
 
     /**
-     * Optionally provide a dynamic, runtime description of this integration instance.
+     * Optionally contribute a dynamic, runtime description of this integration instance
+     * to the namespace-level system prompt.
      *
-     * Called during agent instruction building so the agent's system prompt can include
-     * an up-to-date description of what the integration currently provides or how it is
-     * configured. Because some integrations are remote (e.g. fetching workspace info from
-     * an external API), this method is `suspend` and may perform async I/O.
+     * Called once per [IntegrationConfig] when building the namespace system prompt so
+     * the agent receives an up-to-date description of what this integration provides
+     * within the current namespace. Because some integrations are remote (e.g. fetching
+     * workspace info from an external API), this method is `suspend` and may perform
+     * async I/O.
      *
-     * The service layer calls this once per relevant [IntegrationConfig] when building
-     * agent instructions. The returned string replaces the static
-     * [IntegrationConfig.description] field for that agent run. When this method returns
-     * `null`, the service falls back to [IntegrationConfig.description].
+     * When this method returns `null`, nothing is appended for this integration config.
      *
      * Implementations should be resilient: catch exceptions internally and return `null`
-     * rather than letting errors propagate — a missing dynamic description is non-fatal
-     * and the static fallback is always acceptable.
+     * rather than letting errors propagate — a missing dynamic description is non-fatal.
      *
-     * The default implementation returns `null` (no dynamic description), preserving
-     * binary compatibility with existing plugin JARs.
+     * The default implementation returns `null` (no contribution), preserving binary
+     * compatibility with existing plugin JARs.
      *
      * @param config Parsed JSON parameters from the persisted IntegrationConfig,
      *               or null if no configuration is available.
      * @param configName The name of the IntegrationConfig being described.
      * @param context Resolution context (namespaceId, userId, caseEvents).
-     * @return A dynamic description string, or null to fall back to the static description.
+     * @return A description string to append to the namespace system prompt, or null.
      */
-    suspend fun describeIntegration(
+    suspend fun describeNamespace(
         config: JsonNode?,
         configName: String?,
         context: ToolContext?,

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolPlugin.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolPlugin.kt
@@ -102,4 +102,36 @@ interface ToolPlugin : ExtensionPoint {
         configName: String? = null,
         context: ToolContext? = null,
     ): List<StandardTool<*>>
+
+    /**
+     * Optionally provide a dynamic, runtime description of this integration instance.
+     *
+     * Called during agent instruction building so the agent's system prompt can include
+     * an up-to-date description of what the integration currently provides or how it is
+     * configured. Because some integrations are remote (e.g. fetching workspace info from
+     * an external API), this method is `suspend` and may perform async I/O.
+     *
+     * The service layer calls this once per relevant [IntegrationConfig] when building
+     * agent instructions. The returned string replaces the static
+     * [IntegrationConfig.description] field for that agent run. When this method returns
+     * `null`, the service falls back to [IntegrationConfig.description].
+     *
+     * Implementations should be resilient: catch exceptions internally and return `null`
+     * rather than letting errors propagate — a missing dynamic description is non-fatal
+     * and the static fallback is always acceptable.
+     *
+     * The default implementation returns `null` (no dynamic description), preserving
+     * binary compatibility with existing plugin JARs.
+     *
+     * @param config Parsed JSON parameters from the persisted IntegrationConfig,
+     *               or null if no configuration is available.
+     * @param configName The name of the IntegrationConfig being described.
+     * @param context Resolution context (namespaceId, userId, caseEvents).
+     * @return A dynamic description string, or null to fall back to the static description.
+     */
+    suspend fun describeIntegration(
+        config: JsonNode?,
+        configName: String?,
+        context: ToolContext?,
+    ): String? = null
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -23,7 +23,7 @@ interface AgentService {
      * are scoped to the given namespace and case.
      * Throws if no model matches [namePart].
      */
-    fun findAgentByName(
+    suspend fun findAgentByName(
         namePart: String,
         context: AgentExecutionContext,
     ): Agent
@@ -42,7 +42,7 @@ interface AgentService {
      *
      * Throws [IllegalArgumentException] if the config is not found or no model can be resolved.
      */
-    fun resolveDefinition(
+    suspend fun resolveDefinition(
         agentConfigId: UUID,
         namespaceId: UUID,
         userId: UUID? = null,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -285,6 +285,7 @@ class AgentServiceImpl(
         val namespace = namespaceService.findById(namespaceId)
         return buildString {
             appendLine("## Context: ${namespace?.name ?: namespaceId}")
+            // FIXME: we need to disable this temporarly, feature switch ?
             //namespace?.description?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
         }.trimEnd()
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -126,7 +126,8 @@ class AgentServiceImpl(
                 namespaceId = context.namespaceId,
                 userId = context.userId,
             )
-        val namespaceSystemPrompt = buildNamespaceSystemPrompt(namespaceId = context.namespaceId)
+        val namespaceSystemPrompt =
+            buildNamespaceSystemPrompt(namespaceId = context.namespaceId, context = context, resolvedUser = resolvedUser)
         val instructions =
             buildInstructions(
                 baseInstructions = config.instructions,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -90,8 +90,7 @@ class AgentServiceImpl(
                     namespaceId = namespaceId,
                     userId = userId,
                     agentName = namePart,
-                )
-                .firstOrNull()
+                ).firstOrNull()
                 ?.name
         } else {
             agentConfigService.findByName(namespaceId, namePart)?.name
@@ -112,7 +111,7 @@ class AgentServiceImpl(
     private suspend fun resolveAgentDefinition(
         config: AgentConfig,
         context: AgentExecutionContext,
-        resolvedUser: User?
+        resolvedUser: User?,
     ): ResolvedAgentDefinition {
         val baseModel =
             config.modelName?.let { aiModelService.findAiModel(context.namespaceId, it) }
@@ -122,13 +121,14 @@ class AgentServiceImpl(
                         "(modelName=${config.modelName}, namespace=${context.namespaceId}).",
                 )
         val (modelConfig, providerConfig) = applyOverlaysToModel(baseModel, context.namespaceId, context.userId)
-        val namespaceSystemPrompt = buildNamespaceSystemPrompt(context.namespaceId)
-        val instructions = buildInstructions(
-            baseInstructions = config.instructions,
-            agentIntegrations = config.integrations,
-            context = context,
-            resolvedUser
-        )
+        val namespaceSystemPrompt = buildNamespaceSystemPrompt(context.namespaceId, context, resolvedUser)
+        val instructions =
+            buildInstructions(
+                baseInstructions = config.instructions,
+                agentIntegrations = config.integrations,
+                context = context,
+                resolvedUser = resolvedUser,
+            )
         val tools =
             if (context.userId != null) {
                 toolResolverService.resolveToolsForRun(context.namespaceId, context.userId, config.integrations)
@@ -163,7 +163,7 @@ class AgentServiceImpl(
     private fun instantiateAgent(
         definition: ResolvedAgentDefinition,
         context: AgentExecutionContext,
-        resolvedUser: User?
+        resolvedUser: User?,
     ): Agent {
         val modelConfig = definition.resolvedModel
         val providerConfig = definition.resolvedProvider
@@ -280,13 +280,47 @@ class AgentServiceImpl(
     /**
      * Build the namespace context block to be used as a system prompt, separate from
      * the agent's own instructions. Describes the namespace the agent operates in.
+     *
+     * Each [IntegrationConfig] in the namespace is matched to its [ToolPlugin]. If the
+     * plugin implements [io.whozoss.agentos.sdk.tool.ToolPlugin.describeNamespace], its
+     * result is appended to the system prompt. Results are collected concurrently;
+     * plugins returning null or throwing are silently skipped.
      */
-    private fun buildNamespaceSystemPrompt(namespaceId: UUID): String {
+    private suspend fun buildNamespaceSystemPrompt(
+        namespaceId: UUID,
+        context: AgentExecutionContext,
+        resolvedUser: User?,
+    ): String {
         val namespace = namespaceService.findById(namespaceId)
+        val toolContext =
+            ToolContext(
+                namespaceId = namespaceId,
+                userId = resolvedUser?.id,
+                userExternalId = resolvedUser?.externalId,
+                caseEvents = emptyList(),
+            )
+        val integrationDescriptions =
+            coroutineScope {
+                integrationConfigService
+                    .findByParent(namespaceId)
+                    .mapNotNull { config -> toolRegistryService.findPlugin(config.integrationType)?.let { config to it } }
+                    .map { (config, plugin) ->
+                        async {
+                            plugin
+                                .runCatching { describeNamespace(config.parameters, config.name, toolContext) }
+                                .onFailure {
+                                    logger.warn(
+                                        it,
+                                    ) { "describeNamespace failed for '${config.name}' (${config.integrationType})" }
+                                }.getOrNull()
+                        }
+                    }.mapNotNull { it.await() }
+                    .filter { it.isNotBlank() }
+            }
         return buildString {
             appendLine("## Context: ${namespace?.name ?: namespaceId}")
-            // FIXME: we need to disable this temporarly, feature switch ?
-            //namespace?.description?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
+            namespace?.description?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
+            integrationDescriptions.forEach { appendLine(it) }
         }.trimEnd()
     }
 
@@ -299,22 +333,18 @@ class AgentServiceImpl(
      *
      * The integrations block lists [IntegrationConfig] entries whose
      * [name][io.whozoss.agentos.integrationConfig.IntegrationConfig.name] appears in
-     * [agentIntegrations]. For each matching config, the description is obtained by
-     * calling [io.whozoss.agentos.sdk.tool.ToolPlugin.describeIntegration] on the
-     * corresponding plugin (which may perform async I/O for remote integrations).
-     * When the plugin returns null, the stored [IntegrationConfig.description] is used
-     * as a fallback. Configs with no description from either source are excluded.
-     * The block is omitted entirely when [agentIntegrations] is null (agent has no
-     * declared integrations).
+     * [agentIntegrations], using the static [IntegrationConfig.description] for each.
+     * Configs with no description are excluded. The block is omitted entirely when
+     * [agentIntegrations] is null (agent has no declared integrations).
      *
      * The user context block is included when [context.userId] resolves to a known [User]
      * with at least one human-readable field.
      */
-    private suspend fun buildInstructions(
+    private fun buildInstructions(
         baseInstructions: String?,
         agentIntegrations: Map<String, List<String>?>?,
         context: AgentExecutionContext,
-        resolvedUser: User?
+        resolvedUser: User?,
     ): String {
         val integrationsBlock =
             when {
@@ -323,31 +353,10 @@ class AgentServiceImpl(
                 }
 
                 else -> {
-                    val toolContext = ToolContext(
-                        namespaceId = context.namespaceId,
-                        userId = resolvedUser?.id,
-                        userExternalId = resolvedUser?.externalId,
-                        caseEvents = emptyList(),
-                    )
-                    val matchingConfigs =
+                    val listed =
                         integrationConfigService
                             .findByParent(context.namespaceId)
-                            .filter { it.name in agentIntegrations }
-                    val listed = coroutineScope {
-                        matchingConfigs
-                            .map { config ->
-                                async {
-                                    val plugin = toolRegistryService.findPlugin(config.integrationType)
-                                    val description = plugin
-                                        ?.runCatching { describeIntegration(config.parameters, config.name, toolContext) }
-                                        ?.onFailure { logger.warn(it) { "describeIntegration failed for '${config.name}' (${config.integrationType})" } }
-                                        ?.getOrNull()
-                                        ?: config.description
-                                    description?.takeUnless { it.isBlank() }?.let { config to it }
-                                }
-                            }
-                            .mapNotNull { it.await() }
-                    }
+                            .filter { it.name in agentIntegrations && !it.description.isNullOrBlank() }
                     when {
                         listed.isEmpty() -> {
                             null
@@ -357,8 +366,8 @@ class AgentServiceImpl(
                             buildString {
                                 appendLine()
                                 appendLine("## Integrations")
-                                listed.forEach { (config, description) ->
-                                    appendLine("### ${config.name}\n$description")
+                                listed.forEach { config ->
+                                    appendLine("- ${config.name}: ${config.description}")
                                 }
                             }.trimEnd()
                         }
@@ -367,25 +376,23 @@ class AgentServiceImpl(
             }
 
         val userBlock =
-            context.userId?.let { userId ->
-                userService.findById(userId)?.let { user ->
-                    // Only inject a user block when at least one human-readable field is present.
-                    // Internal UUIDs (id, externalId) are intentionally excluded — they carry no
-                    // conversational meaning and confuse the LLM about who the interlocutor is.
-                    val hasIdentity = !user.firstname.isNullOrBlank() || !user.lastname.isNullOrBlank()
-                    val hasContext = !user.bio.isNullOrBlank() || user.email.isNotBlank()
-                    if (!hasIdentity && !hasContext) {
-                        null
-                    } else {
-                        buildString {
-                            appendLine()
-                            appendLine("## User")
-                            if (!user.firstname.isNullOrBlank()) appendLine("- firstname: ${user.firstname}")
-                            if (!user.lastname.isNullOrBlank()) appendLine("- lastname: ${user.lastname}")
-                            if (user.email.isNotBlank()) appendLine("- email: ${user.email}")
-                            if (!user.bio.isNullOrBlank()) appendLine("- bio: ${user.bio}")
-                        }.trimEnd()
-                    }
+            resolvedUser?.let { user ->
+                // Only inject a user block when at least one human-readable field is present.
+                // Internal UUIDs (id, externalId) are intentionally excluded — they carry no
+                // conversational meaning and confuse the LLM about who the interlocutor is.
+                val hasIdentity = !user.firstname.isNullOrBlank() || !user.lastname.isNullOrBlank()
+                val hasContext = !user.bio.isNullOrBlank() || user.email.isNotBlank()
+                if (!hasIdentity && !hasContext) {
+                    null
+                } else {
+                    buildString {
+                        appendLine()
+                        appendLine("## User")
+                        if (!user.firstname.isNullOrBlank()) appendLine("- firstname: ${user.firstname}")
+                        if (!user.lastname.isNullOrBlank()) appendLine("- lastname: ${user.lastname}")
+                        if (user.email.isNotBlank()) appendLine("- email: ${user.email}")
+                        if (!user.bio.isNullOrBlank()) appendLine("- bio: ${user.bio}")
+                    }.trimEnd()
                 }
             }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -14,9 +14,13 @@ import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.aiProvider.AiProvider
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.tool.ToolResolverService
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import mu.KLogging
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -40,8 +44,9 @@ class AgentServiceImpl(
     private val intentionGenerator: AgentIntentionGenerator,
     private val confirmationManager: ConfirmationManager,
     private val objectMapper: ObjectMapper,
+    private val toolRegistryService: ToolRegistryService,
 ) : AgentService {
-    override fun findAgentByName(
+    override suspend fun findAgentByName(
         namePart: String,
         context: AgentExecutionContext,
     ): Agent {
@@ -50,11 +55,12 @@ class AgentServiceImpl(
                 ?: throw IllegalArgumentException(
                     "No AgentConfig found for name '$namePart' in namespace ${context.namespaceId}.",
                 )
-        val definition = resolveAgentDefinition(agentConfig, context)
-        return instantiateAgent(definition, context)
+        val resolvedUser = context.userId?.let { runCatching { userService.findById(it) }.getOrNull() }
+        val definition = resolveAgentDefinition(agentConfig, context, resolvedUser)
+        return instantiateAgent(definition, context, resolvedUser)
     }
 
-    override fun resolveDefinition(
+    override suspend fun resolveDefinition(
         agentConfigId: UUID,
         namespaceId: UUID,
         userId: UUID?,
@@ -69,7 +75,8 @@ class AgentServiceImpl(
                 namespaceId = namespaceId,
                 userId = userId,
             )
-        return resolveAgentDefinition(agentConfig, context)
+        val resolvedUser = userId?.let { runCatching { userService.findById(it) }.getOrNull() }
+        return resolveAgentDefinition(agentConfig, context, resolvedUser)
     }
 
     override fun resolveAgentName(
@@ -102,9 +109,10 @@ class AgentServiceImpl(
      *
      * Throws [IllegalArgumentException] if no model can be resolved.
      */
-    private fun resolveAgentDefinition(
+    private suspend fun resolveAgentDefinition(
         config: AgentConfig,
         context: AgentExecutionContext,
+        resolvedUser: User?
     ): ResolvedAgentDefinition {
         val baseModel =
             config.modelName?.let { aiModelService.findAiModel(context.namespaceId, it) }
@@ -119,6 +127,7 @@ class AgentServiceImpl(
             baseInstructions = config.instructions,
             agentIntegrations = config.integrations,
             context = context,
+            resolvedUser
         )
         val tools =
             if (context.userId != null) {
@@ -154,10 +163,11 @@ class AgentServiceImpl(
     private fun instantiateAgent(
         definition: ResolvedAgentDefinition,
         context: AgentExecutionContext,
+        resolvedUser: User?
     ): Agent {
         val modelConfig = definition.resolvedModel
         val providerConfig = definition.resolvedProvider
-        val resolvedUser = context.userId?.let { runCatching { userService.findById(it) }.getOrNull() }
+
         return createAgentInstance(
             agentName = definition.name,
             resolvedInstructions = definition.instructions,
@@ -275,7 +285,7 @@ class AgentServiceImpl(
         val namespace = namespaceService.findById(namespaceId)
         return buildString {
             appendLine("## Context: ${namespace?.name ?: namespaceId}")
-            namespace?.description?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
+            //namespace?.description?.takeIf { it.isNotBlank() }?.let { appendLine(it) }
         }.trimEnd()
     }
 
@@ -288,16 +298,22 @@ class AgentServiceImpl(
      *
      * The integrations block lists [IntegrationConfig] entries whose
      * [name][io.whozoss.agentos.integrationConfig.IntegrationConfig.name] appears in
-     * [agentIntegrations] AND that carry a non-null description. It is omitted entirely
-     * when [agentIntegrations] is null (agent has no declared integrations).
+     * [agentIntegrations]. For each matching config, the description is obtained by
+     * calling [io.whozoss.agentos.sdk.tool.ToolPlugin.describeIntegration] on the
+     * corresponding plugin (which may perform async I/O for remote integrations).
+     * When the plugin returns null, the stored [IntegrationConfig.description] is used
+     * as a fallback. Configs with no description from either source are excluded.
+     * The block is omitted entirely when [agentIntegrations] is null (agent has no
+     * declared integrations).
      *
      * The user context block is included when [context.userId] resolves to a known [User]
      * with at least one human-readable field.
      */
-    private fun buildInstructions(
+    private suspend fun buildInstructions(
         baseInstructions: String?,
         agentIntegrations: Map<String, List<String>?>?,
         context: AgentExecutionContext,
+        resolvedUser: User?
     ): String {
         val integrationsBlock =
             when {
@@ -306,10 +322,31 @@ class AgentServiceImpl(
                 }
 
                 else -> {
-                    val listed =
+                    val toolContext = ToolContext(
+                        namespaceId = context.namespaceId,
+                        userId = resolvedUser?.id,
+                        userExternalId = resolvedUser?.externalId,
+                        caseEvents = emptyList(),
+                    )
+                    val matchingConfigs =
                         integrationConfigService
                             .findByParent(context.namespaceId)
-                            .filter { it.name in agentIntegrations && !it.description.isNullOrBlank() }
+                            .filter { it.name in agentIntegrations }
+                    val listed = coroutineScope {
+                        matchingConfigs
+                            .map { config ->
+                                async {
+                                    val plugin = toolRegistryService.findPlugin(config.integrationType)
+                                    val description = plugin
+                                        ?.runCatching { describeIntegration(config.parameters, config.name, toolContext) }
+                                        ?.onFailure { logger.warn(it) { "describeIntegration failed for '${config.name}' (${config.integrationType})" } }
+                                        ?.getOrNull()
+                                        ?: config.description
+                                    description?.takeUnless { it.isBlank() }?.let { config to it }
+                                }
+                            }
+                            .mapNotNull { it.await() }
+                    }
                     when {
                         listed.isEmpty() -> {
                             null
@@ -319,8 +356,8 @@ class AgentServiceImpl(
                             buildString {
                                 appendLine()
                                 appendLine("## Integrations")
-                                listed.forEach { config ->
-                                    appendLine("- ${config.name}: ${config.description}")
+                                listed.forEach { (config, description) ->
+                                    appendLine("### ${config.name}\n$description")
                                 }
                             }.trimEnd()
                         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
@@ -5,11 +5,10 @@ import io.whozoss.agentos.entity.EntityController
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.permissions.EntityType
 import io.whozoss.agentos.permissions.PermissionService
-import io.whozoss.agentos.security.declarative.HideOnAccessDenied
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.security.declarative.HideOnAccessDenied
 import io.whozoss.agentos.user.UserService
 import jakarta.validation.Valid
-import kotlinx.coroutines.runBlocking
 import mu.KLogging
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -46,7 +45,6 @@ class AgentConfigController(
     userService: UserService,
     permissionService: PermissionService,
 ) : EntityController<AgentConfig, UUID, AgentConfigResource>(agentConfigService, userService, permissionService) {
-
     override val entityType = EntityType.AGENT_CONFIG
 
     override fun toResource(entity: AgentConfig): AgentConfigResource =
@@ -106,7 +104,9 @@ class AgentConfigController(
     @GetMapping("/{id}")
     @PreAuthorize("hasPermission(#id, 'AgentConfig', 'READ')")
     @HideOnAccessDenied
-    override fun getById(@PathVariable id: UUID): AgentConfigResource = super.getById(id)
+    override fun getById(
+        @PathVariable id: UUID,
+    ): AgentConfigResource = super.getById(id)
 
     // POST /by-ids — inherited from EntityController.getByIds (batch authorization,
     // story 5-4 factorisation of the pattern introduced by 5-3).
@@ -123,8 +123,9 @@ class AgentConfigController(
      */
     @GetMapping("/by-parentId/{parentId}")
     @PreAuthorize("hasPermission(#parentId, 'Namespace', 'READ')")
-    override fun listByParent(@PathVariable parentId: UUID): List<AgentConfigResource> =
-        listByNamespace(parentId, enabledOnly = false)
+    override fun listByParent(
+        @PathVariable parentId: UUID,
+    ): List<AgentConfigResource> = listByNamespace(parentId, enabledOnly = false)
 
     /**
      * GET /api/agent-configs/by-parentId/{parentId}?enabledOnly=...
@@ -140,13 +141,13 @@ class AgentConfigController(
     fun listByNamespace(
         @PathVariable parentId: UUID,
         @RequestParam(required = false, defaultValue = "false") enabledOnly: Boolean,
-    ): List<AgentConfigResource> =
-        agentConfigService.findByNamespace(parentId, enabledOnly).map { toResource(it) }
+    ): List<AgentConfigResource> = agentConfigService.findByNamespace(parentId, enabledOnly).map { toResource(it) }
 
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("hasPermission(#resource.namespaceId, 'Namespace', 'WRITE')")
-    override fun create(@Valid @RequestBody resource: AgentConfigResource): AgentConfigResource =
-        toResource(agentConfigService.create(toDomain(resource)))
+    override fun create(
+        @Valid @RequestBody resource: AgentConfigResource,
+    ): AgentConfigResource = toResource(agentConfigService.create(toDomain(resource)))
 
     @PutMapping("/{id}", consumes = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("hasPermission(#id, 'AgentConfig', 'WRITE')")
@@ -154,14 +155,17 @@ class AgentConfigController(
         @PathVariable id: UUID,
         @Valid @RequestBody resource: AgentConfigResource,
     ): AgentConfigResource {
-        val existing = agentConfigService.findById(id)
-            ?: throw ResourceNotFoundException("AgentConfig not found: $id")
+        val existing =
+            agentConfigService.findById(id)
+                ?: throw ResourceNotFoundException("AgentConfig not found: $id")
         return toResource(agentConfigService.update(toDomainForUpdate(resource, existing)))
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasPermission(#id, 'AgentConfig', 'DELETE')")
-    override fun delete(@PathVariable id: UUID) = super.delete(id)
+    override fun delete(
+        @PathVariable id: UUID,
+    ) = super.delete(id)
 
     /**
      * POST /api/agent-configs/{id}/enable
@@ -171,7 +175,9 @@ class AgentConfigController(
      */
     @PostMapping("/{id}/enable")
     @PreAuthorize("hasPermission(#id, 'AgentConfig', 'WRITE')")
-    fun enable(@PathVariable id: UUID): AgentConfigResource {
+    fun enable(
+        @PathVariable id: UUID,
+    ): AgentConfigResource {
         logger.info { "[AgentConfig] Enabling agent config $id" }
         return toResource(agentConfigService.enable(id))
     }
@@ -184,7 +190,9 @@ class AgentConfigController(
      */
     @PostMapping("/{id}/disable")
     @PreAuthorize("hasPermission(#id, 'AgentConfig', 'WRITE')")
-    fun disable(@PathVariable id: UUID): AgentConfigResource {
+    fun disable(
+        @PathVariable id: UUID,
+    ): AgentConfigResource {
         logger.info { "[AgentConfig] Disabling agent config $id" }
         return toResource(agentConfigService.disable(id))
     }
@@ -223,20 +231,20 @@ class AgentConfigController(
     @GetMapping("/{id}/definition")
     @PreAuthorize("hasPermission(#id, 'AgentConfig', 'READ')")
     @HideOnAccessDenied
-    fun getDefinition(
+    suspend fun getDefinition(
         @PathVariable id: UUID,
         @RequestParam(required = false, defaultValue = "false") withUserOverlay: Boolean,
     ): AgentDefinitionResource {
-        val agentConfig = agentConfigService.findById(id)
-            ?: throw ResourceNotFoundException("AgentConfig not found: $id")
+        val agentConfig =
+            agentConfigService.findById(id)
+                ?: throw ResourceNotFoundException("AgentConfig not found: $id")
         val resolvedUserId = if (withUserOverlay) userService.getCurrentUser().metadata.id else null
-        val definition = runBlocking {
+        val definition =
             agentService.resolveDefinition(
                 agentConfigId = id,
                 namespaceId = agentConfig.namespaceId,
                 userId = resolvedUserId,
             )
-        }
         return AgentDefinitionResource(
             agentConfigId = definition.agentConfigId,
             name = definition.name,
@@ -244,13 +252,14 @@ class AgentConfigController(
             instructions = definition.instructions,
             resolvedModelApiName = definition.resolvedModelApiName,
             resolvedProviderName = definition.resolvedProviderName,
-            tools = definition.tools.map { tool ->
-                AgentDefinitionResource.ToolSummary(
-                    name = tool.name,
-                    description = tool.description,
-                    inputSchema = tool.inputSchema,
-                )
-            },
+            tools =
+                definition.tools.map { tool ->
+                    AgentDefinitionResource.ToolSummary(
+                        name = tool.name,
+                        description = tool.description,
+                        inputSchema = tool.inputSchema,
+                    )
+                },
             advancedExecution = definition.advancedExecution,
             namespaceId = definition.namespaceId,
             userId = definition.userId,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
@@ -9,6 +9,7 @@ import io.whozoss.agentos.security.declarative.HideOnAccessDenied
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.UserService
 import jakarta.validation.Valid
+import kotlinx.coroutines.runBlocking
 import mu.KLogging
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -171,11 +172,13 @@ class AgentConfigController(
         val agentConfig = agentConfigService.findById(id)
             ?: throw ResourceNotFoundException("AgentConfig not found: $id")
         val resolvedUserId = if (withUserOverlay) userService.getCurrentUser().metadata.id else null
-        val definition = agentService.resolveDefinition(
-            agentConfigId = id,
-            namespaceId = agentConfig.namespaceId,
-            userId = resolvedUserId,
-        )
+        val definition = runBlocking {
+            agentService.resolveDefinition(
+                agentConfigId = id,
+                namespaceId = agentConfig.namespaceId,
+                userId = resolvedUserId,
+            )
+        }
         return AgentDefinitionResource(
             agentConfigId = definition.agentConfigId,
             name = definition.name,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -122,7 +122,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
         every { namespaceService.findById(namespaceId) } returns namespace
         every { integrationConfigService.findByParent(any()) } returns emptyList()
         every { userService.findById(any()) } returns null
-        // No plugin returns a dynamic description by default — tests fall back to config.description
+        // No plugin contributes a namespace description by default
         every { toolRegistryService.findPlugin(any()) } returns null
         // reconciliation services are relaxed mocks — return the base entity unchanged (passthrough) by default
 
@@ -247,7 +247,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
         // Namespace context injection into instructions
         // -------------------------------------------------------------------------
 
-        "findAgentByName appends namespace name and description to instructions" {
+        "findAgentByName includes namespace name and description in system prompt" {
             val config = agentConfig(name = "my-agent", modelName = "sonnet")
             val model = modelConfig(alias = "sonnet")
             val provider = providerConfig()
@@ -373,26 +373,24 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val agent = localService.findAgentByName("my-agent", context) as AgentSimple
 
             agent.instructions shouldContain "## Integrations"
-            agent.instructions shouldContain "JIRA_PROD: Production Jira workspace for the engineering team"
+            agent.instructions shouldContain "### JIRA_PROD"
+            agent.instructions shouldContain "Production Jira workspace for the engineering team"
             agent.instructions shouldNotContain "SLACK_DEV"
         }
 
-        "findAgentByName uses dynamic description from describeIntegration when plugin returns one" {
+        "findAgentByName appends describeNamespace result from matching integration config to the namespace system prompt" {
             val plugin = mockk<ToolPlugin>()
-            coEvery { plugin.describeIntegration(any(), any(), any()) } returns "Dynamic description from remote API"
+            val integrationConfig = IntegrationConfig(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                namespaceId = namespaceId,
+                name = "JIRA_PROD",
+                integrationType = "JIRA",
+                description = null,
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns listOf(integrationConfig)
             every { toolRegistryService.findPlugin("JIRA") } returns plugin
-            val configs = listOf(
-                IntegrationConfig(
-                    metadata = EntityMetadata(id = UUID.randomUUID()),
-                    namespaceId = namespaceId,
-                    name = "JIRA_PROD",
-                    integrationType = "JIRA",
-                    description = "Static fallback description",
-                ),
-            )
-            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            coEvery { plugin.describeNamespace(any(), eq("JIRA_PROD"), any()) } returns "Jira workspace: ACME Engineering (42 open issues)"
             val config = agentConfig(name = "my-agent", modelName = "sonnet")
-                .copy(integrations = mapOf("JIRA_PROD" to null))
             val model = modelConfig(alias = "sonnet")
             val provider = providerConfig()
             val chatClient = mockk<ChatClient>(relaxed = true)
@@ -403,120 +401,114 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
 
-            agent.instructions shouldContain "Dynamic description from remote API"
-            agent.instructions shouldNotContain "Static fallback description"
-
-            // restore default stub
-            every { toolRegistryService.findPlugin(any()) } returns null
-        }
-
-        "findAgentByName falls back to config.description when describeIntegration returns null" {
-            val plugin = mockk<ToolPlugin>()
-            coEvery { plugin.describeIntegration(any(), any(), any()) } returns null
-            every { toolRegistryService.findPlugin("JIRA") } returns plugin
-            val configs = listOf(
-                IntegrationConfig(
-                    metadata = EntityMetadata(id = UUID.randomUUID()),
-                    namespaceId = namespaceId,
-                    name = "JIRA_PROD",
-                    integrationType = "JIRA",
-                    description = "Static fallback description",
-                ),
-            )
-            every { integrationConfigService.findByParent(namespaceId) } returns configs
-            val config = agentConfig(name = "my-agent", modelName = "sonnet")
-                .copy(integrations = mapOf("JIRA_PROD" to null))
-            val model = modelConfig(alias = "sonnet")
-            val provider = providerConfig()
-            val chatClient = mockk<ChatClient>(relaxed = true)
-            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
-            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
-            every { aiProviderService.getById(aiProviderId) } returns provider
-            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
-
-            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
-
-            agent.instructions shouldContain "Static fallback description"
-
-            // restore default stub
-            every { toolRegistryService.findPlugin(any()) } returns null
-        }
-
-        "findAgentByName falls back to config.description when describeIntegration throws" {
-            val plugin = mockk<ToolPlugin>()
-            coEvery { plugin.describeIntegration(any(), any(), any()) } throws RuntimeException("remote API unavailable")
-            every { toolRegistryService.findPlugin("JIRA") } returns plugin
-            val configs = listOf(
-                IntegrationConfig(
-                    metadata = EntityMetadata(id = UUID.randomUUID()),
-                    namespaceId = namespaceId,
-                    name = "JIRA_PROD",
-                    integrationType = "JIRA",
-                    description = "Static fallback description",
-                ),
-            )
-            every { integrationConfigService.findByParent(namespaceId) } returns configs
-            val config = agentConfig(name = "my-agent", modelName = "sonnet")
-                .copy(integrations = mapOf("JIRA_PROD" to null))
-            val model = modelConfig(alias = "sonnet")
-            val provider = providerConfig()
-            val chatClient = mockk<ChatClient>(relaxed = true)
-            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
-            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
-            every { aiProviderService.getById(aiProviderId) } returns provider
-            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
-
-            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
-
-            // Exception must not propagate — agent instantiation succeeds with static fallback
-            agent.instructions shouldContain "Static fallback description"
-
-            // restore default stub
-            every { toolRegistryService.findPlugin(any()) } returns null
-        }
-
-        "findAgentByName calls describeIntegration once per matching integration config" {
-            val jiraPlugin = mockk<ToolPlugin>()
-            val slackPlugin = mockk<ToolPlugin>()
-            coEvery { jiraPlugin.describeIntegration(any(), any(), any()) } returns "Jira dynamic"
-            coEvery { slackPlugin.describeIntegration(any(), any(), any()) } returns "Slack dynamic"
-            every { toolRegistryService.findPlugin("JIRA") } returns jiraPlugin
-            every { toolRegistryService.findPlugin("SLACK") } returns slackPlugin
-            val configs = listOf(
-                IntegrationConfig(
-                    metadata = EntityMetadata(id = UUID.randomUUID()),
-                    namespaceId = namespaceId,
-                    name = "JIRA_PROD",
-                    integrationType = "JIRA",
-                    description = null,
-                ),
-                IntegrationConfig(
-                    metadata = EntityMetadata(id = UUID.randomUUID()),
-                    namespaceId = namespaceId,
-                    name = "SLACK_DEV",
-                    integrationType = "SLACK",
-                    description = null,
-                ),
-            )
-            every { integrationConfigService.findByParent(namespaceId) } returns configs
-            val config = agentConfig(name = "my-agent", modelName = "sonnet")
-                .copy(integrations = mapOf("JIRA_PROD" to null, "SLACK_DEV" to null))
-            val model = modelConfig(alias = "sonnet")
-            val provider = providerConfig()
-            val chatClient = mockk<ChatClient>(relaxed = true)
-            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
-            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
-            every { aiProviderService.getById(aiProviderId) } returns provider
-            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
-
-            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
-
-            agent.instructions shouldContain "Jira dynamic"
-            agent.instructions shouldContain "Slack dynamic"
-            coVerify(exactly = 1) { jiraPlugin.describeIntegration(any(), eq("JIRA_PROD"), any()) }
-            coVerify(exactly = 1) { slackPlugin.describeIntegration(any(), eq("SLACK_DEV"), any()) }
+            agent.systemPrompt shouldContain "Jira workspace: ACME Engineering (42 open issues)"
 
             // restore default stubs
+            every { integrationConfigService.findByParent(any()) } returns emptyList()
+            every { toolRegistryService.findPlugin(any()) } returns null
+        }
+
+        "findAgentByName skips integration config when describeNamespace returns null" {
+            val plugin = mockk<ToolPlugin>()
+            val integrationConfig = IntegrationConfig(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                namespaceId = namespaceId,
+                name = "JIRA_PROD",
+                integrationType = "JIRA",
+                description = null,
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns listOf(integrationConfig)
+            every { toolRegistryService.findPlugin("JIRA") } returns plugin
+            coEvery { plugin.describeNamespace(any(), any(), any()) } returns null
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.systemPrompt shouldContain namespace.name
+            agent.systemPrompt shouldNotContain "null"
+
+            // restore default stubs
+            every { integrationConfigService.findByParent(any()) } returns emptyList()
+            every { toolRegistryService.findPlugin(any()) } returns null
+        }
+
+        "findAgentByName does not propagate exception from describeNamespace" {
+            val plugin = mockk<ToolPlugin>()
+            val integrationConfig = IntegrationConfig(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                namespaceId = namespaceId,
+                name = "JIRA_PROD",
+                integrationType = "JIRA",
+                description = null,
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns listOf(integrationConfig)
+            every { toolRegistryService.findPlugin("JIRA") } returns plugin
+            coEvery { plugin.describeNamespace(any(), any(), any()) } throws RuntimeException("remote API unavailable")
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            // Must not throw — agent instantiation succeeds even when a plugin fails
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+            agent.systemPrompt shouldContain namespace.name
+
+            // restore default stubs
+            every { integrationConfigService.findByParent(any()) } returns emptyList()
+            every { toolRegistryService.findPlugin(any()) } returns null
+        }
+
+        "findAgentByName calls describeNamespace once per integration config with matching plugin" {
+            val jiraPlugin = mockk<ToolPlugin>()
+            val slackPlugin = mockk<ToolPlugin>()
+            val jiraConfig = IntegrationConfig(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                namespaceId = namespaceId,
+                name = "JIRA_PROD",
+                integrationType = "JIRA",
+                description = null,
+            )
+            val slackConfig = IntegrationConfig(
+                metadata = EntityMetadata(id = UUID.randomUUID()),
+                namespaceId = namespaceId,
+                name = "SLACK_DEV",
+                integrationType = "SLACK",
+                description = null,
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns listOf(jiraConfig, slackConfig)
+            every { toolRegistryService.findPlugin("JIRA") } returns jiraPlugin
+            every { toolRegistryService.findPlugin("SLACK") } returns slackPlugin
+            coEvery { jiraPlugin.describeNamespace(any(), eq("JIRA_PROD"), any()) } returns "Jira namespace info"
+            coEvery { slackPlugin.describeNamespace(any(), eq("SLACK_DEV"), any()) } returns "Slack namespace info"
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.systemPrompt shouldContain "Jira namespace info"
+            agent.systemPrompt shouldContain "Slack namespace info"
+            coVerify(exactly = 1) { jiraPlugin.describeNamespace(any(), eq("JIRA_PROD"), any()) }
+            coVerify(exactly = 1) { slackPlugin.describeNamespace(any(), eq("SLACK_DEV"), any()) }
+
+            // restore default stubs
+            every { integrationConfigService.findByParent(any()) } returns emptyList()
             every { toolRegistryService.findPlugin(any()) } returns null
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -117,8 +117,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
     )
 
     init {
-        every { toolResolverService.resolveToolsForNamespace(any(), any()) } returns emptyList()
-        every { toolResolverService.resolveToolsForRun(any(), any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForNamespace(agentIntegrations = any(), context = any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForRun(agentIntegrations = any(), context = any()) } returns emptyList()
+
         every { namespaceService.findById(namespaceId) } returns namespace
         every { integrationConfigService.findByParent(any()) } returns emptyList()
         every { userService.findById(any()) } returns null
@@ -374,8 +375,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val agent = localService.findAgentByName("my-agent", context) as AgentSimple
 
             agent.instructions shouldContain "## Integrations"
-            agent.instructions shouldContain "### JIRA_PROD"
-            agent.instructions shouldContain "Production Jira workspace for the engineering team"
+            agent.instructions shouldContain "- JIRA_PROD: Production Jira workspace for the engineering team"
             agent.instructions shouldNotContain "SLACK_DEV"
         }
 
@@ -701,6 +701,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             verify(exactly = 1) {
                 toolResolverService.resolveToolsForNamespace(
+                    agentIntegrations = null,
                     context = any(),
                 )
             }
@@ -722,8 +723,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             verify(exactly = 1) {
                 toolResolverService.resolveToolsForNamespace(
-                    integrations,
-                    any(),
+                    agentIntegrations = integrations,
+                    context = any(),
                 )
             }
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -7,6 +7,8 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -24,6 +26,8 @@ import io.whozoss.agentos.sdk.aiProvider.AiApiType
 import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.aiProvider.AiProvider
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.sdk.tool.ToolPlugin
+import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.tool.ToolResolverService
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
@@ -44,6 +48,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
     private val intentionGenerator: AgentIntentionGenerator = mockk(relaxed = true)
     private val confirmationManager: ConfirmationManager = mockk(relaxed = true)
     private val testObjectMapper = ObjectMapper()
+    private val toolRegistryService: ToolRegistryService = mockk(relaxed = true)
     private val agentService =
         AgentServiceImpl(
             chatClientProvider,
@@ -58,6 +63,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             intentionGenerator,
             confirmationManager,
             testObjectMapper,
+            toolRegistryService,
         )
 
     private val namespaceId: UUID = UUID.randomUUID()
@@ -116,6 +122,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
         every { namespaceService.findById(namespaceId) } returns namespace
         every { integrationConfigService.findByParent(any()) } returns emptyList()
         every { userService.findById(any()) } returns null
+        // No plugin returns a dynamic description by default — tests fall back to config.description
+        every { toolRegistryService.findPlugin(any()) } returns null
         // reconciliation services are relaxed mocks — return the base entity unchanged (passthrough) by default
 
         // -------------------------------------------------------------------------
@@ -331,6 +339,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     intentionGenerator,
                     confirmationManager,
                     testObjectMapper,
+                    toolRegistryService,
                 )
             val configs =
                 listOf(
@@ -366,6 +375,149 @@ class AgentServiceImplUnitSpec : StringSpec() {
             agent.instructions shouldContain "## Integrations"
             agent.instructions shouldContain "JIRA_PROD: Production Jira workspace for the engineering team"
             agent.instructions shouldNotContain "SLACK_DEV"
+        }
+
+        "findAgentByName uses dynamic description from describeIntegration when plugin returns one" {
+            val plugin = mockk<ToolPlugin>()
+            coEvery { plugin.describeIntegration(any(), any(), any()) } returns "Dynamic description from remote API"
+            every { toolRegistryService.findPlugin("JIRA") } returns plugin
+            val configs = listOf(
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "JIRA_PROD",
+                    integrationType = "JIRA",
+                    description = "Static fallback description",
+                ),
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+                .copy(integrations = mapOf("JIRA_PROD" to null))
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions shouldContain "Dynamic description from remote API"
+            agent.instructions shouldNotContain "Static fallback description"
+
+            // restore default stub
+            every { toolRegistryService.findPlugin(any()) } returns null
+        }
+
+        "findAgentByName falls back to config.description when describeIntegration returns null" {
+            val plugin = mockk<ToolPlugin>()
+            coEvery { plugin.describeIntegration(any(), any(), any()) } returns null
+            every { toolRegistryService.findPlugin("JIRA") } returns plugin
+            val configs = listOf(
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "JIRA_PROD",
+                    integrationType = "JIRA",
+                    description = "Static fallback description",
+                ),
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+                .copy(integrations = mapOf("JIRA_PROD" to null))
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions shouldContain "Static fallback description"
+
+            // restore default stub
+            every { toolRegistryService.findPlugin(any()) } returns null
+        }
+
+        "findAgentByName falls back to config.description when describeIntegration throws" {
+            val plugin = mockk<ToolPlugin>()
+            coEvery { plugin.describeIntegration(any(), any(), any()) } throws RuntimeException("remote API unavailable")
+            every { toolRegistryService.findPlugin("JIRA") } returns plugin
+            val configs = listOf(
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "JIRA_PROD",
+                    integrationType = "JIRA",
+                    description = "Static fallback description",
+                ),
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+                .copy(integrations = mapOf("JIRA_PROD" to null))
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            // Exception must not propagate — agent instantiation succeeds with static fallback
+            agent.instructions shouldContain "Static fallback description"
+
+            // restore default stub
+            every { toolRegistryService.findPlugin(any()) } returns null
+        }
+
+        "findAgentByName calls describeIntegration once per matching integration config" {
+            val jiraPlugin = mockk<ToolPlugin>()
+            val slackPlugin = mockk<ToolPlugin>()
+            coEvery { jiraPlugin.describeIntegration(any(), any(), any()) } returns "Jira dynamic"
+            coEvery { slackPlugin.describeIntegration(any(), any(), any()) } returns "Slack dynamic"
+            every { toolRegistryService.findPlugin("JIRA") } returns jiraPlugin
+            every { toolRegistryService.findPlugin("SLACK") } returns slackPlugin
+            val configs = listOf(
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "JIRA_PROD",
+                    integrationType = "JIRA",
+                    description = null,
+                ),
+                IntegrationConfig(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = namespaceId,
+                    name = "SLACK_DEV",
+                    integrationType = "SLACK",
+                    description = null,
+                ),
+            )
+            every { integrationConfigService.findByParent(namespaceId) } returns configs
+            val config = agentConfig(name = "my-agent", modelName = "sonnet")
+                .copy(integrations = mapOf("JIRA_PROD" to null, "SLACK_DEV" to null))
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+            every { agentConfigService.findByName(namespaceId, "my-agent") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { chatClientProvider.getChatClient(model, provider) } returns chatClient
+
+            val agent = agentService.findAgentByName("my-agent", context) as AgentSimple
+
+            agent.instructions shouldContain "Jira dynamic"
+            agent.instructions shouldContain "Slack dynamic"
+            coVerify(exactly = 1) { jiraPlugin.describeIntegration(any(), eq("JIRA_PROD"), any()) }
+            coVerify(exactly = 1) { slackPlugin.describeIntegration(any(), eq("SLACK_DEV"), any()) }
+
+            // restore default stubs
+            every { toolRegistryService.findPlugin(any()) } returns null
         }
 
         "findAgentByName omits integrations block when listed configs have no description" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerUnitSpec.kt
@@ -4,6 +4,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -545,7 +547,7 @@ class AgentConfigControllerUnitSpec : StringSpec({
         )
         every { service.findById(configId) } returns agentConfig
         every { userService.getCurrentUser() } returns superAdmin
-        every { agentService.resolveDefinition(configId, namespaceId, null) } returns definition
+        coEvery { agentService.resolveDefinition(configId, namespaceId, null) } returns definition
 
         val result = controller.getDefinition(configId, withUserOverlay = false)
 
@@ -566,7 +568,7 @@ class AgentConfigControllerUnitSpec : StringSpec({
         val definition = resolvedDefinition(agentConfigId = configId, systemPrompt = null)
         every { service.findById(configId) } returns agentConfig
         every { userService.getCurrentUser() } returns superAdmin
-        every { agentService.resolveDefinition(configId, namespaceId, null) } returns definition
+        coEvery { agentService.resolveDefinition(configId, namespaceId, null) } returns definition
 
         val result = controller.getDefinition(configId, withUserOverlay = false)
 
@@ -579,12 +581,12 @@ class AgentConfigControllerUnitSpec : StringSpec({
         val definition = resolvedDefinition(agentConfigId = configId, userId = callerId)
         every { service.findById(configId) } returns agentConfig
         every { userService.getCurrentUser() } returns superAdmin
-        every { agentService.resolveDefinition(configId, namespaceId, callerId) } returns definition
+        coEvery { agentService.resolveDefinition(configId, namespaceId, callerId) } returns definition
 
         val result = controller.getDefinition(configId, withUserOverlay = true)
 
         result.userId shouldBe callerId
-        verify(exactly = 1) { agentService.resolveDefinition(configId, namespaceId, callerId) }
+        coVerify(exactly = 1) { agentService.resolveDefinition(configId, namespaceId, callerId) }
     }
 
     "getDefinition maps tool summaries" {
@@ -598,7 +600,7 @@ class AgentConfigControllerUnitSpec : StringSpec({
         val definition = resolvedDefinition(agentConfigId = configId).copy(tools = listOf(tool))
         every { service.findById(configId) } returns agentConfig
         every { userService.getCurrentUser() } returns superAdmin
-        every { agentService.resolveDefinition(configId, namespaceId, null) } returns definition
+        coEvery { agentService.resolveDefinition(configId, namespaceId, null) } returns definition
 
         val result = controller.getDefinition(configId, withUserOverlay = false)
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -55,7 +55,10 @@ import java.util.UUID
  * property automatically, so [runtime.subscriptionCount] is safe to call here.
  * This is race-free: [subscriptionCount] is updated synchronously on each subscribe.
  */
-private suspend fun awaitSubscribers(runtime: CaseRuntime, count: Int = 1) {
+private suspend fun awaitSubscribers(
+    runtime: CaseRuntime,
+    count: Int = 1,
+) {
     runtime.subscriptionCount.first { it >= count }
 }
 
@@ -156,13 +159,14 @@ class CaseServiceImplSpec :
          * Returns a list containing every agent name used across this spec so that
          * [isAgentAuthorized] always passes regardless of which agent is targeted.
          */
-        val allowAllAgentConfigService: AgentConfigService = mockk {
-            every { findAvailableByNamespaceIdAndUserId(any(), any(), any()) } answers {
-                val ns = firstArg<UUID>()
-                val name = thirdArg<String?>()
-                if (name != null) listOf(AgentConfig(namespaceId = ns, name = name)) else emptyList()
+        val allowAllAgentConfigService: AgentConfigService =
+            mockk {
+                every { findAvailableByNamespaceIdAndUserId(any(), any(), any()) } answers {
+                    val ns = firstArg<UUID>()
+                    val name = thirdArg<String?>()
+                    if (name != null) listOf(AgentConfig(namespaceId = ns, name = name)) else emptyList()
+                }
             }
-        }
 
         beforeTest {
             clearMocks(allowAllAgentConfigService, answers = false)
@@ -176,11 +180,12 @@ class CaseServiceImplSpec :
             environmentAgentName: String? = null,
             agentConfigService: AgentConfigService = allowAllAgentConfigService,
         ): CaseServiceImpl {
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = defaultAgentName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = defaultAgentName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
@@ -310,11 +315,12 @@ class CaseServiceImplSpec :
 
         "persisted events contain the full agent lifecycle sequence" {
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = agentName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = agentName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
@@ -322,15 +328,16 @@ class CaseServiceImplSpec :
                     coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(),
-                InMemoryCaseRepository(),
-                caseEventService,
-                userService,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -526,11 +533,12 @@ class CaseServiceImplSpec :
                     }
                 }
 
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = agentName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = agentName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
@@ -538,7 +546,16 @@ class CaseServiceImplSpec :
                     coEvery { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, allowAllAgentConfigService, AgentConfigProperties(), InMemoryCaseRepository(), caseEventService, userService, namespaceService)
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
 
@@ -612,26 +629,29 @@ class CaseServiceImplSpec :
 
         "first message without @mention routes to environment default agent when namespace has none" {
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = null,  // no namespace-level default
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = null, // no namespace-level default
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
-            val agentService = mockk<AgentService> {
-                every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
-                coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
-            }
+            val agentService =
+                mockk<AgentService> {
+                    every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
+                    coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
+                }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(agentName = agentName),  // environment-level default
-                InMemoryCaseRepository(),
-                caseEventService,
-                userService,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(agentName = agentName), // environment-level default
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -657,36 +677,47 @@ class CaseServiceImplSpec :
             val environmentDefaultName = "env-agent"
             val namespaceAgentId = UUID.nameUUIDFromBytes(namespaceDefaultName.toByteArray())
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = namespaceDefaultName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = namespaceDefaultName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
-            val namespaceAgent = mockk<Agent> {
-                every { metadata } returns EntityMetadata(id = namespaceAgentId)
-                every { name } returns namespaceDefaultName
-                every { run(any<List<CaseEvent>>(), any()) } answers {
-                    val caseId = firstArg<List<CaseEvent>>().first().caseId
-                    flow {
-                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId, agentId = namespaceAgentId, agentName = namespaceDefaultName))
+            val namespaceAgent =
+                mockk<Agent> {
+                    every { metadata } returns EntityMetadata(id = namespaceAgentId)
+                    every { name } returns namespaceDefaultName
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = namespaceAgentId,
+                                    agentName = namespaceDefaultName,
+                                ),
+                            )
+                        }
                     }
                 }
-            }
-            val agentService = mockk<AgentService> {
-                every { resolveAgentName(namespaceDefaultName, namespaceId, any()) } returns namespaceDefaultName
-                coEvery { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
-            }
+            val agentService =
+                mockk<AgentService> {
+                    every { resolveAgentName(namespaceDefaultName, namespaceId, any()) } returns namespaceDefaultName
+                    coEvery { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
+                }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(agentName = environmentDefaultName),
-                InMemoryCaseRepository(),
-                caseEventService,
-                userService,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(agentName = environmentDefaultName),
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -704,28 +735,32 @@ class CaseServiceImplSpec :
             val persistedEvents = caseEventService.findByParent(case.id)
             // namespace agent was selected, not the environment default
             persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe namespaceDefaultName
-            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, namespaceDefaultName) }
+            verify(
+                exactly = 1,
+            ) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, namespaceDefaultName) }
         }
 
         "no default agent at any level produces WarnEvent and stops" {
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = null,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = null,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService = mockk<AgentService>(relaxed = true)
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(agentName = null),  // no environment default either
-                InMemoryCaseRepository(),
-                caseEventService,
-                userService,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(agentName = null), // no environment default either
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -773,24 +808,26 @@ class CaseServiceImplSpec :
         "first message without @mention produces WarnEvent and stops when namespace has no default agent" {
             // Wire the service manually to keep a reference to the event store.
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = null,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = null,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             // resolveAgentName is never reached because selectDefaultAgent short-circuits on null
             val agentService = mockk<AgentService>(relaxed = true)
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(),
-                InMemoryCaseRepository(),
-                caseEventService,
-                userService,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -818,37 +855,44 @@ class CaseServiceImplSpec :
         "last active agent unavailable falls back to namespace default" {
             val unavailableAgentName = "old-agent"
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = agentName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = agentName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             // resolveAgentName call sequence:
             //   turn 1, @mention path: resolveAgentName(unavailableAgentName) -> unavailableAgentName (found)
             //   turn 2, sticky-agent availability check: resolveAgentName(unavailableAgentName) -> null (gone)
             //   turn 2, default resolution: resolveAgentName(agentName) -> agentName (found)
-            val resolveCallCount = java.util.concurrent.atomic.AtomicInteger(0)
-            val agentService = mockk<AgentService> {
-                every { resolveAgentName(unavailableAgentName, namespaceId, any()) } answers {
-                    when (resolveCallCount.incrementAndGet()) {
-                        1 -> unavailableAgentName  // turn 1: @mention resolves
-                        else -> null              // turn 2: sticky-agent check fails
+            val resolveCallCount =
+                java.util.concurrent.atomic
+                    .AtomicInteger(0)
+            val agentService =
+                mockk<AgentService> {
+                    every { resolveAgentName(unavailableAgentName, namespaceId, any()) } answers {
+                        when (resolveCallCount.incrementAndGet()) {
+                            1 -> unavailableAgentName
+
+                            // turn 1: @mention resolves
+                            else -> null // turn 2: sticky-agent check fails
+                        }
                     }
+                    every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
+                    coEvery { findAgentByName(any(), any()) } returns finishingAgent()
                 }
-                every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
-                coEvery { findAgentByName(any(), any()) } returns finishingAgent()
-            }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(),
-                InMemoryCaseRepository(),
-                caseEventService,
-                userServiceMock,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userServiceMock,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -881,7 +925,9 @@ class CaseServiceImplSpec :
             // Default agent was ultimately selected after the warn
             persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe agentName
             // turn 1: authorized for unavailableAgentName, turn 2: authorized for agentName (fallback)
-            verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, unavailableAgentName) }
+            verify(
+                exactly = 1,
+            ) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, unavailableAgentName) }
             verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
         }
 
@@ -920,11 +966,12 @@ class CaseServiceImplSpec :
                     }
                 }
 
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = defaultAgentName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = defaultAgentName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService =
                 mockk<AgentService> {
@@ -936,7 +983,16 @@ class CaseServiceImplSpec :
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(agentService, allowAllAgentConfigService, AgentConfigProperties(), caseRepository, caseEventService, userService, namespaceService)
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    caseRepository,
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -985,37 +1041,48 @@ class CaseServiceImplSpec :
             val inspectorName = "inspector"
             val inspectorId = UUID.nameUUIDFromBytes(inspectorName.toByteArray())
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = agentName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = agentName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
-            val inspectorAgent = mockk<Agent> {
-                every { metadata } returns EntityMetadata(id = inspectorId)
-                every { name } returns inspectorName
-                every { run(any<List<CaseEvent>>(), any()) } answers {
-                    val caseId = firstArg<List<CaseEvent>>().first().caseId
-                    flow {
-                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId, agentId = inspectorId, agentName = inspectorName))
+            val inspectorAgent =
+                mockk<Agent> {
+                    every { metadata } returns EntityMetadata(id = inspectorId)
+                    every { name } returns inspectorName
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = inspectorId,
+                                    agentName = inspectorName,
+                                ),
+                            )
+                        }
                     }
                 }
-            }
-            val agentService = mockk<AgentService> {
-                // Only `inspector` resolves — the full string with URL must NOT be passed here
-                every { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
-                every { findAgentByName(inspectorName, any()) } returns inspectorAgent
-            }
+            val agentService =
+                mockk<AgentService> {
+                    // Only `inspector` resolves — the full string with URL must NOT be passed here
+                    coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
+                    coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
+                }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(),
-                InMemoryCaseRepository(),
-                caseEventService,
-                userService,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -1046,36 +1113,47 @@ class CaseServiceImplSpec :
             val inspectorName = "inspector"
             val inspectorId = UUID.nameUUIDFromBytes(inspectorName.toByteArray())
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
-            val namespace = Namespace(
-                metadata = EntityMetadata(id = namespaceId),
-                name = "test-namespace",
-                defaultAgentName = agentName,
-            )
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = agentName,
+                )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
-            val inspectorAgent = mockk<Agent> {
-                every { metadata } returns EntityMetadata(id = inspectorId)
-                every { name } returns inspectorName
-                every { run(any<List<CaseEvent>>(), any()) } answers {
-                    val caseId = firstArg<List<CaseEvent>>().first().caseId
-                    flow {
-                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId, agentId = inspectorId, agentName = inspectorName))
+            val inspectorAgent =
+                mockk<Agent> {
+                    every { metadata } returns EntityMetadata(id = inspectorId)
+                    every { name } returns inspectorName
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = inspectorId,
+                                    agentName = inspectorName,
+                                ),
+                            )
+                        }
                     }
                 }
-            }
-            val agentService = mockk<AgentService> {
-                every { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
-                every { findAgentByName(inspectorName, any()) } returns inspectorAgent
-            }
+            val agentService =
+                mockk<AgentService> {
+                    coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
+                    coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
+                }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
-            val service = CaseServiceImpl(
-                agentService,
-                allowAllAgentConfigService,
-                AgentConfigProperties(),
-                InMemoryCaseRepository(),
-                caseEventService,
-                userService,
-                namespaceService,
-            )
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    InMemoryCaseRepository(),
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.clearMocks
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -184,7 +185,7 @@ class CaseServiceImplSpec :
             val agentService =
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
-                    every { findAgentByName(agentName, any()) } returns agent
+                    coEvery { findAgentByName(agentName, any()) } returns agent
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
@@ -318,7 +319,7 @@ class CaseServiceImplSpec :
             val agentService =
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
-                    every { findAgentByName(agentName, any()) } returns finishingAgent()
+                    coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
@@ -534,7 +535,7 @@ class CaseServiceImplSpec :
             val agentService =
                 mockk<AgentService> {
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
-                    every { findAgentByName(agentName, any()) } returns chunkingAgent
+                    coEvery { findAgentByName(agentName, any()) } returns chunkingAgent
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(agentService, allowAllAgentConfigService, AgentConfigProperties(), InMemoryCaseRepository(), caseEventService, userService, namespaceService)
@@ -619,7 +620,7 @@ class CaseServiceImplSpec :
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
             val agentService = mockk<AgentService> {
                 every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
-                every { findAgentByName(agentName, any()) } returns finishingAgent()
+                coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
             }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
@@ -674,7 +675,7 @@ class CaseServiceImplSpec :
             }
             val agentService = mockk<AgentService> {
                 every { resolveAgentName(namespaceDefaultName, namespaceId, any()) } returns namespaceDefaultName
-                every { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
+                coEvery { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
             }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
@@ -836,7 +837,7 @@ class CaseServiceImplSpec :
                     }
                 }
                 every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
-                every { findAgentByName(any(), any()) } returns finishingAgent()
+                coEvery { findAgentByName(any(), any()) } returns finishingAgent()
             }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service = CaseServiceImpl(
@@ -930,7 +931,7 @@ class CaseServiceImplSpec :
                     // @selected-agent resolves to selectedAgentName
                     every { resolveAgentName(selectedAgentName, any(), any()) } returns selectedAgentName
                     // no other mention resolution needed
-                    every { findAgentByName(selectedAgentName, any()) } returns selectedAgent
+                    coEvery { findAgentByName(selectedAgentName, any()) } returns selectedAgent
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 # Kotlin Coroutines
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "kotlinCoroutines" }
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinCoroutines" }
 
 # PF4J Plugin Framework
 pf4j = { module = "org.pf4j:pf4j", version.ref = "pf4j" }
@@ -140,7 +141,7 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 [bundles]
 jackson = ["jackson-annotations", "jackson-core", "jackson-databind", "jackson-dataformat-yaml", "jackson-module-kotlin"]
 kotlin-common = ["kotlin-stdlib", "kotlin-reflect"]
-kotlin-coroutines = ["kotlinx-coroutines-core", "kotlinx-coroutines-reactive"]
+kotlin-coroutines = ["kotlinx-coroutines-core", "kotlinx-coroutines-reactive", "kotlinx-coroutines-reactor"]
 spring-ai = ["spring-ai-anthropic", "spring-ai-gemini", "spring-ai-openai", "spring-ai-mcp-client"]
 okhttp = ["okhttp", "okhttp-logging-interceptor"]
 testing-common = ["kotest-runner-junit5", "kotest-assertions-core", "kotest-property", "mockk"]

--- a/dev_tools/api/agent-configs.http
+++ b/dev_tools/api/agent-configs.http
@@ -1,5 +1,5 @@
-@namespaceId=4fbbbb65-6aaa-46d7-adf3-5b3fb62ddad3
-@userExternalId=68da433b763c352b7279799f
+@namespaceId=f6f63f36-206f-47de-9cb1-296540970bbd
+@userExternalId=6a01e6ae263fdf6cf112af50
 
 ### Create a agent config
 POST {{apiBaseUrl}}/api/agent-configs
@@ -23,3 +23,8 @@ Content-Type: application/json
   "userExternalId": "{{userExternalId}}",
   "namespaceId": "{{namespaceId}}"
 }
+
+### Get agent definition
+GET {{apiBaseUrl}}/api/agent-configs/c4dcb657-a0f6-4b5a-a2e7-1fb333f00f74/definition?withUserOverlay=true
+Content-Type: application/json
+X-External-User-Id: {{userExternalId}}


### PR DESCRIPTION
## Goal

Enable dynamic prompt descriptions for namespace, allowing each integration to provide its own contextual description at runtime. This dynamic integration prompt is intended to replace most of the static system prompt. *(ref: wz-31566)*

---

## Implementation

Add a `describeNamespace()` method to `ToolPlugin`:

- **Purpose:** Allows integrations to override their static description with a dynamically generated one when available.
- **Async:** The method is `async` to support concurrent fetching across multiple integrations and avoid blocking.