### PR TITLE
fix: wz-32561 add force stop intention to avoid execution hallucination

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.whozoss.agentos.agent.AgentIntentionGenerator.Companion.ANSWER_TOOL
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
@@ -133,7 +134,22 @@ class AgentAdvanced(
                         // and can escalate to ForceStop if the loop persists.
                         accumulatedEvents.add(warnEvent)
                     }
-                    if (repetitionOutcome is RepetitionOutcome.ForceStop) break
+                    if (repetitionOutcome is RepetitionOutcome.ForceStop) {
+                        val forceStopIntention =
+                            IntentionGeneratedEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                agentId = context.agentId,
+                                intention = "Previous tool execution was stopped due to too many repetitions, the operation is not completed.",
+                                toolName = ANSWER_TOOL,
+                                isFailedIntention = false,
+                            )
+                        emit(
+                            forceStopIntention,
+                        )
+                        lastIntention = forceStopIntention
+                        break
+                    }
 
                     val intention =
                         intentionGenerator.generate(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -2773,7 +2773,8 @@ class AgentAdvancedSpec :
             //   iteration THRESHOLD: window has THRESHOLD identical → Warned
             //   iteration THRESHOLD+1: window still has ≥THRESHOLD identical → count > THRESHOLD → ForceStop
             // The loop must exit WITHOUT calling intentionGenerator again and must emit
-            // a second WarnEvent containing the force-stop message.
+            // a WarnEvent containing the force-stop message, an IntentionGeneratedEvent with
+            // toolName=Answer (the force-stop intention), and then a final generated response.
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
             val agentId = UUID.randomUUID()
@@ -2835,6 +2836,27 @@ class AgentAdvancedSpec :
             val warnEvents = events.filterIsInstance<WarnEvent>()
             warnEvents shouldHaveSize 1
             warnEvents[0].message shouldContain "Forcing loop termination"
+
+            // A synthetic IntentionGeneratedEvent with toolName=Answer must be emitted
+            // so that generateFinalResponse is called and can explain the forced stop to the user.
+            val intentionEvents = events.filterIsInstance<IntentionGeneratedEvent>()
+            val forceStopIntention = intentionEvents.last()
+            forceStopIntention.toolName shouldBe AgentIntentionGenerator.ANSWER_TOOL
+            forceStopIntention.intention shouldContain "repetitions"
+            forceStopIntention.isFailedIntention shouldBe false
+
+            // generateFinalResponse must have been called: a TextChunkEvent and MessageEvent
+            // are produced from the mocked streaming response.
+            events.filterIsInstance<TextChunkEvent>() shouldHaveSize 1
+            events.filterIsInstance<TextChunkEvent>()[0].chunk shouldBe "Forced stop."
+            val agentMessages = events.filterIsInstance<MessageEvent>().filter { it.actor.role == ActorRole.AGENT }
+            agentMessages shouldHaveSize 1
+            (agentMessages[0].content.first() as MessageContent.Text).content shouldBe "Forced stop."
+
+            // The WarnEvent must appear before the force-stop IntentionGeneratedEvent.
+            val warnIdx = events.indexOf(warnEvents[0])
+            val intentionIdx = events.indexOf(forceStopIntention)
+            (warnIdx < intentionIdx) shouldBe true
 
             // The run must have terminated cleanly with AgentFinishedEvent.
             events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1


### PR DESCRIPTION
**When the repetition guard triggers a force-stop, set `lastIntention` to a synthetic `IntentionGeneratedEvent` (toolName=`Answer`) describing the loop problem before breaking out of the iteration loop. This ensures `generateFinalResponse` receives an accurate analysis context and produces a grounded explanation to the user, rather than hallucinating a successful outcome.**