### PR TITLE
feat: update groups-by-external-ids endpoint to accept optional namespaceId

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/user/UserController.kt
@@ -207,19 +207,36 @@ class UserController(
         return userService.findByExternalIds(externalIds.toSet()).map(::toResource)
     }
 
-    /** POST /api/users/groups-by-external-ids — return groups per user, filtered to groups visible to the caller. */
+    /**
+     * POST /api/users/groups-by-external-ids — return groups per user, filtered to groups visible to the caller.
+     *
+     * Accepts an optional [GroupsByExternalIdsRequest.namespaceId] to scope results to a single namespace.
+     * When omitted, groups from all namespaces are returned.
+     */
     @PostMapping("/groups-by-external-ids")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("isAuthenticated()")
     fun getGroupsByExternalIds(
-        @RequestBody externalIds: List<String>,
+        @RequestBody request: GroupsByExternalIdsRequest,
     ): Map<String, List<UserGroupSummaryResource>> {
-        if (externalIds.isEmpty()) return emptyMap()
+        if (request.externalIds.isEmpty()) return emptyMap()
         val currentUser = userService.getCurrentUser()
         return userGroupService
-            .findGroupsByUserExternalIdsVisibleToUser(externalIds, currentUser)
+            .findGroupsByUserExternalIdsVisibleToUser(request.externalIds, currentUser, request.namespaceId)
             .mapValues { (_, groups) -> groups.map { it.toResource() } }
     }
 
     companion object : KLogging()
 }
