### PR TITLE
fix: wz-31546 enrich AgentRunningEvent with llmProvider and llmModel

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/agent/Agent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/agent/Agent.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface Agent : Entity {
     val name: String
+    val llmProvider: String
+    val llmModel: String
 
     /**
      * Run the agent with the given case events.

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
@@ -171,9 +171,7 @@ data class AgentRunningEvent(
     override val timestamp: Instant = Instant.now(),
     val agentId: UUID,
     val agentName: String,
-    /** LLM provider name (e.g. "anthropic"), null when not resolved. */
     val llmProvider: String? = null,
-    /** LLM model API name (e.g. "claude-haiku-4-5"), null when not resolved. */
     val llmModel: String? = null,
 ) : CaseEvent {
     override val type: CaseEventType = CaseEventType.AGENT_RUNNING

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
@@ -160,6 +160,8 @@ data class AgentFinishedEvent(
     override val timestamp: Instant = Instant.now(),
     val agentId: UUID,
     val agentName: String,
+    val llmProvider: String? = null,
+    val llmModel: String? = null,
 ) : CaseEvent {
     override val type: CaseEventType = CaseEventType.AGENT_FINISHED
 }

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
@@ -171,6 +171,10 @@ data class AgentRunningEvent(
     override val timestamp: Instant = Instant.now(),
     val agentId: UUID,
     val agentName: String,
+    /** LLM provider name (e.g. "anthropic"), null when not resolved. */
+    val llmProvider: String? = null,
+    /** LLM model API name (e.g. "claude-haiku-4-5"), null when not resolved. */
+    val llmModel: String? = null,
 ) : CaseEvent {
     override val type: CaseEventType = CaseEventType.AGENT_RUNNING
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -48,8 +48,8 @@ class AgentAdvanced(
     private val userExternalId: String? = null,
     private val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
     private val maxIterations: Int = 20,
-    private val llmProviderName: String? = null,
-    private val llmModelApiName: String? = null,
+    override val llmProvider: String,
+    override val llmModel: String,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -88,8 +88,8 @@ class AgentAdvanced(
                                 caseId = caseId,
                                 agentId = id,
                                 agentName = name,
-                                llmProvider = llmProviderName,
-                                llmModel = llmModelApiName,
+                                llmProvider = llmProvider,
+                                llmModel = llmModel,
                             ),
                         )
                         return@flow
@@ -200,32 +200,16 @@ class AgentAdvanced(
                             caseId = caseId,
                             agentId = id,
                             agentName = name,
-                            llmProvider = llmProviderName,
-                            llmModel = llmModelApiName,
+                            llmProvider = llmProvider,
+                            llmModel = llmModel,
                         ),
                     )
                 }
             } catch (e: AgentInterrupt) {
                 // Not an error: a tool requested a structured interruption of this agent run.
-                val finished = AgentFinishedEvent(
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    agentId = id,
-                    agentName = name,
-                    llmProvider = llmProviderName,
-                    llmModel = llmModelApiName,
-                )
-                emitInterruptAndFinishEvents(finished, e, logger)
+                emitInterruptAndFinishEvents(this@AgentAdvanced, e, namespaceId, caseId, logger)
             } catch (e: NonTransientAiException) {
-                val finished = AgentFinishedEvent(
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    agentId = id,
-                    agentName = name,
-                    llmProvider = llmProviderName,
-                    llmModel = llmModelApiName,
-                )
-                emitProviderErrorAndFinishEvents(finished, e, logger)
+                emitProviderErrorAndFinishEvents(this@AgentAdvanced, e, namespaceId, caseId, logger)
             } catch (e: ConfirmationConfigurationException) {
                 // DI wiring bug — surface loudly so prod logs catch it. Still emit a WarnEvent
                 // so the per-case lifecycle terminates cleanly, but the operator-facing signal
@@ -555,8 +539,8 @@ class AgentAdvanced(
                         caseId = caseId,
                         agentId = id,
                         agentName = name,
-                        llmProvider = llmProviderName,
-                        llmModel = llmModelApiName,
+                        llmProvider = llmProvider,
+                        llmModel = llmModel,
                     ),
                 )
                 GateOutcome.AwaitingConfirmation

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -48,6 +48,8 @@ class AgentAdvanced(
     private val userExternalId: String? = null,
     private val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
     private val maxIterations: Int = 20,
+    private val llmProviderName: String? = null,
+    private val llmModelApiName: String? = null,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -86,6 +88,8 @@ class AgentAdvanced(
                                 caseId = caseId,
                                 agentId = id,
                                 agentName = name,
+                                llmProvider = llmProviderName,
+                                llmModel = llmModelApiName,
                             ),
                         )
                         return@flow
@@ -196,14 +200,32 @@ class AgentAdvanced(
                             caseId = caseId,
                             agentId = id,
                             agentName = name,
+                            llmProvider = llmProviderName,
+                            llmModel = llmModelApiName,
                         ),
                     )
                 }
             } catch (e: AgentInterrupt) {
                 // Not an error: a tool requested a structured interruption of this agent run.
-                emitInterruptEvents(this@AgentAdvanced, e, namespaceId, caseId, logger)
+                val finished = AgentFinishedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = id,
+                    agentName = name,
+                    llmProvider = llmProviderName,
+                    llmModel = llmModelApiName,
+                )
+                emitInterruptEvents(finished, e, logger)
             } catch (e: NonTransientAiException) {
-                emitProviderErrorEvents(this@AgentAdvanced, e, namespaceId, caseId, logger)
+                val finished = AgentFinishedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = id,
+                    agentName = name,
+                    llmProvider = llmProviderName,
+                    llmModel = llmModelApiName,
+                )
+                emitProviderErrorEvents(finished, e, logger)
             } catch (e: ConfirmationConfigurationException) {
                 // DI wiring bug — surface loudly so prod logs catch it. Still emit a WarnEvent
                 // so the per-case lifecycle terminates cleanly, but the operator-facing signal
@@ -533,6 +555,8 @@ class AgentAdvanced(
                         caseId = caseId,
                         agentId = id,
                         agentName = name,
+                        llmProvider = llmProviderName,
+                        llmModel = llmModelApiName,
                     ),
                 )
                 GateOutcome.AwaitingConfirmation

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -215,7 +215,7 @@ class AgentAdvanced(
                     llmProvider = llmProviderName,
                     llmModel = llmModelApiName,
                 )
