### PR TITLE
feat: wz-32484 unify confirmationMode into single getConfirmationMode() entry point

### DIFF
--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/RemoveFileTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/RemoveFileTool.kt
@@ -44,7 +44,7 @@ class RemoveFileTool(
     override val paramType: Class<Input> = Input::class.java
 
     // File deletion is irreversible — implicit consent must never be trusted.
-    override val confirmationMode: ConfirmationMode = ConfirmationMode.EVERY_TIME
+    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) = ConfirmationMode.EVERY_TIME
 
     // language=JSON
     override val inputSchema: String =

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/RemoveFileToolSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/RemoveFileToolSpec.kt
@@ -111,9 +111,9 @@ class RemoveFileToolSpec : StringSpec() {
             file.exists() shouldBe true
         }
 
-        "confirmationMode is EVERY_TIME (implicit consent never trusted)" {
+        "getConfirmationMode returns EVERY_TIME (implicit consent never trusted)" {
             val tool = RemoveFileTool(tempDir)
-            tool.confirmationMode shouldBe ConfirmationMode.EVERY_TIME
+            tool.getConfirmationMode() shouldBe ConfirmationMode.EVERY_TIME
         }
     }
 }

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/StandardTool.kt
@@ -53,18 +53,17 @@ interface StandardTool<T> {
 
     // ─── User-confirmation opt-in (WZ-31596) ───────────────────────────────────────────────
     //
-    // A tool opts in to the confirmation flow by setting [confirmationMode] to a value
-    // other than [ConfirmationMode.NONE]. The orchestrator then routes via the
+    // A tool opts in to the confirmation flow by overriding [getConfirmationMode] to return
+    // a value other than [ConfirmationMode.NONE]. The orchestrator then routes via the
     // [PendingConfirmationEvent] persistence cycle and calls [executeWithJson]
     // (post-confirmation) or [onRejected] (post-refusal).
     //
-    // When [confirmationMode] is [ConfirmationMode.NONE] (the default), the tool runs
+    // When [getConfirmationMode] returns [ConfirmationMode.NONE] (the default), the tool runs
     // through its standard [execute] path — same as a tool that never opted in.
 
     /**
-     * Static fallback for the confirmation mode. Read directly only by tools that
-     * don't need dynamic resolution. The orchestrator reads via [getConfirmationMode]
-     * which defaults to this value.
+     * Resolution of the confirmation mode. The orchestrator calls this with the proposed args
+     * and current case events before deciding whether to gate the tool call.
      *
      * - [ConfirmationMode.NONE]: no confirmation required — tool executes directly (default).
      * - [ConfirmationMode.INFER]: confirmation required, but the orchestrator may skip
@@ -72,18 +71,16 @@ interface StandardTool<T> {
      *   (via [ConfirmationManager.shouldConfirm]).
      * - [ConfirmationMode.EVERY_TIME]: confirmation required on every call; implicit consent
      *   is never trusted. Use this for irreversible side-effects (e.g. file deletion).
-     */
-    val confirmationMode: ConfirmationMode get() = ConfirmationMode.NONE
-
-    /**
-     * Dynamic resolution of the confirmation mode. The orchestrator calls this with the
-     * proposed args and current case events before deciding whether to gate the tool call.
-     * Override to compute the mode from business logic — e.g. inspect prior tool calls in
-     * [ToolContext.caseEvents] to bypass confirmation when an in-session create makes a
-     * follow-up update implicit.
      *
-     * Default delegates to the static [confirmationMode] for backward compatibility:
-     * existing plugins that only override [confirmationMode] keep working without change.
+     * Override to return a constant for a fixed mode:
+     * ```kotlin
+     * override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) =
+     *     ConfirmationMode.EVERY_TIME
+     * ```
+     *
+     * Or override with logic to compute the mode dynamically — e.g. inspect prior tool calls
+     * in [ToolContext.caseEvents] to bypass confirmation when an in-session create makes a
+     * follow-up update implicit.
      *
      * ⚠️ HOT PATH — called on **every** tool call by the orchestrator, including those that
      * resolve to [ConfirmationMode.NONE]. Overrides MUST be:
@@ -102,7 +99,7 @@ interface StandardTool<T> {
     suspend fun getConfirmationMode(
         argsJson: String? = null,
         context: ToolContext? = null,
-    ): ConfirmationMode = confirmationMode
+    ): ConfirmationMode = ConfirmationMode.NONE
 
     /**
      * Tool-specific guidance injected as a labelled `Tool-specific confirmation guidance:`

--- a/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolSpec.kt
+++ b/agentos/agentos-sdk/src/test/kotlin/io/whozoss/agentos/sdk/tool/StandardToolSpec.kt
@@ -68,10 +68,9 @@ class StandardToolSpec : StringSpec() {
             ).output shouldBe "America/New_York"
         }
 
-        // getConfirmationMode(args, ctx) defaults to the static confirmationMode val.
-        // Ensures backward compatibility: an existing plugin that only overrides the val
-        // keeps working unchanged after this extension.
-        "getConfirmationMode default delegates to static confirmationMode" {
+        // getConfirmationMode(args, ctx) defaults to NONE when not overridden.
+        // Tools that require confirmation override getConfirmationMode directly.
+        "getConfirmationMode default returns NONE" {
             val noneTool =
                 object : StandardTool<Unit> {
                     override val name = "None"
@@ -82,7 +81,7 @@ class StandardToolSpec : StringSpec() {
 
                     override suspend fun execute(input: Unit?, context: ToolContext) =
                         ToolExecutionResult.success("")
-                    // confirmationMode = NONE (default)
+                    // getConfirmationMode not overridden — defaults to NONE
                 }
             val everyTimeTool =
                 object : StandardTool<Unit> {
@@ -91,7 +90,9 @@ class StandardToolSpec : StringSpec() {
                     override val version = "1.0"
                     override val paramType: Class<Unit>? = null
                     override val inputSchema = "{}"
-                    override val confirmationMode = ConfirmationMode.EVERY_TIME
+
+                    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) =
+                        ConfirmationMode.EVERY_TIME
 
                     override suspend fun execute(input: Unit?, context: ToolContext) =
                         ToolExecutionResult.success("")
@@ -102,9 +103,8 @@ class StandardToolSpec : StringSpec() {
             everyTimeTool.getConfirmationMode("{}", dummyContext) shouldBe ConfirmationMode.EVERY_TIME
         }
 
-        // Dynamic override: a plugin can decide the mode based on args/events without
-        // touching the static val. This is the core mechanism of the PR — used by
-        // CopilotStandardTool to bypass confirmation when an in-session CreateProfile
+        // Dynamic override: a plugin can decide the mode based on args/events.
+        // Used by CopilotStandardTool to bypass confirmation when an in-session CreateProfile
         // makes a subsequent UpdateProfile implicit.
         "getConfirmationMode dynamic override is honored" {
             val dynamicTool =
@@ -114,14 +114,13 @@ class StandardToolSpec : StringSpec() {
                     override val version = "1.0"
                     override val paramType: Class<Unit>? = null
                     override val inputSchema = "{}"
-                    override val confirmationMode = ConfirmationMode.EVERY_TIME // static fallback
 
                     override suspend fun getConfirmationMode(
                         argsJson: String?,
                         context: ToolContext?,
                     ): ConfirmationMode =
                         if (argsJson?.contains("bypass") == true) ConfirmationMode.NONE
-                        else confirmationMode
+                        else ConfirmationMode.EVERY_TIME
 
                     override suspend fun execute(input: Unit?, context: ToolContext) =
                         ToolExecutionResult.success("")

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -366,7 +366,7 @@ class AgentAdvanced(
 
     /**
      * Executes the tool for the given [intention], handling the confirmation gate when the
-     * tool's [confirmationMode] is not [ConfirmationMode.NONE].
+     * tool's [getConfirmationMode] is not [ConfirmationMode.NONE].
      *
      * @return [GateOutcome.AwaitingConfirmation] if a [PendingConfirmationEvent] was emitted
      *   and the agent must exit the loop; [GateOutcome.ContinueLoop] if the tool was executed

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationConfigurationException.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ConfirmationConfigurationException.kt
@@ -2,7 +2,7 @@ package io.whozoss.agentos.agent
 
 /**
  * Signals a misconfiguration of the AgentAdvanced confirmation flow at runtime —
- * typically a tool's [io.whozoss.agentos.sdk.tool.StandardTool.confirmationMode] is not NONE
+ * typically a tool's [io.whozoss.agentos.sdk.tool.StandardTool.getConfirmationMode] returns a value other than NONE
  * but the agent was instantiated without a [ConfirmationManager].
  *
  * Distinct from [IllegalStateException] so the orchestrator can catch and log it at

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -61,7 +61,7 @@ import kotlin.io.path.writeText
 internal class TestRemoveTool(
     private val rootDir: java.nio.file.Path,
     override val name: String = "FILES__remove",
-    private val confirmationMode: ConfirmationMode = ConfirmationMode.EVERY_TIME,
+    private val forcedMode: ConfirmationMode = ConfirmationMode.EVERY_TIME,
 ) : StandardTool<TestRemoveTool.Input> {
     data class Input(
         val path: String? = null,
@@ -85,7 +85,7 @@ internal class TestRemoveTool(
         return ToolExecutionResult.success("File $path deleted successfully")
     }
 
-    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) = confirmationMode
+    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) = forcedMode
 
     override fun getConfirmationInstructions(): String = "Be strict: explicit confirmation only after the assistant's question."
 
@@ -1417,7 +1417,7 @@ class AgentAdvancedSpec :
             val agentId = UUID.randomUUID()
             val tempDir = Files.createTempDirectory("agentadvanced-ac6bis-").also { it.toFile().deleteOnExit() }
             val target = tempDir.resolve("safe.txt").also { it.writeText("data") }
-            val tool = TestRemoveTool(tempDir, name = "TEST__safe", confirmationMode = ConfirmationMode.INFER)
+            val tool = TestRemoveTool(tempDir, name = "TEST__safe", forcedMode = ConfirmationMode.INFER)
             val confirmationManager = mockk<ConfirmationManager>()
             every { confirmationManager.shouldConfirm(any(), any(), any(), any(), any(), any()) } returns false
             val (ctx, chatClient) = confirmationContext(listOf(tool), agentId, confirmationManager)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -61,7 +61,7 @@ import kotlin.io.path.writeText
 internal class TestRemoveTool(
     private val rootDir: java.nio.file.Path,
     override val name: String = "FILES__remove",
-    override val confirmationMode: ConfirmationMode = ConfirmationMode.EVERY_TIME,
+    private val confirmationMode: ConfirmationMode = ConfirmationMode.EVERY_TIME,
 ) : StandardTool<TestRemoveTool.Input> {
     data class Input(
         val path: String? = null,
@@ -84,6 +84,8 @@ internal class TestRemoveTool(
         }
         return ToolExecutionResult.success("File $path deleted successfully")
     }
+
+    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) = confirmationMode
 
     override fun getConfirmationInstructions(): String = "Be strict: explicit confirmation only after the assistant's question."
 
@@ -1473,7 +1475,8 @@ class AgentAdvancedSpec :
                     override val inputSchema = "{}"
                     override val version = "1.0.0"
                     override val paramType = null
-                    override val confirmationMode = ConfirmationMode.INFER
+
+                    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) = ConfirmationMode.INFER
 
                     override suspend fun execute(
                         input: Map<String, Any>?,
@@ -1545,7 +1548,6 @@ class AgentAdvancedSpec :
                     override val inputSchema = "{}"
                     override val version = "1.0.0"
                     override val paramType = null
-                    override val confirmationMode = ConfirmationMode.EVERY_TIME // static fallback
 
                     // Always returns NONE dynamically — mimicking a bypass condition
                     override suspend fun getConfirmationMode(
@@ -1619,7 +1621,8 @@ class AgentAdvancedSpec :
                     override val inputSchema = "{}"
                     override val version = "1.0.0"
                     override val paramType = null
-                    override val confirmationMode = ConfirmationMode.INFER
+
+                    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) = ConfirmationMode.INFER
 
                     override fun getConfirmationInstructions(): String = "Be strict: 'pourquoi pas' is not consent."
 
@@ -1698,7 +1701,6 @@ class AgentAdvancedSpec :
                     override val inputSchema = """{"type":"object","properties":{"id":{"type":"string"}}}"""
                     override val version = "1.0.0"
                     override val paramType = null
-                    override val confirmationMode = ConfirmationMode.NONE
 
                     override suspend fun getConfirmationMode(
                         argsJson: String?,
@@ -1811,7 +1813,8 @@ class AgentAdvancedSpec :
                     override val inputSchema = "{}"
                     override val version = "1.0.0"
                     override val paramType = null
-                    override val confirmationMode = ConfirmationMode.EVERY_TIME
+
+                    override suspend fun getConfirmationMode(argsJson: String?, context: ToolContext?) = ConfirmationMode.EVERY_TIME
 
                     override suspend fun execute(
                         input: Map<String, Any>?,
@@ -1997,7 +2000,6 @@ class AgentAdvancedSpec :
             every { mockTool.description } returns "A test tool"
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
-            every { mockTool.confirmationMode } returns ConfirmationMode.NONE
             coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
@@ -2067,7 +2069,6 @@ class AgentAdvancedSpec :
             every { mockTool.description } returns "A test tool"
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
-            every { mockTool.confirmationMode } returns ConfirmationMode.NONE
             coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 
@@ -2145,7 +2146,6 @@ class AgentAdvancedSpec :
             every { mockTool.inputSchema } returns
                 """{"type":"object","properties":{"entitiesId":{"type":"array","items":{"type":"string"}}}}"""
             every { mockTool.paramType } returns String::class.java
-            every { mockTool.confirmationMode } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("entity data")
 
             val mockChatClient = mockk<ChatClient>(relaxed = true)
@@ -2218,7 +2218,6 @@ class AgentAdvancedSpec :
             every { mockTool.description } returns "A test tool"
             every { mockTool.inputSchema } returns """{"type":"object","properties":{"value":{"type":"string"}}}"""
             every { mockTool.paramType } returns String::class.java
-            every { mockTool.confirmationMode } returns ConfirmationMode.NONE
             coEvery { mockTool.getConfirmationMode(any(), any()) } returns ConfirmationMode.NONE
             coEvery { mockTool.executeWithJson(any(), any()) } returns ToolExecutionResult.success("done")
 


### PR DESCRIPTION
Remove the `val confirmationMode` property from `StandardTool`.
`getConfirmationMode()` is now the sole override point for the confirmation flow.
Eliminates the dual static/dynamic ambiguity without changing behavior.