### PR TITLE
chore: upgrade GitHub Actions to node24-native versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,23 +29,23 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://${{ vars.NPM_REGISTRY }}'
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -97,26 +97,25 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.release.outputs.release_sha }}
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
-          cache: 'gradle'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -212,15 +211,15 @@ jobs:
     outputs:
       projects: ${{ steps.resolve.outputs.projects }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.release.outputs.release_sha }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -253,22 +252,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.release.outputs.release_sha }}
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: 'gradle'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,7 +66,7 @@ jobs:
       # nx affected cannot be used directly with --projects="tag:platform:jvm" because the tag filter
       # gets forwarded to the underlying Gradle/Jest commands as an unknown flag, causing build failures.
       # Instead, we resolve the affected JVM project names first via nx show projects, then pass the
-      # explicit names to nx run-many (which does not forward them to executors)
+      # explicit names to nx run-many (which does not forward them to executors).
       - name: Build and test JVM projects
         run: |
           AFFECTED_JVM=$(npx nx show projects --affected --base=origin/${GITHUB_BASE_REF} --head=HEAD --projects="tag:platform:jvm" --json --quiet | jq -r 'join(",")')

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,7 +66,7 @@ jobs:
       # nx affected cannot be used directly with --projects="tag:platform:jvm" because the tag filter
       # gets forwarded to the underlying Gradle/Jest commands as an unknown flag, causing build failures.
       # Instead, we resolve the affected JVM project names first via nx show projects, then pass the
-      # explicit names to nx run-many (which does not forward them to executors).
+      # explicit names to nx run-many (which does not forward them to executors)
       - name: Build and test JVM projects
         run: |
           AFFECTED_JVM=$(npx nx show projects --affected --base=origin/${GITHUB_BASE_REF} --head=HEAD --projects="tag:platform:jvm" --json --quiet | jq -r 'join(",")')

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,16 +16,16 @@ jobs:
   validate-ts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           filter: tree:0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -39,23 +39,23 @@ jobs:
   validate-jvm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           filter: tree:0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: 'gradle'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'


### PR DESCRIPTION
Upgrade all GitHub Actions to versions that run natively on Node 24, eliminating the Node 20 deprecation warnings introduced on June 16, 2026.

- `actions/checkout` v4 → v5
- `actions/setup-node` v4 → v5
- `actions/setup-java` v4 → v5
- `pnpm/action-setup` v4 → v6

Also removes `cache: 'gradle'` from the `desktop-release` job's `setup-java` step, which was causing a spurious cache path error since that job never invokes Gradle directly.