### PR TITLE
feat: #WZ-32677 use textarea for namespace description field

### DIFF
--- a/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.html
@@ -25,14 +25,13 @@
 
       <div class="namespace-form__field">
         <label class="namespace-form__label" for="ns-description">Description</label>
-        <input
+        <textarea
           id="ns-description"
-          class="namespace-form__input"
-          type="text"
+          class="namespace-form__textarea"
+          rows="4"
           placeholder="Optional description"
           [formControl]="descriptionControl"
-          autocomplete="off"
-        />
+        ></textarea>
       </div>
 
       <div class="namespace-form__field">

--- a/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.scss
+++ b/libs/agentos-ui/src/lib/components/namespace-form/namespace-form.component.scss
@@ -66,7 +66,8 @@
     color: var(--color-text, #1d1d1f);
   }
 
-  &__input {
+  &__input,
+  &__textarea {
     width: 100%;
     padding: 0.625rem 0.875rem;
     border-radius: 8px;
@@ -86,6 +87,12 @@
     &::placeholder {
       color: var(--color-text-secondary, #6e6e73);
     }
+  }
+
+  &__textarea {
+    resize: vertical;
+    min-height: 96px;
+    line-height: 1.5;
   }
 
   &__actions {


### PR DESCRIPTION
## Summary

Replace the single-line `<input type="text">` with a `<textarea>` for the `description` field in `namespace-form`, aligning with the pattern already used in `agent-config-form`.

## Changes

- **`namespace-form.component.html`**: `description` field switched from `<input>` to `<textarea rows="4">` with class `namespace-form__textarea`
- **`namespace-form.component.scss`**: shared styles extracted to `&__input, &__textarea` selector; dedicated `&__textarea` block adds `resize: vertical`, `min-height: 96px`, `line-height: 1.5`

Other fields (`configPath`, `externalId`, `defaultAgentName`) remain `<input>` — they are short technical identifiers.

## Verification

- ✅ `pnpm nx lint agentos-ui`
- ✅ `pnpm nx build client --configuration=development`