### PR TITLE
feat: WZ-31851 prepare permission platform level

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRepository.kt
@@ -12,9 +12,8 @@ import mu.KLogging
  * PermissionNodeNeo4jRepository with its @Query annotations.
  */
 class Neo4jPermissionRepository(
-    private val permissionNodeRepository: PermissionNodeNeo4jRepository
+    private val permissionNodeRepository: PermissionNodeNeo4jRepository,
 ) : PermissionRepository {
-
     companion object : KLogging() {
         /**
          * Entity types where a namespace MEMBER does NOT gain transitive READ
@@ -33,22 +32,23 @@ class Neo4jPermissionRepository(
         userId: String,
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation
-    ): Boolean {
-        return try {
+        relation: PermissionRelation,
+    ): Boolean =
+        try {
             when (relation) {
                 PermissionRelation.ADMIN -> {
                     permissionNodeRepository.hasAdminPermission(
                         userId = userId,
                         entityId = entityId,
-                        entityLabel = entityType.label
+                        entityLabel = entityType.label,
                     )
                 }
+
                 PermissionRelation.MEMBER -> {
                     permissionNodeRepository.hasMemberOrAdminPermission(
                         userId = userId,
                         entityId = entityId,
-                        entityLabel = entityType.label
+                        entityLabel = entityType.label,
                     )
                 }
             }
@@ -56,13 +56,12 @@ class Neo4jPermissionRepository(
             logger.error(e) { "Error checking direct permission for user=$userId, entity=$entityType:$entityId, relation=$relation" }
             false // Fail-closed: any error returns false
         }
-    }
 
     override fun hasTransitivePermission(
         userId: String,
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation
+        relation: PermissionRelation,
     ): Boolean {
         return try {
             // Only check transitive permissions for namespace child entities
@@ -75,9 +74,10 @@ class Neo4jPermissionRepository(
                     permissionNodeRepository.hasAdminAccessViaNamespace(
                         userId = userId,
                         entityId = entityId,
-                        entityLabel = entityType.label
+                        entityLabel = entityType.label,
                     )
                 }
+
                 PermissionRelation.MEMBER -> {
                     if (entityType in OWNER_PRIVATE_ENTITY_TYPES) {
                         // Owner-private entities (e.g. Case, FR15): a namespace MEMBER
@@ -87,7 +87,7 @@ class Neo4jPermissionRepository(
                         permissionNodeRepository.hasAdminAccessViaNamespace(
                             userId = userId,
                             entityId = entityId,
-                            entityLabel = entityType.label
+                            entityLabel = entityType.label,
                         )
                     } else {
                         // Shared entities (AgentConfig, IntegrationConfig, AiProvider,
@@ -96,7 +96,7 @@ class Neo4jPermissionRepository(
                         permissionNodeRepository.hasReadAccessViaNamespace(
                             userId = userId,
                             entityId = entityId,
-                            entityLabel = entityType.label
+                            entityLabel = entityType.label,
                         )
                     }
                 }
@@ -111,20 +111,25 @@ class Neo4jPermissionRepository(
         userId: String,
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation
+        relation: PermissionRelation,
     ) {
         try {
             when (relation) {
-                PermissionRelation.ADMIN -> permissionNodeRepository.createAdminPermission(
-                    userId = userId,
-                    entityId = entityId,
-                    entityLabel = entityType.label
-                )
-                PermissionRelation.MEMBER -> permissionNodeRepository.createMemberPermission(
-                    userId = userId,
-                    entityId = entityId,
-                    entityLabel = entityType.label
-                )
+                PermissionRelation.ADMIN -> {
+                    permissionNodeRepository.createAdminPermission(
+                        userId = userId,
+                        entityId = entityId,
+                        entityLabel = entityType.label,
+                    )
+                }
+
+                PermissionRelation.MEMBER -> {
+                    permissionNodeRepository.createMemberPermission(
+                        userId = userId,
+                        entityId = entityId,
+                        entityLabel = entityType.label,
+                    )
+                }
             }
             logger.info { "Granted $relation permission to user=$userId on $entityType:$entityId" }
         } catch (e: Exception) {
@@ -137,20 +142,25 @@ class Neo4jPermissionRepository(
         userId: String,
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation
+        relation: PermissionRelation,
     ) {
         try {
             when (relation) {
-                PermissionRelation.ADMIN -> permissionNodeRepository.deleteAdminPermission(
-                    userId = userId,
-                    entityId = entityId,
-                    entityLabel = entityType.label
-                )
-                PermissionRelation.MEMBER -> permissionNodeRepository.deleteMemberPermission(
-                    userId = userId,
-                    entityId = entityId,
-                    entityLabel = entityType.label
-                )
+                PermissionRelation.ADMIN -> {
+                    permissionNodeRepository.deleteAdminPermission(
+                        userId = userId,
+                        entityId = entityId,
+                        entityLabel = entityType.label,
+                    )
+                }
+
+                PermissionRelation.MEMBER -> {
+                    permissionNodeRepository.deleteMemberPermission(
+                        userId = userId,
+                        entityId = entityId,
+                        entityLabel = entityType.label,
+                    )
+                }
             }
             logger.info { "Revoked $relation permission from user=$userId on $entityType:$entityId" }
         } catch (e: Exception) {
@@ -162,50 +172,59 @@ class Neo4jPermissionRepository(
     override fun listUsersWithPermission(
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation?
-    ): List<String> {
-        return try {
+        relation: PermissionRelation?,
+    ): List<String> =
+        try {
             when (relation) {
-                PermissionRelation.ADMIN -> permissionNodeRepository.findUsersWithAdminPermission(
-                    entityId = entityId,
-                    entityLabel = entityType.label
-                )
-                PermissionRelation.MEMBER -> permissionNodeRepository.findUsersWithMemberPermission(
-                    entityId = entityId,
-                    entityLabel = entityType.label
-                )
-                null -> permissionNodeRepository.findUsersWithAnyPermission(
-                    entityId = entityId,
-                    entityLabel = entityType.label
-                )
+                PermissionRelation.ADMIN -> {
+                    permissionNodeRepository.findUsersWithAdminPermission(
+                        entityId = entityId,
+                        entityLabel = entityType.label,
+                    )
+                }
+
+                PermissionRelation.MEMBER -> {
+                    permissionNodeRepository.findUsersWithMemberPermission(
+                        entityId = entityId,
+                        entityLabel = entityType.label,
+                    )
+                }
+
+                null -> {
+                    permissionNodeRepository.findUsersWithAnyPermission(
+                        entityId = entityId,
+                        entityLabel = entityType.label,
+                    )
+                }
             }
         } catch (e: Exception) {
             logger.error(e) { "Error listing users with permission on $entityType:$entityId, relation=$relation" }
             emptyList() // Fail-closed: return empty list on error
         }
-    }
 
+    // TODO: used only for namespace, to un-generalize ?
     override fun listEntitiesForUser(
         userId: String,
         entityType: EntityType,
-        relation: PermissionRelation
-    ): List<String> {
-        return try {
+        relation: PermissionRelation,
+    ): List<String> =
+        try {
             // Include both direct and transitive permissions
             when (relation) {
                 PermissionRelation.ADMIN -> {
                     if (isNamespaceChildEntity(entityType)) {
                         permissionNodeRepository.findEntitiesWhereUserIsAdminTransitive(
                             userId = userId,
-                            entityLabel = entityType.label
+                            entityLabel = entityType.label,
                         )
                     } else {
                         permissionNodeRepository.findEntitiesWhereUserIsAdmin(
                             userId = userId,
-                            entityLabel = entityType.label
+                            entityLabel = entityType.label,
                         )
                     }
                 }
+
                 PermissionRelation.MEMBER -> {
                     if (entityType in OWNER_PRIVATE_ENTITY_TYPES) {
                         // Owner-private entities: MEMBER transitivity via namespace-MEMBER
@@ -214,17 +233,17 @@ class Neo4jPermissionRepository(
                         // exact set a user is allowed to "see".
                         permissionNodeRepository.findEntitiesWhereUserIsAdminTransitive(
                             userId = userId,
-                            entityLabel = entityType.label
+                            entityLabel = entityType.label,
                         )
                     } else if (isNamespaceChildEntity(entityType)) {
                         permissionNodeRepository.findEntitiesWhereUserHasAccessTransitive(
                             userId = userId,
-                            entityLabel = entityType.label
+                            entityLabel = entityType.label,
                         )
                     } else {
                         permissionNodeRepository.findEntitiesWhereUserHasAccess(
                             userId = userId,
-                            entityLabel = entityType.label
+                            entityLabel = entityType.label,
                         )
                     }
                 }
@@ -233,21 +252,23 @@ class Neo4jPermissionRepository(
             logger.error(e) { "Error listing entities for user=$userId, type=$entityType, relation=$relation" }
             emptyList() // Fail-closed: return empty list on error
         }
-    }
 
     override fun filterVisibleIds(
         userId: String,
         entityType: EntityType,
         ids: Collection<String>,
         relation: PermissionRelation,
-    ): Set<String> {
-        return try {
+    ): Set<String> =
+        try {
             when (relation) {
-                PermissionRelation.ADMIN -> permissionNodeRepository.filterIdsWhereUserIsAdmin(
-                    userId = userId,
-                    entityLabel = entityType.label,
-                    ids = ids,
-                )
+                PermissionRelation.ADMIN -> {
+                    permissionNodeRepository.filterIdsWhereUserIsAdmin(
+                        userId = userId,
+                        entityLabel = entityType.label,
+                        ids = ids,
+                    )
+                }
+
                 PermissionRelation.MEMBER -> {
                     if (entityType in OWNER_PRIVATE_ENTITY_TYPES) {
                         // Owner-private entities (Case, FR15) — MEMBER on the namespace does NOT
@@ -259,10 +280,15 @@ class Neo4jPermissionRepository(
                             ids = ids,
                         )
                     } else {
+                        // Namespace-child entities may have platform-scoped instances
+                        // (namespaceId IS NULL). Use the variant query that includes a
+                        // third UNION branch for those — safe because all types in
+                        // isNamespaceChildEntity have namespaceId as a node property.
                         permissionNodeRepository.filterIdsWhereUserHasAccess(
                             userId = userId,
                             entityLabel = entityType.label,
                             ids = ids,
+                            checkPlatform = isNamespaceChildEntity(entityType),
                         )
                     }
                 }
@@ -271,20 +297,19 @@ class Neo4jPermissionRepository(
             logger.error(e) { "Error filtering visible ids for user=$userId, type=$entityType, relation=$relation" }
             emptySet() // Fail-closed: return empty set on error
         }
-    }
 
     /**
      * Checks if the entity type is a child of Namespace in the hierarchy.
      * These entities support transitive permissions through their parent namespace.
      */
-    private fun isNamespaceChildEntity(entityType: EntityType): Boolean {
-        return entityType in setOf(
-            EntityType.CASE,
-            EntityType.AGENT_CONFIG,
-            EntityType.INTEGRATION_CONFIG,
-            EntityType.AI_PROVIDER,
-            EntityType.AI_MODEL,
-            EntityType.USER_GROUP,
-        )
-    }
+    private fun isNamespaceChildEntity(entityType: EntityType): Boolean =
+        entityType in
+            setOf(
+                EntityType.CASE,
+                EntityType.AGENT_CONFIG,
+                EntityType.INTEGRATION_CONFIG,
+                EntityType.AI_PROVIDER,
+                EntityType.AI_MODEL,
+                EntityType.USER_GROUP,
+            )
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/Neo4jPermissionRepository.kt
@@ -258,14 +258,16 @@ class Neo4jPermissionRepository(
         entityType: EntityType,
         ids: Collection<String>,
         relation: PermissionRelation,
-    ): Set<String> =
-        try {
+    ): Set<String> {
+        val checkPlatform = isNamespaceChildEntity(entityType)
+        return try {
             when (relation) {
                 PermissionRelation.ADMIN -> {
                     permissionNodeRepository.filterIdsWhereUserIsAdmin(
                         userId = userId,
                         entityLabel = entityType.label,
                         ids = ids,
+                        checkPlatform = checkPlatform,
                     )
                 }
 
@@ -278,6 +280,7 @@ class Neo4jPermissionRepository(
                             userId = userId,
                             entityLabel = entityType.label,
                             ids = ids,
+                            checkPlatform = checkPlatform,
                         )
                     } else {
                         // Namespace-child entities may have platform-scoped instances
@@ -288,7 +291,7 @@ class Neo4jPermissionRepository(
                             userId = userId,
                             entityLabel = entityType.label,
                             ids = ids,
-                            checkPlatform = isNamespaceChildEntity(entityType),
+                            checkPlatform = checkPlatform,
                         )
                     }
                 }
@@ -297,6 +300,7 @@ class Neo4jPermissionRepository(
             logger.error(e) { "Error filtering visible ids for user=$userId, type=$entityType, relation=$relation" }
             emptySet() // Fail-closed: return empty set on error
         }
+    }
 
     /**
      * Checks if the entity type is a child of Namespace in the hierarchy.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionNodeNeo4jRepository.kt
@@ -18,199 +18,230 @@ import org.springframework.data.repository.query.Param
  * via parameters, so we use separate methods per relationship type and IN-based label checks.
  */
 interface PermissionNodeNeo4jRepository : Neo4jRepository<UserNode, String> {
-
     // Direct permission queries
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[r:ADMIN|MEMBER]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[r:ADMIN|MEMBER]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN type(r) AS relation
-    """)
+    """,
+    )
     fun findDirectPermission(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): String?
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[r:ADMIN]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[r:ADMIN]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN COUNT(r) > 0
-    """)
+    """,
+    )
     fun hasAdminPermission(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): Boolean
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[r:ADMIN|MEMBER]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[r:ADMIN|MEMBER]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN COUNT(r) > 0
-    """)
+    """,
+    )
     fun hasMemberOrAdminPermission(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): Boolean
 
     // Transitive permission queries for namespace hierarchy
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN]->(n:Namespace)
-        MATCH (n)<-[:BELONGS_TO]-(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[:ADMIN]->(n:Namespace)
+        MATCH (n)<-[:BELONGS_TO]-(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN COUNT(e) > 0
-    """)
+    """,
+    )
     fun hasAdminAccessViaNamespace(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): Boolean
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN|MEMBER]->(n:Namespace)
-        MATCH (n)<-[:BELONGS_TO]-(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[:ADMIN|MEMBER]->(n:Namespace)
+        MATCH (n)<-[:BELONGS_TO]-(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN COUNT(e) > 0
-    """)
+    """,
+    )
     fun hasReadAccessViaNamespace(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): Boolean
 
     // Permission management queries — separate methods per relationship type
     // because Neo4j does not support parameterized relationship types.
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})
-        MATCH (e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})
+        MATCH (e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         MERGE (u)-[r:ADMIN]->(e)
         RETURN r
-    """)
+    """,
+    )
     fun createAdminPermission(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     )
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})
-        MATCH (e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})
+        MATCH (e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         MERGE (u)-[r:MEMBER]->(e)
         RETURN r
-    """)
+    """,
+    )
     fun createMemberPermission(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     )
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[r:ADMIN]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[r:ADMIN]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         DELETE r
-    """)
+    """,
+    )
     fun deleteAdminPermission(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     )
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[r:MEMBER]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[r:MEMBER]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         DELETE r
-    """)
+    """,
+    )
     fun deleteMemberPermission(
         @Param("userId") userId: String,
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     )
 
     // User listing queries
 