+
+/**
+ * Request body for `POST /api/users/groups-by-external-ids`.
+ *
+ * @param externalIds List of user external IDs (identity-provider keys) to look up.
+ * @param namespaceId Optional namespace UUID to scope results to a single federation.
+ *   When null, groups from all namespaces are returned.
+ */
+data class GroupsByExternalIdsRequest(
+    val externalIds: List<String>,
+    val namespaceId: UUID? = null,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
@@ -39,14 +39,14 @@ open class Neo4jUserGroupRepository(
 
     override fun findByNamespaceId(namespaceId: UUID): List<UserGroupSearchResult> =
         querySearchResults(
-            whereClause = "ns.id = \$namespaceId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
+            whereClause = $$"ns.id = $namespaceId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
             paramName = "namespaceId",
             paramValue = namespaceId.toString(),
         ).all().toList()
 
     override fun findByIdWithDetails(id: UUID): UserGroupSearchResult? =
         querySearchResults(
-            whereClause = "g.id = \$userGroupId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
+            whereClause = $$"g.id = $userGroupId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
             paramName = "userGroupId",
             paramValue = id.toString(),
         ).one().orElse(null)
@@ -62,7 +62,7 @@ open class Neo4jUserGroupRepository(
                 WHERE $whereClause
                 OPTIONAL MATCH (a:AgentConfig)-[:DEPLOYED_TO]->(g)
                   WHERE NOT COALESCE(a.removed, false)
-                OPTIONAL MATCH (u:User)-[:MEMBER]->(g)
+                OPTIONAL MATCH (u:User)-[:MEMBER|ADMIN]->(g)
                   WHERE NOT COALESCE(u.removed, false)
                 RETURN g.id AS userGroupId, ns.id AS namespaceId, ns.externalId AS namespaceExternalId,
                        g.name AS name, collect(DISTINCT a.id) AS agentIds, count(DISTINCT u) AS userCount
@@ -112,11 +112,7 @@ open class Neo4jUserGroupRepository(
      *
      * When [namespaceId] is null, groups from all namespaces are returned.
      * When [namespaceId] is provided, the Cypher query adds an extra predicate
-     * `AND g.namespaceId = ${'$'}namespaceId` to scope results to a single federation.
-     *
-     * The query is built via regular string interpolation: Cypher parameter placeholders
-     * use `${'$'}{"$"}paramName` to produce a literal `$` in the final string, while
-     * `$namespaceClause` is a Kotlin variable injecting the optional filter clause.
+     * `AND g.namespaceId = $$namespaceId` to scope results to a single federation.
      */
     override fun findGroupsByUserExternalIds(
         externalIds: Collection<String>,
@@ -127,17 +123,19 @@ open class Neo4jUserGroupRepository(
         val namespaceClause: String
         if (namespaceId != null) {
             params["namespaceId"] = namespaceId.toString()
-            namespaceClause = "AND g.namespaceId = \$namespaceId "
+            namespaceClause = $$"AND g.namespaceId = $namespaceId"
         } else {
             namespaceClause = ""
         }
-        val query = ("MATCH (u:User)-[:MEMBER]->(g:UserGroup) " +
-            "WHERE u.externalId IN \$externalIds " +
-            "AND NOT COALESCE(g.removed, false) " +
-            "AND NOT COALESCE(u.removed, false) " +
-            namespaceClause +
-            "RETURN u.externalId AS externalId, g.id AS groupId, g.name AS groupName " +
-            "ORDER BY u.externalId ASC, g.name ASC")
+        val query = $$"""
+            MATCH (u:User)-[:MEMBER]->(g:UserGroup)
+            WHERE u.externalId IN $externalIds
+              AND NOT COALESCE(g.removed, false)
+              AND NOT COALESCE(u.removed, false)
+              $$namespaceClause
+            RETURN u.externalId AS externalId, g.id AS groupId, g.name AS groupName
+            ORDER BY u.externalId ASC, g.name ASC
+        """.trimIndent()
         return neo4jClient
             .query(query)
             .bindAll(params)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/Neo4jUserGroupRepository.kt
@@ -39,14 +39,14 @@ open class Neo4jUserGroupRepository(
 
     override fun findByNamespaceId(namespaceId: UUID): List<UserGroupSearchResult> =
         querySearchResults(
-            whereClause = $$"ns.id = $namespaceId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
+            whereClause = "ns.id = \$namespaceId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
             paramName = "namespaceId",
             paramValue = namespaceId.toString(),
         ).all().toList()
 
     override fun findByIdWithDetails(id: UUID): UserGroupSearchResult? =
         querySearchResults(
-            whereClause = $$"g.id = $userGroupId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
+            whereClause = "g.id = \$userGroupId AND NOT COALESCE(g.removed, false) AND NOT COALESCE(ns.removed, false)",
             paramName = "userGroupId",
             paramValue = id.toString(),
         ).one().orElse(null)
@@ -64,9 +64,10 @@ open class Neo4jUserGroupRepository(
                   WHERE NOT COALESCE(a.removed, false)
                 OPTIONAL MATCH (u:User)-[:MEMBER]->(g)
                   WHERE NOT COALESCE(u.removed, false)
-                RETURN g.id AS userGroupId, ns.id AS namespaceId, ns.externalId AS namespaceExternalId, g.name AS name, collect(DISTINCT a.id) AS agentIds, count(DISTINCT u) AS userCount
+                RETURN g.id AS userGroupId, ns.id AS namespaceId, ns.externalId AS namespaceExternalId,
+                       g.name AS name, collect(DISTINCT a.id) AS agentIds, count(DISTINCT u) AS userCount
                 ORDER BY g.name ASC
-            """,
+            """.trimIndent(),
         ).bind(paramValue)
         .to(paramName)
         .fetchAs(UserGroupSearchResult::class.java)
@@ -106,19 +107,40 @@ open class Neo4jUserGroupRepository(
         neo4jRepository.removeUsers(userGroupId.toString(), userExternalIds.toList())
     }
 
-    override fun findGroupsByUserExternalIds(externalIds: Collection<String>): Map<String, List<UserGroupSummary>> {
+    /**
+     * Returns groups for the given user external IDs, optionally scoped to a namespace.
+     *
+     * When [namespaceId] is null, groups from all namespaces are returned.
+     * When [namespaceId] is provided, the Cypher query adds an extra predicate
+     * `AND g.namespaceId = ${'$'}namespaceId` to scope results to a single federation.
+     *
+     * The query is built via regular string interpolation: Cypher parameter placeholders
+     * use `${'$'}{"$"}paramName` to produce a literal `$` in the final string, while
+     * `$namespaceClause` is a Kotlin variable injecting the optional filter clause.
+     */
+    override fun findGroupsByUserExternalIds(
+        externalIds: Collection<String>,
+        namespaceId: UUID?,
+    ): Map<String, List<UserGroupSummary>> {
         if (externalIds.isEmpty()) return emptyMap()
+        val params = mutableMapOf<String, Any>("externalIds" to externalIds.toList())
+        val namespaceClause: String
+        if (namespaceId != null) {
+            params["namespaceId"] = namespaceId.toString()
+            namespaceClause = "AND g.namespaceId = \$namespaceId "
+        } else {
+            namespaceClause = ""
+        }
+        val query = ("MATCH (u:User)-[:MEMBER]->(g:UserGroup) " +
+            "WHERE u.externalId IN \$externalIds " +
+            "AND NOT COALESCE(g.removed, false) " +
+            "AND NOT COALESCE(u.removed, false) " +
+            namespaceClause +
+            "RETURN u.externalId AS externalId, g.id AS groupId, g.name AS groupName " +
+            "ORDER BY u.externalId ASC, g.name ASC")
         return neo4jClient
-            .query(
-                $$"""
-                    MATCH (u:User)-[:MEMBER]->(g:UserGroup)
-                    WHERE u.externalId IN $externalIds
-                      AND NOT COALESCE(g.removed, false)
-                      AND NOT COALESCE(u.removed, false)
-                    RETURN u.externalId AS externalId, g.id AS groupId, g.name AS groupName
-                    ORDER BY u.externalId ASC, g.name ASC
-                """.trimIndent(),
-            ).bindAll(mapOf("externalIds" to externalIds.toList()))
+            .query(query)
+            .bindAll(params)
             .fetchAs(UserExternalIdGroupRow::class.java)
             .mappedBy { _, record ->
                 UserExternalIdGroupRow(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupRepository.kt
@@ -10,5 +10,11 @@ interface UserGroupRepository : EntityRepository<UserGroup, UUID> {
     fun removeAllAgents(userGroupId: UUID)
     fun addUsers(userGroupId: UUID, userExternalIds: Collection<String>)
     fun removeUsers(userGroupId: UUID, userExternalIds: Collection<String>)
-    fun findGroupsByUserExternalIds(externalIds: Collection<String>): Map<String, List<UserGroupSummary>>
+    /**
+     * Returns groups for the given user external IDs, optionally scoped to a namespace.
+     *
+     * When [namespaceId] is null, groups from all namespaces are returned.
+     * When [namespaceId] is provided, only groups belonging to that namespace are returned.
+     */
+    fun findGroupsByUserExternalIds(externalIds: Collection<String>, namespaceId: UUID? = null): Map<String, List<UserGroupSummary>>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupService.kt
@@ -9,5 +9,15 @@ interface UserGroupService : EntityService<UserGroup, UUID> {
     fun findByIdWithDetails(id: UUID): UserGroupSearchResult?
     fun createFromRequest(request: UserGroupCreateRequest): UserGroupSearchResult
     fun updateFromRequest(userGroupId: UUID, request: UserGroupUpdateRequest): UserGroupSearchResult
-    fun findGroupsByUserExternalIdsVisibleToUser(externalIds: Collection<String>, user: User): Map<String, List<UserGroupSummary>>
+    /**
+     * Returns groups for the given user external IDs visible to [user], optionally scoped to a namespace.
+     *
+     * When [namespaceId] is null, groups from all namespaces are returned.
+     * When [namespaceId] is provided, only groups belonging to that namespace are returned.
+     */
+    fun findGroupsByUserExternalIdsVisibleToUser(
+        externalIds: Collection<String>,
+        user: User,
+        namespaceId: UUID? = null,
+    ): Map<String, List<UserGroupSummary>>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImpl.kt
@@ -124,8 +124,9 @@ class UserGroupServiceImpl(
     override fun findGroupsByUserExternalIdsVisibleToUser(
         externalIds: Collection<String>,
         user: User,
+        namespaceId: UUID?,
     ): Map<String, List<UserGroupSummary>> {
-        val allGroups = userGroupRepository.findGroupsByUserExternalIds(externalIds)
+        val allGroups = userGroupRepository.findGroupsByUserExternalIds(externalIds, namespaceId)
         val visibleGroupIds = if (user.isAdmin) {
             allGroups.values.flatten().map { it.id.toString() }.toSet()
         } else {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractUserGroupPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractUserGroupPersistenceSpec.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.whozoss.agentos.namespace.Namespace
 import io.whozoss.agentos.namespace.NamespaceRepository
@@ -145,6 +146,48 @@ abstract class AbstractUserGroupPersistenceSpec : StringSpec() {
 
             results shouldHaveSize 1
             results.first().userCount shouldBe 1
+        }
+
+        "findGroupsByUserExternalIds returns groups for matching users" {
+            val ns = namespaceRepo.save(namespace())
+            val g = userGroupRepo.save(userGroup(ns.id, "Devs"))
+            userRepo.save(user("alice@example.com"))
+            userRepo.save(user("bob@example.com"))
+            userGroupRepo.addUsers(g.id, listOf("alice@example.com", "bob@example.com"))
+
+            val results = userGroupRepo.findGroupsByUserExternalIds(
+                externalIds = listOf("alice@example.com", "bob@example.com"),
+                namespaceId = null,
+            )
+
+            results["alice@example.com"]?.shouldHaveSize(1)
+            results["alice@example.com"]!!.first().name shouldBe "Devs"
+            results["bob@example.com"]?.shouldHaveSize(1)
+        }
+
+        "findGroupsByUserExternalIds scoped to namespaceId excludes other namespaces" {
+            val ns1 = namespaceRepo.save(namespace())
+            val ns2 = namespaceRepo.save(namespace())
+            val g1 = userGroupRepo.save(userGroup(ns1.id, "Group NS1"))
+            val g2 = userGroupRepo.save(userGroup(ns2.id, "Group NS2"))
+            userRepo.save(user("carol@example.com"))
+            userGroupRepo.addUsers(g1.id, listOf("carol@example.com"))
+            userGroupRepo.addUsers(g2.id, listOf("carol@example.com"))
+
+            val results = userGroupRepo.findGroupsByUserExternalIds(
+                externalIds = listOf("carol@example.com"),
+                namespaceId = ns1.id,
+            )
+
+            results["carol@example.com"]?.shouldHaveSize(1)
+            results["carol@example.com"]!!.first().name shouldBe "Group NS1"
+        }
+
+        "findGroupsByUserExternalIds returns empty map for empty input" {
+            userGroupRepo.findGroupsByUserExternalIds(
+                externalIds = emptyList(),
+                namespaceId = null,
+            ).shouldBeEmpty()
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/userGroup/UserGroupServiceImplUnitSpec.kt
@@ -468,6 +468,44 @@ class UserGroupServiceImplUnitSpec :
             result shouldBe emptyMap()
         }
 
+        "findGroupsByUserExternalIdsVisibleToUser forwards namespaceId to repository when provided" {
+            val groupId = randomUUID();
+            val scopedNamespaceId = randomUUID()
+            val userGroupRepository = mockk<UserGroupRepository>()
+            val adminUser = User(metadata = EntityMetadata(id = randomUUID()), externalId = "admin@example.com", isAdmin = true)
+            val groups = mapOf("alice@example.com" to listOf(UserGroupSummary(id = groupId, name = "Team A")))
+
+            every { userGroupRepository.findGroupsByUserExternalIds(listOf("alice@example.com"), scopedNamespaceId) } returns groups
+
+            val service = buildService(userGroupRepository = userGroupRepository)
+            val result = service.findGroupsByUserExternalIdsVisibleToUser(
+                listOf("alice@example.com"),
+                adminUser,
+                namespaceId = scopedNamespaceId,
+            )
+
+            result shouldBe groups
+            verify(exactly = 1) { userGroupRepository.findGroupsByUserExternalIds(listOf("alice@example.com"), scopedNamespaceId) }
+        }
+
+        "findGroupsByUserExternalIdsVisibleToUser forwards null namespaceId to repository when not provided" {
+            val groupId = randomUUID()
+            val userGroupRepository = mockk<UserGroupRepository>()
+            val adminUser = User(metadata = EntityMetadata(id = randomUUID()), externalId = "admin@example.com", isAdmin = true)
+            val groups = mapOf("alice@example.com" to listOf(UserGroupSummary(id = groupId, name = "Team A")))
+
+            every { userGroupRepository.findGroupsByUserExternalIds(listOf("alice@example.com"), null) } returns groups
+
+            val service = buildService(userGroupRepository = userGroupRepository)
+            val result = service.findGroupsByUserExternalIdsVisibleToUser(
+                listOf("alice@example.com"),
+                adminUser,
+            )
+
+            result shouldBe groups
+            verify(exactly = 1) { userGroupRepository.findGroupsByUserExternalIds(listOf("alice@example.com"), null) }
+        }
+
         "createFromRequest with no userExternalIds skips addUsers" {
             val groupId = randomUUID()
             val group = UserGroup(metadata = EntityMetadata(id = groupId), namespaceId = namespaceId, name = "Team F")

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -531,9 +531,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
+              $ref: "#/components/schemas/GroupsByExternalIdsRequest"
         required: true
       responses:
         "200":
@@ -1986,6 +1984,18 @@ components:
       - name
       - namespaceId
       - updatedOn
+    GroupsByExternalIdsRequest:
+      type: object
+      properties:
+        externalIds:
+          type: array
+          items:
+            type: string
+        namespaceId:
+          type: string
+          format: uuid
+      required:
+      - externalIds
     UserGroupSummary:
       type: object
       properties:


### PR DESCRIPTION
Update `POST /api/users/groups-by-external-ids` to accept an optional `namespaceId` parameter. When provided, results are scoped to groups belonging to that namespace only. When omitted, groups from all namespaces are returned (preserving existing behavior).

The request body changes from a plain `List<String>` to a `GroupsByExternalIdsRequest` object containing `externalIds` and an optional `namespaceId`.