-                emitInterruptEvents(finished, e, logger)
+                emitInterruptAndFinishEvents(finished, e, logger)
             } catch (e: NonTransientAiException) {
                 val finished = AgentFinishedEvent(
                     namespaceId = namespaceId,
@@ -225,7 +225,7 @@ class AgentAdvanced(
                     llmProvider = llmProviderName,
                     llmModel = llmModelApiName,
                 )
-                emitProviderErrorEvents(finished, e, logger)
+                emitProviderErrorAndFinishEvents(finished, e, logger)
             } catch (e: ConfirmationConfigurationException) {
                 // DI wiring bug — surface loudly so prod logs catch it. Still emit a WarnEvent
                 // so the per-case lifecycle terminates cleanly, but the operator-facing signal

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
@@ -1,88 +1,61 @@
 package io.whozoss.agentos.agent
 
-import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
-import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import kotlinx.coroutines.flow.FlowCollector
 import mu.KLogger
 import org.springframework.ai.retry.NonTransientAiException
 import java.util.UUID
 
 /**
- * Emits a [WarnEvent] and [AgentFinishedEvent] when the LLM provider rejects a request
- * with a non-transient error (4xx). Retrying with the same payload would produce the
- * same result, so the run is terminated immediately rather than looping.
+ * Emits an [ErrorEvent] and the given [AgentFinishedEvent] when the LLM provider
+ * rejects a request with a non-transient error (4xx).
  *
- * @param agent The agent whose turn is ending.
+ * @param finishedEvent Pre-built event closing the agent's turn.
  * @param e The non-transient provider exception.
- * @param namespaceId Namespace of the current case.
- * @param caseId Current case identifier.
  * @param logger Logger of the calling agent.
  */
 suspend fun FlowCollector<CaseEvent>.emitProviderErrorEvents(
-    agent: Agent,
+    finishedEvent: AgentFinishedEvent,
     e: NonTransientAiException,
-    namespaceId: UUID,
-    caseId: UUID,
     logger: KLogger,
 ) {
-    logger.error(e) { "LLM provider rejected request for case $caseId" }
+    logger.error(e) { "LLM provider rejected request for case ${finishedEvent.caseId}" }
     emit(
         ErrorEvent(
-            namespaceId = namespaceId,
-            caseId = caseId,
+            namespaceId = finishedEvent.namespaceId,
+            caseId = finishedEvent.caseId,
             message = "The AI provider rejected the request and the agent cannot continue: ${e.message}",
         ),
     )
-    emit(
-        AgentFinishedEvent(
-            namespaceId = namespaceId,
-            caseId = caseId,
-            agentId = agent.id,
-            agentName = agent.name,
-        ),
-    )
+    emit(finishedEvent)
 }
 
 /**
- * Emits the orchestration events for a structured agent interruption.
+ * Emits the given [AgentFinishedEvent] then the interrupt-specific follow-up events.
  *
- * Always emits [AgentFinishedEvent] to close the current agent's turn, then emits
- * the interrupt-specific follow-up event(s) — e.g. [AgentSelectedEvent] for a
- * [AgentInterrupt.Redirect]. The [when] is exhaustive over the sealed hierarchy:
- * adding a new [AgentInterrupt] subtype without handling it here is a compile error.
+ * The [when] is exhaustive over the [AgentInterrupt] sealed hierarchy: adding a new
+ * subtype without handling it here is a compile error.
  *
- * @param agent The agent whose turn is ending.
+ * @param finishedEvent Pre-built event closing the agent's turn.
  * @param e The interrupt signal thrown by a tool.
- * @param namespaceId Namespace of the current case.
- * @param caseId Current case identifier.
  * @param logger Logger of the calling agent, used to trace the redirect.
  */
 suspend fun FlowCollector<CaseEvent>.emitInterruptEvents(
-    agent: Agent,
+    finishedEvent: AgentFinishedEvent,
     e: AgentInterrupt,
-    namespaceId: UUID,
-    caseId: UUID,
     logger: KLogger,
 ) {
-    emit(
-        AgentFinishedEvent(
-            namespaceId = namespaceId,
-            caseId = caseId,
-            agentId = agent.id,
-            agentName = agent.name,
-        ),
-    )
+    emit(finishedEvent)
     when (e) {
         is AgentInterrupt.Redirect -> {
-            logger.info { "[${agent.name}] redirecting to '${e.targetAgentName}'" }
+            logger.info { "[${finishedEvent.agentName}] redirecting to '${e.targetAgentName}'" }
             emit(
                 AgentSelectedEvent(
-                    namespaceId = namespaceId,
-                    caseId = caseId,
+                    namespaceId = finishedEvent.namespaceId,
+                    caseId = finishedEvent.caseId,
                     agentId = UUID.nameUUIDFromBytes(e.targetAgentName.toByteArray()),
                     agentName = e.targetAgentName,
                 ),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
@@ -17,7 +17,7 @@ import java.util.UUID
  * @param e The non-transient provider exception.
  * @param logger Logger of the calling agent.
  */
-suspend fun FlowCollector<CaseEvent>.emitProviderErrorEvents(
+suspend fun FlowCollector<CaseEvent>.emitProviderErrorAndFinishEvents(
     finishedEvent: AgentFinishedEvent,
     e: NonTransientAiException,
     logger: KLogger,
@@ -43,7 +43,7 @@ suspend fun FlowCollector<CaseEvent>.emitProviderErrorEvents(
  * @param e The interrupt signal thrown by a tool.
  * @param logger Logger of the calling agent, used to trace the redirect.
  */
-suspend fun FlowCollector<CaseEvent>.emitInterruptEvents(
+suspend fun FlowCollector<CaseEvent>.emitInterruptAndFinishEvents(
     finishedEvent: AgentFinishedEvent,
     e: AgentInterrupt,
     logger: KLogger,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.agent
 
+import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
@@ -10,52 +11,68 @@ import org.springframework.ai.retry.NonTransientAiException
 import java.util.UUID
 
 /**
- * Emits an [ErrorEvent] and the given [AgentFinishedEvent] when the LLM provider
- * rejects a request with a non-transient error (4xx).
- *
- * @param finishedEvent Pre-built event closing the agent's turn.
- * @param e The non-transient provider exception.
- * @param logger Logger of the calling agent.
+ * Emits an [ErrorEvent] and [AgentFinishedEvent] when the LLM provider rejects a request
+ * with a non-transient error (4xx). Retrying with the same payload would produce the
+ * same result, so the run is terminated immediately rather than looping.
  */
 suspend fun FlowCollector<CaseEvent>.emitProviderErrorAndFinishEvents(
-    finishedEvent: AgentFinishedEvent,
+    agent: Agent,
     e: NonTransientAiException,
+    namespaceId: UUID,
+    caseId: UUID,
     logger: KLogger,
 ) {
-    logger.error(e) { "LLM provider rejected request for case ${finishedEvent.caseId}" }
+    logger.error(e) { "LLM provider rejected request for case $caseId" }
     emit(
         ErrorEvent(
-            namespaceId = finishedEvent.namespaceId,
-            caseId = finishedEvent.caseId,
+            namespaceId = namespaceId,
+            caseId = caseId,
             message = "The AI provider rejected the request and the agent cannot continue: ${e.message}",
         ),
     )
-    emit(finishedEvent)
+    emit(
+        AgentFinishedEvent(
+            namespaceId = namespaceId,
+            caseId = caseId,
+            agentId = agent.id,
+            agentName = agent.name,
+            llmProvider = agent.llmProvider,
+            llmModel = agent.llmModel,
+        ),
+    )
 }
 
 /**
- * Emits the given [AgentFinishedEvent] then the interrupt-specific follow-up events.
+ * Emits [AgentFinishedEvent] to close the current agent's turn, then emits
+ * the interrupt-specific follow-up events.
  *
  * The [when] is exhaustive over the [AgentInterrupt] sealed hierarchy: adding a new
  * subtype without handling it here is a compile error.
- *
- * @param finishedEvent Pre-built event closing the agent's turn.
- * @param e The interrupt signal thrown by a tool.
- * @param logger Logger of the calling agent, used to trace the redirect.
  */
 suspend fun FlowCollector<CaseEvent>.emitInterruptAndFinishEvents(
-    finishedEvent: AgentFinishedEvent,
+    agent: Agent,
     e: AgentInterrupt,
+    namespaceId: UUID,
+    caseId: UUID,
     logger: KLogger,
 ) {
-    emit(finishedEvent)
+    emit(
+        AgentFinishedEvent(
+            namespaceId = namespaceId,
+            caseId = caseId,
+            agentId = agent.id,
+            agentName = agent.name,
+            llmProvider = agent.llmProvider,
+            llmModel = agent.llmModel,
+        ),
+    )
     when (e) {
         is AgentInterrupt.Redirect -> {
-            logger.info { "[${finishedEvent.agentName}] redirecting to '${e.targetAgentName}'" }
+            logger.info { "[${agent.name}] redirecting to '${e.targetAgentName}'" }
             emit(
                 AgentSelectedEvent(
-                    namespaceId = finishedEvent.namespaceId,
-                    caseId = finishedEvent.caseId,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
                     agentId = UUID.nameUUIDFromBytes(e.targetAgentName.toByteArray()),
                     agentName = e.targetAgentName,
                 ),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -29,25 +29,6 @@ interface AgentService {
     ): Agent
 
     /**
-     * Resolve the fully-computed definition for an agent by name, without instantiating
-     * a live [Agent].
-     *
-     * Runs the same resolution pipeline as [findAgentByName] — model overlay, provider
-     * overlay, instruction building, tool resolution — but stops before constructing the
-     * Spring AI chat client and agent objects.
-     *
-     * Intended for callers that need the LLM metadata (provider, model) before running
-     * the agent, so that the [io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent] can be
-     * enriched without a second full resolution pass.
-     *
-     * Throws [IllegalArgumentException] if the config is not found or no model can be resolved.
-     */
-    suspend fun resolveDefinitionByName(
-        agentName: String,
-        context: AgentExecutionContext,
-    ): ResolvedAgentDefinition
-
-    /**
      * Resolve the fully-computed definition for an agent config, without instantiating
      * a live [Agent].
      *
@@ -85,4 +66,21 @@ interface AgentService {
         namespaceId: UUID,
         userId: UUID? = null,
     ): String?
+
+    /**
+     * Lightweight resolution of the LLM provider and model names for an agent.
+     *
+     * Only resolves the agent config, AI model and AI provider (with user overlay).
+     * Does not build instructions, system prompt, or tools.
+     *
+     * Used by the runtime to enrich [io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent]
+     * with observability metadata before the agent executes.
+     *
+     * @return a [Pair] of (providerName, modelApiName), or null if the agent config or model is not found.
+     */
+    fun resolveModelInfo(
+        agentName: String,
+        namespaceId: UUID,
+        userId: UUID? = null,
+    ): Pair<String, String>?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -29,6 +29,25 @@ interface AgentService {
     ): Agent
 
     /**
+     * Resolve the fully-computed definition for an agent by name, without instantiating
+     * a live [Agent].
+     *
+     * Runs the same resolution pipeline as [findAgentByName] — model overlay, provider
+     * overlay, instruction building, tool resolution — but stops before constructing the
+     * Spring AI chat client and agent objects.
+     *
+     * Intended for callers that need the LLM metadata (provider, model) before running
+     * the agent, so that the [io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent] can be
+     * enriched without a second full resolution pass.
+     *
+     * Throws [IllegalArgumentException] if the config is not found or no model can be resolved.
+     */
+    suspend fun resolveDefinitionByName(
+        agentName: String,
+        context: AgentExecutionContext,
+    ): ResolvedAgentDefinition
+
+    /**
      * Resolve the fully-computed definition for an agent config, without instantiating
      * a live [Agent].
      *

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentService.kt
@@ -67,20 +67,4 @@ interface AgentService {
         userId: UUID? = null,
     ): String?
 
-    /**
-     * Lightweight resolution of the LLM provider and model names for an agent.
-     *
-     * Only resolves the agent config, AI model and AI provider (with user overlay).
-     * Does not build instructions, system prompt, or tools.
-     *
-     * Used by the runtime to enrich [io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent]
-     * with observability metadata before the agent executes.
-     *
-     * @return a [Pair] of (providerName, modelApiName), or null if the agent config or model is not found.
-     */
-    fun resolveModelInfo(
-        agentName: String,
-        namespaceId: UUID,
-        userId: UUID? = null,
-    ): Pair<String, String>?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -304,6 +304,8 @@ class AgentServiceImpl(
                 userId = resolvedUser?.metadata?.id,
                 userExternalId = resolvedUser?.externalId,
                 caseEventsProvider = context.caseEventsProvider,
+                llmProviderName = providerConfig.name,
+                llmModelApiName = modelConfig.apiModelName,
             )
         } else {
             AgentSimple(
@@ -316,6 +318,8 @@ class AgentServiceImpl(
                 userId = resolvedUser?.metadata?.id,
                 userExternalId = resolvedUser?.externalId,
                 caseEventsProvider = context.caseEventsProvider,
+                llmProviderName = providerConfig.name,
+                llmModelApiName = modelConfig.apiModelName,
             )
         }
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -46,19 +46,6 @@ class AgentServiceImpl(
     private val objectMapper: ObjectMapper,
     private val toolRegistryService: ToolRegistryService,
 ) : AgentService {
-    override suspend fun resolveDefinitionByName(
-        agentName: String,
-        context: AgentExecutionContext,
-    ): ResolvedAgentDefinition {
-        val agentConfig =
-            agentConfigService.findByName(context.namespaceId, agentName)
-                ?: throw IllegalArgumentException(
-                    "No AgentConfig found for name '$agentName' in namespace ${context.namespaceId}.",
-                )
-        val resolvedUser = context.userId?.let { runCatching { userService.findById(it) }.getOrNull() }
-        return resolveAgentDefinition(agentConfig, context, resolvedUser)
-    }
-
     override suspend fun findAgentByName(
         namePart: String,
         context: AgentExecutionContext,
@@ -112,6 +99,32 @@ class AgentServiceImpl(
     // -------------------------------------------------------------------------
     // Resolution helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Lightweight resolution of the LLM provider and model names for an agent.
+     *
+     * Only resolves the [AgentConfig], [AiModel] and [AiProvider] (with user overlay).
+     * Does NOT build instructions, system prompt, or tools — unlike [resolveAgentDefinition]
+     * which performs the full resolution pipeline.
+     *
+     * Used by the runtime callback to enrich [io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent]
+     * with observability metadata before the agent executes.
+     *
+     * @return a [Pair] of (providerName, modelApiName), or null if the agent config is not found.
+     */
+    override fun resolveModelInfo(
+        agentName: String,
+        namespaceId: UUID,
+        userId: UUID?,
+    ): Pair<String, String>? {
+        val config = agentConfigService.findByName(namespaceId, agentName) ?: return null
+        val baseModel =
+            config.modelName?.let { aiModelService.findAiModel(namespaceId, it) }
+                ?: findDefaultModelConfig(namespaceId)
+                ?: return null
+        val (_, providerConfig) = applyOverlaysToModel(baseModel, namespaceId, userId)
+        return providerConfig.name to baseModel.apiModelName
+    }
 
     /**
      * Phase 1: resolve all configuration for an [AgentConfig] into a [ResolvedAgentDefinition].

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -101,32 +101,6 @@ class AgentServiceImpl(
     // -------------------------------------------------------------------------
 
     /**
-     * Lightweight resolution of the LLM provider and model names for an agent.
-     *
-     * Only resolves the [AgentConfig], [AiModel] and [AiProvider] (with user overlay).
-     * Does NOT build instructions, system prompt, or tools — unlike [resolveAgentDefinition]
-     * which performs the full resolution pipeline.
-     *
-     * Used by the runtime callback to enrich [io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent]
-     * with observability metadata before the agent executes.
-     *
-     * @return a [Pair] of (providerName, modelApiName), or null if the agent config is not found.
-     */
-    override fun resolveModelInfo(
-        agentName: String,
-        namespaceId: UUID,
-        userId: UUID?,
-    ): Pair<String, String>? {
-        val config = agentConfigService.findByName(namespaceId, agentName) ?: return null
-        val baseModel =
-            config.modelName?.let { aiModelService.findAiModel(namespaceId, it) }
-                ?: findDefaultModelConfig(namespaceId)
-                ?: return null
-        val (_, providerConfig) = applyOverlaysToModel(baseModel, namespaceId, userId)
-        return providerConfig.name to baseModel.apiModelName
-    }
-
-    /**
      * Phase 1: resolve all configuration for an [AgentConfig] into a [ResolvedAgentDefinition].
      *
      * Performs model / provider overlay resolution, instruction building, and tool resolution.
@@ -304,8 +278,8 @@ class AgentServiceImpl(
                 userId = resolvedUser?.metadata?.id,
                 userExternalId = resolvedUser?.externalId,
                 caseEventsProvider = context.caseEventsProvider,
-                llmProviderName = providerConfig.name,
-                llmModelApiName = modelConfig.apiModelName,
+                llmProvider = providerConfig.name,
+                llmModel = modelConfig.apiModelName,
             )
         } else {
             AgentSimple(
@@ -318,8 +292,8 @@ class AgentServiceImpl(
                 userId = resolvedUser?.metadata?.id,
                 userExternalId = resolvedUser?.externalId,
                 caseEventsProvider = context.caseEventsProvider,
-                llmProviderName = providerConfig.name,
-                llmModelApiName = modelConfig.apiModelName,
+                llmProvider = providerConfig.name,
+                llmModel = modelConfig.apiModelName,
             )
         }
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -46,6 +46,19 @@ class AgentServiceImpl(
     private val objectMapper: ObjectMapper,
     private val toolRegistryService: ToolRegistryService,
 ) : AgentService {
+    override suspend fun resolveDefinitionByName(
+        agentName: String,
+        context: AgentExecutionContext,
+    ): ResolvedAgentDefinition {
+        val agentConfig =
+            agentConfigService.findByName(context.namespaceId, agentName)
+                ?: throw IllegalArgumentException(
+                    "No AgentConfig found for name '$agentName' in namespace ${context.namespaceId}.",
+                )
+        val resolvedUser = context.userId?.let { runCatching { userService.findById(it) }.getOrNull() }
+        return resolveAgentDefinition(agentConfig, context, resolvedUser)
+    }
+
     override suspend fun findAgentByName(
         namePart: String,
         context: AgentExecutionContext,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -69,8 +69,8 @@ class AgentSimple(
     private val userExternalId: String? = null,
     /** Returns the live event list of the current case at the moment of invocation. */
     private val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
-    private val llmProviderName: String? = null,
-    private val llmModelApiName: String? = null,
+    override val llmProvider: String,
+    override val llmModel: String,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -115,8 +115,8 @@ class AgentSimple(
                             caseId = caseId,
                             agentId = id,
                             agentName = name,
-                            llmProvider = llmProviderName,
-                            llmModel = llmModelApiName,
+                            llmProvider = llmProvider,
+                            llmModel = llmModel,
                         ),
                     )
                     return@flow
@@ -228,8 +228,8 @@ class AgentSimple(
                         caseId = caseId,
                         agentId = id,
                         agentName = name,
-                        llmProvider = llmProviderName,
-                        llmModel = llmModelApiName,
+                        llmProvider = llmProvider,
+                        llmModel = llmModel,
                     ),
                 )
             } catch (e: AgentInterrupt) {
@@ -240,25 +240,9 @@ class AgentSimple(
                 for (toolEvent in toolEventChannel) {
                     emit(toolEvent)
                 }
-                val finished = AgentFinishedEvent(
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    agentId = id,
-                    agentName = name,
-                    llmProvider = llmProviderName,
-                    llmModel = llmModelApiName,
-                )
-                emitInterruptAndFinishEvents(finished, e, logger)
+                emitInterruptAndFinishEvents(this@AgentSimple, e, namespaceId, caseId, logger)
             } catch (e: NonTransientAiException) {
-                val finished = AgentFinishedEvent(
-                    namespaceId = namespaceId,
-                    caseId = caseId,
-                    agentId = id,
-                    agentName = name,
-                    llmProvider = llmProviderName,
-                    llmModel = llmModelApiName,
-                )
-                emitProviderErrorAndFinishEvents(finished, e, logger)
+                emitProviderErrorAndFinishEvents(this@AgentSimple, e, namespaceId, caseId, logger)
             } catch (e: Exception) {
                 logger.error(e) { "Error during agent execution" }
                 emit(
@@ -275,8 +259,8 @@ class AgentSimple(
                         caseId = caseId,
                         agentId = id,
                         agentName = name,
-                        llmProvider = llmProviderName,
-                        llmModel = llmModelApiName,
+                        llmProvider = llmProvider,
+                        llmModel = llmModel,
                     ),
                 )
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -248,7 +248,7 @@ class AgentSimple(
                     llmProvider = llmProviderName,
                     llmModel = llmModelApiName,
                 )
-                emitInterruptEvents(finished, e, logger)
+                emitInterruptAndFinishEvents(finished, e, logger)
             } catch (e: NonTransientAiException) {
                 val finished = AgentFinishedEvent(
                     namespaceId = namespaceId,
@@ -258,7 +258,7 @@ class AgentSimple(
                     llmProvider = llmProviderName,
                     llmModel = llmModelApiName,
                 )
-                emitProviderErrorEvents(finished, e, logger)
+                emitProviderErrorAndFinishEvents(finished, e, logger)
             } catch (e: Exception) {
                 logger.error(e) { "Error during agent execution" }
                 emit(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -69,6 +69,8 @@ class AgentSimple(
     private val userExternalId: String? = null,
     /** Returns the live event list of the current case at the moment of invocation. */
     private val caseEventsProvider: () -> List<CaseEvent> = { emptyList() },
+    private val llmProviderName: String? = null,
+    private val llmModelApiName: String? = null,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -113,6 +115,8 @@ class AgentSimple(
                             caseId = caseId,
                             agentId = id,
                             agentName = name,
+                            llmProvider = llmProviderName,
+                            llmModel = llmModelApiName,
                         ),
                     )
                     return@flow
@@ -224,6 +228,8 @@ class AgentSimple(
                         caseId = caseId,
                         agentId = id,
                         agentName = name,
+                        llmProvider = llmProviderName,
+                        llmModel = llmModelApiName,
                     ),
                 )
             } catch (e: AgentInterrupt) {
@@ -234,9 +240,25 @@ class AgentSimple(
                 for (toolEvent in toolEventChannel) {
                     emit(toolEvent)
                 }
-                emitInterruptEvents(this@AgentSimple, e, namespaceId, caseId, logger)
+                val finished = AgentFinishedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = id,
+                    agentName = name,
+                    llmProvider = llmProviderName,
+                    llmModel = llmModelApiName,
+                )
+                emitInterruptEvents(finished, e, logger)
             } catch (e: NonTransientAiException) {
-                emitProviderErrorEvents(this@AgentSimple, e, namespaceId, caseId, logger)
+                val finished = AgentFinishedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = id,
+                    agentName = name,
+                    llmProvider = llmProviderName,
+                    llmModel = llmModelApiName,
+                )
+                emitProviderErrorEvents(finished, e, logger)
             } catch (e: Exception) {
                 logger.error(e) { "Error during agent execution" }
                 emit(
@@ -253,6 +275,8 @@ class AgentSimple(
                         caseId = caseId,
                         agentId = id,
                         agentName = name,
+                        llmProvider = llmProviderName,
+                        llmModel = llmModelApiName,
                     ),
                 )
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
@@ -122,6 +122,10 @@ class AgentRunningEventNode(
     timestamp: Instant,
     val agentId: String,
     val agentName: String,
+    /** LLM provider name (e.g. "anthropic"), null for nodes predating this field. */
+    val llmProvider: String? = null,
+    /** LLM model API name (e.g. "claude-haiku-4-5"), null for nodes predating this field. */
+    val llmModel: String? = null,
     created: Instant = Instant.now(),
     createdBy: String? = null,
     modified: Instant = Instant.now(),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
@@ -107,6 +107,8 @@ class AgentFinishedEventNode(
     timestamp: Instant,
     val agentId: String,
     val agentName: String,
+    val llmProvider: String? = null,
+    val llmModel: String? = null,
     created: Instant = Instant.now(),
     createdBy: String? = null,
     modified: Instant = Instant.now(),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
@@ -122,9 +122,7 @@ class AgentRunningEventNode(
     timestamp: Instant,
     val agentId: String,
     val agentName: String,
-    /** LLM provider name (e.g. "anthropic"), null for nodes predating this field. */
     val llmProvider: String? = null,
-    /** LLM model API name (e.g. "claude-haiku-4-5"), null for nodes predating this field. */
     val llmModel: String? = null,
     created: Instant = Instant.now(),
     createdBy: String? = null,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
@@ -173,6 +173,8 @@ class CaseEventNodeMapper(
                     node.timestamp,
                     node.agentId,
                     node.agentName,
+                    node.llmProvider,
+                    node.llmModel,
                     node.created,
                     node.createdBy,
                     node.modified,
@@ -430,6 +432,8 @@ class CaseEventNodeMapper(
             timestamp = n.timestamp,
             agentId = UUID.fromString(n.agentId),
             agentName = n.agentName,
+            llmProvider = n.llmProvider,
+            llmModel = n.llmModel,
         )
 
     private fun toDomain(n: MessageEventNode) =
@@ -635,6 +639,8 @@ class CaseEventNodeMapper(
             timestamp = e.timestamp,
             agentId = e.agentId.toString(),
             agentName = e.agentName,
+            llmProvider = e.llmProvider,
+            llmModel = e.llmModel,
             created = e.metadata.created,
             createdBy = e.metadata.createdBy,
             modified = e.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
@@ -157,6 +157,8 @@ class CaseEventNodeMapper(
                     node.timestamp,
                     node.agentId,
                     node.agentName,
+                    node.llmProvider,
+                    node.llmModel,
                     node.created,
                     node.createdBy,
                     node.modified,
@@ -422,6 +424,8 @@ class CaseEventNodeMapper(
             timestamp = n.timestamp,
             agentId = UUID.fromString(n.agentId),
             agentName = n.agentName,
+            llmProvider = n.llmProvider,
+            llmModel = n.llmModel,
         )
 
     private fun toDomain(n: AgentRunningEventNode) =
@@ -624,6 +628,8 @@ class CaseEventNodeMapper(
             timestamp = e.timestamp,
             agentId = e.agentId.toString(),
             agentName = e.agentName,
+            llmProvider = e.llmProvider,
+            llmModel = e.llmModel,
             created = e.metadata.created,
             createdBy = e.metadata.createdBy,
             modified = e.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -39,10 +39,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   [AgentSelectedEvent] emitted by an agent (redirect). Returns true if the target agent
  *   is accessible to the current user. Called at redirect time — not pre-computed.
  * @param runAgent fetches the named agent, runs it against the current event history,
- *   and pipes each produced event through [storeEvent]. The [skipRunningEvent] boolean
- *   tells the implementation whether to suppress emitting a duplicate [AgentRunningEvent]
- *   (true when rehydrating from a persisted [AgentRunningEvent]). Error handling is the
- *   responsibility of the service implementation.
+ *   and pipes each produced event through [storeEvent]. The implementation is responsible
+ *   for deciding whether to emit [AgentRunningEvent] by inspecting the event history
+ *   (e.g. skip if already the most recent orchestration event, to avoid duplicates on
+ *   rehydration). Error handling is the responsibility of the service implementation.
  */
 class CaseRuntime(
     val id: UUID,
@@ -51,7 +51,7 @@ class CaseRuntime(
     private val storeEvent: (CaseEvent) -> CaseEvent,
     private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>) -> List<CaseEvent>,
     private val isAgentAuthorized: (agentName: String, userId: UUID?) -> Boolean,
-    private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean, skipRunningEvent: Boolean) -> Unit,
+    private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
     private val emitter: DefaultCaseEventEmitter = DefaultCaseEventEmitter(),
 ) : CaseEventEmitter by emitter {
@@ -297,11 +297,11 @@ class CaseRuntime(
                 }
 
                 is AgentRunningEvent -> {
-                    // Rehydration: the AgentRunningEvent was already persisted before the
-                    // crash/restart. Pass skipRunningEvent=true so runAgent does not emit
-                    // a duplicate AgentRunningEvent.
-                    logger.info { "[CaseRuntime $id] Found AgentRunningEvent for agent: ${event.agentName}" }
-                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, resolveUserId(events), { !interruptRequested.get() }, true)
+                    // Rehydration: agent was running when the case crashed.
+                    // Delegate to runAgent which inspects the event history
+                    // and skips the duplicate AgentRunningEvent emission.
+                    logger.info { "[CaseRuntime $id] Rehydrating from AgentRunningEvent for agent: ${event.agentName}" }
+                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, resolveUserId(events)) { !interruptRequested.get() }
                     return
                 }
 
@@ -325,7 +325,7 @@ class CaseRuntime(
                         interruptRequested.set(true)
                         return
                     }
-                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, userId, { !interruptRequested.get() }, false)
+                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, userId) { !interruptRequested.get() }
                     return
                 }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -38,6 +38,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param isAgentAuthorized defensive check called when [processNextStep] encounters an
  *   [AgentSelectedEvent] emitted by an agent (redirect). Returns true if the target agent
  *   is accessible to the current user. Called at redirect time — not pre-computed.
+ * @param resolveAgentLlmInfo resolves the LLM provider and model names for a given agent
+ *   name and user, called just before emitting [AgentRunningEvent] so the event can carry
+ *   observability metadata. Returns a [Pair] of (llmProvider, llmModel), or null on failure
+ *   (the event is emitted with null fields rather than blocking execution).
  * @param runAgent fetches the named agent, runs it against the current event history,
  *   and pipes each produced event through [storeEvent]. Error handling is the
  *   responsibility of the service implementation.
@@ -49,6 +53,7 @@ class CaseRuntime(
     private val storeEvent: (CaseEvent) -> CaseEvent,
     private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>) -> List<CaseEvent>,
     private val isAgentAuthorized: (agentName: String, userId: UUID?) -> Boolean,
+    private val resolveAgentLlmInfo: suspend (agentName: String, userId: UUID?) -> Pair<String?, String?>?,
     private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
     private val emitter: DefaultCaseEventEmitter = DefaultCaseEventEmitter(),
@@ -321,12 +326,17 @@ class CaseRuntime(
                         interruptRequested.set(true)
                         return
                     }
+                    val llmInfo = runCatching { resolveAgentLlmInfo(event.agentName, userId) }
+                        .onFailure { logger.warn(it) { "[CaseRuntime $id] Could not resolve LLM info for agent '${event.agentName}'" } }
+                        .getOrNull()
                     storeAndEmitEvent(
                         AgentRunningEvent(
                             namespaceId = namespaceId,
                             caseId = id,
                             agentId = event.agentId,
                             agentName = event.agentName,
+                            llmProvider = llmInfo?.first,
+                            llmModel = llmInfo?.second,
                         ),
                     )
                     return

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -38,12 +38,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param isAgentAuthorized defensive check called when [processNextStep] encounters an
  *   [AgentSelectedEvent] emitted by an agent (redirect). Returns true if the target agent
  *   is accessible to the current user. Called at redirect time — not pre-computed.
- * @param resolveAgentLlmInfo resolves the LLM provider and model names for a given agent
- *   name and user, called just before emitting [AgentRunningEvent] so the event can carry
- *   observability metadata. Returns a [Pair] of (llmProvider, llmModel), or null on failure
- *   (the event is emitted with null fields rather than blocking execution).
  * @param runAgent fetches the named agent, runs it against the current event history,
- *   and pipes each produced event through [storeEvent]. Error handling is the
+ *   and pipes each produced event through [storeEvent]. The [skipRunningEvent] boolean
+ *   tells the implementation whether to suppress emitting a duplicate [AgentRunningEvent]
+ *   (true when rehydrating from a persisted [AgentRunningEvent]). Error handling is the
  *   responsibility of the service implementation.
  */
 class CaseRuntime(
@@ -53,8 +51,7 @@ class CaseRuntime(
     private val storeEvent: (CaseEvent) -> CaseEvent,
     private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>) -> List<CaseEvent>,
     private val isAgentAuthorized: (agentName: String, userId: UUID?) -> Boolean,
-    private val resolveAgentLlmInfo: suspend (agentName: String, userId: UUID?) -> Pair<String?, String?>?,
-    private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
+    private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean, skipRunningEvent: Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
     private val emitter: DefaultCaseEventEmitter = DefaultCaseEventEmitter(),
 ) : CaseEventEmitter by emitter {
@@ -300,15 +297,17 @@ class CaseRuntime(
                 }
 
                 is AgentRunningEvent -> {
+                    // Rehydration: the AgentRunningEvent was already persisted before the
+                    // crash/restart. Pass skipRunningEvent=true so runAgent does not emit
+                    // a duplicate AgentRunningEvent.
                     logger.info { "[CaseRuntime $id] Found AgentRunningEvent for agent: ${event.agentName}" }
-                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, resolveUserId(events)) { !interruptRequested.get() }
+                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, resolveUserId(events), { !interruptRequested.get() }, true)
                     return
                 }
 
                 is AgentSelectedEvent -> {
                     logger.info {
-                        "[CaseRuntime $id] Found AgentSelectedEvent for agent: ${event.agentName}, " +
-                            "transitioning to running"
+                        "[CaseRuntime $id] Found AgentSelectedEvent for agent: ${event.agentName}"
                     }
                     val userId = resolveUserId(events)
                     if (!isAgentAuthorized(event.agentName, userId)) {
@@ -326,19 +325,7 @@ class CaseRuntime(
                         interruptRequested.set(true)
                         return
                     }
-                    val llmInfo = runCatching { resolveAgentLlmInfo(event.agentName, userId) }
-                        .onFailure { logger.warn(it) { "[CaseRuntime $id] Could not resolve LLM info for agent '${event.agentName}'" } }
-                        .getOrNull()
-                    storeAndEmitEvent(
-                        AgentRunningEvent(
-                            namespaceId = namespaceId,
-                            caseId = id,
-                            agentId = event.agentId,
-                            agentName = event.agentName,
-                            llmProvider = llmInfo?.first,
-                            llmModel = llmInfo?.second,
-                        ),
-                    )
+                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, userId, { !interruptRequested.get() }, false)
                     return
                 }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -152,6 +152,15 @@ class CaseServiceImpl(
                             agentName = agentName,
                         ).isNotEmpty()
             },
+            resolveAgentLlmInfo = { agentName, userId ->
+                val context = AgentExecutionContext(
+                    namespaceId = case.namespaceId,
+                    caseId = case.id,
+                    userId = userId,
+                )
+                val definition = agentService.resolveDefinitionByName(agentName, context)
+                definition.resolvedProviderName to definition.resolvedModelApiName
+            },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue ->
                 runAgent(
                     agentName,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -405,17 +405,7 @@ class CaseServiceImpl(
             )
         val agent = agentService.findAgentByName(agentName, context)
 
-        // Decide whether to emit AgentRunningEvent by inspecting the event history.
-        // If the last AgentSelectedEvent is more recent than the last AgentRunningEvent
-        // (or there is no AgentRunningEvent), this is a fresh run and we emit.
-        // If AgentRunningEvent is already the most recent orchestration event, we are
-        // rehydrating from a crash — skip to avoid a duplicate that would cause an
-        // infinite loop in processNextStep.
-        val lastSelectedIndex = events.indexOfLast { it is AgentSelectedEvent }
-        val lastRunningIndex = events.indexOfLast { it is AgentRunningEvent }
-        val shouldEmitRunningEvent = lastRunningIndex < 0 || lastSelectedIndex > lastRunningIndex
-
-        if (shouldEmitRunningEvent) {
+        if (shouldEmitRunningEvent(events)) {
             val runningEvent =
                 AgentRunningEvent(
                     namespaceId = runtime.namespaceId,
@@ -555,6 +545,31 @@ class CaseServiceImpl(
         activeRuntimes.clear()
         scope.cancel()
         logger.info { "CaseService shutdown complete" }
+    }
+
+    /**
+     * Determines whether a new [AgentRunningEvent] should be emitted by inspecting
+     * the event history.
+     *
+     * Returns `true` when the most recent [AgentSelectedEvent] is newer than the most
+     * recent [AgentRunningEvent] (or when no [AgentRunningEvent] exists yet) — this is
+     * the normal fresh-run path.
+     *
+     * Returns `false` when [AgentRunningEvent] is already the most recent of the two —
+     * the case is rehydrating from a crash and emitting a duplicate would cause
+     * [CaseRuntime.processNextStep] to re-trigger execution indefinitely.
+     *
+     * This comparison is safe because agent execution is strictly sequential within a
+     * case: [CaseRuntime.run] is guarded by an [AtomicBoolean] that prevents concurrent
+     * invocations, and [runAgent] suspends in [Flow.collect] until the agent's flow
+     * terminates. No two agents can overlap, so the relative positions of
+     * [AgentSelectedEvent] and [AgentRunningEvent] in the event list are always
+     * well-ordered.
+     */
+    private fun shouldEmitRunningEvent(events: List<CaseEvent>): Boolean {
+        val lastSelectedIndex = events.indexOfLast { it is AgentSelectedEvent }
+        val lastRunningIndex = events.indexOfLast { it is AgentRunningEvent }
+        return lastRunningIndex < 0 || lastSelectedIndex > lastRunningIndex
     }
 
     companion object : KLogging() {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -9,6 +9,7 @@ import io.whozoss.agentos.caseEvent.lastUserIdOrNull
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
@@ -152,10 +153,7 @@ class CaseServiceImpl(
                             agentName = agentName,
                         ).isNotEmpty()
             },
-            resolveAgentLlmInfo = { agentName, userId ->
-                agentService.resolveModelInfo(agentName, case.namespaceId, userId)
-            },
-            runAgent = { agentName, events, eventsProvider, userId, shouldContinue ->
+            runAgent = { agentName, events, eventsProvider, userId, shouldContinue, skipRunningEvent ->
                 runAgent(
                     agentName,
                     case.id,
@@ -163,6 +161,7 @@ class CaseServiceImpl(
                     eventsProvider,
                     userId,
                     shouldContinue,
+                    skipRunningEvent,
                 )
             },
             inputEvents = inputEvents,
@@ -387,6 +386,7 @@ class CaseServiceImpl(
         eventsProvider: () -> List<CaseEvent>,
         userId: UUID?,
         shouldContinue: () -> Boolean,
+        skipRunningEvent: Boolean = false,
     ) {
         val runtime = activeRuntimes[caseId] ?: throw ResourceNotFoundException("No active case runtime found: $caseId")
 
@@ -405,9 +405,27 @@ class CaseServiceImpl(
                 userId = userId,
                 caseEventsProvider = eventsProvider,
             )
-        agentService
-            .findAgentByName(agentName, context)
-            .run(events, shouldContinue)
+        val agent = agentService.findAgentByName(agentName, context)
+
+        if (!skipRunningEvent) {
+            // Emit AgentRunningEvent after resolution — the agent carries the resolved
+            // LLM provider and model from its construction.
+            val runningEvent =
+                AgentRunningEvent(
+                    namespaceId = runtime.namespaceId,
+                    caseId = caseId,
+                    agentId = agent.id,
+                    agentName = agent.name,
+                    llmProvider = agent.llmProvider,
+                    llmModel = agent.llmModel,
+                )
+            storeEvent(runningEvent).also { saved ->
+                runtime.pushEvents(listOf(saved))
+                runtime.emitEvent(saved)
+            }
+        }
+
+        agent.run(events, shouldContinue)
             .catch { error ->
                 logger.error(error) { "Error in agent $agentName for case $caseId" }
                 storeEvent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -153,13 +153,7 @@ class CaseServiceImpl(
                         ).isNotEmpty()
             },
             resolveAgentLlmInfo = { agentName, userId ->
-                val context = AgentExecutionContext(
-                    namespaceId = case.namespaceId,
-                    caseId = case.id,
-                    userId = userId,
-                )
-                val definition = agentService.resolveDefinitionByName(agentName, context)
-                definition.resolvedProviderName to definition.resolvedModelApiName
+                agentService.resolveModelInfo(agentName, case.namespaceId, userId)
             },
             runAgent = { agentName, events, eventsProvider, userId, shouldContinue ->
                 runAgent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -153,7 +153,7 @@ class CaseServiceImpl(
                             agentName = agentName,
                         ).isNotEmpty()
             },
-            runAgent = { agentName, events, eventsProvider, userId, shouldContinue, skipRunningEvent ->
+            runAgent = { agentName, events, eventsProvider, userId, shouldContinue ->
                 runAgent(
                     agentName,
                     case.id,
@@ -161,7 +161,6 @@ class CaseServiceImpl(
                     eventsProvider,
                     userId,
                     shouldContinue,
-                    skipRunningEvent,
                 )
             },
             inputEvents = inputEvents,
@@ -386,7 +385,6 @@ class CaseServiceImpl(
         eventsProvider: () -> List<CaseEvent>,
         userId: UUID?,
         shouldContinue: () -> Boolean,
-        skipRunningEvent: Boolean = false,
     ) {
         val runtime = activeRuntimes[caseId] ?: throw ResourceNotFoundException("No active case runtime found: $caseId")
 
@@ -407,9 +405,17 @@ class CaseServiceImpl(
             )
         val agent = agentService.findAgentByName(agentName, context)
 
-        if (!skipRunningEvent) {
-            // Emit AgentRunningEvent after resolution — the agent carries the resolved
-            // LLM provider and model from its construction.
+        // Decide whether to emit AgentRunningEvent by inspecting the event history.
+        // If the last AgentSelectedEvent is more recent than the last AgentRunningEvent
+        // (or there is no AgentRunningEvent), this is a fresh run and we emit.
+        // If AgentRunningEvent is already the most recent orchestration event, we are
+        // rehydrating from a crash — skip to avoid a duplicate that would cause an
+        // infinite loop in processNextStep.
+        val lastSelectedIndex = events.indexOfLast { it is AgentSelectedEvent }
+        val lastRunningIndex = events.indexOfLast { it is AgentRunningEvent }
+        val shouldEmitRunningEvent = lastRunningIndex < 0 || lastSelectedIndex > lastRunningIndex
+
+        if (shouldEmitRunningEvent) {
             val runningEvent =
                 AgentRunningEvent(
                     namespaceId = runtime.namespaceId,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -131,6 +131,8 @@ class AgentAdvancedSpec :
                 context = context,
                 intentionGenerator = mockk(),
                 objectMapper = testObjectMapper,
+                llmProvider = "test-provider",
+                llmModel = "test-model",
             )
         }
 
@@ -201,6 +203,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events =
@@ -274,6 +278,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events =
@@ -343,6 +349,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events =
@@ -421,6 +429,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -543,6 +553,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 10,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -603,6 +615,8 @@ class AgentAdvancedSpec :
                     context = context,
                     intentionGenerator = mockk(),
                     objectMapper = testObjectMapper,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -645,6 +659,8 @@ class AgentAdvancedSpec :
                     context = context,
                     intentionGenerator = mockk(),
                     objectMapper = testObjectMapper,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -680,6 +696,8 @@ class AgentAdvancedSpec :
                     context = context,
                     intentionGenerator = mockk(),
                     objectMapper = testObjectMapper,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -716,6 +734,8 @@ class AgentAdvancedSpec :
                     context = context,
                     intentionGenerator = mockk(),
                     objectMapper = testObjectMapper,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -768,6 +788,8 @@ class AgentAdvancedSpec :
                     context = context,
                     intentionGenerator = mockk(),
                     objectMapper = testObjectMapper,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
@@ -1188,6 +1210,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGeneratorReturning(namespaceId, caseId, agentId, "FILES__remove"),
                     objectMapper = testObjectMapper,
                     maxIterations = 3,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
@@ -1243,6 +1267,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGeneratorReturning(namespaceId, caseId, agentId, "Answer"),
                     objectMapper = testObjectMapper,
                     maxIterations = 1,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId) + pending + userReply).toList()
 
@@ -1301,6 +1327,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = intentionGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId) + pending + userReply).toList()
 
@@ -1365,6 +1393,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGeneratorReturning(namespaceId, caseId, agentId, "Answer"),
                     objectMapper = testObjectMapper,
                     maxIterations = 1,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId) + pending + userReply).toList()
 
@@ -1420,6 +1450,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
@@ -1482,6 +1514,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
@@ -1558,6 +1592,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
@@ -1634,6 +1670,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             agent.run(makeInitialEvents(namespaceId, caseId)).toList()
 
@@ -1709,6 +1747,8 @@ class AgentAdvancedSpec :
                     objectMapper = testObjectMapper,
                     maxIterations = 2,
                     caseEventsProvider = { initialEvents },
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             agent.run(initialEvents).toList()
 
@@ -1749,6 +1789,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockk(),
                     objectMapper = testObjectMapper,
                     maxIterations = 1,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(initialUserMsg + pending).toList()
 
@@ -1807,6 +1849,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGeneratorReturning(namespaceId, caseId, agentId, "Answer"),
                     objectMapper = testObjectMapper,
                     maxIterations = 1,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId) + pending + userYes).toList()
 
@@ -1856,6 +1900,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGeneratorReturning(namespaceId, caseId, agentId, "Answer"),
                     objectMapper = testObjectMapper,
                     maxIterations = 1,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
             val events = agent.run(makeInitialEvents(namespaceId, caseId) + pending).toList()
 
@@ -1919,6 +1965,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 10,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -1996,6 +2044,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2068,6 +2118,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2140,6 +2192,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2212,6 +2266,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2242,6 +2298,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGeneratorReturning(namespaceId, caseId, agentId, "DOES_NOT_EXIST"),
                     objectMapper = testObjectMapper,
                     maxIterations = 1,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2348,6 +2406,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2439,6 +2499,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2544,6 +2606,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2666,6 +2730,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2756,6 +2822,8 @@ class AgentAdvancedSpec :
                     objectMapper = testObjectMapper,
                     // High maxIterations: without the fix the agent would run until exhaustion.
                     maxIterations = 50,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
@@ -2841,6 +2909,8 @@ class AgentAdvancedSpec :
                     intentionGenerator = mockGenerator,
                     objectMapper = testObjectMapper,
                     maxIterations = 20,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
                 )
 
             val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
@@ -65,6 +65,8 @@ class AgentSimpleToolCallbackUnitSpec :
                 name = "TestAgent",
                 chatClient = chatClient,
                 tools = tools,
+                llmProvider = "test-provider",
+                llmModel = "test-model",
             )
 
         fun userMessage(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleUnitSpec.kt
@@ -44,6 +44,8 @@ class AgentSimpleUnitSpec :
                 chatClient = chatClient,
                 tools = tools,
                 instructions = instructions,
+                llmProvider = "test-provider",
+                llmModel = "test-model",
             )
 
         fun userMessage(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperAgentLifecycleSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperAgentLifecycleSpec.kt
@@ -51,6 +51,8 @@ class CaseEventNodeMapperAgentLifecycleSpec :
                     timestamp = Instant.parse("2026-05-19T15:01:00Z"),
                     agentId = agentId,
                     agentName = "WorkerAgent",
+                    llmProvider = "anthropic",
+                    llmModel = "claude-sonnet-4-20250514",
                 )
 
             val node = nodeMapper.fromDomain(original)
@@ -62,6 +64,8 @@ class CaseEventNodeMapperAgentLifecycleSpec :
             roundTripped.timestamp shouldBe original.timestamp
             roundTripped.agentId shouldBe agentId
             roundTripped.agentName shouldBe "WorkerAgent"
+            roundTripped.llmProvider shouldBe "anthropic"
+            roundTripped.llmModel shouldBe "claude-sonnet-4-20250514"
         }
 
         "AgentFinishedEvent survives the fromDomain/toDomain round-trip" {
@@ -74,6 +78,8 @@ class CaseEventNodeMapperAgentLifecycleSpec :
                     timestamp = Instant.parse("2026-05-19T15:02:00Z"),
                     agentId = agentId,
                     agentName = "WorkerAgent",
+                    llmProvider = "anthropic",
+                    llmModel = "claude-sonnet-4-20250514",
                 )
 
             val node = nodeMapper.fromDomain(original)
@@ -85,5 +91,7 @@ class CaseEventNodeMapperAgentLifecycleSpec :
             roundTripped.timestamp shouldBe original.timestamp
             roundTripped.agentId shouldBe agentId
             roundTripped.agentName shouldBe "WorkerAgent"
+            roundTripped.llmProvider shouldBe "anthropic"
+            roundTripped.llmModel shouldBe "claude-sonnet-4-20250514"
         }
     })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -41,7 +41,7 @@ class RecordingRunAgent(
     val callCount: Int get() = _calls.size
 
     /** Expose as the function type [CaseRuntime] expects. */
-    val asCallback: suspend (String, List<CaseEvent>, () -> List<CaseEvent>, UUID?, () -> Boolean, Boolean) -> Unit = { name, events, _, _, _, _ ->
+    val asCallback: suspend (String, List<CaseEvent>, () -> List<CaseEvent>, UUID?, () -> Boolean) -> Unit = { name, events, _, _, _ ->
         _calls += name to events
         delegate(name, events)
     }
@@ -234,7 +234,7 @@ class CaseRuntimeSpec : StringSpec() {
                         )
                     },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    runAgent = { _, events, _, _, _, _ ->
+                    runAgent = { _, events, _, _, _ ->
                         agent.run(events).collect { event ->
                             savedEvents.add(event)
                             runtime.pushEvents(listOf(event))
@@ -292,7 +292,7 @@ class CaseRuntimeSpec : StringSpec() {
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    runAgent = { _, events, _, _, _, _ ->
+                    runAgent = { _, events, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
                             runtime.pushEvents(listOf(event))
@@ -329,7 +329,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    runAgent = { _, _, _, _, shouldContinue, _ ->
+                    runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
                         // so we can inspect shouldContinue before the loop exits naturally.
@@ -364,7 +364,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    runAgent = { _, _, _, _, shouldContinue, _ ->
+                    runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                     },
                 )
@@ -398,7 +398,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    runAgent = { _, _, _, _, shouldContinue, _ ->
+                    runAgent = { _, _, _, _, shouldContinue ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
                         lambdaResultDuringRun = shouldContinue()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -25,6 +25,9 @@ import java.util.UUID
 /** Authorization check that grants access to all agents. */
 private val TRUE_FOR_ANY_AGENTS: (String, UUID?) -> Boolean = { _, _ -> true }
 
+/** LLM info resolver that returns null — used in tests that don't care about LLM metadata. */
+private val NO_LLM_INFO: suspend (String, UUID?) -> Pair<String?, String?>? = { _, _ -> null }
+
 /**
  * A simple recording wrapper for the runAgent callback.
  *
@@ -153,6 +156,7 @@ class CaseRuntimeSpec : StringSpec() {
                 },
                 selectAgent = selectAgent.asCallback,
                 isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                resolveAgentLlmInfo = NO_LLM_INFO,
                 runAgent = runAgent.asCallback,
             )
 
@@ -247,6 +251,7 @@ class CaseRuntimeSpec : StringSpec() {
                         )
                     },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                    resolveAgentLlmInfo = NO_LLM_INFO,
                     runAgent = { _, events, _, _, _ ->
                         agent.run(events).collect { event ->
                             savedEvents.add(event)
@@ -305,6 +310,7 @@ class CaseRuntimeSpec : StringSpec() {
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                    resolveAgentLlmInfo = NO_LLM_INFO,
                     runAgent = { _, events, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
@@ -321,6 +327,126 @@ class CaseRuntimeSpec : StringSpec() {
 
             (runningIdx >= 0) shouldBe true
             (runIdx > runningIdx) shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // resolveAgentLlmInfo: llmProvider and llmModel propagation
+        // -------------------------------------------------------------------------
+
+        "AgentRunningEvent carries llmProvider and llmModel when resolveAgentLlmInfo succeeds" {
+            // Verifies the happy path: the Pair returned by resolveAgentLlmInfo is forwarded
+            // verbatim onto the AgentRunningEvent that is stored and emitted.
+            val runtimeId = UUID.randomUUID()
+            val agentName = "my-agent"
+            val agent = finishingAgent(agentName)
+            val savedEvents = mutableListOf<CaseEvent>()
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = runtimeId,
+                namespaceId = namespaceId,
+                updateStatus = { _, _ -> },
+                storeEvent = { event ->
+                    savedEvents.add(event)
+                    event
+                },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                resolveAgentLlmInfo = { _, _ -> "anthropic" to "claude-haiku-4-5" },
+                runAgent = { _, events, _, _, _ ->
+                    agent.run(events).collect { event ->
+                        savedEvents.add(event)
+                        runtime.pushEvents(listOf(event))
+                    }
+                },
+            )
+
+            runtime.addUserMessage(userActor, userMessage)
+            runtime.run()
+
+            val runningEvent = savedEvents.filterIsInstance<AgentRunningEvent>().first()
+            runningEvent.llmProvider shouldBe "anthropic"
+            runningEvent.llmModel shouldBe "claude-haiku-4-5"
+        }
+
+        "AgentRunningEvent has null llmProvider and llmModel when resolveAgentLlmInfo throws" {
+            // Verifies degraded mode: a failure in resolveAgentLlmInfo must not block
+            // execution — the AgentRunningEvent is emitted with null fields and the agent
+            // still runs normally.
+            val runtimeId = UUID.randomUUID()
+            val agentName = "my-agent"
+            val agent = finishingAgent(agentName)
+            val savedEvents = mutableListOf<CaseEvent>()
+            var agentDidRun = false
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = runtimeId,
+                namespaceId = namespaceId,
+                updateStatus = { _, _ -> },
+                storeEvent = { event ->
+                    savedEvents.add(event)
+                    event
+                },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                resolveAgentLlmInfo = { _, _ -> throw RuntimeException("DB unavailable") },
+                runAgent = { _, events, _, _, _ ->
+                    agentDidRun = true
+                    agent.run(events).collect { event ->
+                        savedEvents.add(event)
+                        runtime.pushEvents(listOf(event))
+                    }
+                },
+            )
+
+            runtime.addUserMessage(userActor, userMessage)
+            runtime.run()
+
+            // Degraded mode: event emitted with null LLM fields
+            val runningEvent = savedEvents.filterIsInstance<AgentRunningEvent>().first()
+            runningEvent.llmProvider shouldBe null
+            runningEvent.llmModel shouldBe null
+
+            // Agent still ran despite the resolve failure
+            agentDidRun shouldBe true
+            savedEvents.filterIsInstance<AgentFinishedEvent>().size shouldBe 1
+        }
+
+        "AgentRunningEvent has null llmProvider and llmModel when resolveAgentLlmInfo returns null" {
+            // Verifies the case where the callback returns null explicitly
+            // (e.g. provider not configured) — same null propagation as a throw.
+            val runtimeId = UUID.randomUUID()
+            val agentName = "my-agent"
+            val agent = finishingAgent(agentName)
+            val savedEvents = mutableListOf<CaseEvent>()
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = runtimeId,
+                namespaceId = namespaceId,
+                updateStatus = { _, _ -> },
+                storeEvent = { event ->
+                    savedEvents.add(event)
+                    event
+                },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                resolveAgentLlmInfo = { _, _ -> null },
+                runAgent = { _, events, _, _, _ ->
+                    agent.run(events).collect { event ->
+                        savedEvents.add(event)
+                        runtime.pushEvents(listOf(event))
+                    }
+                },
+            )
+
+            runtime.addUserMessage(userActor, userMessage)
+            runtime.run()
+
+            val runningEvent = savedEvents.filterIsInstance<AgentRunningEvent>().first()
+            runningEvent.llmProvider shouldBe null
+            runningEvent.llmModel shouldBe null
         }
 
         // -------------------------------------------------------------------------
@@ -346,6 +472,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                    resolveAgentLlmInfo = NO_LLM_INFO,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
@@ -381,6 +508,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                    resolveAgentLlmInfo = NO_LLM_INFO,
                     runAgent = { _, _, _, _, shouldContinue ->
                         capturedShouldContinue = shouldContinue
                     },
@@ -415,6 +543,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                    resolveAgentLlmInfo = NO_LLM_INFO,
                     runAgent = { _, _, _, _, shouldContinue ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
@@ -507,6 +636,7 @@ class CaseRuntimeSpec : StringSpec() {
                 storeEvent = { event -> savedEvents.add(event); event },
                 selectAgent = selectAgent.asCallback,
                 isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                resolveAgentLlmInfo = NO_LLM_INFO,
                 runAgent = runAgent.asCallback,
             )
 
@@ -567,6 +697,7 @@ class CaseRuntimeSpec : StringSpec() {
                 storeEvent = { event -> savedEvents.add(event); event },
                 selectAgent = selectAgent.asCallback,
                 isAgentAuthorized = { name, _ -> name == agentA }, // agentB not authorized
+                resolveAgentLlmInfo = NO_LLM_INFO,
                 runAgent = runAgent.asCallback,
             )
 
@@ -625,6 +756,7 @@ class CaseRuntimeSpec : StringSpec() {
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                    resolveAgentLlmInfo = NO_LLM_INFO,
                     runAgent = recorder.asCallback,
                 )
             runtime.pushEvents(listOf(existingUserMessage, existingRunningEvent))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -25,9 +25,6 @@ import java.util.UUID
 /** Authorization check that grants access to all agents. */
 private val TRUE_FOR_ANY_AGENTS: (String, UUID?) -> Boolean = { _, _ -> true }
 
-/** LLM info resolver that returns null — used in tests that don't care about LLM metadata. */
-private val NO_LLM_INFO: suspend (String, UUID?) -> Pair<String?, String?>? = { _, _ -> null }
-
 /**
  * A simple recording wrapper for the runAgent callback.
  *
@@ -44,7 +41,7 @@ class RecordingRunAgent(
     val callCount: Int get() = _calls.size
 
     /** Expose as the function type [CaseRuntime] expects. */
-    val asCallback: suspend (String, List<CaseEvent>, () -> List<CaseEvent>, UUID?, () -> Boolean) -> Unit = { name, events, _, _, _ ->
+    val asCallback: suspend (String, List<CaseEvent>, () -> List<CaseEvent>, UUID?, () -> Boolean, Boolean) -> Unit = { name, events, _, _, _, _ ->
         _calls += name to events
         delegate(name, events)
     }
@@ -156,7 +153,6 @@ class CaseRuntimeSpec : StringSpec() {
                 },
                 selectAgent = selectAgent.asCallback,
                 isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                resolveAgentLlmInfo = NO_LLM_INFO,
                 runAgent = runAgent.asCallback,
             )
 
@@ -190,7 +186,7 @@ class CaseRuntimeSpec : StringSpec() {
         // Event sequence
         // -------------------------------------------------------------------------
 
-        "AgentSelectedEvent then AgentRunningEvent then AgentFinishedEvent are saved in order" {
+        "AgentSelectedEvent then AgentFinishedEvent are saved in order" {
             val (runtime, _, _, savedEvents) = buildRuntime()
 
             runtime.addUserMessage(userActor, userMessage)
@@ -198,27 +194,14 @@ class CaseRuntimeSpec : StringSpec() {
 
             val agentEvents =
                 savedEvents.filter {
-                    it is AgentSelectedEvent || it is AgentRunningEvent || it is AgentFinishedEvent
+                    it is AgentSelectedEvent || it is AgentFinishedEvent
                 }
-            agentEvents shouldHaveAtLeastSize 3
+            agentEvents shouldHaveAtLeastSize 2
             agentEvents[0].shouldBeInstanceOf<AgentSelectedEvent>()
-            agentEvents[1].shouldBeInstanceOf<AgentRunningEvent>()
-            agentEvents[2].shouldBeInstanceOf<AgentFinishedEvent>()
+            agentEvents[1].shouldBeInstanceOf<AgentFinishedEvent>()
         }
 
-        "AgentSelectedEvent and AgentRunningEvent carry the same agentId and agentName" {
-            val (runtime, _, _, savedEvents) = buildRuntime(agentName = "gemini-flash")
 
-            runtime.addUserMessage(userActor, userMessage)
-            runtime.run()
-
-            val selected = savedEvents.filterIsInstance<AgentSelectedEvent>().first()
-            val running = savedEvents.filterIsInstance<AgentRunningEvent>().first()
-
-            selected.agentName shouldBe "gemini-flash"
-            running.agentName shouldBe "gemini-flash"
-            selected.agentId shouldBe running.agentId
-        }
 
         // -------------------------------------------------------------------------
         // selectAgent returning a WarnEvent + AgentSelectedEvent
@@ -251,8 +234,7 @@ class CaseRuntimeSpec : StringSpec() {
                         )
                     },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    resolveAgentLlmInfo = NO_LLM_INFO,
-                    runAgent = { _, events, _, _, _ ->
+                    runAgent = { _, events, _, _, _, _ ->
                         agent.run(events).collect { event ->
                             savedEvents.add(event)
                             runtime.pushEvents(listOf(event))
@@ -273,7 +255,7 @@ class CaseRuntimeSpec : StringSpec() {
         // processNextStep: AgentSelectedEvent -> AgentRunningEvent ordering
         // -------------------------------------------------------------------------
 
-        "processNextStep emits AgentRunningEvent before runAgent is ever called" {
+        "processNextStep calls runAgent after AgentSelectedEvent is stored" {
             val agentName = "ordered-agent"
             val callOrder = mutableListOf<String>()
             val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
@@ -305,13 +287,12 @@ class CaseRuntimeSpec : StringSpec() {
                     namespaceId = namespaceId,
                     updateStatus = { _, _ -> },
                     storeEvent = { event ->
-                        if (event is AgentRunningEvent) callOrder.add("AgentRunningEvent saved")
+                        if (event is AgentSelectedEvent) callOrder.add("AgentSelectedEvent saved")
                         event
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    resolveAgentLlmInfo = NO_LLM_INFO,
-                    runAgent = { _, events, _, _, _ ->
+                    runAgent = { _, events, _, _, _, _ ->
                         callOrder.add("runAgent")
                         orderedAgent.run(events).collect { event ->
                             runtime.pushEvents(listOf(event))
@@ -322,136 +303,12 @@ class CaseRuntimeSpec : StringSpec() {
             runtime.addUserMessage(userActor, userMessage)
             runtime.run()
 
-            val runningIdx = callOrder.indexOf("AgentRunningEvent saved")
+            val selectedIdx = callOrder.indexOf("AgentSelectedEvent saved")
             val runIdx = callOrder.indexOf("runAgent")
 
-            (runningIdx >= 0) shouldBe true
-            (runIdx > runningIdx) shouldBe true
+            (selectedIdx >= 0) shouldBe true
+            (runIdx > selectedIdx) shouldBe true
         }
-
-        // -------------------------------------------------------------------------
-        // resolveAgentLlmInfo: llmProvider and llmModel propagation
-        // -------------------------------------------------------------------------
-
-        "AgentRunningEvent carries llmProvider and llmModel when resolveAgentLlmInfo succeeds" {
-            // Verifies the happy path: the Pair returned by resolveAgentLlmInfo is forwarded
-            // verbatim onto the AgentRunningEvent that is stored and emitted.
-            val runtimeId = UUID.randomUUID()
-            val agentName = "my-agent"
-            val agent = finishingAgent(agentName)
-            val savedEvents = mutableListOf<CaseEvent>()
-
-            lateinit var runtime: CaseRuntime
-            runtime = CaseRuntime(
-                id = runtimeId,
-                namespaceId = namespaceId,
-                updateStatus = { _, _ -> },
-                storeEvent = { event ->
-                    savedEvents.add(event)
-                    event
-                },
-                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
-                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                resolveAgentLlmInfo = { _, _ -> "anthropic" to "claude-haiku-4-5" },
-                runAgent = { _, events, _, _, _ ->
-                    agent.run(events).collect { event ->
-                        savedEvents.add(event)
-                        runtime.pushEvents(listOf(event))
-                    }
-                },
-            )
-
-            runtime.addUserMessage(userActor, userMessage)
-            runtime.run()
-
-            val runningEvent = savedEvents.filterIsInstance<AgentRunningEvent>().first()
-            runningEvent.llmProvider shouldBe "anthropic"
-            runningEvent.llmModel shouldBe "claude-haiku-4-5"
-        }
-
-        "AgentRunningEvent has null llmProvider and llmModel when resolveAgentLlmInfo throws" {
-            // Verifies degraded mode: a failure in resolveAgentLlmInfo must not block
-            // execution — the AgentRunningEvent is emitted with null fields and the agent
-            // still runs normally.
-            val runtimeId = UUID.randomUUID()
-            val agentName = "my-agent"
-            val agent = finishingAgent(agentName)
-            val savedEvents = mutableListOf<CaseEvent>()
-            var agentDidRun = false
-
-            lateinit var runtime: CaseRuntime
-            runtime = CaseRuntime(
-                id = runtimeId,
-                namespaceId = namespaceId,
-                updateStatus = { _, _ -> },
-                storeEvent = { event ->
-                    savedEvents.add(event)
-                    event
-                },
-                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
-                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                resolveAgentLlmInfo = { _, _ -> throw RuntimeException("DB unavailable") },
-                runAgent = { _, events, _, _, _ ->
-                    agentDidRun = true
-                    agent.run(events).collect { event ->
-                        savedEvents.add(event)
-                        runtime.pushEvents(listOf(event))
-                    }
-                },
-            )
-
-            runtime.addUserMessage(userActor, userMessage)
-            runtime.run()
-
-            // Degraded mode: event emitted with null LLM fields
-            val runningEvent = savedEvents.filterIsInstance<AgentRunningEvent>().first()
-            runningEvent.llmProvider shouldBe null
-            runningEvent.llmModel shouldBe null
-
-            // Agent still ran despite the resolve failure
-            agentDidRun shouldBe true
-            savedEvents.filterIsInstance<AgentFinishedEvent>().size shouldBe 1
-        }
-
-        "AgentRunningEvent has null llmProvider and llmModel when resolveAgentLlmInfo returns null" {
-            // Verifies the case where the callback returns null explicitly
-            // (e.g. provider not configured) — same null propagation as a throw.
-            val runtimeId = UUID.randomUUID()
-            val agentName = "my-agent"
-            val agent = finishingAgent(agentName)
-            val savedEvents = mutableListOf<CaseEvent>()
-
-            lateinit var runtime: CaseRuntime
-            runtime = CaseRuntime(
-                id = runtimeId,
-                namespaceId = namespaceId,
-                updateStatus = { _, _ -> },
-                storeEvent = { event ->
-                    savedEvents.add(event)
-                    event
-                },
-                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, agentName)) },
-                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                resolveAgentLlmInfo = { _, _ -> null },
-                runAgent = { _, events, _, _, _ ->
-                    agent.run(events).collect { event ->
-                        savedEvents.add(event)
-                        runtime.pushEvents(listOf(event))
-                    }
-                },
-            )
-
-            runtime.addUserMessage(userActor, userMessage)
-            runtime.run()
-
-            val runningEvent = savedEvents.filterIsInstance<AgentRunningEvent>().first()
-            runningEvent.llmProvider shouldBe null
-            runningEvent.llmModel shouldBe null
-        }
-
-        // -------------------------------------------------------------------------
-        // AgentRunningEvent already in history (case resumed mid-run)
-        // -------------------------------------------------------------------------
 
         // -------------------------------------------------------------------------
         // shouldContinue lambda contract
@@ -472,8 +329,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    resolveAgentLlmInfo = NO_LLM_INFO,
-                    runAgent = { _, _, _, _, shouldContinue ->
+                    runAgent = { _, _, _, _, shouldContinue, _ ->
                         capturedShouldContinue = shouldContinue
                         // Simulate a long-running agent: don't push AgentFinishedEvent
                         // so we can inspect shouldContinue before the loop exits naturally.
@@ -508,8 +364,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    resolveAgentLlmInfo = NO_LLM_INFO,
-                    runAgent = { _, _, _, _, shouldContinue ->
+                    runAgent = { _, _, _, _, shouldContinue, _ ->
                         capturedShouldContinue = shouldContinue
                     },
                 )
@@ -543,8 +398,7 @@ class CaseRuntimeSpec : StringSpec() {
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    resolveAgentLlmInfo = NO_LLM_INFO,
-                    runAgent = { _, _, _, _, shouldContinue ->
+                    runAgent = { _, _, _, _, shouldContinue, _ ->
                         // Sample BEFORE pushing AgentFinishedEvent: interruptRequested is
                         // still false at this point, so shouldContinue() must return true.
                         lambdaResultDuringRun = shouldContinue()
@@ -636,8 +490,7 @@ class CaseRuntimeSpec : StringSpec() {
                 storeEvent = { event -> savedEvents.add(event); event },
                 selectAgent = selectAgent.asCallback,
                 isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                resolveAgentLlmInfo = NO_LLM_INFO,
-                runAgent = runAgent.asCallback,
+                    runAgent = runAgent.asCallback,
             )
 
             runtime.addUserMessage(userActor, userMessage)
@@ -697,8 +550,7 @@ class CaseRuntimeSpec : StringSpec() {
                 storeEvent = { event -> savedEvents.add(event); event },
                 selectAgent = selectAgent.asCallback,
                 isAgentAuthorized = { name, _ -> name == agentA }, // agentB not authorized
-                resolveAgentLlmInfo = NO_LLM_INFO,
-                runAgent = runAgent.asCallback,
+                    runAgent = runAgent.asCallback,
             )
 
             runtime.addUserMessage(userActor, userMessage)
@@ -756,7 +608,6 @@ class CaseRuntimeSpec : StringSpec() {
                     },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                    resolveAgentLlmInfo = NO_LLM_INFO,
                     runAgent = recorder.asCallback,
                 )
             runtime.pushEvents(listOf(existingUserMessage, existingRunningEvent))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -11,7 +11,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentService
-import io.whozoss.agentos.agent.ResolvedAgentDefinition
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
@@ -21,9 +20,6 @@ import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
-import io.whozoss.agentos.sdk.aiProvider.AiApiType
-import io.whozoss.agentos.sdk.aiProvider.AiModel
-import io.whozoss.agentos.sdk.aiProvider.AiProvider
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
@@ -50,31 +46,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import java.util.UUID
-
-/** Minimal [ResolvedAgentDefinition] stub for tests that run an agent but do not assert on LLM metadata. */
-private fun stubDefinition(
-    agentName: String,
-    namespaceId: UUID,
-): ResolvedAgentDefinition {
-    val providerId = UUID.nameUUIDFromBytes("stub-provider".toByteArray())
-    val modelId = UUID.nameUUIDFromBytes("stub-model".toByteArray())
-    return ResolvedAgentDefinition(
-        agentConfigId = UUID.nameUUIDFromBytes(agentName.toByteArray()),
-        name = agentName,
-        systemPrompt = null,
-        instructions = null,
-        resolvedModelApiName = "stub-model",
-        resolvedProviderName = "stub-provider",
-        resolvedModelId = modelId,
-        resolvedProviderId = providerId,
-        resolvedModel = AiModel(aiProviderId = providerId, apiModelName = "stub-model"),
-        resolvedProvider = AiProvider(name = "stub-provider", apiType = AiApiType.Anthropic),
-        tools = emptyList(),
-        advancedExecution = false,
-        namespaceId = namespaceId,
-        userId = null,
-    )
-}
 
 /**
  * Suspends until [runtime]'s SSE flow has at least [count] active subscribers.
@@ -220,7 +191,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns agent
-                    coEvery { resolveDefinitionByName(agentName, any()) } answers { stubDefinition(agentName, namespaceId) }
+                    every { resolveModelInfo(agentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
@@ -352,30 +323,11 @@ class CaseServiceImplSpec :
                     defaultAgentName = agentName,
                 )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
-            val providerId = UUID.randomUUID()
-            val modelId = UUID.randomUUID()
-            val resolvedDefinition =
-                ResolvedAgentDefinition(
-                    agentConfigId = agentId,
-                    name = agentName,
-                    systemPrompt = null,
-                    instructions = null,
-                    resolvedModelApiName = "claude-haiku-4-5",
-                    resolvedProviderName = "anthropic",
-                    resolvedModelId = modelId,
-                    resolvedProviderId = providerId,
-                    resolvedModel = AiModel(aiProviderId = providerId, apiModelName = "claude-haiku-4-5"),
-                    resolvedProvider = AiProvider(name = "anthropic", apiType = AiApiType.Anthropic),
-                    tools = emptyList(),
-                    advancedExecution = false,
-                    namespaceId = namespaceId,
-                    userId = null,
-                )
             val agentService =
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
-                    coEvery { resolveDefinitionByName(agentName, any()) } returns resolvedDefinition
+                    every { resolveModelInfo(agentName, any(), any()) } returns ("anthropic" to "claude-haiku-4-5")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -596,7 +548,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns chunkingAgent
-                    coEvery { resolveDefinitionByName(agentName, any()) } answers { stubDefinition(agentName, namespaceId) }
+                    every { resolveModelInfo(agentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -693,7 +645,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
-                    coEvery { resolveDefinitionByName(agentName, any()) } answers { stubDefinition(agentName, namespaceId) }
+                    every { resolveModelInfo(agentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -760,7 +712,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(namespaceDefaultName, namespaceId, any()) } returns namespaceDefaultName
                     coEvery { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
-                    coEvery { resolveDefinitionByName(namespaceDefaultName, any()) } answers { stubDefinition(namespaceDefaultName, namespaceId) }
+                    every { resolveModelInfo(namespaceDefaultName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -936,7 +888,7 @@ class CaseServiceImplSpec :
                     }
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(any(), any()) } returns finishingAgent()
-                    coEvery { resolveDefinitionByName(any(), any()) } answers { stubDefinition(firstArg(), namespaceId) }
+                    every { resolveModelInfo(any(), any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -1035,7 +987,7 @@ class CaseServiceImplSpec :
                     every { resolveAgentName(selectedAgentName, any(), any()) } returns selectedAgentName
                     // no other mention resolution needed
                     coEvery { findAgentByName(selectedAgentName, any()) } returns selectedAgent
-                    coEvery { resolveDefinitionByName(selectedAgentName, any()) } answers { stubDefinition(selectedAgentName, namespaceId) }
+                    every { resolveModelInfo(selectedAgentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
@@ -1128,7 +1080,7 @@ class CaseServiceImplSpec :
                     // Only `inspector` resolves — the full string with URL must NOT be passed here
                     coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
                     coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
-                    coEvery { resolveDefinitionByName(inspectorName, any()) } answers { stubDefinition(inspectorName, namespaceId) }
+                    every { resolveModelInfo(inspectorName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -1200,7 +1152,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
                     coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
-                    coEvery { resolveDefinitionByName(inspectorName, any()) } answers { stubDefinition(inspectorName, namespaceId) }
+                    every { resolveModelInfo(inspectorName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -11,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentService
+import io.whozoss.agentos.agent.ResolvedAgentDefinition
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
@@ -20,6 +21,9 @@ import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
+import io.whozoss.agentos.sdk.aiProvider.AiApiType
+import io.whozoss.agentos.sdk.aiProvider.AiModel
+import io.whozoss.agentos.sdk.aiProvider.AiProvider
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
@@ -46,6 +50,31 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import java.util.UUID
+
+/** Minimal [ResolvedAgentDefinition] stub for tests that run an agent but do not assert on LLM metadata. */
+private fun stubDefinition(
+    agentName: String,
+    namespaceId: UUID,
+): ResolvedAgentDefinition {
+    val providerId = UUID.nameUUIDFromBytes("stub-provider".toByteArray())
+    val modelId = UUID.nameUUIDFromBytes("stub-model".toByteArray())
+    return ResolvedAgentDefinition(
+        agentConfigId = UUID.nameUUIDFromBytes(agentName.toByteArray()),
+        name = agentName,
+        systemPrompt = null,
+        instructions = null,
+        resolvedModelApiName = "stub-model",
+        resolvedProviderName = "stub-provider",
+        resolvedModelId = modelId,
+        resolvedProviderId = providerId,
+        resolvedModel = AiModel(aiProviderId = providerId, apiModelName = "stub-model"),
+        resolvedProvider = AiProvider(name = "stub-provider", apiType = AiApiType.Anthropic),
+        tools = emptyList(),
+        advancedExecution = false,
+        namespaceId = namespaceId,
+        userId = null,
+    )
+}
 
 /**
  * Suspends until [runtime]'s SSE flow has at least [count] active subscribers.
@@ -191,6 +220,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns agent
+                    coEvery { resolveDefinitionByName(agentName, any()) } answers { stubDefinition(agentName, namespaceId) }
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
@@ -322,10 +352,30 @@ class CaseServiceImplSpec :
                     defaultAgentName = agentName,
                 )
             val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            val providerId = UUID.randomUUID()
+            val modelId = UUID.randomUUID()
+            val resolvedDefinition =
+                ResolvedAgentDefinition(
+                    agentConfigId = agentId,
+                    name = agentName,
+                    systemPrompt = null,
+                    instructions = null,
+                    resolvedModelApiName = "claude-haiku-4-5",
+                    resolvedProviderName = "anthropic",
+                    resolvedModelId = modelId,
+                    resolvedProviderId = providerId,
+                    resolvedModel = AiModel(aiProviderId = providerId, apiModelName = "claude-haiku-4-5"),
+                    resolvedProvider = AiProvider(name = "anthropic", apiType = AiApiType.Anthropic),
+                    tools = emptyList(),
+                    advancedExecution = false,
+                    namespaceId = namespaceId,
+                    userId = null,
+                )
             val agentService =
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
+                    coEvery { resolveDefinitionByName(agentName, any()) } returns resolvedDefinition
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -365,7 +415,9 @@ class CaseServiceImplSpec :
             agentEvents shouldHaveAtLeastSize 4
             agentEvents[0].shouldBeInstanceOf<MessageEvent>()
             agentEvents[1].shouldBeInstanceOf<AgentSelectedEvent>()
-            agentEvents[2].shouldBeInstanceOf<AgentRunningEvent>()
+            val runningEvent = agentEvents[2].shouldBeInstanceOf<AgentRunningEvent>()
+            runningEvent.llmProvider shouldBe "anthropic"
+            runningEvent.llmModel shouldBe "claude-haiku-4-5"
             agentEvents[3].shouldBeInstanceOf<AgentFinishedEvent>()
             // isAgentAuthorized called once for the AgentSelectedEvent -> AgentRunningEvent transition
             verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
@@ -544,6 +596,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns chunkingAgent
+                    coEvery { resolveDefinitionByName(agentName, any()) } answers { stubDefinition(agentName, namespaceId) }
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -640,6 +693,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
+                    coEvery { resolveDefinitionByName(agentName, any()) } answers { stubDefinition(agentName, namespaceId) }
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -706,6 +760,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(namespaceDefaultName, namespaceId, any()) } returns namespaceDefaultName
                     coEvery { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
+                    coEvery { resolveDefinitionByName(namespaceDefaultName, any()) } answers { stubDefinition(namespaceDefaultName, namespaceId) }
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -881,6 +936,7 @@ class CaseServiceImplSpec :
                     }
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(any(), any()) } returns finishingAgent()
+                    coEvery { resolveDefinitionByName(any(), any()) } answers { stubDefinition(firstArg(), namespaceId) }
                 }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -979,6 +1035,7 @@ class CaseServiceImplSpec :
                     every { resolveAgentName(selectedAgentName, any(), any()) } returns selectedAgentName
                     // no other mention resolution needed
                     coEvery { findAgentByName(selectedAgentName, any()) } returns selectedAgent
+                    coEvery { resolveDefinitionByName(selectedAgentName, any()) } answers { stubDefinition(selectedAgentName, namespaceId) }
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
@@ -1071,6 +1128,7 @@ class CaseServiceImplSpec :
                     // Only `inspector` resolves — the full string with URL must NOT be passed here
                     coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
                     coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
+                    coEvery { resolveDefinitionByName(inspectorName, any()) } answers { stubDefinition(inspectorName, namespaceId) }
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -1142,6 +1200,7 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
                     coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
+                    coEvery { resolveDefinitionByName(inspectorName, any()) } answers { stubDefinition(inspectorName, namespaceId) }
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -139,6 +139,9 @@ class CaseServiceImplSpec :
             mockk<Agent> {
                 every { metadata } returns EntityMetadata(id = agentId)
                 every { name } returns agentName
+                every { id } returns agentId
+                every { llmProvider } returns "test-provider"
+                every { llmModel } returns "test-model"
                 every { run(any<List<CaseEvent>>(), any()) } answers {
                     val caseId = firstArg<List<CaseEvent>>().first().caseId
                     flow {
@@ -191,7 +194,6 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns agent
-                    every { resolveModelInfo(agentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
@@ -226,6 +228,9 @@ class CaseServiceImplSpec :
                 mockk<Agent> {
                     every { metadata } returns EntityMetadata(id = agentId)
                     every { name } returns agentName
+                    every { id } returns agentId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         runCallCount++
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
@@ -327,7 +332,6 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(any(), any(), any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
-                    every { resolveModelInfo(agentName, any(), any()) } returns ("anthropic" to "claude-haiku-4-5")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -367,9 +371,7 @@ class CaseServiceImplSpec :
             agentEvents shouldHaveAtLeastSize 4
             agentEvents[0].shouldBeInstanceOf<MessageEvent>()
             agentEvents[1].shouldBeInstanceOf<AgentSelectedEvent>()
-            val runningEvent = agentEvents[2].shouldBeInstanceOf<AgentRunningEvent>()
-            runningEvent.llmProvider shouldBe "anthropic"
-            runningEvent.llmModel shouldBe "claude-haiku-4-5"
+            agentEvents[2].shouldBeInstanceOf<AgentRunningEvent>()
             agentEvents[3].shouldBeInstanceOf<AgentFinishedEvent>()
             // isAgentAuthorized called once for the AgentSelectedEvent -> AgentRunningEvent transition
             verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
@@ -526,6 +528,9 @@ class CaseServiceImplSpec :
                 mockk<Agent> {
                     every { metadata } returns EntityMetadata(id = agentId)
                     every { name } returns agentName
+                    every { id } returns agentId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
                         flow {
@@ -548,7 +553,6 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns chunkingAgent
-                    every { resolveModelInfo(agentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -645,7 +649,6 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(agentName, any()) } returns finishingAgent()
-                    every { resolveModelInfo(agentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -694,6 +697,9 @@ class CaseServiceImplSpec :
                 mockk<Agent> {
                     every { metadata } returns EntityMetadata(id = namespaceAgentId)
                     every { name } returns namespaceDefaultName
+                    every { id } returns namespaceAgentId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
                         flow {
@@ -712,7 +718,6 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     every { resolveAgentName(namespaceDefaultName, namespaceId, any()) } returns namespaceDefaultName
                     coEvery { findAgentByName(namespaceDefaultName, any()) } returns namespaceAgent
-                    every { resolveModelInfo(namespaceDefaultName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -888,7 +893,6 @@ class CaseServiceImplSpec :
                     }
                     every { resolveAgentName(agentName, namespaceId, any()) } returns agentName
                     coEvery { findAgentByName(any(), any()) } returns finishingAgent()
-                    every { resolveModelInfo(any(), any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userServiceMock = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -958,6 +962,9 @@ class CaseServiceImplSpec :
                 mockk<Agent> {
                     every { metadata } returns EntityMetadata(id = selectedAgentId)
                     every { name } returns selectedAgentName
+                    every { id } returns selectedAgentId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         agentCallNames.add(selectedAgentName)
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
@@ -987,7 +994,6 @@ class CaseServiceImplSpec :
                     every { resolveAgentName(selectedAgentName, any(), any()) } returns selectedAgentName
                     // no other mention resolution needed
                     coEvery { findAgentByName(selectedAgentName, any()) } returns selectedAgent
-                    every { resolveModelInfo(selectedAgentName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val caseRepository = InMemoryCaseRepository()
             val caseEventService = CaseEventServiceImpl(InMemoryCaseEventRepository())
@@ -1061,6 +1067,9 @@ class CaseServiceImplSpec :
                 mockk<Agent> {
                     every { metadata } returns EntityMetadata(id = inspectorId)
                     every { name } returns inspectorName
+                    every { id } returns inspectorId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
                         flow {
@@ -1080,7 +1089,6 @@ class CaseServiceImplSpec :
                     // Only `inspector` resolves — the full string with URL must NOT be passed here
                     coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
                     coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
-                    every { resolveModelInfo(inspectorName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -1134,6 +1142,9 @@ class CaseServiceImplSpec :
                 mockk<Agent> {
                     every { metadata } returns EntityMetadata(id = inspectorId)
                     every { name } returns inspectorName
+                    every { id } returns inspectorId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
                         flow {
@@ -1152,7 +1163,6 @@ class CaseServiceImplSpec :
                 mockk<AgentService> {
                     coEvery { resolveAgentName(inspectorName, namespaceId, any()) } returns inspectorName
                     coEvery { findAgentByName(inspectorName, any()) } returns inspectorAgent
-                    every { resolveModelInfo(inspectorName, any(), any()) } returns ("stub-provider" to "stub-model")
                 }
             val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
             val service =
@@ -1193,6 +1203,9 @@ class CaseServiceImplSpec :
                 mockk<Agent> {
                     every { metadata } returns EntityMetadata(id = agentId)
                     every { name } returns agentName
+                    every { id } returns agentId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         runCallCount++
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
@@ -1244,5 +1257,120 @@ class CaseServiceImplSpec :
             runCallCount shouldBe 2
             service.getById(case.id).status shouldBe CaseStatus.IDLE
             verify(exactly = 2) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, agentName) }
+        }
+
+        // -------------------------------------------------------------------------
+        // Rehydration: crash recovery from persisted AgentRunningEvent
+        // -------------------------------------------------------------------------
+
+        "rehydrated case with AgentRunningEvent as last event runs agent exactly once and reaches IDLE" {
+            // Regression: when a case is rehydrated from persistence after a crash,
+            // the last persisted event may be an AgentRunningEvent (emitted by runAgent
+            // before agent.run()). processNextStep finds it and calls runAgent, which
+            // now emits ANOTHER AgentRunningEvent. After the agent finishes, the second
+            // AgentRunningEvent could be found by the next processNextStep iteration
+            // (it's newer than AgentFinishedEvent), causing an infinite loop.
+            //
+            // Expected: the agent runs exactly once, no infinite loop, case reaches IDLE.
+
+            var runCallCount = 0
+            val countingAgent =
+                mockk<Agent> {
+                    every { id } returns agentId
+                    every { metadata } returns EntityMetadata(id = agentId)
+                    every { name } returns agentName
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        runCallCount++
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = agentId,
+                                    agentName = agentName,
+                                ),
+                            )
+                        }
+                    }
+                }
+
+            // Build the service with a pre-existing case that has events simulating a crash
+            // after AgentRunningEvent was emitted but before AgentFinishedEvent.
+            val caseEventRepo = InMemoryCaseEventRepository()
+            val caseEventService = CaseEventServiceImpl(caseEventRepo)
+            val caseRepository = InMemoryCaseRepository()
+            val namespace =
+                Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-namespace",
+                    defaultAgentName = agentName,
+                )
+            val namespaceService = mockk<NamespaceService> { every { findById(namespaceId) } returns namespace }
+            val agentService =
+                mockk<AgentService> {
+                    every { resolveAgentName(any(), any(), any()) } returns agentName
+                    coEvery { findAgentByName(agentName, any()) } returns countingAgent
+                }
+            val userService = mockk<UserService> { every { findById(userId) } returns activeUser }
+            val service =
+                CaseServiceImpl(
+                    agentService,
+                    allowAllAgentConfigService,
+                    AgentConfigProperties(),
+                    caseRepository,
+                    caseEventService,
+                    userService,
+                    namespaceService,
+                )
+
+            // Insert the case directly into the repository so no runtime is created in
+            // activeRuntimes. The subsequent getCaseRuntime() call will then trigger
+            // rehydrate(), which loads the pre-populated events from the event store
+            // and passes them as inputEvents to buildRuntime().
+            val case = Case(namespaceId = namespaceId, status = CaseStatus.RUNNING)
+            caseRepository.save(case)
+
+            // Pre-populate events as if the case crashed after AgentRunningEvent
+            val existingMessage = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            val existingSelected = AgentSelectedEvent(
+                namespaceId = namespaceId,
+                caseId = case.id,
+                agentId = agentId,
+                agentName = agentName,
+            )
+            val existingRunning = AgentRunningEvent(
+                namespaceId = namespaceId,
+                caseId = case.id,
+                agentId = agentId,
+                agentName = agentName,
+                llmProvider = "test-provider",
+                llmModel = "test-model",
+            )
+            caseEventService.create(existingMessage)
+            caseEventService.create(existingSelected)
+            caseEventService.create(existingRunning)
+
+            // Rehydrate: getCaseRuntime loads past events from the event store
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE, CaseStatus.ERROR)
+            awaitSubscribers(runtime)
+
+            // Trigger the run loop — no new message, just resume from persisted state
+            runtime.run()
+
+            awaiter.join()
+
+            runCallCount shouldBe 1
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
         }
     })

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -2381,6 +2381,10 @@ components:
             format: uuid
           agentName:
             type: string
+          llmModel:
+            type: string
+          llmProvider:
+            type: string
       required:
       - agentId
       - agentName

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -2400,6 +2400,10 @@ components:
             format: uuid
           agentName:
             type: string
+          llmModel:
+            type: string
+          llmProvider:
+            type: string
       required:
       - agentId
       - agentName


### PR DESCRIPTION
## Problem

`AgentRunningEvent` and `AgentFinishedEvent` carried no LLM metadata, impossible to trace which provider/model handled each agent run.

## Solution

Add `llmProvider: String? = null` and `llmModel: String? = null` to both events. Add `llmProvider: String` and `llmModel: String` to the `Agent` interface, populated at construction from resolved overlays.

```
User: "hello"
├── AgentRunningEvent  { Coday,    anthropic, claude-sonnet-4-20250514 }
├── AgentFinishedEvent { Coday,    anthropic, claude-sonnet-4-20250514 }
├── AgentRunningEvent  { Searchay, anthropic, claude-haiku-4-5 }
├── AgentFinishedEvent { Searchay, anthropic, claude-haiku-4-5 }
└── IDLE
```

## Key architectural change

`AgentRunningEvent` emission moved from `CaseRuntime` to `CaseServiceImpl.runAgent()`, **after** agent instantiation. The agent already carries resolved `llmProvider`/`llmModel`, no separate resolution callback needed. 

`CaseRuntime.processNextStep` now calls `runAgent` directly for both handlers.
`runAgent` inspects the event history to decide whether to emit `AgentRunningEvent`:
emits when `AgentSelectedEvent` is more recent than `AgentRunningEvent` (fresh run),
skips when `AgentRunningEvent` is already the most recent (rehydration after crash).

## Changes

### SDK
- **`Agent.kt`**: `val llmProvider: String`, `val llmModel: String`
- **`CaseEvent.kt`**: `llmProvider`/`llmModel` on `AgentRunningEvent` and `AgentFinishedEvent`

### Runtime & service
- **`CaseRuntime.kt`**: `AgentSelectedEvent`/`AgentRunningEvent` handlers both call `runAgent` directly; 
- **`CaseServiceImpl.kt`**: `runAgent` emits `AgentRunningEvent` from agent fields, guarded by event history inspection (last `AgentSelectedEvent` vs last `AgentRunningEvent` position)

### Agents
- **`AgentSimple.kt`** / **`AgentAdvanced.kt`**: constructor params `llmProviderName`/`llmModelApiName`, implement `Agent.llmProvider`/`llmModel`, populate every `AgentFinishedEvent`
- **`AgentServiceImpl.kt`**: passes provider/model names to constructors

### Persistence
- **`CaseEventNode.kt`** / **`CaseEventNodeMapper.kt`**: `llmProvider`/`llmModel` on both event node types, `toDomain`/`fromDomain`/`withRemoved` updated

### Tests
- **`CaseServiceImplSpec.kt`**: all mock agents stubbed with `id`/`llmProvider`/`llmModel`; two rehydration tests (crash after `AgentSelectedEvent`, crash after `AgentRunningEvent`)
- **`CaseRuntimeSpec.kt`**: `runAgent` callback updated with `skipRunningEvent`
- **`AgentAdvancedSpec.kt`** / **`AgentSimple*Spec.kt`**: constructors updated

## Backward compatibility

Event fields default to `null` — existing Neo4j nodes deserialize without migration. `Agent.llmProvider`/`llmModel` are non-nullable, always resolved at construction. Agent resolution is always performed; only `AgentRunningEvent` emission is conditional.