-    @Query("""
-        MATCH (u:User)-[r:ADMIN|MEMBER]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User)-[r:ADMIN|MEMBER]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN u.id
-    """)
+    """,
+    )
     fun findUsersWithAnyPermission(
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): List<String>
 
-    @Query("""
-        MATCH (u:User)-[r:ADMIN]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User)-[r:ADMIN]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN u.id
-    """)
+    """,
+    )
     fun findUsersWithAdminPermission(
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): List<String>
 
-    @Query("""
-        MATCH (u:User)-[r:MEMBER]->(e {id: ${'$'}entityId})
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User)-[r:MEMBER]->(e {id: $entityId})
+        WHERE $entityLabel IN labels(e)
         RETURN u.id
-    """)
+    """,
+    )
     fun findUsersWithMemberPermission(
         @Param("entityId") entityId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): List<String>
 
     // Entity listing queries
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[r:ADMIN]->(e)
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[r:ADMIN]->(e)
+        WHERE $entityLabel IN labels(e)
         RETURN e.id
-    """)
+    """,
+    )
     fun findEntitiesWhereUserIsAdmin(
         @Param("userId") userId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): List<String>
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[r:ADMIN|MEMBER]->(e)
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[r:ADMIN|MEMBER]->(e)
+        WHERE $entityLabel IN labels(e)
         RETURN e.id
-    """)
+    """,
+    )
     fun findEntitiesWhereUserHasAccess(
         @Param("userId") userId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): List<String>
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN]->(n:Namespace)<-[:BELONGS_TO]-(e)
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[:ADMIN]->(n:Namespace)<-[:BELONGS_TO]-(e)
+        WHERE $entityLabel IN labels(e)
         RETURN e.id
         UNION
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN]->(e)
-        WHERE ${'$'}entityLabel IN labels(e)
+        MATCH (u:User {id: $userId})-[:ADMIN]->(e)
+        WHERE $entityLabel IN labels(e)
         RETURN e.id
-    """)
+    """,
+    )
     fun findEntitiesWhereUserIsAdminTransitive(
         @Param("userId") userId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): List<String>
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN|MEMBER]->(n:Namespace)<-[:BELONGS_TO]-(e)
-        WHERE ${'$'}entityLabel IN labels(e)
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[:ADMIN|MEMBER]->(n:Namespace)<-[:BELONGS_TO]-(e)
+        WHERE $entityLabel IN labels(e)
         RETURN e.id
         UNION
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN|MEMBER]->(e)
-        WHERE ${'$'}entityLabel IN labels(e)
+        MATCH (u:User {id: $userId})-[:ADMIN|MEMBER]->(e)
+        WHERE $entityLabel IN labels(e)
         RETURN e.id
-    """)
+    """,
+    )
     fun findEntitiesWhereUserHasAccessTransitive(
         @Param("userId") userId: String,
-        @Param("entityLabel") entityLabel: String
+        @Param("entityLabel") entityLabel: String,
     ): List<String>
 
     // Batch authorization queries — filter a candidate list of ids by user permission
@@ -219,30 +250,34 @@ interface PermissionNodeNeo4jRepository : Neo4jRepository<UserNode, String> {
     // but bounded by `e.id IN $ids` so the result set scales linearly with the input
     // rather than the namespace size.
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN|MEMBER]->(n:Namespace)<-[:BELONGS_TO]-(e)
-        WHERE ${'$'}entityLabel IN labels(e) AND e.id IN ${'$'}ids
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[:ADMIN|MEMBER]->(n:Namespace)<-[:BELONGS_TO]-(e)
+        WHERE $entityLabel IN labels(e) AND e.id IN $ids
         RETURN e.id
         UNION
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN|MEMBER]->(e)
-        WHERE ${'$'}entityLabel IN labels(e) AND e.id IN ${'$'}ids
+        MATCH (u:User {id: $userId})-[:ADMIN|MEMBER]->(e)
+        WHERE $entityLabel IN labels(e) AND e.id IN $ids
         RETURN e.id
-    """)
+    """,
+    )
     fun filterIdsWhereUserHasAccess(
         @Param("userId") userId: String,
         @Param("entityLabel") entityLabel: String,
         @Param("ids") ids: Collection<String>,
     ): List<String>
 
-    @Query("""
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN]->(n:Namespace)<-[:BELONGS_TO]-(e)
-        WHERE ${'$'}entityLabel IN labels(e) AND e.id IN ${'$'}ids
+    @Query(
+        $$"""
+        MATCH (u:User {id: $userId})-[:ADMIN]->(n:Namespace)<-[:BELONGS_TO]-(e)
+        WHERE $entityLabel IN labels(e) AND e.id IN $ids
         RETURN e.id
         UNION
-        MATCH (u:User {id: ${'$'}userId})-[:ADMIN]->(e)
-        WHERE ${'$'}entityLabel IN labels(e) AND e.id IN ${'$'}ids
+        MATCH (u:User {id: $userId})-[:ADMIN]->(e)
+        WHERE $entityLabel IN labels(e) AND e.id IN $ids
         RETURN e.id
-    """)
+    """,
+    )
     fun filterIdsWhereUserIsAdmin(
         @Param("userId") userId: String,
         @Param("entityLabel") entityLabel: String,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionNodeNeo4jRepository.kt
@@ -252,12 +252,16 @@ interface PermissionNodeNeo4jRepository : Neo4jRepository<UserNode, String> {
 
     @Query(
         $$"""
-        MATCH (u:User {id: $userId})-[:ADMIN|MEMBER]->(n:Namespace)<-[:BELONGS_TO]-(e)
-        WHERE $entityLabel IN labels(e) AND e.id IN $ids
-        RETURN e.id
-        UNION
-        MATCH (u:User {id: $userId})-[:ADMIN|MEMBER]->(e)
-        WHERE $entityLabel IN labels(e) AND e.id IN $ids
+        MATCH (u:User {id: $userId})
+        MATCH (e)
+        WHERE $entityLabel IN labels(e)
+          AND e.id IN $ids
+          AND (e.removed IS NULL OR e.removed = false)
+          AND (
+            ($checkPlatform AND e.namespaceId IS NULL)
+            OR EXISTS { (u)-[:ADMIN|MEMBER]->(e) }
+            OR EXISTS { (e)-[:BELONGS_TO]->(n:Namespace)<-[:ADMIN|MEMBER]-(u) }
+          )
         RETURN e.id
     """,
     )
@@ -265,16 +269,20 @@ interface PermissionNodeNeo4jRepository : Neo4jRepository<UserNode, String> {
         @Param("userId") userId: String,
         @Param("entityLabel") entityLabel: String,
         @Param("ids") ids: Collection<String>,
+        @Param("checkPlatform") checkPlatform: Boolean,
     ): List<String>
 
     @Query(
         $$"""
