### PR TITLE
feat: #WZ-32858 evict idle CaseRuntime when no SSE subscribers

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos
 
 import io.whozoss.agentos.agent.AgentConfigProperties
+import io.whozoss.agentos.caseFlow.CaseConfigProperties
 import io.whozoss.agentos.config.PersistenceConfigProperties
 import io.whozoss.agentos.service.config.AgentOsPluginsConfigProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -15,7 +16,12 @@ import org.springframework.boot.runApplication
         org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration::class,
     ],
 )
-@EnableConfigurationProperties(AgentConfigProperties::class, AgentOsPluginsConfigProperties::class, PersistenceConfigProperties::class)
+@EnableConfigurationProperties(
+    AgentConfigProperties::class,
+    CaseConfigProperties::class,
+    AgentOsPluginsConfigProperties::class,
+    PersistenceConfigProperties::class,
+)
 class AgentOSApplication
 
 fun main(args: Array<String>) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
@@ -4,13 +4,17 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import io.whozoss.agentos.caseFlow.CaseConfigProperties
 import io.whozoss.agentos.caseFlow.CaseService
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.security.declarative.HideOnAccessDenied
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import mu.KLogging
 import org.springframework.security.access.prepost.PreAuthorize
@@ -34,7 +38,9 @@ import java.util.UUID
 class CaseEventSseController(
     private val caseService: CaseService,
     private val caseEventService: CaseEventService,
+    private val caseConfig: CaseConfigProperties = CaseConfigProperties(),
 ) {
+    private val heartbeatIntervalMs get() = caseConfig.sseHeartbeatIntervalMs
     /**
      * Stream events for a case via SSE.
      *
@@ -107,27 +113,57 @@ class CaseEventSseController(
                         }
                     }
                     emitter.complete()
+                } catch (_: CancellationException) {
+                    // Normal path: collectorJob was cancelled because the client disconnected
+                    // (onError/onCompletion fired and called scope.cancel()). Not an error.
+                    logger.debug { "SSE collector cancelled for case $caseId (client disconnected)" }
                 } catch (error: Exception) {
                     logger.error("Error in event stream for case $caseId", error)
                     emitter.completeWithError(error)
                 }
             }
 
+        // Heartbeat: periodically send an SSE comment frame so that a client
+        // disconnect is detected even when the case is IDLE and emits no events.
+        // Without this, the collector coroutine above stays suspended on collect()
+        // indefinitely, keeping the SharedFlow subscriber alive and blocking eviction.
+        val heartbeatJob =
+            scope.launch {
+                while (isActive) {
+                    delay(heartbeatIntervalMs)
+                    try {
+                        // SSE comment — ignored by EventSource but forces a socket write.
+                        emitter.send(
+                            SseEmitter
+                                .event()
+                                .comment("keep-alive"),
+                        )
+                    } catch (e: Exception) {
+                        // The socket is gone. collectorJob will be cancelled via onError/onCompletion.
+                        logger.debug { "Heartbeat write failed for case $caseId — client likely disconnected" }
+                        break
+                    }
+                }
+            }
+
         emitter.onCompletion {
             logger.debug { "SSE emitter completed for case $caseId" }
             collectorJob.cancel()
+            heartbeatJob.cancel()
             scope.cancel()
         }
 
         emitter.onTimeout {
             logger.debug { "SSE emitter timed out for case $caseId" }
             collectorJob.cancel()
+            heartbeatJob.cancel()
             scope.cancel()
         }
 
         emitter.onError { throwable ->
-            logger.warn { "SSE emitter error for case $caseId: ${throwable.message}" }
+            logger.debug { "SSE emitter error for case $caseId: ${throwable.message}" }
             collectorJob.cancel()
+            heartbeatJob.cancel()
             scope.cancel()
         }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 class CaseEventSseController(
     private val caseService: CaseService,
     private val caseEventService: CaseEventService,
-    private val caseConfig: CaseConfigProperties = CaseConfigProperties(),
+    private val caseConfig: CaseConfigProperties,
 ) {
     private val heartbeatIntervalMs get() = caseConfig.sseHeartbeatIntervalMs
     /**
@@ -139,8 +139,11 @@ class CaseEventSseController(
                                 .comment("keep-alive"),
                         )
                     } catch (e: Exception) {
-                        // The socket is gone. collectorJob will be cancelled via onError/onCompletion.
+                        // The socket is gone. Cancel the scope explicitly here rather than
+                        // relying solely on Tomcat's onError callback: if that callback never
+                        // fires, collectorJob would stay subscribed indefinitely.
                         logger.debug { "Heartbeat write failed for case $caseId — client likely disconnected" }
+                        scope.cancel()
                         break
                     }
                 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
@@ -11,6 +11,7 @@ import io.whozoss.agentos.security.declarative.HideOnAccessDenied
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -41,6 +42,7 @@ class CaseEventSseController(
     private val caseConfig: CaseConfigProperties,
 ) {
     private val heartbeatIntervalMs get() = caseConfig.sseHeartbeatIntervalMs
+
     /**
      * Stream events for a case via SSE.
      *
@@ -113,10 +115,11 @@ class CaseEventSseController(
                         }
                     }
                     emitter.complete()
-                } catch (_: CancellationException) {
+                } catch (e: CancellationException) {
                     // Normal path: collectorJob was cancelled because the client disconnected
                     // (onError/onCompletion fired and called scope.cancel()). Not an error.
                     logger.debug { "SSE collector cancelled for case $caseId (client disconnected)" }
+                    throw e  // re-throw so cancellation propagates correctly through the coroutine hierarchy
                 } catch (error: Exception) {
                     logger.error("Error in event stream for case $caseId", error)
                     emitter.completeWithError(error)
@@ -127,52 +130,54 @@ class CaseEventSseController(
         // disconnect is detected even when the case is IDLE and emits no events.
         // Without this, the collector coroutine above stays suspended on collect()
         // indefinitely, keeping the SharedFlow subscriber alive and blocking eviction.
-        val heartbeatJob =
-            scope.launch {
-                while (isActive) {
-                    delay(heartbeatIntervalMs)
-                    try {
-                        // SSE comment — ignored by EventSource but forces a socket write.
-                        emitter.send(
-                            SseEmitter
-                                .event()
-                                .comment("keep-alive"),
-                        )
-                    } catch (e: Exception) {
-                        // The socket is gone. Cancel the scope explicitly here rather than
-                        // relying solely on Tomcat's onError callback: if that callback never
-                        // fires, collectorJob would stay subscribed indefinitely.
-                        logger.debug { "Heartbeat write failed for case $caseId — client likely disconnected" }
-                        scope.cancel()
-                        break
-                    }
-                }
-            }
+        startHeartbeatJob(scope, emitter, caseId)
 
         emitter.onCompletion {
             logger.debug { "SSE emitter completed for case $caseId" }
-            collectorJob.cancel()
-            heartbeatJob.cancel()
-            scope.cancel()
+            scope.cancel()  // cancels all child jobs (collectorJob, heartbeatJob)
         }
 
         emitter.onTimeout {
             logger.debug { "SSE emitter timed out for case $caseId" }
-            collectorJob.cancel()
-            heartbeatJob.cancel()
             scope.cancel()
         }
 
         emitter.onError { throwable ->
             logger.debug { "SSE emitter error for case $caseId: ${throwable.message}" }
-            collectorJob.cancel()
-            heartbeatJob.cancel()
             scope.cancel()
         }
 
         logger.info { "SSE connection established for case: $caseId" }
         return emitter
     }
+
+    private fun startHeartbeatJob(
+        scope: CoroutineScope,
+        emitter: SseEmitter,
+        caseId: UUID,
+    ): Job =
+        scope.launch {
+            while (isActive) {
+                delay(heartbeatIntervalMs)
+                try {
+                    // SSE comment — ignored by EventSource but forces a socket write.
+                    emitter.send(
+                        SseEmitter
+                            .event()
+                            .comment("keep-alive"),
+                    )
+                } catch (e: Exception) {
+                    // The socket is gone. Cancel the scope explicitly here rather than
+                    // relying solely on Tomcat's onError callback: if that callback never
+                    // fires, collectorJob would stay subscribed indefinitely.
+                    // scope.cancel() propagates to all child jobs so no explicit break is
+                    // needed — this coroutine will receive CancellationException at the
+                    // next delay() and exit the while loop naturally.
+                    logger.debug { "Heartbeat write failed for case $caseId — client likely disconnected" }
+                    scope.cancel()
+                }
+            }
+        }
 
     companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
@@ -91,40 +91,39 @@ class CaseEventSseController(
                     .data(event),
             )
 
-        val collectorJob =
-            scope.launch {
-                try {
-                    if (includePreviousEvents == true) {
-                        // Replay persisted history first so clients connecting mid-run
-                        // or reconnecting after a disconnect receive the full sequence.
-                        caseEventService.findByParent(caseId).forEach { sendEvent(it) }
-                    }
-
-                    // If the case is still active, subscribe to the live flow.
-                    // findActiveRuntime never rehydrates — safe for observation only.
-                    // If the case is completed, the history replay above is sufficient
-                    // and the emitter completes at the end of the try block.
-                    val activeCase = caseService.findActiveRuntime(caseId)
-                    activeCase?.events?.collect { event ->
-                        try {
-                            sendEvent(event)
-                            logger.trace { "Event ${event.type} sent to SSE for case $caseId" }
-                        } catch (e: Exception) {
-                            logger.debug { "Failed to send event to SSE for case $caseId: ${e.message}" }
-                            throw e
-                        }
-                    }
-                    emitter.complete()
-                } catch (e: CancellationException) {
-                    // Normal path: collectorJob was cancelled because the client disconnected
-                    // (onError/onCompletion fired and called scope.cancel()). Not an error.
-                    logger.debug { "SSE collector cancelled for case $caseId (client disconnected)" }
-                    throw e  // re-throw so cancellation propagates correctly through the coroutine hierarchy
-                } catch (error: Exception) {
-                    logger.error("Error in event stream for case $caseId", error)
-                    emitter.completeWithError(error)
+        scope.launch {
+            try {
+                if (includePreviousEvents == true) {
+                    // Replay persisted history first so clients connecting mid-run
+                    // or reconnecting after a disconnect receive the full sequence.
+                    caseEventService.findByParent(caseId).forEach { sendEvent(it) }
                 }
+
+                // If the case is still active, subscribe to the live flow.
+                // findActiveRuntime never rehydrates — safe for observation only.
+                // If the case is completed, the history replay above is sufficient
+                // and the emitter completes at the end of the try block.
+                val activeCase = caseService.findActiveRuntime(caseId)
+                activeCase?.events?.collect { event ->
+                    try {
+                        sendEvent(event)
+                        logger.trace { "Event ${event.type} sent to SSE for case $caseId" }
+                    } catch (e: Exception) {
+                        logger.debug { "Failed to send event to SSE for case $caseId: ${e.message}" }
+                        throw e
+                    }
+                }
+                emitter.complete()
+            } catch (e: CancellationException) {
+                // Normal path: collectorJob was cancelled because the client disconnected
+                // (onError/onCompletion fired and called scope.cancel()). Not an error.
+                logger.debug { "SSE collector cancelled for case $caseId (client disconnected)" }
+                throw e // re-throw so cancellation propagates correctly through the coroutine hierarchy
+            } catch (error: Exception) {
+                logger.error("Error in event stream for case $caseId", error)
+                emitter.completeWithError(error)
             }
+        }
 
         // Heartbeat: periodically send an SSE comment frame so that a client
         // disconnect is detected even when the case is IDLE and emits no events.
@@ -134,7 +133,7 @@ class CaseEventSseController(
 
         emitter.onCompletion {
             logger.debug { "SSE emitter completed for case $caseId" }
-            scope.cancel()  // cancels all child jobs (collectorJob, heartbeatJob)
+            scope.cancel() // cancels all child jobs (collectorJob, heartbeatJob)
         }
 
         emitter.onTimeout {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseController.kt
@@ -82,54 +82,22 @@ class CaseEventSseController(
 
         val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-        fun sendEvent(event: CaseEvent) =
-            emitter.send(
-                SseEmitter
-                    .event()
-                    .id(event.id.toString())
-                    .name(event.type.value)
-                    .data(event),
-            )
-
-        scope.launch {
-            try {
-                if (includePreviousEvents == true) {
-                    // Replay persisted history first so clients connecting mid-run
-                    // or reconnecting after a disconnect receive the full sequence.
-                    caseEventService.findByParent(caseId).forEach { sendEvent(it) }
-                }
-
-                // If the case is still active, subscribe to the live flow.
-                // findActiveRuntime never rehydrates — safe for observation only.
-                // If the case is completed, the history replay above is sufficient
-                // and the emitter completes at the end of the try block.
-                val activeCase = caseService.findActiveRuntime(caseId)
-                activeCase?.events?.collect { event ->
-                    try {
-                        sendEvent(event)
-                        logger.trace { "Event ${event.type} sent to SSE for case $caseId" }
-                    } catch (e: Exception) {
-                        logger.debug { "Failed to send event to SSE for case $caseId: ${e.message}" }
-                        throw e
-                    }
-                }
-                emitter.complete()
-            } catch (e: CancellationException) {
-                // Normal path: collectorJob was cancelled because the client disconnected
-                // (onError/onCompletion fired and called scope.cancel()). Not an error.
-                logger.debug { "SSE collector cancelled for case $caseId (client disconnected)" }
-                throw e // re-throw so cancellation propagates correctly through the coroutine hierarchy
-            } catch (error: Exception) {
-                logger.error("Error in event stream for case $caseId", error)
-                emitter.completeWithError(error)
-            }
-        }
+        startCaseJob(
+            scope = scope,
+            includePreviousEvents = includePreviousEvents,
+            caseId = caseId,
+            emitter = emitter,
+        )
 
         // Heartbeat: periodically send an SSE comment frame so that a client
         // disconnect is detected even when the case is IDLE and emits no events.
         // Without this, the collector coroutine above stays suspended on collect()
         // indefinitely, keeping the SharedFlow subscriber alive and blocking eviction.
-        startHeartbeatJob(scope, emitter, caseId)
+        startHeartbeatJob(
+            scope = scope,
+            emitter = emitter,
+            caseId = caseId,
+        )
 
         emitter.onCompletion {
             logger.debug { "SSE emitter completed for case $caseId" }
@@ -149,6 +117,58 @@ class CaseEventSseController(
         logger.info { "SSE connection established for case: $caseId" }
         return emitter
     }
+
+    private fun startCaseJob(
+        scope: CoroutineScope,
+        includePreviousEvents: Boolean?,
+        caseId: UUID,
+        emitter: SseEmitter,
+    ) {
+        scope.launch {
+            try {
+                if (includePreviousEvents == true) {
+                    // Replay persisted history first so clients connecting mid-run
+                    // or reconnecting after a disconnect receive the full sequence.
+                    caseEventService.findByParent(caseId).forEach { sendEvent(it, emitter) }
+                }
+
+                // If the case is still active, subscribe to the live flow.
+                // findActiveRuntime never rehydrates — safe for observation only.
+                // If the case is completed, the history replay above is sufficient
+                // and the emitter completes at the end of the try block.
+                val activeCase = caseService.findActiveRuntime(caseId)
+                activeCase?.events?.collect { event ->
+                    try {
+                        sendEvent(event, emitter)
+                        logger.trace { "Event ${event.type} sent to SSE for case $caseId" }
+                    } catch (e: Exception) {
+                        logger.debug { "Failed to send event to SSE for case $caseId: ${e.message}" }
+                        throw e
+                    }
+                }
+                emitter.complete()
+            } catch (e: CancellationException) {
+                // Normal path: collectorJob was cancelled because the client disconnected
+                // (onError/onCompletion fired and called scope.cancel()). Not an error.
+                logger.debug { "SSE collector cancelled for case $caseId (client disconnected)" }
+                throw e // re-throw so cancellation propagates correctly through the coroutine hierarchy
+            } catch (error: Exception) {
+                logger.error("Error in event stream for case $caseId", error)
+                emitter.completeWithError(error)
+            }
+        }
+    }
+
+    private fun sendEvent(
+        event: CaseEvent,
+        emitter: SseEmitter,
+    ) = emitter.send(
+        SseEmitter
+            .event()
+            .id(event.id.toString())
+            .name(event.type.value)
+            .data(event),
+    )
 
     private fun startHeartbeatJob(
         scope: CoroutineScope,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseConfigProperties.kt
@@ -1,0 +1,50 @@
+package io.whozoss.agentos.caseFlow
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Runtime configuration for the case execution engine.
+ *
+ * Bound from the `agentos.case` prefix in application.yml.
+ *
+ * Override with environment variables (Spring Boot relaxed binding):
+ * - AGENTOS_CASE_IDLE_EVICTION_GRACE_MS
+ * - AGENTOS_CASE_SSE_HEARTBEAT_INTERVAL_MS
+ *
+ * Example (application.yml):
+ * ```yaml
+ * agentos:
+ *   case:
+ *     idle-eviction-grace-ms: 300000   # 5 min (default)
+ *     sse-heartbeat-interval-ms: 30000 # 30 s (default)
+ * ```
+ */
+@ConfigurationProperties(prefix = "agentos.case")
+data class CaseConfigProperties(
+    /**
+     * Grace period after the last SSE subscriber disconnects from an idle case before
+     * the runtime is evicted from memory.
+     *
+     * Aligned with typical LLM prompt-cache TTLs (~5 min): keeping the runtime alive
+     * beyond that offers no cache benefit. A user who takes more than 5 min to reply
+     * is unlikely to continue the conversation immediately.
+     *
+     * Defaults to 5 min (300 000 ms).
+     */
+    val idleEvictionGraceMs: Long = 5 * 60 * 1_000L,
+
+    /**
+     * Interval between SSE keep-alive comment frames sent to connected clients.
+     *
+     * When a case is IDLE the live flow emits nothing. Tomcat cannot detect a client
+     * disconnect until the next write attempt. Without periodic writes, the collector
+     * coroutine stays suspended indefinitely, keeping the SharedFlow subscriber alive
+     * and preventing the eviction watcher from seeing `subscriptionCount == 0`.
+     *
+     * A comment frame is invisible to the browser EventSource API but forces a socket
+     * write that reveals the disconnect on the next heartbeat after the client closes.
+     *
+     * Defaults to 30 s (30 000 ms).
+     */
+    val sseHeartbeatIntervalMs: Long = 30_000L,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -56,6 +56,7 @@ class CaseRuntime(
     private val isAgentAuthorized: (agentName: String, userId: UUID?) -> Boolean,
     private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
+    initialStatus: CaseStatus = CaseStatus.PENDING,
     private val emitter: DefaultCaseEventEmitter = DefaultCaseEventEmitter(),
 ) : CaseEventEmitter by emitter {
     private val eventList = InMemoryCaseEventList(inputEvents)
@@ -87,7 +88,7 @@ class CaseRuntime(
     private val maxIterations = 100
     private var iterationCount = 0
 
-    private val _statusFlow = MutableStateFlow(CaseStatus.PENDING)
+    private val _statusFlow = MutableStateFlow(initialStatus)
 
     // -------------------------------------------------------------------------
     // Public state
@@ -95,8 +96,9 @@ class CaseRuntime(
 
     /**
      * Reactive view of the current [CaseStatus].
-     * Updated synchronously inside [run] before and after each transition,
-     * and by [requestKill] for the terminal path.
+     * Updated synchronously inside [run] before and after each transition.
+     * Initialised to [initialStatus] so rehydrated runtimes start with the
+     * correct persisted status rather than always [CaseStatus.PENDING].
      * Consumers can combine this with [subscriptionCount] to react to the
      * conjunction of "case is idle" and "no SSE subscribers".
      */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Owns only execution state: the event list, the SSE flow, and the kill flag.
  * All business logic is delegated back to [CaseService] through four callbacks:
  *
- * @param updateStatus called whenever the runtime transitions to a new [CaseStatus].
+ * @param updateStatusCallback called whenever the runtime transitions to a new [CaseStatus].
  * @param storeEvent called for every event produced by this runtime.
  *   The service persists the event and returns the saved copy (with stable id).
  *   The runtime then adds it to its list and emits it on the SSE flow itself —
@@ -50,11 +50,17 @@ import java.util.concurrent.atomic.AtomicBoolean
 class CaseRuntime(
     val id: UUID,
     val namespaceId: UUID,
-    private val updateStatus: (UUID, CaseStatus) -> Unit,
+    private val updateStatusCallback: (UUID, CaseStatus) -> Unit,
     private val storeEvent: (CaseEvent) -> CaseEvent,
     private val selectAgent: (content: List<MessageContent>, pastEvents: List<CaseEvent>) -> List<CaseEvent>,
     private val isAgentAuthorized: (agentName: String, userId: UUID?) -> Boolean,
-    private val runAgent: suspend (agentName: String, events: List<CaseEvent>, eventsProvider: () -> List<CaseEvent>, userId: UUID?, shouldContinue: () -> Boolean) -> Unit,
+    private val runAgent: suspend (
+        agentName: String,
+        events: List<CaseEvent>,
+        eventsProvider: () -> List<CaseEvent>,
+        userId: UUID?,
+        shouldContinue: () -> Boolean,
+    ) -> Unit,
     inputEvents: List<CaseEvent> = emptyList(),
     initialStatus: CaseStatus = CaseStatus.PENDING,
     private val emitter: DefaultCaseEventEmitter = DefaultCaseEventEmitter(),
@@ -212,7 +218,9 @@ class CaseRuntime(
             }
         }
 
-        storeAndEmitEvent(MessageEvent(caseId = id, namespaceId = namespaceId, actor = actor, content = content, sessionContext = sessionContext))
+        storeAndEmitEvent(
+            MessageEvent(caseId = id, namespaceId = namespaceId, actor = actor, content = content, sessionContext = sessionContext),
+        )
         selectAgent(content, eventList.getAll()).forEach { storeAndEmitEvent(it) }
     }
 
@@ -244,8 +252,7 @@ class CaseRuntime(
         logger.info { "[CaseRuntime $id] run() started" }
         interruptRequested.set(false)
         killRequested.set(false)
-        _statusFlow.value = CaseStatus.RUNNING
-        updateStatus(id, CaseStatus.RUNNING)
+        updateStatus(CaseStatus.RUNNING)
         iterationCount = 0
 
         try {
@@ -261,30 +268,32 @@ class CaseRuntime(
             when {
                 iterationCount >= maxIterations -> {
                     logger.error { "[CaseRuntime $id] Maximum iterations ($maxIterations) reached" }
-                    _statusFlow.value = CaseStatus.ERROR
-                    updateStatus(id, CaseStatus.ERROR)
+                    updateStatus(CaseStatus.ERROR)
                 }
 
                 killRequested.get() -> {
-                    // Explicit kill: permanent termination. Service will evict the runtime.
-                    _statusFlow.value = CaseStatus.KILLED
-                    updateStatus(id, CaseStatus.KILLED)
+                    updateStatus(CaseStatus.KILLED)
                 }
 
                 else -> {
                     // Normal turn-end: agent finished, waiting for next user message.
                     // Non-terminal — runtime stays alive, SSE flow stays open.
-                    _statusFlow.value = CaseStatus.IDLE
-                    updateStatus(id, CaseStatus.IDLE)
+                    updateStatus(CaseStatus.IDLE)
                 }
             }
         } catch (e: Exception) {
             logger.error(e) { "[CaseRuntime $id] Error during execution" }
-            _statusFlow.value = CaseStatus.ERROR
-            updateStatus(id, CaseStatus.ERROR)
+            updateStatus(CaseStatus.ERROR)
         } finally {
             runInFlight.set(false)
         }
+    }
+
+    private fun updateStatus(caseStatus: CaseStatus) {
+        // _statusFlow is updated first so reactive watchers (e.g. eviction watcher)
+        // see the new status immediately, before the persistence round-trip completes.
+        _statusFlow.value = caseStatus
+        updateStatusCallback(id, caseStatus)
     }
 
     private suspend fun processNextStep() {
@@ -322,7 +331,12 @@ class CaseRuntime(
                     // Delegate to runAgent which inspects the event history
                     // and skips the duplicate AgentRunningEvent emission.
                     logger.info { "[CaseRuntime $id] Rehydrating from AgentRunningEvent for agent: ${event.agentName}" }
-                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, resolveUserId(events)) { !interruptRequested.get() }
+                    runAgent(
+                        event.agentName,
+                        eventList.getAll(),
+                        { eventList.getAll() },
+                        resolveUserId(events),
+                    ) { !interruptRequested.get() }
                     return
                 }
 
@@ -346,7 +360,12 @@ class CaseRuntime(
                         interruptRequested.set(true)
                         return
                     }
-                    runAgent(event.agentName, eventList.getAll(), { eventList.getAll() }, userId) { !interruptRequested.get() }
+                    runAgent(
+                        event.agentName,
+                        eventList.getAll(),
+                        { eventList.getAll() },
+                        userId,
+                    ) { !interruptRequested.get() }
                     return
                 }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -14,6 +14,9 @@ import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
 import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import mu.KLogging
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
@@ -84,9 +87,20 @@ class CaseRuntime(
     private val maxIterations = 100
     private var iterationCount = 0
 
+    private val _statusFlow = MutableStateFlow(CaseStatus.PENDING)
+
     // -------------------------------------------------------------------------
     // Public state
     // -------------------------------------------------------------------------
+
+    /**
+     * Reactive view of the current [CaseStatus].
+     * Updated synchronously inside [run] before and after each transition,
+     * and by [requestKill] for the terminal path.
+     * Consumers can combine this with [subscriptionCount] to react to the
+     * conjunction of "case is idle" and "no SSE subscribers".
+     */
+    val statusFlow: StateFlow<CaseStatus> = _statusFlow.asStateFlow()
 
     /**
      * Interrupt the current agent turn and return to [CaseStatus.IDLE].
@@ -228,6 +242,7 @@ class CaseRuntime(
         logger.info { "[CaseRuntime $id] run() started" }
         interruptRequested.set(false)
         killRequested.set(false)
+        _statusFlow.value = CaseStatus.RUNNING
         updateStatus(id, CaseStatus.RUNNING)
         iterationCount = 0
 
@@ -244,22 +259,26 @@ class CaseRuntime(
             when {
                 iterationCount >= maxIterations -> {
                     logger.error { "[CaseRuntime $id] Maximum iterations ($maxIterations) reached" }
+                    _statusFlow.value = CaseStatus.ERROR
                     updateStatus(id, CaseStatus.ERROR)
                 }
 
                 killRequested.get() -> {
                     // Explicit kill: permanent termination. Service will evict the runtime.
+                    _statusFlow.value = CaseStatus.KILLED
                     updateStatus(id, CaseStatus.KILLED)
                 }
 
                 else -> {
                     // Normal turn-end: agent finished, waiting for next user message.
                     // Non-terminal — runtime stays alive, SSE flow stays open.
+                    _statusFlow.value = CaseStatus.IDLE
                     updateStatus(id, CaseStatus.IDLE)
                 }
             }
         } catch (e: Exception) {
             logger.error(e) { "[CaseRuntime $id] Error during execution" }
+            _statusFlow.value = CaseStatus.ERROR
             updateStatus(id, CaseStatus.ERROR)
         } finally {
             runInFlight.set(false)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -46,7 +46,7 @@ class CaseServiceImpl(
     private val caseEventService: CaseEventService,
     private val userService: UserService,
     private val namespaceService: NamespaceService,
-    private val caseConfig: CaseConfigProperties = CaseConfigProperties(),
+    private val caseConfig: CaseConfigProperties,
 ) : CaseService {
     private val idleEvictionGraceMs get() = caseConfig.idleEvictionGraceMs
 
@@ -194,7 +194,10 @@ class CaseServiceImpl(
                             runtime.statusFlow.value == CaseStatus.IDLE
                         ) {
                             activeRuntimes.remove(caseId)
-                            cancelEvictionWatcher(caseId)
+                            // Remove from watcherJobs without cancelling: we are executing
+                            // inside this very coroutine, so cancel() would be a no-op and
+                            // is semantically misleading. The coroutine ends naturally here.
+                            watcherJobs.remove(caseId)
                             logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
                         } else {
                             logger.debug {
@@ -207,11 +210,6 @@ class CaseServiceImpl(
         watcherJobs[caseId] = job
     }
 
-    /** Cancels the eviction watcher for [caseId] and removes it from [watcherJobs]. */
-    private fun cancelEvictionWatcher(caseId: UUID) {
-        watcherJobs.remove(caseId)?.cancel()
-    }
-
     /** Constructs a [CaseRuntime] wired with all service callbacks. */
     private fun buildRuntime(
         case: Case,
@@ -220,7 +218,7 @@ class CaseServiceImpl(
         CaseRuntime(
             id = case.id,
             namespaceId = case.namespaceId,
-            updateStatus = { caseId, newStatus -> handleStatusChange(caseId, newStatus) },
+            updateStatusCallback = { caseId, newStatus -> handleStatusChange(caseId, newStatus) },
             storeEvent = { event -> storeEvent(event) },
             selectAgent = { content, pastEvents -> selectAgent(content, pastEvents, case.namespaceId, case.id) },
             isAgentAuthorized = { agentName, userId ->
@@ -579,7 +577,7 @@ class CaseServiceImpl(
             it.emitEvent(savedStatusEvent)
             if (newStatus.isTerminal()) {
                 activeRuntimes.remove(caseId)
-                cancelEvictionWatcher(caseId)
+                watcherJobs.remove(caseId)?.cancel()
                 logger.info { "Case $caseId reached terminal status $newStatus, evicted" }
             }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -24,6 +24,7 @@ import jakarta.annotation.PreDestroy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
@@ -65,6 +66,12 @@ class CaseServiceImpl(
 
     private val activeRuntimes = ConcurrentHashMap<UUID, CaseRuntime>()
 
+    /**
+     * Eviction watcher [Job] per active runtime, keyed by case id.
+     * Cancelled whenever the runtime leaves [activeRuntimes] (terminal status or eviction).
+     */
+    private val watcherJobs = ConcurrentHashMap<UUID, Job>()
+
     // ======================================================
     // EntityService
     // ======================================================
@@ -76,6 +83,7 @@ class CaseServiceImpl(
         val saved = caseRepository.save(entity)
         activeRuntimes[saved.id] = buildRuntime(saved)
         logger.info { "Case created: ${saved.id} for namespace ${entity.namespaceId}" }
+        // Watcher is started inside buildRuntime via .also { startEvictionWatcher(...) }
         return saved
     }
 
@@ -145,6 +153,7 @@ class CaseServiceImpl(
         val pastEvents = caseEventService.findByParent(caseId)
         logger.info { "Rehydrating case $caseId with ${pastEvents.size} past events" }
         return buildRuntime(case, pastEvents)
+        // Watcher is started inside buildRuntime via .also { startEvictionWatcher(...) }
     }
 
     /**
@@ -170,7 +179,7 @@ class CaseServiceImpl(
      * cancelled when [scope] is cancelled (service shutdown).
      */
     private fun startEvictionWatcher(caseId: UUID, runtime: CaseRuntime) {
-        scope.launch {
+        val job = scope.launch {
             combine(runtime.subscriptionCount, runtime.statusFlow) { count, status ->
                 count == 0 && status == CaseStatus.IDLE
             }
@@ -186,6 +195,7 @@ class CaseServiceImpl(
                         runtime.statusFlow.value == CaseStatus.IDLE
                     ) {
                         activeRuntimes.remove(caseId)
+                        cancelEvictionWatcher(caseId)
                         logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
                     } else {
                         logger.debug {
@@ -195,6 +205,12 @@ class CaseServiceImpl(
                     }
                 }
         }
+        watcherJobs[caseId] = job
+    }
+
+    /** Cancels the eviction watcher for [caseId] and removes it from [watcherJobs]. */
+    private fun cancelEvictionWatcher(caseId: UUID) {
+        watcherJobs.remove(caseId)?.cancel()
     }
 
     /** Constructs a [CaseRuntime] wired with all service callbacks. */
@@ -228,6 +244,7 @@ class CaseServiceImpl(
                 )
             },
             inputEvents = inputEvents,
+            initialStatus = case.status,
         ).also { startEvictionWatcher(case.id, it) }
 
     // ======================================================
@@ -562,6 +579,7 @@ class CaseServiceImpl(
             it.emitEvent(savedStatusEvent)
             if (newStatus.isTerminal()) {
                 activeRuntimes.remove(caseId)
+                cancelEvictionWatcher(caseId)
                 logger.info { "Case $caseId reached terminal status $newStatus, evicted" }
             }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -23,8 +23,8 @@ import io.whozoss.agentos.user.UserService
 import jakarta.annotation.PreDestroy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
@@ -46,18 +46,10 @@ class CaseServiceImpl(
     private val caseEventService: CaseEventService,
     private val userService: UserService,
     private val namespaceService: NamespaceService,
-    /**
-     * Grace period after the last SSE subscriber disconnects from an idle case.
-     * The runtime is evicted only if no subscriber reconnects within this window.
-     *
-     * Aligned with typical LLM prompt-cache TTLs (~5 min): keeping the runtime alive
-     * beyond that offers no cache benefit, and a user who takes more than 5 min to
-     * reply is unlikely to continue the conversation immediately anyway.
-     *
-     * Defaults to 5 min.
-     */
-    private val idleEvictionGraceMs: Long = 5 * 60 * 1_000L,
+    private val caseConfig: CaseConfigProperties = CaseConfigProperties(),
 ) : CaseService {
+    private val idleEvictionGraceMs get() = caseConfig.idleEvictionGraceMs
+
     /**
      * Coroutine scope used to run case execution loops in the background.
      * Each [run] call is launched here so HTTP threads are never blocked.
@@ -102,7 +94,10 @@ class CaseServiceImpl(
         }
     }
 
-    override fun findByIds(ids: Collection<UUID>, withRemoved: Boolean): List<Case> = caseRepository.findByIds(ids, withRemoved)
+    override fun findByIds(
+        ids: Collection<UUID>,
+        withRemoved: Boolean,
+    ): List<Case> = caseRepository.findByIds(ids, withRemoved)
 
     override fun findByParent(parentId: UUID): List<Case> = caseRepository.findByParent(parentId)
 
@@ -178,33 +173,37 @@ class CaseServiceImpl(
      * The coroutine runs for the lifetime of the service scope. It is automatically
      * cancelled when [scope] is cancelled (service shutdown).
      */
-    private fun startEvictionWatcher(caseId: UUID, runtime: CaseRuntime) {
-        val job = scope.launch {
-            combine(runtime.subscriptionCount, runtime.statusFlow) { count, status ->
-                count == 0 && status == CaseStatus.IDLE
-            }
-                .filter { it }
-                .collect {
-                    // Grace period: absorb brief reconnects and fast follow-up messages.
-                    delay(idleEvictionGraceMs)
+    private fun startEvictionWatcher(
+        caseId: UUID,
+        runtime: CaseRuntime,
+    ) {
+        logger.trace { "Case $caseId eviction watcher started" }
+        val job =
+            scope.launch {
+                combine(runtime.subscriptionCount, runtime.statusFlow) { count, status ->
+                    count == 0 && status == CaseStatus.IDLE
+                }.filter { it }
+                    .collect {
+                        // Grace period: absorb brief reconnects and fast follow-up messages.
+                        delay(idleEvictionGraceMs)
 
-                    // Re-check: a subscriber may have reconnected or a new message may
-                    // have arrived (status back to RUNNING) during the grace period.
-                    if (activeRuntimes.containsKey(caseId) &&
-                        runtime.subscriptionCount.value == 0 &&
-                        runtime.statusFlow.value == CaseStatus.IDLE
-                    ) {
-                        activeRuntimes.remove(caseId)
-                        cancelEvictionWatcher(caseId)
-                        logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
-                    } else {
-                        logger.debug {
-                            "Case $caseId: eviction skipped — " +
-                                "status=${runtime.statusFlow.value}, subscribers=${runtime.subscriptionCount.value}"
+                        // Re-check: a subscriber may have reconnected or a new message may
+                        // have arrived (status back to RUNNING) during the grace period.
+                        if (activeRuntimes.containsKey(caseId) &&
+                            runtime.subscriptionCount.value == 0 &&
+                            runtime.statusFlow.value == CaseStatus.IDLE
+                        ) {
+                            activeRuntimes.remove(caseId)
+                            cancelEvictionWatcher(caseId)
+                            logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
+                        } else {
+                            logger.debug {
+                                "Case $caseId: eviction skipped — " +
+                                    "status=${runtime.statusFlow.value}, subscribers=${runtime.subscriptionCount.value}"
+                            }
                         }
                     }
-                }
-        }
+            }
         watcherJobs[caseId] = job
     }
 
@@ -502,7 +501,8 @@ class CaseServiceImpl(
             }
         }
 
-        agent.run(events, shouldContinue)
+        agent
+            .run(events, shouldContinue)
             .catch { error ->
                 logger.error(error) { "Error in agent $agentName for case $caseId" }
                 storeEvent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -27,9 +27,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Service
@@ -45,11 +44,6 @@ class CaseServiceImpl(
     private val caseEventService: CaseEventService,
     private val userService: UserService,
     private val namespaceService: NamespaceService,
-    /**
-     * How long to wait for SSE subscribers to disconnect before giving up and keeping the runtime.
-     * After this timeout with subscribers still active, eviction is skipped. Defaults to 30 s.
-     */
-    private val idleEvictionTimeoutMs: Long = 30_000L,
     /**
      * Stabilisation grace period after the last SSE subscriber disconnects.
      * Prevents evicting a runtime that is briefly between reconnects (e.g. page refresh).
@@ -147,6 +141,43 @@ class CaseServiceImpl(
         return buildRuntime(case, pastEvents)
     }
 
+    /**
+     * Starts a long-lived eviction watcher for [runtime].
+     *
+     * The watcher collects [CaseRuntime.subscriptionCount] — a [kotlinx.coroutines.flow.StateFlow] —
+     * and reacts to every transition to 0. On each such transition it:
+     * 1. Waits [idleEvictionGraceMs] to absorb brief reconnects (e.g. page refresh).
+     * 2. Re-checks that the runtime is still in [activeRuntimes], the case status is
+     *    still [CaseStatus.IDLE], and [subscriptionCount] is still 0.
+     * 3. If all conditions hold, evicts the runtime.
+     *
+     * The coroutine runs for the lifetime of the runtime. It is automatically cancelled
+     * when [scope] is cancelled (service shutdown).
+     *
+     * A single watcher per runtime handles all subscription lifecycle events — including
+     * late connections (clients that connect after the run completes) and multiple
+     * connect/disconnect cycles.
+     */
+    private fun startEvictionWatcher(caseId: UUID, runtime: CaseRuntime) {
+        scope.launch {
+            runtime.subscriptionCount
+                .filter { it == 0 }
+                .collect {
+                    // Grace period: absorb brief reconnects before committing to eviction.
+                    delay(idleEvictionGraceMs)
+
+                    val currentRuntime = activeRuntimes[caseId] ?: return@collect
+                    val currentStatus = caseRepository.findByIds(listOf(caseId)).firstOrNull()?.status
+                    if (currentStatus == CaseStatus.IDLE && currentRuntime.subscriptionCount.value == 0) {
+                        activeRuntimes.remove(caseId)
+                        logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
+                    } else {
+                        logger.debug { "Case $caseId: eviction skipped — status=$currentStatus, subscribers=${currentRuntime.subscriptionCount.value}" }
+                    }
+                }
+        }
+    }
+
     /** Constructs a [CaseRuntime] wired with all service callbacks. */
     private fun buildRuntime(
         case: Case,
@@ -178,7 +209,7 @@ class CaseServiceImpl(
                 )
             },
             inputEvents = inputEvents,
-        )
+        ).also { startEvictionWatcher(case.id, it) }
 
     // ======================================================
     // Message handling (called by controller)
@@ -510,12 +541,9 @@ class CaseServiceImpl(
         // Emit the status event before eviction so SSE clients receive it.
         activeRuntimes[caseId]?.let {
             it.emitEvent(savedStatusEvent)
-            when {
-                newStatus.isTerminal() -> {
-                    activeRuntimes.remove(caseId)
-                    logger.info { "Case $caseId reached terminal status $newStatus, evicted" }
-                }
-                newStatus == CaseStatus.IDLE -> scheduleIdleEviction(caseId, it)
+            if (newStatus.isTerminal()) {
+                activeRuntimes.remove(caseId)
+                logger.info { "Case $caseId reached terminal status $newStatus, evicted" }
             }
         }
     }
@@ -523,50 +551,6 @@ class CaseServiceImpl(
     // ======================================================
     // Execution control
     // ======================================================
-
-    /**
-     * Schedules eviction of an IDLE runtime once all SSE subscribers have disconnected.
-     *
-     * After the grace period ([idleEvictionDelayMs]) expires, the runtime is evicted only
-     * if it is still IDLE and still has no active SSE subscribers. If a new user message
-     * arrives in the meantime the runtime transitions back to RUNNING and the eviction
-     * guard (`subscriptionCount > 0 || status != IDLE`) prevents premature removal.
-     *
-     * The eviction uses a two-step check:
-     * 1. Wait up to [idleEvictionDelayMs] for subscriptionCount to reach 0.
-     * 2. Once at 0, apply the grace delay, then re-check subscriptionCount and the
-     *    persisted case status before removing from [activeRuntimes].
-     */
-    private fun scheduleIdleEviction(caseId: UUID, runtime: CaseRuntime) {
-        scope.launch {
-            // Step 1: wait for all SSE subscribers to disconnect.
-            // If they are still connected after the timeout, keep the runtime alive.
-            val disconnected = withTimeoutOrNull(idleEvictionTimeoutMs) {
-                runtime.subscriptionCount.first { it == 0 }
-            }
-            if (disconnected == null) {
-                logger.debug { "Case $caseId: SSE subscribers still connected after ${idleEvictionTimeoutMs}ms, skipping eviction" }
-                return@launch
-            }
-
-            // Step 2: stabilisation grace period — handles brief reconnects (e.g. page refresh).
-            delay(idleEvictionGraceMs)
-
-            // Step 3: re-check before committing to eviction.
-            val currentRuntime = activeRuntimes[caseId]
-            if (currentRuntime == null) {
-                return@launch // already evicted by a terminal status change or explicit kill
-            }
-            val currentStatus = caseRepository.findByIds(listOf(caseId)).firstOrNull()?.status
-            if (currentStatus != CaseStatus.IDLE || currentRuntime.subscriptionCount.value > 0) {
-                logger.debug { "Case $caseId: not evicting — status=$currentStatus, subscribers=${currentRuntime.subscriptionCount.value}" }
-                return@launch
-            }
-
-            activeRuntimes.remove(caseId)
-            logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
-        }
-    }
 
     override fun getActiveCasesByNamespace(namespaceId: UUID): List<CaseRuntime> =
         activeRuntimes.values.filter { it.namespaceId == namespaceId }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -26,9 +26,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import mu.KLogging
@@ -182,11 +182,11 @@ class CaseServiceImpl(
             scope.launch {
                 combine(runtime.subscriptionCount, runtime.statusFlow) { count, status ->
                     count == 0 && status == CaseStatus.IDLE
-                }.filter { it }
+                }
+                    // Grace period: absorb brief reconnects and fast follow-up messages.
+                    .debounce(idleEvictionGraceMs)
+                    .filter { it }
                     .collect {
-                        // Grace period: absorb brief reconnects and fast follow-up messages.
-                        delay(idleEvictionGraceMs)
-
                         // Re-check: a subscriber may have reconnected or a new message may
                         // have arrived (status back to RUNNING) during the grace period.
                         if (activeRuntimes.containsKey(caseId) &&

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -25,8 +25,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Service
@@ -42,6 +45,17 @@ class CaseServiceImpl(
     private val caseEventService: CaseEventService,
     private val userService: UserService,
     private val namespaceService: NamespaceService,
+    /**
+     * How long to wait for SSE subscribers to disconnect before giving up and keeping the runtime.
+     * After this timeout with subscribers still active, eviction is skipped. Defaults to 30 s.
+     */
+    private val idleEvictionTimeoutMs: Long = 30_000L,
+    /**
+     * Stabilisation grace period after the last SSE subscriber disconnects.
+     * Prevents evicting a runtime that is briefly between reconnects (e.g. page refresh).
+     * Defaults to 5 s.
+     */
+    private val idleEvictionGraceMs: Long = 5_000L,
 ) : CaseService {
     /**
      * Coroutine scope used to run case execution loops in the background.
@@ -496,9 +510,12 @@ class CaseServiceImpl(
         // Emit the status event before eviction so SSE clients receive it.
         activeRuntimes[caseId]?.let {
             it.emitEvent(savedStatusEvent)
-            if (newStatus.isTerminal()) {
-                activeRuntimes.remove(caseId)
-                logger.info { "Case $caseId reached terminal status $newStatus, evicted" }
+            when {
+                newStatus.isTerminal() -> {
+                    activeRuntimes.remove(caseId)
+                    logger.info { "Case $caseId reached terminal status $newStatus, evicted" }
+                }
+                newStatus == CaseStatus.IDLE -> scheduleIdleEviction(caseId, it)
             }
         }
     }
@@ -506,6 +523,50 @@ class CaseServiceImpl(
     // ======================================================
     // Execution control
     // ======================================================
+
+    /**
+     * Schedules eviction of an IDLE runtime once all SSE subscribers have disconnected.
+     *
+     * After the grace period ([idleEvictionDelayMs]) expires, the runtime is evicted only
+     * if it is still IDLE and still has no active SSE subscribers. If a new user message
+     * arrives in the meantime the runtime transitions back to RUNNING and the eviction
+     * guard (`subscriptionCount > 0 || status != IDLE`) prevents premature removal.
+     *
+     * The eviction uses a two-step check:
+     * 1. Wait up to [idleEvictionDelayMs] for subscriptionCount to reach 0.
+     * 2. Once at 0, apply the grace delay, then re-check subscriptionCount and the
+     *    persisted case status before removing from [activeRuntimes].
+     */
+    private fun scheduleIdleEviction(caseId: UUID, runtime: CaseRuntime) {
+        scope.launch {
+            // Step 1: wait for all SSE subscribers to disconnect.
+            // If they are still connected after the timeout, keep the runtime alive.
+            val disconnected = withTimeoutOrNull(idleEvictionTimeoutMs) {
+                runtime.subscriptionCount.first { it == 0 }
+            }
+            if (disconnected == null) {
+                logger.debug { "Case $caseId: SSE subscribers still connected after ${idleEvictionTimeoutMs}ms, skipping eviction" }
+                return@launch
+            }
+
+            // Step 2: stabilisation grace period — handles brief reconnects (e.g. page refresh).
+            delay(idleEvictionGraceMs)
+
+            // Step 3: re-check before committing to eviction.
+            val currentRuntime = activeRuntimes[caseId]
+            if (currentRuntime == null) {
+                return@launch // already evicted by a terminal status change or explicit kill
+            }
+            val currentStatus = caseRepository.findByIds(listOf(caseId)).firstOrNull()?.status
+            if (currentStatus != CaseStatus.IDLE || currentRuntime.subscriptionCount.value > 0) {
+                logger.debug { "Case $caseId: not evicting — status=$currentStatus, subscribers=${currentRuntime.subscriptionCount.value}" }
+                return@launch
+            }
+
+            activeRuntimes.remove(caseId)
+            logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
+        }
+    }
 
     override fun getActiveCasesByNamespace(namespaceId: UUID): List<CaseRuntime> =
         activeRuntimes.values.filter { it.namespaceId == namespaceId }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import mu.KLogging
@@ -45,11 +46,16 @@ class CaseServiceImpl(
     private val userService: UserService,
     private val namespaceService: NamespaceService,
     /**
-     * Stabilisation grace period after the last SSE subscriber disconnects.
-     * Prevents evicting a runtime that is briefly between reconnects (e.g. page refresh).
-     * Defaults to 5 s.
+     * Grace period after the last SSE subscriber disconnects from an idle case.
+     * The runtime is evicted only if no subscriber reconnects within this window.
+     *
+     * Aligned with typical LLM prompt-cache TTLs (~5 min): keeping the runtime alive
+     * beyond that offers no cache benefit, and a user who takes more than 5 min to
+     * reply is unlikely to continue the conversation immediately anyway.
+     *
+     * Defaults to 5 min.
      */
-    private val idleEvictionGraceMs: Long = 5_000L,
+    private val idleEvictionGraceMs: Long = 5 * 60 * 1_000L,
 ) : CaseService {
     /**
      * Coroutine scope used to run case execution loops in the background.
@@ -144,35 +150,48 @@ class CaseServiceImpl(
     /**
      * Starts a long-lived eviction watcher for [runtime].
      *
-     * The watcher collects [CaseRuntime.subscriptionCount] — a [kotlinx.coroutines.flow.StateFlow] —
-     * and reacts to every transition to 0. On each such transition it:
-     * 1. Waits [idleEvictionGraceMs] to absorb brief reconnects (e.g. page refresh).
-     * 2. Re-checks that the runtime is still in [activeRuntimes], the case status is
-     *    still [CaseStatus.IDLE], and [subscriptionCount] is still 0.
-     * 3. If all conditions hold, evicts the runtime.
+     * Combines [CaseRuntime.subscriptionCount] and [CaseRuntime.statusFlow] into a
+     * single signal: eviction is only triggered when **both** conditions hold at the
+     * same time — the case is [CaseStatus.IDLE] **and** no SSE subscribers are connected.
      *
-     * The coroutine runs for the lifetime of the runtime. It is automatically cancelled
-     * when [scope] is cancelled (service shutdown).
+     * This avoids the race where a client disconnects while the agent is still running:
+     * `subscriptionCount` would fall to 0 during [CaseStatus.RUNNING], but `combine`
+     * emits `false` for that state and the grace period never starts.
      *
-     * A single watcher per runtime handles all subscription lifecycle events — including
-     * late connections (clients that connect after the run completes) and multiple
-     * connect/disconnect cycles.
+     * On each transition to `(IDLE, 0)`, the watcher:
+     * 1. Waits [idleEvictionGraceMs] to absorb brief reconnects (e.g. page refresh,
+     *    or a user typing a quick follow-up).
+     * 2. Re-checks the combined condition — if a subscriber reconnected or a new
+     *    message arrived (status back to RUNNING) during the grace period, eviction
+     *    is skipped.
+     * 3. If both conditions still hold, evicts the runtime.
+     *
+     * The coroutine runs for the lifetime of the service scope. It is automatically
+     * cancelled when [scope] is cancelled (service shutdown).
      */
     private fun startEvictionWatcher(caseId: UUID, runtime: CaseRuntime) {
         scope.launch {
-            runtime.subscriptionCount
-                .filter { it == 0 }
+            combine(runtime.subscriptionCount, runtime.statusFlow) { count, status ->
+                count == 0 && status == CaseStatus.IDLE
+            }
+                .filter { it }
                 .collect {
-                    // Grace period: absorb brief reconnects before committing to eviction.
+                    // Grace period: absorb brief reconnects and fast follow-up messages.
                     delay(idleEvictionGraceMs)
 
-                    val currentRuntime = activeRuntimes[caseId] ?: return@collect
-                    val currentStatus = caseRepository.findByIds(listOf(caseId)).firstOrNull()?.status
-                    if (currentStatus == CaseStatus.IDLE && currentRuntime.subscriptionCount.value == 0) {
+                    // Re-check: a subscriber may have reconnected or a new message may
+                    // have arrived (status back to RUNNING) during the grace period.
+                    if (activeRuntimes.containsKey(caseId) &&
+                        runtime.subscriptionCount.value == 0 &&
+                        runtime.statusFlow.value == CaseStatus.IDLE
+                    ) {
                         activeRuntimes.remove(caseId)
                         logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
                     } else {
-                        logger.debug { "Case $caseId: eviction skipped — status=$currentStatus, subscribers=${currentRuntime.subscriptionCount.value}" }
+                        logger.debug {
+                            "Case $caseId: eviction skipped — " +
+                                "status=${runtime.statusFlow.value}, subscribers=${runtime.subscriptionCount.value}"
+                        }
                     }
                 }
         }

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -79,6 +79,13 @@ management:
       show-details: always
 
 agentos:
+  case:
+    # Grace period (ms) before an idle runtime with no SSE subscribers is evicted.
+    # Override with env var: AGENTOS_CASE_IDLE_EVICTION_GRACE_MS
+    # idle-eviction-grace-ms: 300000
+    # Interval (ms) between SSE keep-alive comment frames sent to connected clients.
+    # Override with env var: AGENTOS_CASE_SSE_HEARTBEAT_INTERVAL_MS
+    # sse-heartbeat-interval-ms: 30000
   defaults:
     # Environment-level fallback agent name. Consulted when a namespace has no
     # defaultAgentName configured. The named agent must exist in the case's namespace.

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseControllerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventSseControllerUnitSpec.kt
@@ -1,9 +1,11 @@
 package io.whozoss.agentos.caseEvent
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.whozoss.agentos.caseFlow.CaseConfigProperties
 import io.whozoss.agentos.caseFlow.CaseRuntime
 import io.whozoss.agentos.caseFlow.CaseService
 import io.whozoss.agentos.sdk.actor.Actor
@@ -14,13 +16,20 @@ import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /**
  * Unit tests for [CaseEventSseController.streamEvents].
+ *
+ * All controller instances are built with sseHeartbeatIntervalMs set to a very large
+ * value (Long.MAX_VALUE) so the heartbeat coroutine never fires during the test.
+ * Tests that specifically exercise the heartbeat/disconnect path set a short interval
+ * and drive the disconnect themselves.
  *
  * Validates the three connection scenarios:
  * 1. Active case  — history replayed, then live flow subscribed.
@@ -73,7 +82,12 @@ class CaseEventSseControllerUnitSpec : StringSpec() {
                     }
                 }
 
-            val controller = CaseEventSseController(caseService, caseEventService)
+            val controller =
+                CaseEventSseController(
+                    caseService = caseService,
+                    caseEventService = caseEventService,
+                    caseConfig = CaseConfigProperties(sseHeartbeatIntervalMs = Long.MAX_VALUE),
+                )
             controller.streamEvents(caseId)
 
             latch.await(2, TimeUnit.SECONDS)
@@ -97,7 +111,12 @@ class CaseEventSseControllerUnitSpec : StringSpec() {
                     }
                 }
 
-            val controller = CaseEventSseController(caseService, caseEventService)
+            val controller =
+                CaseEventSseController(
+                    caseService = caseService,
+                    caseEventService = caseEventService,
+                    caseConfig = CaseConfigProperties(sseHeartbeatIntervalMs = Long.MAX_VALUE),
+                )
             controller.streamEvents(caseId)
 
             latch.await(2, TimeUnit.SECONDS)
@@ -130,7 +149,12 @@ class CaseEventSseControllerUnitSpec : StringSpec() {
                     every { findByParent(caseId) } returns history
                 }
 
-            val controller = CaseEventSseController(caseService, caseEventService)
+            val controller =
+                CaseEventSseController(
+                    caseService = caseService,
+                    caseEventService = caseEventService,
+                    caseConfig = CaseConfigProperties(sseHeartbeatIntervalMs = Long.MAX_VALUE),
+                )
             controller.streamEvents(caseId)
 
             latch.await(2, TimeUnit.SECONDS)
@@ -159,12 +183,57 @@ class CaseEventSseControllerUnitSpec : StringSpec() {
                     every { findByParent(caseId) } returns emptyList()
                 }
 
-            val controller = CaseEventSseController(caseService, caseEventService)
+            val controller =
+                CaseEventSseController(
+                    caseService = caseService,
+                    caseEventService = caseEventService,
+                    caseConfig = CaseConfigProperties(sseHeartbeatIntervalMs = Long.MAX_VALUE),
+                )
             controller.streamEvents(caseId)
 
             latch.await(2, TimeUnit.SECONDS)
             verify(exactly = 1) { caseEventService.findByParent(caseId) }
             verify(exactly = 1) { caseService.findActiveRuntime(caseId) }
+        }
+
+        // -------------------------------------------------------------------------
+        // Heartbeat — disconnect detection
+        // -------------------------------------------------------------------------
+        //
+        // The full disconnect path (heartbeat write fails → Tomcat calls onError →
+        // scope.cancel() → subscriptionCount drops) requires a live Servlet container
+        // and cannot be exercised in a unit test without a full Spring MVC context.
+        //
+        // The eviction behaviour that depends on subscriptionCount is covered by the
+        // integration-level tests in CaseServiceImplSpec
+        // ("idle runtime is evicted after all SSE subscribers disconnect...").
+        //
+        // What we can test here is that the controller subscribes to the live flow
+        // (subscriptionCount reaches 1) when an active runtime is present, confirming
+        // the collector coroutine is launched and the heartbeat interval is accepted
+        // without error.
+
+        "active case: collector subscribes to live flow and heartbeat config is accepted" {
+            val caseId = UUID.randomUUID()
+            val liveFlow = MutableSharedFlow<CaseEvent>(replay = 0)
+            val subscriptionCount: StateFlow<Int> = liveFlow.subscriptionCount
+
+            val activeCase = mockk<CaseRuntime> { every { events } returns liveFlow }
+            val caseService = mockk<CaseService> { every { findActiveRuntime(caseId) } returns activeCase }
+            val caseEventService = mockk<CaseEventService> { every { findByParent(caseId) } returns emptyList() }
+
+            // Use a short heartbeat interval to confirm the config is wired through.
+            val controller =
+                CaseEventSseController(
+                    caseService,
+                    caseEventService,
+                    CaseConfigProperties(sseHeartbeatIntervalMs = 50L),
+                )
+            controller.streamEvents(caseId)
+
+            // The collector coroutine must subscribe to the live flow.
+            subscriptionCount.first { it >= 1 }
+            subscriptionCount.value shouldBe 1
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
@@ -122,6 +123,8 @@ class CaseRuntimeSpec : StringSpec() {
      * - [runAgent] mirrors what [CaseServiceImpl] does: drives the agent flow and
      *   feeds each produced event back through pushEvents so the loop can detect
      *   [AgentFinishedEvent] and stop.
+     * - [updateStatus] defaults to a no-op: status transitions are observable via
+     *   [CaseRuntime.statusFlow] without needing a callback.
      */
     fun buildRuntime(
         agentName: String = "default-agent",
@@ -172,6 +175,7 @@ class CaseRuntimeSpec : StringSpec() {
             runtime.run()
 
             runAgent.callCount shouldBe 1
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
         }
 
         "selectAgent is called exactly once per user message" {
@@ -199,6 +203,7 @@ class CaseRuntimeSpec : StringSpec() {
             agentEvents shouldHaveAtLeastSize 2
             agentEvents[0].shouldBeInstanceOf<AgentSelectedEvent>()
             agentEvents[1].shouldBeInstanceOf<AgentFinishedEvent>()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
         }
 
 
@@ -426,6 +431,54 @@ class CaseRuntimeSpec : StringSpec() {
         // -------------------------------------------------------------------------
         // Redirect: AgentFinishedEvent followed by AgentSelectedEvent
         // -------------------------------------------------------------------------
+
+        "statusFlow reflects RUNNING during run() and IDLE after normal completion" {
+            val (runtime) = buildRuntime()
+
+            runtime.statusFlow.value shouldBe CaseStatus.PENDING
+            runtime.addUserMessage(userActor, userMessage)
+            runtime.run()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "statusFlow reflects ERROR when max iterations are exceeded" {
+            // An agent that never emits AgentFinishedEvent forces the loop to hit maxIterations.
+            val loopingAgent = mockk<Agent> {
+                every { metadata } returns EntityMetadata(id = UUID.randomUUID())
+                every { name } returns "looping"
+                every { run(any<List<CaseEvent>>(), any()) } returns flow { /* never finishes */ }
+            }
+            val (runtime) = buildRuntime(agentName = "looping", agent = loopingAgent)
+
+            runtime.addUserMessage(userActor, userMessage)
+            runtime.run()
+
+            runtime.statusFlow.value shouldBe CaseStatus.ERROR
+        }
+
+        "statusFlow reflects KILLED after requestKill during run" {
+            // requestKill() must be called while run() is executing — run() resets
+            // the kill flag at startup, so calling it before run() has no effect.
+            val runtimeId = UUID.randomUUID()
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = runtimeId,
+                namespaceId = namespaceId,
+                updateStatus = { _, _ -> },
+                storeEvent = { it },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { _, _, _, _, _ ->
+                    // Signal kill from inside runAgent — before pushing AgentFinishedEvent.
+                    runtime.requestKill()
+                },
+            )
+
+            runtime.addUserMessage(userActor, userMessage)
+            runtime.run()
+
+            runtime.statusFlow.value shouldBe CaseStatus.KILLED
+        }
 
         "runAgent is called twice when agent A redirects to agent B" {
             // Regression: processNextStep scanned events newest-first and stopped at

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -8,7 +8,6 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
-import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
@@ -19,6 +18,7 @@ import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.WarnEvent
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import kotlinx.coroutines.flow.flow
 import java.util.UUID
@@ -149,7 +149,7 @@ class CaseRuntimeSpec : StringSpec() {
             CaseRuntime(
                 id = runtimeId,
                 namespaceId = namespaceId,
-                updateStatus = { _, _ -> },
+                updateStatusCallback = { _, _ -> },
                 storeEvent = { event ->
                     savedEvents.add(event)
                     event
@@ -206,8 +206,6 @@ class CaseRuntimeSpec : StringSpec() {
             runtime.statusFlow.value shouldBe CaseStatus.IDLE
         }
 
-
-
         // -------------------------------------------------------------------------
         // selectAgent returning a WarnEvent + AgentSelectedEvent
         // -------------------------------------------------------------------------
@@ -223,7 +221,7 @@ class CaseRuntimeSpec : StringSpec() {
                 CaseRuntime(
                     id = runtimeId,
                     namespaceId = namespaceId,
-                    updateStatus = { _, _ -> },
+                    updateStatusCallback = { _, _ -> },
                     storeEvent = { event ->
                         savedEvents.add(event)
                         event
@@ -290,7 +288,7 @@ class CaseRuntimeSpec : StringSpec() {
                 CaseRuntime(
                     id = runtimeId,
                     namespaceId = namespaceId,
-                    updateStatus = { _, _ -> },
+                    updateStatusCallback = { _, _ -> },
                     storeEvent = { event ->
                         if (event is AgentSelectedEvent) callOrder.add("AgentSelectedEvent saved")
                         event
@@ -330,7 +328,7 @@ class CaseRuntimeSpec : StringSpec() {
                 CaseRuntime(
                     id = runtimeId,
                     namespaceId = namespaceId,
-                    updateStatus = { _, _ -> },
+                    updateStatusCallback = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
@@ -365,7 +363,7 @@ class CaseRuntimeSpec : StringSpec() {
                 CaseRuntime(
                     id = runtimeId,
                     namespaceId = namespaceId,
-                    updateStatus = { _, _ -> },
+                    updateStatusCallback = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
@@ -399,7 +397,7 @@ class CaseRuntimeSpec : StringSpec() {
                 CaseRuntime(
                     id = runtimeId,
                     namespaceId = namespaceId,
-                    updateStatus = { _, _ -> },
+                    updateStatusCallback = { _, _ -> },
                     storeEvent = { it },
                     selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
                     isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
@@ -443,11 +441,12 @@ class CaseRuntimeSpec : StringSpec() {
 
         "statusFlow reflects ERROR when max iterations are exceeded" {
             // An agent that never emits AgentFinishedEvent forces the loop to hit maxIterations.
-            val loopingAgent = mockk<Agent> {
-                every { metadata } returns EntityMetadata(id = UUID.randomUUID())
-                every { name } returns "looping"
-                every { run(any<List<CaseEvent>>(), any()) } returns flow { /* never finishes */ }
-            }
+            val loopingAgent =
+                mockk<Agent> {
+                    every { metadata } returns EntityMetadata(id = UUID.randomUUID())
+                    every { name } returns "looping"
+                    every { run(any<List<CaseEvent>>(), any()) } returns flow { /* never finishes */ }
+                }
             val (runtime) = buildRuntime(agentName = "looping", agent = loopingAgent)
 
             runtime.addUserMessage(userActor, userMessage)
@@ -461,18 +460,19 @@ class CaseRuntimeSpec : StringSpec() {
             // the kill flag at startup, so calling it before run() has no effect.
             val runtimeId = UUID.randomUUID()
             lateinit var runtime: CaseRuntime
-            runtime = CaseRuntime(
-                id = runtimeId,
-                namespaceId = namespaceId,
-                updateStatus = { _, _ -> },
-                storeEvent = { it },
-                selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
-                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
-                runAgent = { _, _, _, _, _ ->
-                    // Signal kill from inside runAgent — before pushing AgentFinishedEvent.
-                    runtime.requestKill()
-                },
-            )
+            runtime =
+                CaseRuntime(
+                    id = runtimeId,
+                    namespaceId = namespaceId,
+                    updateStatusCallback = { _, _ -> },
+                    storeEvent = { it },
+                    selectAgent = { _, _ -> listOf(agentSelectedEvent(runtimeId, "agent")) },
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                    runAgent = { _, _, _, _, _ ->
+                        // Signal kill from inside runAgent — before pushing AgentFinishedEvent.
+                        runtime.requestKill()
+                    },
+                )
 
             runtime.addUserMessage(userActor, userMessage)
             runtime.run()
@@ -497,54 +497,79 @@ class CaseRuntimeSpec : StringSpec() {
 
             // Agent A emits: ToolRequestEvent, ToolResponseEvent, AgentFinishedEvent(A), AgentSelectedEvent(B)
             // — the redirect order produced by AgentSimple after the fix.
-            val agentAMock = mockk<Agent>(name = "mock-$agentA") {
-                every { metadata } returns EntityMetadata(id = UUID.nameUUIDFromBytes(agentA.toByteArray()))
-                every { name } returns agentA
-                every { run(any<List<CaseEvent>>(), any()) } answers {
-                    val caseId = firstArg<List<CaseEvent>>().first().caseId
-                    flow {
-                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId,
-                            agentId = UUID.nameUUIDFromBytes(agentA.toByteArray()), agentName = agentA))
-                        emit(AgentSelectedEvent(namespaceId = namespaceId, caseId = caseId,
-                            agentId = agentBId, agentName = agentB))
+            val agentAMock =
+                mockk<Agent>(name = "mock-$agentA") {
+                    every { metadata } returns EntityMetadata(id = UUID.nameUUIDFromBytes(agentA.toByteArray()))
+                    every { name } returns agentA
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = UUID.nameUUIDFromBytes(agentA.toByteArray()),
+                                    agentName = agentA,
+                                ),
+                            )
+                            emit(
+                                AgentSelectedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = agentBId,
+                                    agentName = agentB,
+                                ),
+                            )
+                        }
                     }
                 }
-            }
 
             // Agent B finishes normally.
-            val agentBMock = mockk<Agent>(name = "mock-$agentB") {
-                every { metadata } returns EntityMetadata(id = agentBId)
-                every { name } returns agentB
-                every { run(any<List<CaseEvent>>(), any()) } answers {
-                    val caseId = firstArg<List<CaseEvent>>().first().caseId
-                    flow {
-                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId,
-                            agentId = agentBId, agentName = agentB))
+            val agentBMock =
+                mockk<Agent>(name = "mock-$agentB") {
+                    every { metadata } returns EntityMetadata(id = agentBId)
+                    every { name } returns agentB
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = agentBId,
+                                    agentName = agentB,
+                                ),
+                            )
+                        }
                     }
                 }
-            }
 
             val selectAgent = RecordingSelectAgent { _, _ -> listOf(agentSelectedEvent(runtimeId, agentA)) }
 
-            val runAgent = RecordingRunAgent { name, events ->
-                runOrder += name
-                val agent = if (name == agentA) agentAMock else agentBMock
-                agent.run(events).collect { event ->
-                    savedEvents.add(event)
-                    runtime.emitEvent(event)
-                    runtime.pushEvents(listOf(event))
+            val runAgent =
+                RecordingRunAgent { name, events ->
+                    runOrder += name
+                    val agent = if (name == agentA) agentAMock else agentBMock
+                    agent.run(events).collect { event ->
+                        savedEvents.add(event)
+                        runtime.emitEvent(event)
+                        runtime.pushEvents(listOf(event))
+                    }
                 }
-            }
 
-            runtime = CaseRuntime(
-                id = runtimeId,
-                namespaceId = namespaceId,
-                updateStatus = { _, _ -> },
-                storeEvent = { event -> savedEvents.add(event); event },
-                selectAgent = selectAgent.asCallback,
-                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+            runtime =
+                CaseRuntime(
+                    id = runtimeId,
+                    namespaceId = namespaceId,
+                    updateStatusCallback = { _, _ -> },
+                    storeEvent = { event ->
+                        savedEvents.add(event)
+                        event
+                    },
+                    selectAgent = selectAgent.asCallback,
+                    isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
                     runAgent = runAgent.asCallback,
-            )
+                )
 
             runtime.addUserMessage(userActor, userMessage)
             runtime.run()
@@ -572,39 +597,57 @@ class CaseRuntimeSpec : StringSpec() {
 
             lateinit var runtime: CaseRuntime
 
-            val agentAMock = mockk<Agent>(name = "mock-$agentA") {
-                every { metadata } returns EntityMetadata(id = UUID.nameUUIDFromBytes(agentA.toByteArray()))
-                every { name } returns agentA
-                every { run(any<List<CaseEvent>>(), any()) } answers {
-                    val caseId = firstArg<List<CaseEvent>>().first().caseId
-                    flow {
-                        emit(AgentFinishedEvent(namespaceId = namespaceId, caseId = caseId,
-                            agentId = UUID.nameUUIDFromBytes(agentA.toByteArray()), agentName = agentA))
-                        emit(AgentSelectedEvent(namespaceId = namespaceId, caseId = caseId,
-                            agentId = UUID.nameUUIDFromBytes(agentB.toByteArray()), agentName = agentB))
+            val agentAMock =
+                mockk<Agent>(name = "mock-$agentA") {
+                    every { metadata } returns EntityMetadata(id = UUID.nameUUIDFromBytes(agentA.toByteArray()))
+                    every { name } returns agentA
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = UUID.nameUUIDFromBytes(agentA.toByteArray()),
+                                    agentName = agentA,
+                                ),
+                            )
+                            emit(
+                                AgentSelectedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = UUID.nameUUIDFromBytes(agentB.toByteArray()),
+                                    agentName = agentB,
+                                ),
+                            )
+                        }
                     }
                 }
-            }
 
             val selectAgent = RecordingSelectAgent { _, _ -> listOf(agentSelectedEvent(runtimeId, agentA)) }
-            val runAgent = RecordingRunAgent { name, events ->
-                runOrder += name
-                agentAMock.run(events).collect { event ->
-                    savedEvents.add(event)
-                    runtime.emitEvent(event)
-                    runtime.pushEvents(listOf(event))
+            val runAgent =
+                RecordingRunAgent { name, events ->
+                    runOrder += name
+                    agentAMock.run(events).collect { event ->
+                        savedEvents.add(event)
+                        runtime.emitEvent(event)
+                        runtime.pushEvents(listOf(event))
+                    }
                 }
-            }
 
-            runtime = CaseRuntime(
-                id = runtimeId,
-                namespaceId = namespaceId,
-                updateStatus = { _, _ -> },
-                storeEvent = { event -> savedEvents.add(event); event },
-                selectAgent = selectAgent.asCallback,
-                isAgentAuthorized = { name, _ -> name == agentA }, // agentB not authorized
+            runtime =
+                CaseRuntime(
+                    id = runtimeId,
+                    namespaceId = namespaceId,
+                    updateStatusCallback = { _, _ -> },
+                    storeEvent = { event ->
+                        savedEvents.add(event)
+                        event
+                    },
+                    selectAgent = selectAgent.asCallback,
+                    isAgentAuthorized = { name, _ -> name == agentA }, // agentB not authorized
                     runAgent = runAgent.asCallback,
-            )
+                )
 
             runtime.addUserMessage(userActor, userMessage)
             runtime.run()
@@ -654,7 +697,7 @@ class CaseRuntimeSpec : StringSpec() {
                 CaseRuntime(
                     id = caseId,
                     namespaceId = namespaceId,
-                    updateStatus = { _, _ -> },
+                    updateStatusCallback = { _, _ -> },
                     storeEvent = { event ->
                         savedEvents.add(event)
                         event

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -11,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentService
+import io.whozoss.agentos.caseFlow.CaseConfigProperties
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseEvent.CaseEventServiceImpl
@@ -206,7 +207,7 @@ class CaseServiceImplSpec :
                 caseEventService,
                 userService,
                 namespaceService,
-                idleEvictionGraceMs = idleEvictionGraceMs,
+                caseConfig = CaseConfigProperties(idleEvictionGraceMs = idleEvictionGraceMs),
             )
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -182,6 +182,8 @@ class CaseServiceImplSpec :
             defaultAgentName: String? = agentName,
             environmentAgentName: String? = null,
             agentConfigService: AgentConfigService = allowAllAgentConfigService,
+            idleEvictionTimeoutMs: Long = 30_000L,
+            idleEvictionGraceMs: Long = 5_000L,
         ): CaseServiceImpl {
             val namespace =
                 Namespace(
@@ -205,6 +207,8 @@ class CaseServiceImplSpec :
                 caseEventService,
                 userService,
                 namespaceService,
+                idleEvictionTimeoutMs = idleEvictionTimeoutMs,
+                idleEvictionGraceMs = idleEvictionGraceMs,
             )
         }
 
@@ -1121,6 +1125,109 @@ class CaseServiceImplSpec :
             // The selected agent must be `inspector`, not `inspector https://...`
             persistedEvents.filterIsInstance<AgentSelectedEvent>().last().agentName shouldBe inspectorName
             verify(exactly = 1) { allowAllAgentConfigService.findAvailableByNamespaceIdAndUserId(namespaceId, userId, inspectorName) }
+        }
+
+        // -------------------------------------------------------------------------
+        // Idle runtime eviction
+        // -------------------------------------------------------------------------
+
+        "idle runtime is evicted after all SSE subscribers disconnect and grace period elapses" {
+            // With idleEvictionTimeoutMs=0 the timeout fires immediately if subscribers > 0,
+            // but since we won't subscribe at all, subscriptionCount is already 0 when
+            // scheduleIdleEviction runs. With idleEvictionGraceMs=50 the eviction happens
+            // quickly enough to observe in a test without long waits.
+            val service = buildService(idleEvictionTimeoutMs = 2_000L, idleEvictionGraceMs = 50L)
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            // Subscribe, let the case reach IDLE, then unsubscribe.
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
+            awaitSubscribers(runtime)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+            // awaiter job ends, which cancels its coroutine -> subscriptionCount drops to 0.
+
+            // Wait for the grace period + a small margin to let the eviction coroutine run.
+            delay(200)
+
+            // The runtime must have been evicted: findActiveRuntime returns null.
+            service.findActiveRuntime(case.id) shouldBe null
+            // The case itself is still persisted and accessible.
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+        }
+
+        "idle runtime is NOT evicted when a new message arrives before grace period elapses" {
+            // idleEvictionGraceMs=500 gives us a window to send a second message.
+            val service = buildService(idleEvictionTimeoutMs = 2_000L, idleEvictionGraceMs = 500L)
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            // First message -> IDLE
+            val firstIdle = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
+            awaitSubscribers(runtime)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("first")),
+            )
+            firstIdle.join()
+            awaitNotRunning(runtime)
+
+            // Send a second message immediately — the runtime transitions IDLE -> RUNNING
+            // before the grace period elapses, which should cancel the pending eviction.
+            val secondIdle = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
+            awaitSubscribers(runtime)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("second")),
+            )
+            secondIdle.join()
+
+            // Wait past the grace period to confirm eviction did NOT happen.
+            delay(700)
+
+            // Runtime must still be alive because a new message arrived before grace elapsed.
+            service.findActiveRuntime(case.id) shouldBe runtime
+            service.getById(case.id).status shouldBe CaseStatus.IDLE
+        }
+
+        "idle runtime is NOT evicted while SSE subscribers remain connected" {
+            // idleEvictionTimeoutMs=100 — if subscribers were 0 the eviction would fire quickly.
+            // We keep a subscriber alive for the whole duration to verify it is NOT evicted.
+            val service = buildService(idleEvictionTimeoutMs = 100L, idleEvictionGraceMs = 50L)
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
+            awaitSubscribers(runtime)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+
+            // Keep a long-lived subscriber open so subscriptionCount stays > 0.
+            val longLivedJob = scope.launch {
+                withTimeout(5_000) {
+                    runtime.events.collect { /* keep alive */ }
+                }
+            }
+
+            // Wait well past idleEvictionTimeoutMs to confirm no eviction happened.
+            delay(300)
+
+            service.findActiveRuntime(case.id) shouldBe runtime
+
+            longLivedJob.cancel()
         }
 
         "@mention followed by a URL with non-breaking space selects the agent and ignores the URL" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -1134,9 +1134,9 @@ class CaseServiceImplSpec :
             // If subscriptionCount drops to 0 while status is RUNNING, combine emits false
             // and the grace period never starts — the runtime must survive until the run completes.
             //
-            // This test uses a slow agent (500ms delay) so there is a clear window where
-            // subscriptionCount == 0 AND status == RUNNING simultaneously.
-            // We verify at 200ms — well inside RUNNING, well before the agent finishes.
+            // This test uses a slow agent (200ms delay) so subscriptionCount == 0 and
+            // status == RUNNING overlap. The assertion is made immediately after the
+            // subscriber disconnects — no timing margin needed.
 
             val slowAgent =
                 mockk<Agent> {
@@ -1148,7 +1148,7 @@ class CaseServiceImplSpec :
                     every { run(any<List<CaseEvent>>(), any()) } answers {
                         val caseId = firstArg<List<CaseEvent>>().first().caseId
                         flow {
-                            delay(500) // simulate a slow agent run
+                            delay(200) // simulate a slow agent run
                             emit(
                                 AgentFinishedEvent(
                                     namespaceId = namespaceId,
@@ -1183,11 +1183,12 @@ class CaseServiceImplSpec :
                 content = listOf(MessageContent.Text("hello")),
             )
             shortLivedJob.join() // unsubscribes when RUNNING is seen
-            // subscriptionCount is now 0, status is RUNNING — eviction must NOT fire
-
-            // Verify at 200ms: the agent is still running (500ms delay), no eviction should happen.
-            delay(200)
+            // subscriptionCount is now 0, status is RUNNING — eviction must NOT fire.
+            // Assert immediately: statusFlow is RUNNING by construction at this point
+            // (shortLivedJob only completed after seeing the RUNNING CaseStatusEvent,
+            // and _statusFlow is updated before emitEvent so it is guaranteed RUNNING here).
             service.findActiveRuntime(case.id) shouldBe runtime
+            runtime.statusFlow.value shouldBe CaseStatus.RUNNING
         }
 
         "idle runtime is evicted after all SSE subscribers disconnect and grace period elapses" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -346,6 +346,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -567,6 +568,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -663,6 +665,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -732,6 +735,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -775,6 +779,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -842,6 +847,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -907,6 +913,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userServiceMock,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -1010,6 +1017,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -1103,6 +1111,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -1250,12 +1259,13 @@ class CaseServiceImplSpec :
                 content = listOf(MessageContent.Text("second")),
             )
             secondIdle.join()
+            // awaitNotRunning ensures run() has fully exited and the runtime is in a
+            // stable IDLE state before we assert. No arbitrary delay needed.
+            awaitNotRunning(runtime)
 
-            // Check BEFORE the second grace period elapses (delay << graceMs=500).
+            // Check BEFORE the second grace period elapses.
             // The runtime must still be alive: the first eviction was cancelled by the
             // second message, and the second eviction hasn't fired yet.
-            delay(100)
-
             service.findActiveRuntime(case.id) shouldBe runtime
             service.getById(case.id).status shouldBe CaseStatus.IDLE
         }
@@ -1343,6 +1353,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -1493,6 +1504,7 @@ class CaseServiceImplSpec :
                     caseEventService,
                     userService,
                     namespaceService,
+                    caseConfig = CaseConfigProperties(),
                 )
 
             // Insert the case directly into the repository so no runtime is created in

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -1163,6 +1163,11 @@ class CaseServiceImplSpec :
 
         "idle runtime is NOT evicted when a new message arrives before grace period elapses" {
             // idleEvictionGraceMs=500 gives us a window to send a second message.
+            // The test verifies that the FIRST eviction coroutine (launched at the first IDLE)
+            // does NOT evict the runtime when a second message arrives within the grace period.
+            //
+            // After the second IDLE a new eviction coroutine fires, but we verify the runtime
+            // is still alive *before* that second grace period elapses (delay < graceMs).
             val service = buildService(idleEvictionTimeoutMs = 2_000L, idleEvictionGraceMs = 500L)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
@@ -1180,7 +1185,7 @@ class CaseServiceImplSpec :
             awaitNotRunning(runtime)
 
             // Send a second message immediately — the runtime transitions IDLE -> RUNNING
-            // before the grace period elapses, which should cancel the pending eviction.
+            // before the first grace period elapses, which cancels the first eviction.
             val secondIdle = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
             awaitSubscribers(runtime)
             service.addMessage(
@@ -1190,10 +1195,11 @@ class CaseServiceImplSpec :
             )
             secondIdle.join()
 
-            // Wait past the grace period to confirm eviction did NOT happen.
-            delay(700)
+            // Check BEFORE the second grace period elapses (delay << graceMs=500).
+            // The runtime must still be alive: the first eviction was cancelled by the
+            // second message, and the second eviction hasn't fired yet.
+            delay(100)
 
-            // Runtime must still be alive because a new message arrived before grace elapsed.
             service.findActiveRuntime(case.id) shouldBe runtime
             service.getById(case.id).status shouldBe CaseStatus.IDLE
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -1129,6 +1129,67 @@ class CaseServiceImplSpec :
         // Idle runtime eviction
         // -------------------------------------------------------------------------
 
+        "idle runtime is NOT evicted when client disconnects while agent is still running" {
+            // The eviction watcher combines subscriptionCount and statusFlow.
+            // If subscriptionCount drops to 0 while status is RUNNING, combine emits false
+            // and the grace period never starts — the runtime must survive until the run completes.
+            //
+            // This test uses a slow agent (500ms delay) so there is a clear window where
+            // subscriptionCount == 0 AND status == RUNNING simultaneously.
+            // We verify at 200ms — well inside RUNNING, well before the agent finishes.
+
+            val slowAgent =
+                mockk<Agent> {
+                    every { metadata } returns EntityMetadata(id = agentId)
+                    every { name } returns agentName
+                    every { id } returns agentId
+                    every { llmProvider } returns "test-provider"
+                    every { llmModel } returns "test-model"
+                    every { run(any<List<CaseEvent>>(), any()) } answers {
+                        val caseId = firstArg<List<CaseEvent>>().first().caseId
+                        flow {
+                            delay(500) // simulate a slow agent run
+                            emit(
+                                AgentFinishedEvent(
+                                    namespaceId = namespaceId,
+                                    caseId = caseId,
+                                    agentId = agentId,
+                                    agentName = agentName,
+                                ),
+                            )
+                        }
+                    }
+                }
+
+            val service = buildService(agent = slowAgent, idleEvictionGraceMs = 50L)
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            // Subscribe just long enough to observe RUNNING, then unsubscribe.
+            // This creates the window: subscriptionCount == 0 while status == RUNNING.
+            val shortLivedJob =
+                scope.launch {
+                    withTimeout(8_000) {
+                        runtime.events
+                            .filterIsInstance<CaseStatusEvent>()
+                            .first { it.status == CaseStatus.RUNNING }
+                    }
+                }
+            awaitSubscribers(runtime)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            shortLivedJob.join() // unsubscribes when RUNNING is seen
+            // subscriptionCount is now 0, status is RUNNING — eviction must NOT fire
+
+            // Verify at 200ms: the agent is still running (500ms delay), no eviction should happen.
+            delay(200)
+            service.findActiveRuntime(case.id) shouldBe runtime
+        }
+
         "idle runtime is evicted after all SSE subscribers disconnect and grace period elapses" {
             val service = buildService(idleEvictionGraceMs = 50L)
             val case = service.create(Case(namespaceId = namespaceId))

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -182,7 +182,6 @@ class CaseServiceImplSpec :
             defaultAgentName: String? = agentName,
             environmentAgentName: String? = null,
             agentConfigService: AgentConfigService = allowAllAgentConfigService,
-            idleEvictionTimeoutMs: Long = 30_000L,
             idleEvictionGraceMs: Long = 5_000L,
         ): CaseServiceImpl {
             val namespace =
@@ -207,7 +206,6 @@ class CaseServiceImplSpec :
                 caseEventService,
                 userService,
                 namespaceService,
-                idleEvictionTimeoutMs = idleEvictionTimeoutMs,
                 idleEvictionGraceMs = idleEvictionGraceMs,
             )
         }
@@ -1132,11 +1130,7 @@ class CaseServiceImplSpec :
         // -------------------------------------------------------------------------
 
         "idle runtime is evicted after all SSE subscribers disconnect and grace period elapses" {
-            // With idleEvictionTimeoutMs=0 the timeout fires immediately if subscribers > 0,
-            // but since we won't subscribe at all, subscriptionCount is already 0 when
-            // scheduleIdleEviction runs. With idleEvictionGraceMs=50 the eviction happens
-            // quickly enough to observe in a test without long waits.
-            val service = buildService(idleEvictionTimeoutMs = 2_000L, idleEvictionGraceMs = 50L)
+            val service = buildService(idleEvictionGraceMs = 50L)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -1163,12 +1157,11 @@ class CaseServiceImplSpec :
 
         "idle runtime is NOT evicted when a new message arrives before grace period elapses" {
             // idleEvictionGraceMs=500 gives us a window to send a second message.
-            // The test verifies that the FIRST eviction coroutine (launched at the first IDLE)
-            // does NOT evict the runtime when a second message arrives within the grace period.
-            //
-            // After the second IDLE a new eviction coroutine fires, but we verify the runtime
-            // is still alive *before* that second grace period elapses (delay < graceMs).
-            val service = buildService(idleEvictionTimeoutMs = 2_000L, idleEvictionGraceMs = 500L)
+            // The eviction watcher fires when subscriptionCount hits 0 after the first IDLE.
+            // A second message arrives within the grace period, making the status RUNNING again.
+            // The guard (currentStatus == IDLE) prevents eviction, and we verify the runtime
+            // is still alive before the second grace period elapses.
+            val service = buildService(idleEvictionGraceMs = 500L)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)
@@ -1205,9 +1198,9 @@ class CaseServiceImplSpec :
         }
 
         "idle runtime is NOT evicted while SSE subscribers remain connected" {
-            // idleEvictionTimeoutMs=100 — if subscribers were 0 the eviction would fire quickly.
-            // We keep a subscriber alive for the whole duration to verify it is NOT evicted.
-            val service = buildService(idleEvictionTimeoutMs = 100L, idleEvictionGraceMs = 50L)
+            // The eviction watcher only fires when subscriptionCount == 0.
+            // We keep a subscriber alive so subscriptionCount never reaches 0.
+            val service = buildService(idleEvictionGraceMs = 50L)
             val case = service.create(Case(namespaceId = namespaceId))
             val runtime = service.getCaseRuntime(case.id)
             val scope = CoroutineScope(Dispatchers.IO)


### PR DESCRIPTION
## What

Idle `CaseRuntime` instances now evict themselves from `activeRuntimes` once all SSE subscribers have disconnected, preventing unbounded memory growth in long-running deployments.

## How

- heartbeat added to SSE to detect disconnected clients
- grace delay started when no subscriber AND case is IDLE
