### PR TITLE
feat: #32839 #32841 improve redirect tool description for no-agent and relevance cases

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectTool.kt
@@ -66,26 +66,32 @@ class RedirectTool(
 
     override val name: String = configName?.let { "${it}__redirect" } ?: "redirect"
 
-    override val description: String = buildString {
-        appendLine("Route the current request to another agent. Use this when the request is better handled by a specialised agent.")
-        appendLine("Available agents:")
-        eligibleAgents.forEach { agent ->
-            val desc = agent.description?.takeIf { it.isNotBlank() }
-            when (desc) {
-                null -> appendLine("  - ${agent.name}")
-                else -> appendLine("  - ${agent.name}: $desc")
-            }
-            if (agent.integrations.isNotEmpty()) {
-                appendLine("    Integrations:")
-                agent.integrations.forEach { integration ->
-                    when (val tools = integration.allowedTools) {
-                        null -> appendLine("      - ${integration.name}")
-                        else -> appendLine("      - ${integration.name}: ${tools.joinToString(", ")}")
+    override val description: String = when {
+        eligibleAgents.isEmpty() ->
+            "No other agents are currently available for redirection. Do not attempt to delegate — handle the request yourself or inform the user that no other agent can address it."
+        else -> buildString {
+            appendLine("Route the current request to another agent.")
+            appendLine("Only use this tool if at least one of the available agents below is clearly relevant to the user's request.")
+            appendLine("If no available agent is relevant, do NOT call this tool — instead, respond directly to the user explaining that no agent can handle the request.")
+            appendLine("Available agents:")
+            eligibleAgents.forEach { agent ->
+                val desc = agent.description?.takeIf { it.isNotBlank() }
+                when (desc) {
+                    null -> appendLine("  - ${agent.name}")
+                    else -> appendLine("  - ${agent.name}: $desc")
+                }
+                if (agent.integrations.isNotEmpty()) {
+                    appendLine("    Integrations:")
+                    agent.integrations.forEach { integration ->
+                        when (val tools = integration.allowedTools) {
+                            null -> appendLine("      - ${integration.name}")
+                            else -> appendLine("      - ${integration.name}: ${tools.joinToString(", ")}")
+                        }
                     }
                 }
             }
-        }
-    }.trimEnd()
+        }.trimEnd()
+    }
 
     override val inputSchema: String = buildString {
         val names = eligibleAgents.joinToString(", ") { "\"${it.name}\"" }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
@@ -91,10 +91,9 @@ class RedirectToolPlugin(
 
         if (eligibleAgents.isEmpty()) {
             logger.warn { "[RedirectToolPlugin] No eligible agents found for namespace $namespaceId with patterns $patterns" }
-            return emptyList()
+        } else {
+            logger.info { "[RedirectToolPlugin] Resolved ${eligibleAgents.size} eligible agent(s) for namespace $namespaceId" }
         }
-
-        logger.info { "[RedirectToolPlugin] Resolved ${eligibleAgents.size} eligible agent(s) for namespace $namespaceId" }
         return listOf(RedirectTool(configName = configName, eligibleAgents = eligibleAgents))
     }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
@@ -140,12 +140,16 @@ class RedirectToolPluginSpec : StringSpec({
         tool.eligibleAgents.first().integrations shouldBe emptyList()
     }
 
-    "provideTools returns empty list when resolver returns no agents" {
+    "provideTools returns a RedirectTool with no-agents description when resolver returns no agents" {
         val plugin = RedirectToolPlugin { _, _, _ -> emptyList() }
 
         val tools = plugin.provideTools(config = null, context = context(userId = userId))
 
-        tools.shouldBeEmpty()
+        tools shouldHaveSize 1
+        val tool = tools.first() as RedirectTool
+        tool.eligibleAgents.shouldBeEmpty()
+        tool.description shouldBe
+            "No other agents are currently available for redirection. Do not attempt to delegate — handle the request yourself or inform the user that no other agent can address it."
     }
 
     // -------------------------------------------------------------------------
@@ -163,12 +167,14 @@ class RedirectToolPluginSpec : StringSpec({
         tool.eligibleAgents.map { it.name } shouldBe listOf("AgentB")
     }
 
-    "provideTools returns empty list when calling agent is the only eligible agent" {
+    "provideTools returns a RedirectTool with no-agents description when calling agent is the only eligible agent" {
         val agents = listOf(agentConfig("AgentA", "Does A"))
         val plugin = RedirectToolPlugin { _, _, _ -> agents }
 
         val tools = plugin.provideTools(config = null, context = context(agentName = "AgentA"))
-        tools.shouldBeEmpty()
+        tools shouldHaveSize 1
+        val tool = tools.first() as RedirectTool
+        tool.eligibleAgents.shouldBeEmpty()
     }
 
     "provideTools does not exclude anything when context has no agentName" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolSpec.kt
@@ -19,6 +19,26 @@ class RedirectToolSpec : StringSpec({
     // description - integration rendering
     // -------------------------------------------------------------------------
 
+    "description is the no-agents warning when eligible agents list is empty" {
+        val tool = RedirectTool(configName = null, eligibleAgents = emptyList())
+        tool.description shouldBe
+            "No other agents are currently available for redirection. Do not attempt to delegate — handle the request yourself or inform the user that no other agent can address it."
+    }
+
+    "description includes relevance instructions and agent list when agents are available" {
+        val tool = RedirectTool(
+            configName = null,
+            eligibleAgents = listOf(RedirectTool.EligibleAgent(name = "AgentA", description = "Does A")),
+        )
+        tool.description shouldBe """
+            Route the current request to another agent.
+            Only use this tool if at least one of the available agents below is clearly relevant to the user's request.
+            If no available agent is relevant, do NOT call this tool — instead, respond directly to the user explaining that no agent can handle the request.
+            Available agents:
+              - AgentA: Does A
+        """.trimIndent()
+    }
+
     "description includes integration names when agent has integrations" {
         val tool = RedirectTool(
             configName = null,
@@ -34,7 +54,9 @@ class RedirectToolSpec : StringSpec({
             ),
         )
         tool.description shouldBe """
-            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Route the current request to another agent.
+            Only use this tool if at least one of the available agents below is clearly relevant to the user's request.
+            If no available agent is relevant, do NOT call this tool — instead, respond directly to the user explaining that no agent can handle the request.
             Available agents:
               - AgentA: Does A
                 Integrations:
@@ -57,7 +79,9 @@ class RedirectToolSpec : StringSpec({
             ),
         )
         tool.description shouldBe """
-            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Route the current request to another agent.
+            Only use this tool if at least one of the available agents below is clearly relevant to the user's request.
+            If no available agent is relevant, do NOT call this tool — instead, respond directly to the user explaining that no agent can handle the request.
             Available agents:
               - AgentA: Does A
                 Integrations:
@@ -73,7 +97,9 @@ class RedirectToolSpec : StringSpec({
             ),
         )
         tool.description shouldBe """
-            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Route the current request to another agent.
+            Only use this tool if at least one of the available agents below is clearly relevant to the user's request.
+            If no available agent is relevant, do NOT call this tool — instead, respond directly to the user explaining that no agent can handle the request.
             Available agents:
               - AgentA: Does A
         """.trimIndent()
@@ -94,7 +120,9 @@ class RedirectToolSpec : StringSpec({
             ),
         )
         tool.description shouldBe """
-            Route the current request to another agent. Use this when the request is better handled by a specialised agent.
+            Route the current request to another agent.
+            Only use this tool if at least one of the available agents below is clearly relevant to the user's request.
+            If no available agent is relevant, do NOT call this tool — instead, respond directly to the user explaining that no agent can handle the request.
             Available agents:
               - AgentA: Does A
                 Integrations:


### PR DESCRIPTION
## What

Two improvements to the `RedirectTool` description to prevent hallucinations and irrelevant delegations.

**WZ-32839 — no-agent-available case**
`provideTools` now always returns a `RedirectTool`, even when `eligibleAgents` is empty. When empty, the tool's description is a sentinel message explicitly telling the agent that no redirection is possible and it must not attempt to delegate.

**WZ-32841 — relevance assessment before redirecting**
When agents are available, the description now opens with three explicit instructions: only redirect if a relevant agent exists, otherwise respond directly to the user. The agent list follows as before.

## Why this approach

The tool is the only agent-scoped channel for this signal. `describeNamespace` was considered but rejected — it feeds the namespace system prompt shared by all agents regardless of their integration config, which would inject irrelevant noise for agents that don't have REDIRECT in their integrations.

## Changes

- `RedirectTool.description`: bifurcated on `eligibleAgents.isEmpty()` — sentinel string vs. relevance-prefixed agent list
- `RedirectToolPlugin.provideTools`: always returns a `RedirectTool` (was: `emptyList()` when no agents)
- Tests updated accordingly