-        MATCH (u:User {id: $userId})-[:ADMIN]->(n:Namespace)<-[:BELONGS_TO]-(e)
-        WHERE $entityLabel IN labels(e) AND e.id IN $ids
-        RETURN e.id
-        UNION
-        MATCH (u:User {id: $userId})-[:ADMIN]->(e)
-        WHERE $entityLabel IN labels(e) AND e.id IN $ids
+        MATCH (u:User {id: $userId})
+        MATCH (e)
+        WHERE $entityLabel IN labels(e)
+          AND e.id IN $ids
+          AND (e.removed IS NULL OR e.removed = false)
+          AND (
+            EXISTS { (u)-[:ADMIN]->(e) }
+            OR EXISTS { (e)-[:BELONGS_TO]->(n:Namespace)<-[:ADMIN]-(u) }
+          )
         RETURN e.id
     """,
     )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionNodeNeo4jRepository.kt
@@ -280,7 +280,8 @@ interface PermissionNodeNeo4jRepository : Neo4jRepository<UserNode, String> {
           AND e.id IN $ids
           AND (e.removed IS NULL OR e.removed = false)
           AND (
-            EXISTS { (u)-[:ADMIN]->(e) }
+            (u.isAdmin = true AND $checkPlatform AND e.namespaceId IS NULL)
+            OR EXISTS { (u)-[:ADMIN]->(e) }
             OR EXISTS { (e)-[:BELONGS_TO]->(n:Namespace)<-[:ADMIN]-(u) }
           )
         RETURN e.id
@@ -290,5 +291,6 @@ interface PermissionNodeNeo4jRepository : Neo4jRepository<UserNode, String> {
         @Param("userId") userId: String,
         @Param("entityLabel") entityLabel: String,
         @Param("ids") ids: Collection<String>,
+        @Param("checkPlatform") checkPlatform: Boolean,
     ): List<String>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionService.kt
@@ -20,16 +20,20 @@ interface PermissionService {
      * 3. Direct permission check
      * 4. Transitive permission check (namespace → child entities)
      *
+     * **Platform-scoped entities** ([entityId] = null): these entities have no parent namespace.
+     * - READ is granted to any authenticated user.
+     * - WRITE / DELETE require super-admin (`user.isAdmin`).
+     *
      * @param userId The ID of the user to check permissions for
      * @param entityType The type of entity (e.g., "Namespace", "Case", "AgentConfig")
-     * @param entityId The ID of the specific entity
+     * @param entityId The ID of the specific entity, or null for platform-scoped entities
      * @param action The action to perform (READ, WRITE, DELETE)
      * @return true if permission is granted, false otherwise (fail-closed)
      */
     fun hasPermission(
         userId: String,
         entityType: EntityType,
-        entityId: String,
+        entityId: String?,
         action: Action
     ): Boolean
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
@@ -25,25 +25,25 @@ import java.util.UUID
 class PermissionServiceImpl(
     private val userService: UserService,
     private val permissionRepository: PermissionRepository,
-    private val permissionCache: PermissionCache
+    private val permissionCache: PermissionCache,
 ) : PermissionService {
-
     companion object : KLogging()
 
     override fun hasPermission(
         userId: String,
         entityType: EntityType,
         entityId: String?,
-        action: Action
+        action: Action,
     ): Boolean {
         return try {
             // 1. Super-admin bypass check
-            val user = try {
-                userService.findById(UUID.fromString(userId))
-            } catch (e: IllegalArgumentException) {
-                logger.debug { "Invalid UUID format for userId: $userId" }
-                null
-            }
+            val user =
+                try {
+                    userService.findById(UUID.fromString(userId))
+                } catch (e: IllegalArgumentException) {
+                    logger.debug { "Invalid UUID format for userId: $userId" }
+                    null
+                }
             if (user?.isAdmin == true) {
                 logger.debug { "Super-admin bypass: user=$userId has all permissions" }
                 return true
@@ -85,13 +85,16 @@ class PermissionServiceImpl(
         userId: String,
         entityType: EntityType,
         entityId: String,
-        action: Action
+        action: Action,
     ): Boolean {
         // Determine required relation based on action
-        val requiredRelation = when (action) {
-            Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
-            Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
-        }
+        val requiredRelation =
+            when (action) {
+                Action.READ -> PermissionRelation.MEMBER
+
+                // MEMBER or ADMIN can READ
+                Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
+            }
 
         // Check direct permission first
         if (permissionRepository.hasDirectPermission(userId, entityType, entityId, requiredRelation)) {
@@ -113,7 +116,7 @@ class PermissionServiceImpl(
         userId: String,
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation
+        relation: PermissionRelation,
     ) {
         try {
             permissionRepository.grantPermission(userId, entityType, entityId, relation)
@@ -130,7 +133,7 @@ class PermissionServiceImpl(
         userId: String,
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation
+        relation: PermissionRelation,
     ) {
         try {
             permissionRepository.revokePermission(userId, entityType, entityId, relation)
@@ -146,32 +149,33 @@ class PermissionServiceImpl(
     override fun listUsersWithPermission(
         entityType: EntityType,
         entityId: String,
-        relation: PermissionRelation?
-    ): List<String> {
-        return try {
+        relation: PermissionRelation?,
+    ): List<String> =
+        try {
             permissionRepository.listUsersWithPermission(entityType, entityId, relation)
         } catch (e: Exception) {
             logger.error(e) { "Failed to list users with permission on $entityType:$entityId, relation=$relation" }
             emptyList() // Fail-closed: return empty list on error
         }
-    }
 
     override fun listEntitiesForUser(
         userId: String,
         entityType: EntityType,
-        action: Action
-    ): List<String> {
-        return try {
-            val requiredRelation = when (action) {
-                Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
-                Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
-            }
+        action: Action,
+    ): List<String> =
+        try {
+            val requiredRelation =
+                when (action) {
+                    Action.READ -> PermissionRelation.MEMBER
+
+                    // MEMBER or ADMIN can READ
+                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
+                }
             permissionRepository.listEntitiesForUser(userId, entityType, requiredRelation)
         } catch (e: Exception) {
             logger.error(e) { "Failed to list entities for user=$userId, type=$entityType, action=$action" }
             emptyList() // Fail-closed: return empty list on error
         }
-    }
 
     override fun filterVisibleIds(
         userId: String,
@@ -181,10 +185,18 @@ class PermissionServiceImpl(
     ): Set<String> {
         if (ids.isEmpty()) return emptySet()
         return try {
-            val requiredRelation = when (action) {
-                Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
-                Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
+            val user = userService.findById(UUID.fromString(userId))
+            if (user?.isAdmin == true) {
+                return ids.toSet()
             }
+
+            val requiredRelation =
+                when (action) {
+                    Action.READ -> PermissionRelation.MEMBER
+
+                    // MEMBER or ADMIN can READ
+                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
+                }
             permissionRepository.filterVisibleIds(userId, entityType, ids, requiredRelation)
         } catch (e: Exception) {
             logger.error(e) { "Failed to filter visible ids for user=$userId, type=$entityType, action=$action" }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
@@ -90,10 +90,8 @@ class PermissionServiceImpl(
         // Determine required relation based on action
         val requiredRelation =
             when (action) {
-                Action.READ -> PermissionRelation.MEMBER
-
-                // MEMBER or ADMIN can READ
-                Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
+                Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
+                Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
             }
 
         // Check direct permission first
@@ -166,10 +164,8 @@ class PermissionServiceImpl(
         try {
             val requiredRelation =
                 when (action) {
-                    Action.READ -> PermissionRelation.MEMBER
-
-                    // MEMBER or ADMIN can READ
-                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
+                    Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
+                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
                 }
             permissionRepository.listEntitiesForUser(userId, entityType, requiredRelation)
         } catch (e: Exception) {
@@ -192,10 +188,8 @@ class PermissionServiceImpl(
 
             val requiredRelation =
                 when (action) {
-                    Action.READ -> PermissionRelation.MEMBER
-
-                    // MEMBER or ADMIN can READ
-                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
+                    Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
+                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
                 }
             permissionRepository.filterVisibleIds(userId, entityType, ids, requiredRelation)
         } catch (e: Exception) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
@@ -167,8 +167,6 @@ class PermissionServiceImpl(
             val requiredRelation =
                 when (action) {
                     Action.READ -> PermissionRelation.MEMBER
-
-                    // MEMBER or ADMIN can READ
                     Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
                 }
             permissionRepository.listEntitiesForUser(userId, entityType, requiredRelation)
@@ -188,8 +186,6 @@ class PermissionServiceImpl(
             val requiredRelation =
                 when (action) {
                     Action.READ -> PermissionRelation.MEMBER
-
-                    // MEMBER or ADMIN can READ
                     Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
                 }
             permissionRepository.filterVisibleIds(userId, entityType, ids, requiredRelation)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
@@ -90,8 +90,10 @@ class PermissionServiceImpl(
         // Determine required relation based on action
         val requiredRelation =
             when (action) {
-                Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
-                Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
+                Action.READ -> PermissionRelation.MEMBER
+
+                // MEMBER or ADMIN can READ
+                Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
             }
 
         // Check direct permission first
@@ -164,8 +166,10 @@ class PermissionServiceImpl(
         try {
             val requiredRelation =
                 when (action) {
-                    Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
-                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
+                    Action.READ -> PermissionRelation.MEMBER
+
+                    // MEMBER or ADMIN can READ
+                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
                 }
             permissionRepository.listEntitiesForUser(userId, entityType, requiredRelation)
         } catch (e: Exception) {
@@ -181,15 +185,12 @@ class PermissionServiceImpl(
     ): Set<String> {
         if (ids.isEmpty()) return emptySet()
         return try {
-            val user = userService.findById(UUID.fromString(userId))
-            if (user?.isAdmin == true) {
-                return ids.toSet()
-            }
-
             val requiredRelation =
                 when (action) {
-                    Action.READ -> PermissionRelation.MEMBER  // MEMBER or ADMIN can READ
-                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN  // Only ADMIN can WRITE/DELETE
+                    Action.READ -> PermissionRelation.MEMBER
+
+                    // MEMBER or ADMIN can READ
+                    Action.WRITE, Action.DELETE -> PermissionRelation.ADMIN // Only ADMIN can WRITE/DELETE
                 }
             permissionRepository.filterVisibleIds(userId, entityType, ids, requiredRelation)
         } catch (e: Exception) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/permissions/PermissionServiceImpl.kt
@@ -33,7 +33,7 @@ class PermissionServiceImpl(
     override fun hasPermission(
         userId: String,
         entityType: EntityType,
-        entityId: String,
+        entityId: String?,
         action: Action
     ): Boolean {
         return try {
@@ -49,17 +49,26 @@ class PermissionServiceImpl(
                 return true
             }
 
-            // 2. Cache lookup
+            // 2. Platform-scope check (entityId = null means the entity belongs to no namespace).
+            //    READ is open to any authenticated user; WRITE/DELETE are super-admin only
+            //    (already handled by the bypass above, so we deny here for non-admins).
+            if (entityId == null) {
+                val granted = action == Action.READ
+                logger.debug { "Platform-scope check: user=$userId, action=$action -> $granted" }
+                return granted
+            }
+
+            // 3. Cache lookup
             val cacheKey = PermissionCache.generateKey(userId, entityType, entityId, action)
             permissionCache.get(cacheKey)?.let { cached ->
                 logger.debug { "Cache hit for permission check: $cacheKey -> $cached" }
                 return cached
             }
 
-            // 3. Evaluate permissions
+            // 4. Evaluate permissions
             val hasPermission = evaluatePermission(userId, entityType, entityId, action)
 
-            // 4. Cache the result
+            // 5. Cache the result
             permissionCache.put(cacheKey, hasPermission)
 
             hasPermission

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/security/declarative/AgentOsPermissionEvaluator.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/security/declarative/AgentOsPermissionEvaluator.kt
@@ -49,7 +49,7 @@ class AgentOsPermissionEvaluator(
         targetType: String?,
         permission: Any?,
     ): Boolean {
-        if (authentication == null || targetId == null || targetType == null || permission == null) return false
+        if (authentication == null || targetType == null || permission == null) return false
         val userId = authentication.name ?: return false
         val action = runCatching { Action.valueOf(permission.toString()) }.getOrNull() ?: return false
 
@@ -65,14 +65,17 @@ class AgentOsPermissionEvaluator(
         // 1) Try the membership/super-admin path first. Super-admins bypass here ; regular
         //    members succeed only when an explicit permission edge or namespace relation
         //    grants the action. This is the canonical path inherited from Epic 5.
-        if (permissionService.hasPermission(userId, entityType, targetId.toString(), action)) return true
+        //    targetId may be null for platform-scoped entities (namespaceId = null) —
+        //    PermissionService handles the null case explicitly.
+        if (permissionService.hasPermission(userId, entityType, targetId?.toString(), action)) return true
 
         // 2) Fall-through to ownership for the scope-aware entities (Epic 6 user-level
         //    overlays). The ownership check is intentionally placed AFTER the membership
         //    path : super-admin requests short-circuit without paying a findById Neo4j
         //    round-trip. The cache `PermissionServiceImpl.permissionCache` is NOT hit
         //    by this branch — owner-miss requests pay 1 extra DB read.
-        if (entityType in ownershipResolver.supportedTypes) {
+        //    Ownership resolution requires a concrete entityId — skip for platform scope.
+        if (targetId != null && entityType in ownershipResolver.supportedTypes) {
             val ownerUserId = runCatching { ownershipResolver.resolveOwner(entityType, UUID.fromString(targetId.toString())) }
                 .getOrNull()
             if (ownerUserId != null && ownerUserId.toString() == userId) return true

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
@@ -18,13 +18,13 @@ import io.whozoss.agentos.persistence.neo4j.Neo4jContainerSupport
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserRepository
-import io.whozoss.agentos.user.UserService
 import org.neo4j.driver.Driver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import java.util.UUID
 
 /**
  * Integration tests for Transitive Permission Evaluation.
@@ -40,8 +40,7 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
     companion object {
         @JvmStatic
         @DynamicPropertySource
-        fun registerNeo4jProperties(registry: DynamicPropertyRegistry) =
-            Neo4jContainerSpec.registerProperties(registry)
+        fun registerNeo4jProperties(registry: DynamicPropertyRegistry) = Neo4jContainerSpec.registerProperties(registry)
     }
 
     @Autowired
@@ -65,24 +64,27 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
     @Autowired
     lateinit var driver: Driver
 
-    private fun createUser(externalId: String = "test@example.com", isAdmin: Boolean = false): User =
+    private fun createUser(
+        externalId: String = "test@example.com",
+        isAdmin: Boolean = false,
+    ): User =
         userRepository.save(
             User(
                 metadata = EntityMetadata(),
                 externalId = externalId,
                 email = externalId,
-                isAdmin = isAdmin
-            )
+                isAdmin = isAdmin,
+            ),
         )
 
     private fun createNamespace(name: String = "test-namespace"): Namespace =
         namespaceRepository.save(
-            Namespace(metadata = EntityMetadata(), name = name)
+            Namespace(metadata = EntityMetadata(), name = name),
         )
 
     private fun createCase(namespaceId: java.util.UUID): Case =
         caseRepository.save(
-            Case(metadata = EntityMetadata(), namespaceId = namespaceId)
+            Case(metadata = EntityMetadata(), namespaceId = namespaceId),
         )
 
     init {
@@ -97,23 +99,35 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createAdminPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
-                entityLabel = "Namespace"
+                entityLabel = "Namespace",
             )
 
             // Verify transitive READ on child Case
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.READ
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.READ,
+                ).shouldBeTrue()
 
             // Verify transitive WRITE on child Case
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.WRITE
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.WRITE,
+                ).shouldBeTrue()
 
             // Verify transitive DELETE on child Case
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.DELETE
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.DELETE,
+                ).shouldBeTrue()
         }
 
         /**
@@ -131,13 +145,17 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createMemberPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
-                entityLabel = "Namespace"
+                entityLabel = "Namespace",
             )
 
             // Before this returned true (bug). It must now be false.
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.READ
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.READ,
+                ).shouldBeFalse()
         }
 
         "MEMBER with direct ADMIN on a case retains full access" {
@@ -149,25 +167,37 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createMemberPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
-                entityLabel = "Namespace"
+                entityLabel = "Namespace",
             )
             // Plus direct ADMIN on the case (simulates the auto-grant)
             permissionNodeRepository.createAdminPermission(
                 userId = user.id.toString(),
                 entityId = case.id.toString(),
-                entityLabel = "Case"
+                entityLabel = "Case",
             )
 
             // Direct relation grants full access regardless of the transitive rule
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.READ
-            ).shouldBeTrue()
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.WRITE
-            ).shouldBeTrue()
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.DELETE
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.READ,
+                ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.WRITE,
+                ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.DELETE,
+                ).shouldBeTrue()
         }
 
         /**
@@ -191,14 +221,15 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createAdminPermission(
                 userId = user.id.toString(),
                 entityId = case.id.toString(),
-                entityLabel = "Case"
+                entityLabel = "Case",
             )
             // Sanity check: ADMIN relation exists before the delete
-            permissionNodeRepository.hasAdminPermission(
-                userId = user.id.toString(),
-                entityId = case.id.toString(),
-                entityLabel = "Case"
-            ).shouldBeTrue()
+            permissionNodeRepository
+                .hasAdminPermission(
+                    userId = user.id.toString(),
+                    entityId = case.id.toString(),
+                    entityLabel = "Case",
+                ).shouldBeTrue()
 
             // Soft-delete the case via the repository
             val deleted = caseRepository.delete(case.id)
@@ -208,11 +239,12 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             caseRepository.findByIds(listOf(case.id)).shouldBeEmpty()
 
             // But the direct [:ADMIN] relation in Neo4j is preserved for audit
-            permissionNodeRepository.hasAdminPermission(
-                userId = user.id.toString(),
-                entityId = case.id.toString(),
-                entityLabel = "Case"
-            ).shouldBeTrue()
+            permissionNodeRepository
+                .hasAdminPermission(
+                    userId = user.id.toString(),
+                    entityId = case.id.toString(),
+                    entityLabel = "Case",
+                ).shouldBeTrue()
         }
 
         /**
@@ -226,13 +258,14 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             val member = createUser("member@example.com")
             val admin = createUser("admin@example.com")
             val namespace = createNamespace()
-            val config = agentConfigRepository.save(
-                AgentConfig(
-                    metadata = EntityMetadata(),
-                    namespaceId = namespace.id,
-                    name = "shared-agent",
-                ),
-            )
+            val config =
+                agentConfigRepository.save(
+                    AgentConfig(
+                        metadata = EntityMetadata(),
+                        namespaceId = namespace.id,
+                        name = "shared-agent",
+                    ),
+                )
 
             // member gets MEMBER on namespace → should READ transitively but NOT WRITE/DELETE
             permissionNodeRepository.createMemberPermission(
@@ -240,15 +273,27 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
                 entityId = namespace.id.toString(),
                 entityLabel = "Namespace",
             )
-            permissionService.hasPermission(
-                member.id.toString(), EntityType.AGENT_CONFIG, config.metadata.id.toString(), Action.READ,
-            ).shouldBeTrue()
-            permissionService.hasPermission(
-                member.id.toString(), EntityType.AGENT_CONFIG, config.metadata.id.toString(), Action.WRITE,
-            ).shouldBeFalse()
-            permissionService.hasPermission(
-                member.id.toString(), EntityType.AGENT_CONFIG, config.metadata.id.toString(), Action.DELETE,
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    member.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    config.metadata.id.toString(),
+                    Action.READ,
+                ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    member.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    config.metadata.id.toString(),
+                    Action.WRITE,
+                ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    member.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    config.metadata.id.toString(),
+                    Action.DELETE,
+                ).shouldBeFalse()
 
             // admin gets ADMIN on namespace → full transitive CRUD
             permissionNodeRepository.createAdminPermission(
@@ -256,22 +301,39 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
                 entityId = namespace.id.toString(),
                 entityLabel = "Namespace",
             )
-            permissionService.hasPermission(
-                admin.id.toString(), EntityType.AGENT_CONFIG, config.metadata.id.toString(), Action.READ,
-            ).shouldBeTrue()
-            permissionService.hasPermission(
-                admin.id.toString(), EntityType.AGENT_CONFIG, config.metadata.id.toString(), Action.WRITE,
-            ).shouldBeTrue()
-            permissionService.hasPermission(
-                admin.id.toString(), EntityType.AGENT_CONFIG, config.metadata.id.toString(), Action.DELETE,
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    admin.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    config.metadata.id.toString(),
+                    Action.READ,
+                ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    admin.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    config.metadata.id.toString(),
+                    Action.WRITE,
+                ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    admin.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    config.metadata.id.toString(),
+                    Action.DELETE,
+                ).shouldBeTrue()
         }
 
         "namespace MEMBER still grants transitive READ on non-Case shared entities" {
             val user = createUser()
             val namespace = createNamespace()
-            // Create an AgentConfig-like node directly in Neo4j with a BELONGS_TO edge
-            val agentConfigId = java.util.UUID.randomUUID().toString()
+            // Node created directly via Cypher rather than agentConfigRepository.save() to
+            // avoid coupling this anti-regression test to the domain layer — the point is
+            // purely to verify the Cypher traversal, not the repository mapping.
+            val agentConfigId =
+                java.util.UUID
+                    .randomUUID()
+                    .toString()
             driver.session().use { session ->
                 session.run(
                     "MATCH (ns:Namespace {id: \$nsId}) " +
@@ -283,13 +345,17 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createMemberPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
-                entityLabel = "Namespace"
+                entityLabel = "Namespace",
             )
 
             // MEMBER transitivity DOES apply to AgentConfig (FR21 legitimate)
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.AGENT_CONFIG, agentConfigId, Action.READ
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    agentConfigId,
+                    Action.READ,
+                ).shouldBeTrue()
         }
 
         "MEMBER on namespace denies WRITE on child Case" {
@@ -301,13 +367,17 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createMemberPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
-                entityLabel = "Namespace"
+                entityLabel = "Namespace",
             )
 
             // MEMBER should NOT grant WRITE
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.WRITE
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.WRITE,
+                ).shouldBeFalse()
         }
 
         "MEMBER on namespace denies DELETE on child Case" {
@@ -319,13 +389,17 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createMemberPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
-                entityLabel = "Namespace"
+                entityLabel = "Namespace",
             )
 
             // MEMBER should NOT grant DELETE
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.DELETE
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.DELETE,
+                ).shouldBeFalse()
         }
 
         "direct permission takes precedence over transitive permission" {
@@ -337,20 +411,24 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             permissionNodeRepository.createMemberPermission(
                 userId = user.id.toString(),
                 entityId = namespace.id.toString(),
-                entityLabel = "Namespace"
+                entityLabel = "Namespace",
             )
 
             // Grant direct ADMIN on the Case
             permissionNodeRepository.createAdminPermission(
                 userId = user.id.toString(),
                 entityId = case.id.toString(),
-                entityLabel = "Case"
+                entityLabel = "Case",
             )
 
             // Direct ADMIN should grant WRITE even though namespace is only MEMBER
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.WRITE
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.WRITE,
+                ).shouldBeTrue()
         }
 
         "no permission on namespace denies all actions on child Case" {
@@ -359,17 +437,29 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             val case = createCase(namespace.id)
 
             // No permission granted - should deny all actions (fail-closed)
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.READ
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.READ,
+                ).shouldBeFalse()
 
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.WRITE
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.WRITE,
+                ).shouldBeFalse()
 
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.CASE, case.id.toString(), Action.DELETE
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.DELETE,
+                ).shouldBeFalse()
         }
 
         "super-admin bypass works with real Neo4j" {
@@ -378,17 +468,29 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             val case = createCase(namespace.id)
 
             // No permission relations - super-admin should bypass all checks
-            permissionService.hasPermission(
-                superAdmin.id.toString(), EntityType.CASE, case.id.toString(), Action.READ
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    superAdmin.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.READ,
+                ).shouldBeTrue()
 
-            permissionService.hasPermission(
-                superAdmin.id.toString(), EntityType.CASE, case.id.toString(), Action.WRITE
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    superAdmin.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.WRITE,
+                ).shouldBeTrue()
 
-            permissionService.hasPermission(
-                superAdmin.id.toString(), EntityType.CASE, case.id.toString(), Action.DELETE
-            ).shouldBeTrue()
+            permissionService
+                .hasPermission(
+                    superAdmin.id.toString(),
+                    EntityType.CASE,
+                    case.id.toString(),
+                    Action.DELETE,
+                ).shouldBeTrue()
         }
 
         "hasPermission returns false when no relation exists (fail-closed)" {
@@ -396,9 +498,13 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             val namespace = createNamespace()
 
             // No relation exists at all
-            permissionService.hasPermission(
-                user.id.toString(), EntityType.NAMESPACE, namespace.id.toString(), Action.READ
-            ).shouldBeFalse()
+            permissionService
+                .hasPermission(
+                    user.id.toString(),
+                    EntityType.NAMESPACE,
+                    namespace.id.toString(),
+                    Action.READ,
+                ).shouldBeFalse()
         }
 
         /**
@@ -436,15 +542,27 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             // adminUser has NO direct relation on either case, yet should have
             // full ADMIN privileges via transitive namespace ADMIN.
             listOf(case1, case2).forEach { case ->
-                permissionService.hasPermission(
-                    adminUser.id.toString(), EntityType.CASE, case.id.toString(), Action.READ,
-                ).shouldBeTrue()
-                permissionService.hasPermission(
-                    adminUser.id.toString(), EntityType.CASE, case.id.toString(), Action.WRITE,
-                ).shouldBeTrue()
-                permissionService.hasPermission(
-                    adminUser.id.toString(), EntityType.CASE, case.id.toString(), Action.DELETE,
-                ).shouldBeTrue()
+                permissionService
+                    .hasPermission(
+                        adminUser.id.toString(),
+                        EntityType.CASE,
+                        case.id.toString(),
+                        Action.READ,
+                    ).shouldBeTrue()
+                permissionService
+                    .hasPermission(
+                        adminUser.id.toString(),
+                        EntityType.CASE,
+                        case.id.toString(),
+                        Action.WRITE,
+                    ).shouldBeTrue()
+                permissionService
+                    .hasPermission(
+                        adminUser.id.toString(),
+                        EntityType.CASE,
+                        case.id.toString(),
+                        Action.DELETE,
+                    ).shouldBeTrue()
             }
 
             // Service layer: findByParent returns every case in the namespace,
@@ -461,15 +579,18 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             val memberUser = createUser("member@example.com")
             val nsAccessible = createNamespace("ns-accessible")
             val nsForeign = createNamespace("ns-foreign")
-            val agentInside1 = agentConfigRepository.save(
-                AgentConfig(metadata = EntityMetadata(), namespaceId = nsAccessible.id, name = "agent-1"),
-            )
-            val agentInside2 = agentConfigRepository.save(
-                AgentConfig(metadata = EntityMetadata(), namespaceId = nsAccessible.id, name = "agent-2"),
-            )
-            val agentForeign = agentConfigRepository.save(
-                AgentConfig(metadata = EntityMetadata(), namespaceId = nsForeign.id, name = "agent-foreign"),
-            )
+            val agentInside1 =
+                agentConfigRepository.save(
+                    AgentConfig(metadata = EntityMetadata(), namespaceId = nsAccessible.id, name = "agent-1"),
+                )
+            val agentInside2 =
+                agentConfigRepository.save(
+                    AgentConfig(metadata = EntityMetadata(), namespaceId = nsAccessible.id, name = "agent-2"),
+                )
+            val agentForeign =
+                agentConfigRepository.save(
+                    AgentConfig(metadata = EntityMetadata(), namespaceId = nsForeign.id, name = "agent-foreign"),
+                )
 
             // memberUser has MEMBER on ns-accessible only — should inherit READ
             // on agent-1 and agent-2 transitively, NOT on agent-foreign.
@@ -479,18 +600,20 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
                 entityLabel = "Namespace",
             )
 
-            val candidateIds = listOf(
-                agentInside1.id.toString(),
-                agentInside2.id.toString(),
-                agentForeign.id.toString(),
-            )
+            val candidateIds =
+                listOf(
+                    agentInside1.id.toString(),
+                    agentInside2.id.toString(),
+                    agentForeign.id.toString(),
+                )
 
-            val visible = permissionService.filterVisibleIds(
-                memberUser.id.toString(),
-                EntityType.AGENT_CONFIG,
-                candidateIds,
-                Action.READ,
-            )
+            val visible =
+                permissionService.filterVisibleIds(
+                    memberUser.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    candidateIds,
+                    Action.READ,
+                )
 
             visible shouldHaveSize 2
             visible shouldBe setOf(agentInside1.id.toString(), agentInside2.id.toString())
@@ -499,8 +622,14 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
         "filterVisibleIds includes platform AgentConfigs (namespaceId = null) for any authenticated user" {
             val regularUser = createUser("regular@example.com")
             val namespace = createNamespace("ns-for-platform-test")
-            val namespacedAgentId = java.util.UUID.randomUUID().toString()
-            val platformAgentId = java.util.UUID.randomUUID().toString()
+            val namespacedAgentId =
+                java.util.UUID
+                    .randomUUID()
+                    .toString()
+            val platformAgentId =
+                java.util.UUID
+                    .randomUUID()
+                    .toString()
             driver.session().use { session ->
                 // Namespaced agent — has BELONGS_TO edge and a namespaceId property
                 session.run(
@@ -516,12 +645,13 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             }
 
             // regularUser has NO permission on any namespace — should still see the platform agent.
-            val visible = permissionService.filterVisibleIds(
-                regularUser.id.toString(),
-                EntityType.AGENT_CONFIG,
-                listOf(namespacedAgentId, platformAgentId),
-                Action.READ,
-            )
+            val visible =
+                permissionService.filterVisibleIds(
+                    regularUser.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    listOf(namespacedAgentId, platformAgentId),
+                    Action.READ,
+                )
 
             // Only the platform agent is visible — no namespace relation for the namespaced one.
             visible shouldBe setOf(platformAgentId)
@@ -529,7 +659,10 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
 
         "filterVisibleIds excludes platform AgentConfigs from WRITE results for non-admin users" {
             val regularUser = createUser("regular-write@example.com")
-            val platformAgentId = java.util.UUID.randomUUID().toString()
+            val platformAgentId =
+                java.util.UUID
+                    .randomUUID()
+                    .toString()
             driver.session().use { session ->
                 session.run(
                     "CREATE (e:AgentConfig {id: \$id, removed: false})",
@@ -538,20 +671,154 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             }
 
             // WRITE on a platform entity requires super-admin — regular user must get nothing.
+            permissionService
+                .filterVisibleIds(
+                    regularUser.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    listOf(platformAgentId),
+                    Action.WRITE,
+                ).shouldBeEmpty()
+        }
+
+        "filterVisibleIds returns all ids for super-admin including removed and platform entities" {
+            val superAdmin = createUser("super-admin-filter@example.com", isAdmin = true)
+            val namespace = createNamespace("ns-super-admin-filter")
+            val activeAgentId = UUID.randomUUID().toString()
+            val removedAgentId = UUID.randomUUID().toString()
+            val platformAgentId = UUID.randomUUID().toString()
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, removed: false})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to activeAgentId, "nsId" to namespace.id.toString()),
+                )
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, removed: true})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to removedAgentId, "nsId" to namespace.id.toString()),
+                )
+                session.run(
+                    "CREATE (e:AgentConfig {id: \$id})",
+                    mapOf("id" to platformAgentId),
+                )
+            }
+
+            // The service-level bypass (user.isAdmin == true) short-circuits before any
+            // Cypher query runs — the graph state is irrelevant. The unit test in
+            // PermissionServiceImplSpec verifies the bypass itself; this test verifies
+            // that the bypass correctly propagates through the full Spring context.
+            val visible =
+                permissionService.filterVisibleIds(
+                    superAdmin.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    listOf(activeAgentId, removedAgentId, platformAgentId),
+                    Action.READ,
+                )
+
+            visible shouldBe setOf(activeAgentId, removedAgentId, platformAgentId)
+        }
+
+        "filterVisibleIds for namespace ADMIN returns entities in own namespace and excludes other namespaces" {
+            val adminUser = createUser("admin-filter@example.com")
+            val ownNamespace = createNamespace("ns-admin-own")
+            val otherNamespace = createNamespace("ns-admin-other")
+            val ownAgentId = UUID.randomUUID().toString()
+            val otherAgentId = UUID.randomUUID().toString()
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, namespaceId: \$nsId, removed: false})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to ownAgentId, "nsId" to ownNamespace.id.toString()),
+                )
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, namespaceId: \$nsId, removed: false})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to otherAgentId, "nsId" to otherNamespace.id.toString()),
+                )
+            }
+            permissionNodeRepository.createAdminPermission(
+                userId = adminUser.id.toString(),
+                entityId = ownNamespace.id.toString(),
+                entityLabel = "Namespace",
+            )
+
+            val visible =
+                permissionService.filterVisibleIds(
+                    adminUser.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    listOf(ownAgentId, otherAgentId),
+                    Action.READ,
+                )
+
+            visible shouldBe setOf(ownAgentId)
+        }
+
+        "filterVisibleIds for namespace ADMIN grants WRITE on own namespace entities" {
+            val adminUser = createUser("admin-write-filter@example.com")
+            val namespace = createNamespace("ns-admin-write")
+            val agentId = UUID.randomUUID().toString()
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, namespaceId: \$nsId, removed: false})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to agentId, "nsId" to namespace.id.toString()),
+                )
+            }
+            permissionNodeRepository.createAdminPermission(
+                userId = adminUser.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace",
+            )
+
             permissionService.filterVisibleIds(
-                regularUser.id.toString(),
+                adminUser.id.toString(),
                 EntityType.AGENT_CONFIG,
-                listOf(platformAgentId),
+                listOf(agentId),
                 Action.WRITE,
-            ).shouldBeEmpty()
+            ) shouldBe setOf(agentId)
+        }
+
+        "filterVisibleIds excludes removed entities for namespace MEMBER" {
+            val memberUser = createUser("member-removed@example.com")
+            val namespace = createNamespace("ns-removed-filter")
+            val activeAgentId = UUID.randomUUID().toString()
+            val removedAgentId = UUID.randomUUID().toString()
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, namespaceId: \$nsId, removed: false})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to activeAgentId, "nsId" to namespace.id.toString()),
+                )
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, namespaceId: \$nsId, removed: true})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to removedAgentId, "nsId" to namespace.id.toString()),
+                )
+            }
+            permissionNodeRepository.createMemberPermission(
+                userId = memberUser.id.toString(),
+                entityId = namespace.id.toString(),
+                entityLabel = "Namespace",
+            )
+
+            val visible =
+                permissionService.filterVisibleIds(
+                    memberUser.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    listOf(activeAgentId, removedAgentId),
+                    Action.READ,
+                )
+
+            visible shouldBe setOf(activeAgentId)
         }
 
         "filterVisibleIds with WRITE action requires ADMIN — namespace MEMBER returns empty set" {
             val memberUser = createUser("member-write@example.com")
             val namespace = createNamespace("ns-member-write")
-            val agent = agentConfigRepository.save(
-                AgentConfig(metadata = EntityMetadata(), namespaceId = namespace.id, name = "agent-write"),
-            )
+            val agent =
+                agentConfigRepository.save(
+                    AgentConfig(metadata = EntityMetadata(), namespaceId = namespace.id, name = "agent-write"),
+                )
 
             // Member-only relation — no ADMIN propagation.
             permissionNodeRepository.createMemberPermission(
@@ -560,12 +827,13 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
                 entityLabel = "Namespace",
             )
 
-            permissionService.filterVisibleIds(
-                memberUser.id.toString(),
-                EntityType.AGENT_CONFIG,
-                listOf(agent.id.toString()),
-                Action.WRITE,
-            ).shouldBeEmpty()
+            permissionService
+                .filterVisibleIds(
+                    memberUser.id.toString(),
+                    EntityType.AGENT_CONFIG,
+                    listOf(agent.id.toString()),
+                    Action.WRITE,
+                ).shouldBeEmpty()
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
@@ -496,6 +496,56 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
             visible shouldBe setOf(agentInside1.id.toString(), agentInside2.id.toString())
         }
 
+        "filterVisibleIds includes platform AgentConfigs (namespaceId = null) for any authenticated user" {
+            val regularUser = createUser("regular@example.com")
+            val namespace = createNamespace("ns-for-platform-test")
+            val namespacedAgentId = java.util.UUID.randomUUID().toString()
+            val platformAgentId = java.util.UUID.randomUUID().toString()
+            driver.session().use { session ->
+                // Namespaced agent — has BELONGS_TO edge and a namespaceId property
+                session.run(
+                    "MATCH (ns:Namespace {id: \$nsId}) " +
+                        "CREATE (e:AgentConfig {id: \$id, namespaceId: \$nsId, removed: false})-[:BELONGS_TO]->(ns)",
+                    mapOf("id" to namespacedAgentId, "nsId" to namespace.id.toString()),
+                )
+                // Platform agent — no BELONGS_TO edge, namespaceId IS NULL
+                session.run(
+                    "CREATE (e:AgentConfig {id: \$id, removed: false})",
+                    mapOf("id" to platformAgentId),
+                )
+            }
+
+            // regularUser has NO permission on any namespace — should still see the platform agent.
+            val visible = permissionService.filterVisibleIds(
+                regularUser.id.toString(),
+                EntityType.AGENT_CONFIG,
+                listOf(namespacedAgentId, platformAgentId),
+                Action.READ,
+            )
+
+            // Only the platform agent is visible — no namespace relation for the namespaced one.
+            visible shouldBe setOf(platformAgentId)
+        }
+
+        "filterVisibleIds excludes platform AgentConfigs from WRITE results for non-admin users" {
+            val regularUser = createUser("regular-write@example.com")
+            val platformAgentId = java.util.UUID.randomUUID().toString()
+            driver.session().use { session ->
+                session.run(
+                    "CREATE (e:AgentConfig {id: \$id, removed: false})",
+                    mapOf("id" to platformAgentId),
+                )
+            }
+
+            // WRITE on a platform entity requires super-admin — regular user must get nothing.
+            permissionService.filterVisibleIds(
+                regularUser.id.toString(),
+                EntityType.AGENT_CONFIG,
+                listOf(platformAgentId),
+                Action.WRITE,
+            ).shouldBeEmpty()
+        }
+
         "filterVisibleIds with WRITE action requires ADMIN — namespace MEMBER returns empty set" {
             val memberUser = createUser("member-write@example.com")
             val namespace = createNamespace("ns-member-write")

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/Neo4jTransitivePermissionsSpec.kt
@@ -680,7 +680,11 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
                 ).shouldBeEmpty()
         }
 
-        "filterVisibleIds returns all ids for super-admin including removed and platform entities" {
+        "filterVisibleIds for super-admin returns active and platform entities but excludes removed" {
+            // Super-admin access to platform entities is resolved in the Cypher query via
+            // (u.isAdmin = true AND checkPlatform AND e.namespaceId IS NULL). Removed entities
+            // are filtered by (e.removed IS NULL OR e.removed = false) for everyone, including
+            // super-admins — there is no service-level bypass for filterVisibleIds.
             val superAdmin = createUser("super-admin-filter@example.com", isAdmin = true)
             val namespace = createNamespace("ns-super-admin-filter")
             val activeAgentId = UUID.randomUUID().toString()
@@ -697,16 +701,13 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
                         "CREATE (e:AgentConfig {id: \$id, removed: true})-[:BELONGS_TO]->(ns)",
                     mapOf("id" to removedAgentId, "nsId" to namespace.id.toString()),
                 )
+                // Platform agent: no BELONGS_TO edge, namespaceId IS NULL
                 session.run(
                     "CREATE (e:AgentConfig {id: \$id})",
                     mapOf("id" to platformAgentId),
                 )
             }
 
-            // The service-level bypass (user.isAdmin == true) short-circuits before any
-            // Cypher query runs — the graph state is irrelevant. The unit test in
-            // PermissionServiceImplSpec verifies the bypass itself; this test verifies
-            // that the bypass correctly propagates through the full Spring context.
             val visible =
                 permissionService.filterVisibleIds(
                     superAdmin.id.toString(),
@@ -715,7 +716,7 @@ class Neo4jTransitivePermissionsSpec : StringSpec() {
                     Action.READ,
                 )
 
-            visible shouldBe setOf(activeAgentId, removedAgentId, platformAgentId)
+            visible shouldBe setOf(activeAgentId, platformAgentId)
         }
 
         "filterVisibleIds for namespace ADMIN returns entities in own namespace and excludes other namespaces" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
@@ -262,6 +262,57 @@ class PermissionServiceImplSpec : StringSpec({
     }
 
     // -------------------------------------------------------------------------
+    // Platform-scope (entityId = null)
+    // -------------------------------------------------------------------------
+
+    "platform-scope READ is granted to any non-admin authenticated user" {
+        val regularUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "user@example.com",
+            email = "user@example.com",
+            isAdmin = false
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+
+        val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.READ)
+
+        result shouldBe true
+        // Repository must NOT be consulted — no entityId to query.
+        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+        verify(exactly = 0) { mockPermissionCache.get(any<String>()) }
+    }
+
+    "platform-scope WRITE is denied for non-admin users" {
+        val regularUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "user@example.com",
+            email = "user@example.com",
+            isAdmin = false
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+
+        val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.WRITE)
+
+        result shouldBe false
+        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+    }
+
+    "platform-scope WRITE is granted to super-admin via the existing bypass" {
+        val adminUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "admin@example.com",
+            email = "admin@example.com",
+            isAdmin = true
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
+
+        val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.WRITE)
+
+        result shouldBe true
+        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+    }
+
+    // -------------------------------------------------------------------------
     // filterVisibleIds — batch authorization (story 5-3)
     // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
@@ -317,6 +317,13 @@ class PermissionServiceImplSpec : StringSpec({
     // -------------------------------------------------------------------------
 
     "filterVisibleIds returns the subset reported visible by the repository" {
+        val regularUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "user@example.com",
+            email = "user@example.com",
+            isAdmin = false,
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
         val id1 = UUID.randomUUID().toString()
         val id2 = UUID.randomUUID().toString()
         val id3 = UUID.randomUUID().toString()
@@ -328,6 +335,13 @@ class PermissionServiceImplSpec : StringSpec({
     }
 
     "filterVisibleIds maps WRITE/DELETE actions to ADMIN relation" {
+        val regularUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "user@example.com",
+            email = "user@example.com",
+            isAdmin = false,
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
         val id1 = UUID.randomUUID().toString()
         every {
             mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), PermissionRelation.ADMIN)
@@ -349,6 +363,13 @@ class PermissionServiceImplSpec : StringSpec({
     }
 
     "filterVisibleIds returns empty set when no candidate id is visible" {
+        val regularUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "user@example.com",
+            email = "user@example.com",
+            isAdmin = false,
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
         val id1 = UUID.randomUUID().toString()
         val id2 = UUID.randomUUID().toString()
         every {
@@ -359,11 +380,35 @@ class PermissionServiceImplSpec : StringSpec({
     }
 
     "filterVisibleIds returns empty set (fail-closed) when the repository throws" {
+        val regularUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "user@example.com",
+            email = "user@example.com",
+            isAdmin = false,
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
         val id1 = UUID.randomUUID().toString()
         every {
             mockPermissionRepository.filterVisibleIds(any(), any(), any(), any())
         } throws RuntimeException("Cypher failure")
 
         permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.READ) shouldBe emptySet()
+    }
+
+    "filterVisibleIds returns all ids for a super-admin WITHOUT calling the repository" {
+        val adminUser = User(
+            metadata = EntityMetadata(id = UUID.fromString(userId)),
+            externalId = "admin@example.com",
+            email = "admin@example.com",
+            isAdmin = true,
+        )
+        every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
+        val id1 = UUID.randomUUID().toString()
+        val id2 = UUID.randomUUID().toString()
+
+        val result = permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), Action.READ)
+
+        result shouldBe setOf(id1, id2)
+        verify(exactly = 0) { mockPermissionRepository.filterVisibleIds(any(), any(), any(), any()) }
     }
 })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
@@ -421,21 +421,20 @@ class PermissionServiceImplSpec :
             permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.READ) shouldBe emptySet()
         }
 
-        "filterVisibleIds returns all ids for a super-admin WITHOUT calling the repository" {
-            val adminUser =
-                User(
-                    metadata = EntityMetadata(id = UUID.fromString(userId)),
-                    externalId = "admin@example.com",
-                    email = "admin@example.com",
-                    isAdmin = true,
-                )
-            every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
+        "filterVisibleIds delegates to the repository for super-admin (no service-level bypass)" {
+            // Super-admin access to platform entities is handled inside the Cypher query
+            // (u.isAdmin = true AND checkPlatform AND e.namespaceId IS NULL), not by a
+            // service-level short-circuit. Removed entities are filtered by the query for
+            // everyone, including super-admins.
             val id1 = UUID.randomUUID().toString()
             val id2 = UUID.randomUUID().toString()
+            every {
+                mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), PermissionRelation.MEMBER)
+            } returns setOf(id1, id2)
 
             val result = permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), Action.READ)
 
             result shouldBe setOf(id1, id2)
-            verify(exactly = 0) { mockPermissionRepository.filterVisibleIds(any(), any(), any(), any()) }
+            verify(exactly = 1) { mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), PermissionRelation.MEMBER) }
         }
     })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
@@ -1,414 +1,451 @@
 package io.whozoss.agentos.permissions
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
 import java.util.UUID
 
-class PermissionServiceImplSpec : StringSpec({
+class PermissionServiceImplSpec :
+    StringSpec({
 
-    val mockUserService = mockk<UserService>()
-    val mockPermissionRepository = mockk<PermissionRepository>()
-    val mockPermissionCache = mockk<PermissionCache>()
+        val mockUserService = mockk<UserService>()
+        val mockPermissionRepository = mockk<PermissionRepository>()
+        val mockPermissionCache = mockk<PermissionCache>()
 
-    val permissionService = PermissionServiceImpl(
-        userService = mockUserService,
-        permissionRepository = mockPermissionRepository,
-        permissionCache = mockPermissionCache
-    )
-
-    val userId = UUID.randomUUID().toString()
-    val entityId = UUID.randomUUID().toString()
-    val entityType = EntityType.CASE
-
-    beforeTest {
-        clearAllMocks()
-    }
-
-    "should return true for super-admin users bypassing all checks" {
-        // Given
-        val adminUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "admin@example.com",
-            email = "admin@example.com",
-            isAdmin = true
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
-
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.DELETE)
-
-        // Then
-        result shouldBe true
-        verify(exactly = 0) { mockPermissionCache.get(any<String>()) }
-        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
-    }
-
-    "should return cached result when available" {
-        // Given
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        every {
-            mockPermissionCache.get(
-                "perm:$userId:$entityType:$entityId:${Action.READ}"
+        val permissionService =
+            PermissionServiceImpl(
+                userService = mockUserService,
+                permissionRepository = mockPermissionRepository,
+                permissionCache = mockPermissionCache,
             )
-        } returns true
 
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
+        val userId = UUID.randomUUID().toString()
+        val entityId = UUID.randomUUID().toString()
+        val entityType = EntityType.CASE
 
-        // Then
-        result shouldBe true
-        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
-    }
-
-    "should check direct permissions when not cached" {
-        // Given
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        every { mockPermissionCache.get(any<String>()) } returns null
-        every { mockPermissionCache.put(any(), any()) } just Runs
-        every {
-            mockPermissionRepository.hasDirectPermission(userId, entityType, entityId, PermissionRelation.MEMBER)
-        } returns true
-        every {
-            mockPermissionRepository.hasTransitivePermission(any(), any(), any(), any())
-        } returns false
-
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
-
-        // Then
-        result shouldBe true
-        verify { mockPermissionCache.put(any(), true) }
-    }
-
-    "should check transitive permissions when direct permission denied" {
-        // Given
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        every { mockPermissionCache.get(any<String>()) } returns null
-        every { mockPermissionCache.put(any(), any()) } just Runs
-        every {
-            mockPermissionRepository.hasDirectPermission(any(), any(), any(), any())
-        } returns false
-        every {
-            mockPermissionRepository.hasTransitivePermission(userId, entityType, entityId, PermissionRelation.ADMIN)
-        } returns true
-
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.WRITE)
-
-        // Then
-        result shouldBe true
-        verify { mockPermissionCache.put(any(), true) }
-    }
-
-    "should return false (fail-closed) when user not found" {
-        // Given
-        every { mockUserService.findById(UUID.fromString(userId)) } returns null
-        every { mockPermissionCache.get(any<String>()) } returns null
-        every { mockPermissionCache.put(any(), any()) } just Runs
-        every {
-            mockPermissionRepository.hasDirectPermission(any(), any(), any(), any())
-        } returns false
-        every {
-            mockPermissionRepository.hasTransitivePermission(any(), any(), any(), any())
-        } returns false
-
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
-
-        // Then
-        result shouldBe false
-    }
-
-    "should return false (fail-closed) on invalid UUID" {
-        // Given
-        val invalidUserId = "not-a-uuid"
-
-        // When
-        val result = permissionService.hasPermission(invalidUserId, entityType, entityId, Action.READ)
-
-        // Then
-        result shouldBe false
-    }
-
-    "should return false (fail-closed) on any exception" {
-        // Given
-        every { mockUserService.findById(any()) } throws RuntimeException("Database error")
-
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
-
-        // Then
-        result shouldBe false
-    }
-
-    "should invalidate entire cache when granting permission" {
-        // Given
-        every {
-            mockPermissionRepository.grantPermission(userId, entityType, entityId, PermissionRelation.ADMIN)
-        } just Runs
-        every { mockPermissionCache.clear() } just Runs
-
-        // When
-        permissionService.grantPermission(userId, entityType, entityId, PermissionRelation.ADMIN)
-
-        // Then
-        verify { mockPermissionCache.clear() }
-        verify { mockPermissionRepository.grantPermission(userId, entityType, entityId, PermissionRelation.ADMIN) }
-    }
-
-    "should invalidate entire cache when revoking permission" {
-        // Given
-        every {
-            mockPermissionRepository.revokePermission(userId, entityType, entityId, PermissionRelation.MEMBER)
-        } just Runs
-        every { mockPermissionCache.clear() } just Runs
-
-        // When
-        permissionService.revokePermission(userId, entityType, entityId, PermissionRelation.MEMBER)
-
-        // Then
-        verify { mockPermissionCache.clear() }
-        verify { mockPermissionRepository.revokePermission(userId, entityType, entityId, PermissionRelation.MEMBER) }
-    }
-
-    "READ action should accept MEMBER or ADMIN permission" {
-        // Given
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        every { mockPermissionCache.get(any<String>()) } returns null
-        every { mockPermissionCache.put(any(), any()) } just Runs
-        every {
-            mockPermissionRepository.hasDirectPermission(userId, entityType, entityId, PermissionRelation.MEMBER)
-        } returns true
-
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
-
-        // Then
-        result shouldBe true
-    }
-
-    "WRITE action should require ADMIN permission" {
-        // Given
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        every { mockPermissionCache.get(any<String>()) } returns null
-        every { mockPermissionCache.put(any(), any()) } just Runs
-        every {
-            mockPermissionRepository.hasDirectPermission(userId, entityType, entityId, PermissionRelation.ADMIN)
-        } returns false
-        every {
-            mockPermissionRepository.hasTransitivePermission(any(), any(), any(), any())
-        } returns false
-
-        // When
-        val result = permissionService.hasPermission(userId, entityType, entityId, Action.WRITE)
-
-        // Then
-        result shouldBe false
-    }
-
-    "should return empty list when listing entities fails" {
-        // Given
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        every {
-            mockPermissionRepository.listEntitiesForUser(any(), any(), any())
-        } throws RuntimeException("Database error")
-
-        // When
-        val result = permissionService.listEntitiesForUser(userId, entityType, Action.READ)
-
-        // Then
-        result shouldBe emptyList()
-    }
-
-    // -------------------------------------------------------------------------
-    // Platform-scope (entityId = null)
-    // -------------------------------------------------------------------------
-
-    "platform-scope READ is granted to any non-admin authenticated user" {
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-
-        val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.READ)
-
-        result shouldBe true
-        // Repository must NOT be consulted — no entityId to query.
-        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
-        verify(exactly = 0) { mockPermissionCache.get(any<String>()) }
-    }
-
-    "platform-scope WRITE is denied for non-admin users" {
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-
-        val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.WRITE)
-
-        result shouldBe false
-        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
-    }
-
-    "platform-scope WRITE is granted to super-admin via the existing bypass" {
-        val adminUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "admin@example.com",
-            email = "admin@example.com",
-            isAdmin = true
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
-
-        val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.WRITE)
-
-        result shouldBe true
-        verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
-    }
-
-    // -------------------------------------------------------------------------
-    // filterVisibleIds — batch authorization (story 5-3)
-    // -------------------------------------------------------------------------
-
-    "filterVisibleIds returns the subset reported visible by the repository" {
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false,
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        val id1 = UUID.randomUUID().toString()
-        val id2 = UUID.randomUUID().toString()
-        val id3 = UUID.randomUUID().toString()
-        every {
-            mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2, id3), PermissionRelation.MEMBER)
-        } returns setOf(id1, id3)
-
-        permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2, id3), Action.READ) shouldBe setOf(id1, id3)
-    }
-
-    "filterVisibleIds maps WRITE/DELETE actions to ADMIN relation" {
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false,
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        val id1 = UUID.randomUUID().toString()
-        every {
-            mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), PermissionRelation.ADMIN)
-        } returns setOf(id1)
-
-        permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.WRITE) shouldBe setOf(id1)
-        permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.DELETE) shouldBe setOf(id1)
-
-        verify(exactly = 2) {
-            mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), PermissionRelation.ADMIN)
+        beforeTest {
+            clearAllMocks()
         }
-    }
 
-    "filterVisibleIds short-circuits to empty set on empty input WITHOUT touching the repository" {
-        val result = permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, emptyList(), Action.READ)
+        "should return true for super-admin users bypassing all checks" {
+            // Given
+            val adminUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "admin@example.com",
+                    email = "admin@example.com",
+                    isAdmin = true,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
 
-        result shouldBe emptySet()
-        verify(exactly = 0) { mockPermissionRepository.filterVisibleIds(any(), any(), any(), any()) }
-    }
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.DELETE)
 
-    "filterVisibleIds returns empty set when no candidate id is visible" {
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false,
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        val id1 = UUID.randomUUID().toString()
-        val id2 = UUID.randomUUID().toString()
-        every {
-            mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), PermissionRelation.MEMBER)
-        } returns emptySet()
+            // Then
+            result shouldBe true
+            verify(exactly = 0) { mockPermissionCache.get(any<String>()) }
+            verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+        }
 
-        permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), Action.READ) shouldBe emptySet()
-    }
+        "should return cached result when available" {
+            // Given
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            every {
+                mockPermissionCache.get(
+                    "perm:$userId:$entityType:$entityId:${Action.READ}",
+                )
+            } returns true
 
-    "filterVisibleIds returns empty set (fail-closed) when the repository throws" {
-        val regularUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "user@example.com",
-            email = "user@example.com",
-            isAdmin = false,
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
-        val id1 = UUID.randomUUID().toString()
-        every {
-            mockPermissionRepository.filterVisibleIds(any(), any(), any(), any())
-        } throws RuntimeException("Cypher failure")
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
 
-        permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.READ) shouldBe emptySet()
-    }
+            // Then
+            result shouldBe true
+            verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+        }
 
-    "filterVisibleIds returns all ids for a super-admin WITHOUT calling the repository" {
-        val adminUser = User(
-            metadata = EntityMetadata(id = UUID.fromString(userId)),
-            externalId = "admin@example.com",
-            email = "admin@example.com",
-            isAdmin = true,
-        )
-        every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
-        val id1 = UUID.randomUUID().toString()
-        val id2 = UUID.randomUUID().toString()
+        "should check direct permissions when not cached" {
+            // Given
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            every { mockPermissionCache.get(any<String>()) } returns null
+            every { mockPermissionCache.put(any(), any()) } just Runs
+            every {
+                mockPermissionRepository.hasDirectPermission(userId, entityType, entityId, PermissionRelation.MEMBER)
+            } returns true
+            every {
+                mockPermissionRepository.hasTransitivePermission(any(), any(), any(), any())
+            } returns false
 
-        val result = permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), Action.READ)
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
 
-        result shouldBe setOf(id1, id2)
-        verify(exactly = 0) { mockPermissionRepository.filterVisibleIds(any(), any(), any(), any()) }
-    }
-})
+            // Then
+            result shouldBe true
+            verify { mockPermissionCache.put(any(), true) }
+        }
+
+        "should check transitive permissions when direct permission denied" {
+            // Given
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            every { mockPermissionCache.get(any<String>()) } returns null
+            every { mockPermissionCache.put(any(), any()) } just Runs
+            every {
+                mockPermissionRepository.hasDirectPermission(any(), any(), any(), any())
+            } returns false
+            every {
+                mockPermissionRepository.hasTransitivePermission(userId, entityType, entityId, PermissionRelation.ADMIN)
+            } returns true
+
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.WRITE)
+
+            // Then
+            result shouldBe true
+            verify { mockPermissionCache.put(any(), true) }
+        }
+
+        "should return false (fail-closed) when user not found" {
+            // Given
+            every { mockUserService.findById(UUID.fromString(userId)) } returns null
+            every { mockPermissionCache.get(any<String>()) } returns null
+            every { mockPermissionCache.put(any(), any()) } just Runs
+            every {
+                mockPermissionRepository.hasDirectPermission(any(), any(), any(), any())
+            } returns false
+            every {
+                mockPermissionRepository.hasTransitivePermission(any(), any(), any(), any())
+            } returns false
+
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
+
+            // Then
+            result shouldBe false
+        }
+
+        "should return false (fail-closed) on invalid UUID" {
+            // Given
+            val invalidUserId = "not-a-uuid"
+
+            // When
+            val result = permissionService.hasPermission(invalidUserId, entityType, entityId, Action.READ)
+
+            // Then
+            result shouldBe false
+        }
+
+        "should return false (fail-closed) on any exception" {
+            // Given
+            every { mockUserService.findById(any()) } throws RuntimeException("Database error")
+
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
+
+            // Then
+            result shouldBe false
+        }
+
+        "should invalidate entire cache when granting permission" {
+            // Given
+            every {
+                mockPermissionRepository.grantPermission(userId, entityType, entityId, PermissionRelation.ADMIN)
+            } just Runs
+            every { mockPermissionCache.clear() } just Runs
+
+            // When
+            permissionService.grantPermission(userId, entityType, entityId, PermissionRelation.ADMIN)
+
+            // Then
+            verify { mockPermissionCache.clear() }
+            verify { mockPermissionRepository.grantPermission(userId, entityType, entityId, PermissionRelation.ADMIN) }
+        }
+
+        "should invalidate entire cache when revoking permission" {
+            // Given
+            every {
+                mockPermissionRepository.revokePermission(userId, entityType, entityId, PermissionRelation.MEMBER)
+            } just Runs
+            every { mockPermissionCache.clear() } just Runs
+
+            // When
+            permissionService.revokePermission(userId, entityType, entityId, PermissionRelation.MEMBER)
+
+            // Then
+            verify { mockPermissionCache.clear() }
+            verify { mockPermissionRepository.revokePermission(userId, entityType, entityId, PermissionRelation.MEMBER) }
+        }
+
+        "READ action should accept MEMBER or ADMIN permission" {
+            // Given
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            every { mockPermissionCache.get(any<String>()) } returns null
+            every { mockPermissionCache.put(any(), any()) } just Runs
+            every {
+                mockPermissionRepository.hasDirectPermission(userId, entityType, entityId, PermissionRelation.MEMBER)
+            } returns true
+
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
+
+            // Then
+            result shouldBe true
+        }
+
+        "WRITE action should require ADMIN permission" {
+            // Given
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            every { mockPermissionCache.get(any<String>()) } returns null
+            every { mockPermissionCache.put(any(), any()) } just Runs
+            every {
+                mockPermissionRepository.hasDirectPermission(userId, entityType, entityId, PermissionRelation.ADMIN)
+            } returns false
+            every {
+                mockPermissionRepository.hasTransitivePermission(any(), any(), any(), any())
+            } returns false
+
+            // When
+            val result = permissionService.hasPermission(userId, entityType, entityId, Action.WRITE)
+
+            // Then
+            result shouldBe false
+        }
+
+        "should return empty list when listing entities fails" {
+            // Given
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            every {
+                mockPermissionRepository.listEntitiesForUser(any(), any(), any())
+            } throws RuntimeException("Database error")
+
+            // When
+            val result = permissionService.listEntitiesForUser(userId, entityType, Action.READ)
+
+            // Then
+            result shouldBe emptyList()
+        }
+
+        // -------------------------------------------------------------------------
+        // Platform-scope (entityId = null)
+        // -------------------------------------------------------------------------
+
+        "platform-scope READ is granted to any non-admin authenticated user" {
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+
+            val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.READ)
+
+            result shouldBe true
+            // Repository must NOT be consulted — no entityId to query.
+            verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+            verify(exactly = 0) { mockPermissionCache.get(any<String>()) }
+        }
+
+        "platform-scope WRITE is denied for non-admin users" {
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+
+            val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.WRITE)
+
+            result shouldBe false
+            verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+        }
+
+        "platform-scope DELETE is denied for non-admin users" {
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+
+            val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.DELETE)
+
+            result shouldBe false
+            verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+        }
+
+        "platform-scope WRITE is granted to super-admin via the existing bypass" {
+            val adminUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "admin@example.com",
+                    email = "admin@example.com",
+                    isAdmin = true,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
+
+            val result = permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.WRITE)
+
+            result shouldBe true
+            verify(exactly = 0) { mockPermissionRepository.hasDirectPermission(any(), any(), any(), any()) }
+        }
+
+        // -------------------------------------------------------------------------
+        // filterVisibleIds — batch authorization (story 5-3)
+        // -------------------------------------------------------------------------
+
+        "filterVisibleIds returns the subset reported visible by the repository" {
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            val id1 = UUID.randomUUID().toString()
+            val id2 = UUID.randomUUID().toString()
+            val id3 = UUID.randomUUID().toString()
+            every {
+                mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2, id3), PermissionRelation.MEMBER)
+            } returns setOf(id1, id3)
+
+            permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2, id3), Action.READ) shouldBe setOf(id1, id3)
+        }
+
+        "filterVisibleIds maps WRITE/DELETE actions to ADMIN relation" {
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            val id1 = UUID.randomUUID().toString()
+            every {
+                mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), PermissionRelation.ADMIN)
+            } returns setOf(id1)
+
+            permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.WRITE) shouldBe setOf(id1)
+            permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.DELETE) shouldBe setOf(id1)
+
+            verify(exactly = 2) {
+                mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), PermissionRelation.ADMIN)
+            }
+        }
+
+        "filterVisibleIds short-circuits to empty set on empty input WITHOUT touching the repository" {
+            val result = permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, emptyList(), Action.READ)
+
+            result shouldBe emptySet()
+            verify(exactly = 0) { mockPermissionRepository.filterVisibleIds(any(), any(), any(), any()) }
+        }
+
+        "filterVisibleIds returns empty set when no candidate id is visible" {
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            val id1 = UUID.randomUUID().toString()
+            val id2 = UUID.randomUUID().toString()
+            every {
+                mockPermissionRepository.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), PermissionRelation.MEMBER)
+            } returns emptySet()
+
+            permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), Action.READ) shouldBe emptySet()
+        }
+
+        "filterVisibleIds returns empty set (fail-closed) when the repository throws" {
+            val regularUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "user@example.com",
+                    email = "user@example.com",
+                    isAdmin = false,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            val id1 = UUID.randomUUID().toString()
+            every {
+                mockPermissionRepository.filterVisibleIds(any(), any(), any(), any())
+            } throws RuntimeException("Cypher failure")
+
+            permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1), Action.READ) shouldBe emptySet()
+        }
+
+        "filterVisibleIds returns all ids for a super-admin WITHOUT calling the repository" {
+            val adminUser =
+                User(
+                    metadata = EntityMetadata(id = UUID.fromString(userId)),
+                    externalId = "admin@example.com",
+                    email = "admin@example.com",
+                    isAdmin = true,
+                )
+            every { mockUserService.findById(UUID.fromString(userId)) } returns adminUser
+            val id1 = UUID.randomUUID().toString()
+            val id2 = UUID.randomUUID().toString()
+
+            val result = permissionService.filterVisibleIds(userId, EntityType.AGENT_CONFIG, listOf(id1, id2), Action.READ)
+
+            result shouldBe setOf(id1, id2)
+            verify(exactly = 0) { mockPermissionRepository.filterVisibleIds(any(), any(), any(), any()) }
+        }
+    })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/permissions/PermissionServiceImplSpec.kt
@@ -133,8 +133,10 @@ class PermissionServiceImplSpec :
             verify { mockPermissionCache.put(any(), true) }
         }
 
-        "should return false (fail-closed) when user not found" {
-            // Given
+        "should return false when user not found — falls through to direct/transitive checks which deny" {
+            // User not found means isAdmin is null/false — no bypass. The code then
+            // proceeds to the normal evaluation path, which returns false here because
+            // neither direct nor transitive permission is granted.
             every { mockUserService.findById(UUID.fromString(userId)) } returns null
             every { mockPermissionCache.get(any<String>()) } returns null
             every { mockPermissionCache.put(any(), any()) } just Runs
@@ -145,10 +147,8 @@ class PermissionServiceImplSpec :
                 mockPermissionRepository.hasTransitivePermission(any(), any(), any(), any())
             } returns false
 
-            // When
             val result = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
 
-            // Then
             result shouldBe false
         }
 
@@ -254,23 +254,13 @@ class PermissionServiceImplSpec :
         }
 
         "should return empty list when listing entities fails" {
-            // Given
-            val regularUser =
-                User(
-                    metadata = EntityMetadata(id = UUID.fromString(userId)),
-                    externalId = "user@example.com",
-                    email = "user@example.com",
-                    isAdmin = false,
-                )
-            every { mockUserService.findById(UUID.fromString(userId)) } returns regularUser
+            // listEntitiesForUser does not resolve the user — no userService stub needed.
             every {
                 mockPermissionRepository.listEntitiesForUser(any(), any(), any())
             } throws RuntimeException("Database error")
 
-            // When
             val result = permissionService.listEntitiesForUser(userId, entityType, Action.READ)
 
-            // Then
             result shouldBe emptyList()
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/security/declarative/AgentOsPermissionEvaluatorSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/security/declarative/AgentOsPermissionEvaluatorSpec.kt
@@ -140,8 +140,30 @@ class AgentOsPermissionEvaluatorSpec : StringSpec({
         evaluator.hasPermission(null, UUID.randomUUID(), "Case", "READ") shouldBe false
     }
 
-    "hasPermission returns false when targetId is null" {
-        evaluator.hasPermission(auth, null, "Case", "READ") shouldBe false
+    "hasPermission returns false when targetId is null and targetType is null" {
+        evaluator.hasPermission(auth, null, null, "READ") shouldBe false
+    }
+
+    "hasPermission delegates null targetId to PermissionService for platform-scoped READ" {
+        every {
+            permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.READ)
+        } returns true
+
+        evaluator.hasPermission(auth, null, "AgentConfig", "READ") shouldBe true
+
+        verify(exactly = 1) {
+            permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.READ)
+        }
+        // Ownership branch must NOT be consulted when targetId is null.
+        verify(exactly = 0) { ownershipResolver.resolveOwner(any(), any()) }
+    }
+
+    "hasPermission delegates null targetId to PermissionService for platform-scoped WRITE (denied for non-admin)" {
+        every {
+            permissionService.hasPermission(userId, EntityType.AGENT_CONFIG, null, Action.WRITE)
+        } returns false
+
+        evaluator.hasPermission(auth, null, "AgentConfig", "WRITE") shouldBe false
     }
 
     "hasPermission returns false when targetType is null" {


### PR DESCRIPTION
Prepare platform level for permission system by making `entityId` nullable as it will correspond to the absence of namespaceId, signaling a platform-level entity.

In that case:
- READ for all
- WRITE for super-admins only (`user.isAdmin == true`)