### PR TITLE
fix: wz-32642 use max character count to filter ToolResponse in context

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -57,12 +57,11 @@ data class AgentAdvancedContext(
      */
     internal fun convertEventsToMessages(
         events: List<CaseEvent>,
-        maxDetailedToolCalls: Int = 6,
-        maxDetailedMessagesWithSteps: Int = 3,
+        maxDetailedChars: Int = 100_000,
     ): List<Message> {
         val responsesByRequestId = indexToolResponses(events)
         val detailedRequestIds =
-            selectDetailedToolRequestIds(events, maxDetailedToolCalls, maxDetailedMessagesWithSteps)
+            selectDetailedToolRequestIds(events, responsesByRequestId, maxDetailedChars)
 
         val lastUserMsgIndex =
             events.indexOfLast {
@@ -101,34 +100,33 @@ data class AgentAdvancedContext(
 
     private fun selectDetailedToolRequestIds(
         events: List<CaseEvent>,
-        maxPairs: Int,
-        maxTurns: Int,
+        responsesByRequestId: Map<String, ToolResponseEvent>,
+        maxDetailedChars: Int,
     ): Set<String> {
         val result = mutableSetOf<String>()
-        var pairsCollected = 0
-        var turnsCollected = 0
-        var inTurn = false
+        var charsCollected = 0
 
         for (event in events.reversed()) {
-            if (pairsCollected >= maxPairs || turnsCollected >= maxTurns) break
-            when (event) {
-                is ToolRequestEvent -> {
-                    if (!inTurn) {
-                        turnsCollected++
-                        inTurn = true
-                    }
-                    result.add(event.toolRequestId)
-                    pairsCollected++
-                }
+            if (event !is ToolRequestEvent) continue
 
-                is MessageEvent, is IntentionGeneratedEvent -> {
-                    inTurn = false
-                }
+            val response = responsesByRequestId[event.toolRequestId]
+            val cost = estimateDetailedCharCost(event, response)
 
-                else -> {}
-            }
+            if (charsCollected + cost > maxDetailedChars) break
+
+            result.add(event.toolRequestId)
+            charsCollected += cost
         }
         return result
+    }
+
+    private fun estimateDetailedCharCost(
+        request: ToolRequestEvent,
+        response: ToolResponseEvent?,
+    ): Int {
+        val argsCost = request.args?.length ?: 0
+        val responseCost = response?.let { extractText(it.output).length } ?: 0
+        return argsCost + responseCost
     }
 
     private fun toToolMessages(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -40,7 +40,10 @@ data class AgentAdvancedContext(
      *   generation, final response, etc.). Null when the caller needs the base history
      *   without any additional prompt (e.g. confirmation manager calls).
      */
-    internal fun buildMessages(events: List<CaseEvent>, prompt: String? = null): List<Message> {
+    internal fun buildMessages(
+        events: List<CaseEvent>,
+        prompt: String? = null,
+    ): List<Message> {
         val history = convertEventsToMessages(events)
         val operationalMessage = listOfNotNull(instructions, prompt).joinToString("\n\n").takeUnless { it.isBlank() }
         val messages = if (operationalMessage != null) history + UserMessage(operationalMessage) else history
@@ -57,7 +60,7 @@ data class AgentAdvancedContext(
      */
     internal fun convertEventsToMessages(
         events: List<CaseEvent>,
-        maxDetailedChars: Int = 100_000,
+        maxDetailedChars: Int = 300_000,
     ): List<Message> {
         val responsesByRequestId = indexToolResponses(events)
         val detailedRequestIds =

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
@@ -267,7 +267,7 @@ class AgentAdvancedContextSpec :
                             toolResponse("r$i", "TOOL__x", "result $i"),
                         )
                     }
-            val messages = context.convertEventsToMessages(events, maxDetailedToolCalls = 3)
+            val messages = context.convertEventsToMessages(events, maxDetailedChars = 30)
 
             // First message is the user message
             messages[0].shouldBeInstanceOf<UserMessage>()
@@ -312,7 +312,7 @@ class AgentAdvancedContextSpec :
                     toolRequest("r6", "TOOL__x"),
                     toolResponse("r6", "TOOL__x", "ok"),
                 )
-            val messages = context.convertEventsToMessages(events, maxDetailedToolCalls = 2)
+            val messages = context.convertEventsToMessages(events, maxDetailedChars = 8)
 
             val userMessages = messages.filterIsInstance<UserMessage>()
             userMessages shouldHaveSize 2
@@ -329,7 +329,7 @@ class AgentAdvancedContextSpec :
                     toolRequest("r2", "TOOL__x"),
                     toolResponse("r2", "TOOL__x", "ok"),
                 )
-            val messages = context.convertEventsToMessages(events, maxDetailedToolCalls = 6)
+            val messages = context.convertEventsToMessages(events, maxDetailedChars = 100)
 
             // No summary messages — all tool calls are in native format
             val summaries =
@@ -350,7 +350,7 @@ class AgentAdvancedContextSpec :
                     toolRequest("r2", "TOOL__x"),
                     toolResponse("r2", "TOOL__x", "ok"),
                 )
-            val messages = context.convertEventsToMessages(events, maxDetailedToolCalls = 1)
+            val messages = context.convertEventsToMessages(events, maxDetailedChars = 4)
 
             val summaries =
                 messages.filterIsInstance<AssistantMessage>().filter {
@@ -371,7 +371,7 @@ class AgentAdvancedContextSpec :
                     toolRequest("r2", "TOOL__new"),
                     toolResponse("r2", "TOOL__new", "new result"),
                 )
-            val messages = context.convertEventsToMessages(events, maxDetailedToolCalls = 1)
+            val messages = context.convertEventsToMessages(events, maxDetailedChars = 12)
 
             val intentionMessages =
                 messages.filterIsInstance<AssistantMessage>().filter {
@@ -424,7 +424,7 @@ class AgentAdvancedContextSpec :
                     toolRequest("r1", "TOOL__x"),
                     toolResponse("r1", "TOOL__x", "ok"),
                 )
-            val messages = context.convertEventsToMessages(events, maxDetailedToolCalls = 1)
+            val messages = context.convertEventsToMessages(events, maxDetailedChars = 4)
 
             // The orphaned request should be summarized, not detailed
             val summaries =


### PR DESCRIPTION
Replace the dual-parameter sliding window (maxDetailedToolCalls / maxDetailedMessagesWithSteps) in AgentAdvancedContext.convertEventsToMessages with a single maxDetailedChars character budget (default 100K). 