### PR TITLE
feat: add OpenTelemetry distributed tracing with coroutine context propagation

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/Trace.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/Trace.kt
@@ -1,0 +1,16 @@
+package io.whozoss.agentos.sdk.tool
+
+/**
+ * Marks a method as a tracing boundary.
+ *
+ * Applied to [StandardTool.executeWithJson] to signal that this entry point
+ * is the intended span root for tool-call tracing. Instrumentation infrastructure
+ * (e.g. Micrometer Tracing in agentos-service) can use this annotation as a
+ * marker when creating spans programmatically.
+ *
+ * This is a compile-time marker only ([AnnotationRetention.SOURCE]) — it carries
+ * no runtime overhead and does not require any tracing dependency in the SDK.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Trace

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -122,6 +122,13 @@ dependencies {
     // Disabled by default (requires DATADOG_API_KEY + management.datadog.metrics.export.enabled=true).
     implementation(libs.micrometer.registry.statsd)
 
+    // Micrometer Tracing — OTel bridge propagates trace context; OTLP exporter sends spans
+    // to any OTLP-compatible backend (Datadog agent, Jaeger, Tempo, …).
+    // Both versions are managed by the Spring Boot BOM (micrometer-tracing 1.5.5, OTel 1.49.0).
+    // Disabled by default via management.tracing.enabled=false in application.yml.
+    implementation(libs.micrometer.tracing.bridge.otel)
+    implementation(libs.opentelemetry.exporter.otlp)
+
     // Jackson for JSON processing
     implementation(libs.jackson.module.kotlin)
 

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -118,6 +118,10 @@ dependencies {
     // Logstash Logback Encoder — JSON structured logging (used by logback-spring.xml docker profile)
     runtimeOnly(libs.logstash.logback.encoder)
 
+    // Micrometer Datadog registry — exports tool-call metrics to Datadog.
+    // Disabled by default (requires DATADOG_API_KEY + management.datadog.metrics.export.enabled=true).
+    implementation(libs.micrometer.registry.datadog)
+
     // Jackson for JSON processing
     implementation(libs.jackson.module.kotlin)
 

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -120,7 +120,7 @@ dependencies {
 
     // Micrometer Datadog registry — exports tool-call metrics to Datadog.
     // Disabled by default (requires DATADOG_API_KEY + management.datadog.metrics.export.enabled=true).
-    implementation(libs.micrometer.registry.datadog)
+    implementation(libs.micrometer.registry.statsd)
 
     // Jackson for JSON processing
     implementation(libs.jackson.module.kotlin)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -1,7 +1,10 @@
 package io.whozoss.agentos.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.whozoss.agentos.agent.AgentAdvanced.Companion.REPETITION_WINDOW
 import io.whozoss.agentos.agent.AgentIntentionGenerator.Companion.ANSWER_TOOL
+import io.whozoss.agentos.metrics.ConfirmationOutcome
+import io.whozoss.agentos.metrics.ToolMetricsService
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
@@ -23,8 +26,6 @@ import io.whozoss.agentos.sdk.tool.EnrichmentPhaseTrace
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
-import io.whozoss.agentos.metrics.ConfirmationOutcome
-import io.whozoss.agentos.metrics.ToolMetricsService
 import io.whozoss.agentos.util.AttemptFailure
 import io.whozoss.agentos.util.AttemptResult
 import io.whozoss.agentos.util.AttemptSuccess
@@ -585,9 +586,18 @@ class AgentAdvanced(
         caseId: UUID,
         emitEvent: suspend (CaseEvent) -> Unit,
     ): GateOutcome {
+        val sample = toolMetricsService?.startTimer()
         val response =
             try {
                 val result = tool.executeWithJson(argsJson, toolCtx)
+                val durationMs =
+                    toolMetricsService?.stopTimerAndSendMetrics(
+                        sample = sample,
+                        toolName = parameters.toolName,
+                        agentName = name,
+                        namespaceId = namespaceId,
+                        success = result.success,
+                    )
                 ToolResponseEvent(
                     namespaceId = namespaceId,
                     caseId = caseId,
@@ -595,12 +605,21 @@ class AgentAdvanced(
                     toolName = parameters.toolName,
                     output = MessageContent.Text(result.output),
                     success = result.success,
+                    durationMs = durationMs,
                     toolMetadata = result.metadata,
                 )
             } catch (e: Exception) {
                 logger.warn(e) {
                     "[AgentAdvanced] implicit-consent tool execution failed for ${tool.name}"
                 }
+                val durationMs =
+                    toolMetricsService?.stopTimerAndSendMetrics(
+                        sample = sample,
+                        toolName = parameters.toolName,
+                        agentName = name,
+                        namespaceId = namespaceId,
+                        success = false,
+                    )
                 ToolResponseEvent(
                     namespaceId = namespaceId,
                     caseId = caseId,
@@ -608,6 +627,7 @@ class AgentAdvanced(
                     toolName = parameters.toolName,
                     output = MessageContent.Text("Error executing tool: ${e.message}"),
                     success = false,
+                    durationMs = durationMs,
                 )
             }
         emitEvent(response)
@@ -811,14 +831,29 @@ class AgentAdvanced(
         if (confirmed) {
             var failed = false
             var result: ToolExecutionResult? = null
+            val sample = toolMetricsService?.startTimer()
             val output =
                 try {
                     result = tool.executeWithJson(pending.inputJson, toolCtx)
+                    toolMetricsService?.stopTimerAndSendMetrics(
+                        sample = sample,
+                        toolName = pending.toolName,
+                        agentName = name,
+                        namespaceId = namespaceId,
+                        success = result.success,
+                    )
                     result.output
                 } catch (e: Exception) {
                     logger.warn(e) {
                         "[AgentAdvanced] tool execution failed during confirmation resolution for ${pending.toolName}"
                     }
+                    toolMetricsService?.stopTimerAndSendMetrics(
+                        sample = sample,
+                        toolName = pending.toolName,
+                        agentName = name,
+                        namespaceId = namespaceId,
+                        success = false,
+                    )
                     failed = true
                     "Error during tool execution: ${e.message}"
                 }
@@ -1370,8 +1405,14 @@ Output requirements:
         val traces =
             (0 until tool.getIntermediatePhaseCount()).mapWhile(
                 transform = { phaseIndex ->
-                    runEnrichmentPhase(tool, phaseIndex, previousContent, accumulatedEvents, intentionEvent, namespaceId)
-                        .also { trace -> if (trace.success) previousContent = trace.enrichmentContent }
+                    runEnrichmentPhase(
+                        tool,
+                        phaseIndex,
+                        previousContent,
+                        accumulatedEvents,
+                        intentionEvent,
+                        namespaceId,
+                    ).also { trace -> if (trace.success) previousContent = trace.enrichmentContent }
                 },
                 predicate = { phaseIndex, trace ->
                     trace.success.also {
@@ -1491,13 +1532,14 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
                                 caseEvents = filteredEvents,
                             ),
                         )
-                    val durationMs = toolMetricsService?.stopTimer(
-                        sample = sample,
-                        toolName = toolRequest.toolName,
-                        agentName = name,
-                        namespaceId = namespaceId,
-                        success = result.success,
-                    )
+                    val durationMs =
+                        toolMetricsService?.stopTimerAndSendMetrics(
+                            sample = sample,
+                            toolName = toolRequest.toolName,
+                            agentName = name,
+                            namespaceId = namespaceId,
+                            success = result.success,
+                        )
                     ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
@@ -1512,7 +1554,7 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
                     // Re-throw so handleToolExecution() can emit a proper ToolResponseEvent
                     // before the interrupt propagates to the run() catch block.
                     // Stop the timer here so the sample is not leaked.
-                    toolMetricsService?.stopTimer(
+                    toolMetricsService?.stopTimerAndSendMetrics(
                         sample = sample,
                         toolName = toolRequest.toolName,
                         agentName = name,
@@ -1524,13 +1566,14 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
                     logger.warn(e) {
                         "[AgentAdvanced] error during tool execution for ${tool.name}"
                     }
-                    val durationMs = toolMetricsService?.stopTimer(
-                        sample = sample,
-                        toolName = toolRequest.toolName,
-                        agentName = name,
-                        namespaceId = namespaceId,
-                        success = false,
-                    )
+                    val durationMs =
+                        toolMetricsService?.stopTimerAndSendMetrics(
+                            sample = sample,
+                            toolName = toolRequest.toolName,
+                            agentName = name,
+                            namespaceId = namespaceId,
+                            success = false,
+                        )
                     ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -23,6 +23,8 @@ import io.whozoss.agentos.sdk.tool.EnrichmentPhaseTrace
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+import io.whozoss.agentos.metrics.ConfirmationOutcome
+import io.whozoss.agentos.metrics.ToolMetricsService
 import io.whozoss.agentos.util.AttemptFailure
 import io.whozoss.agentos.util.AttemptResult
 import io.whozoss.agentos.util.AttemptSuccess
@@ -51,6 +53,8 @@ class AgentAdvanced(
     private val maxIterations: Int = 20,
     override val llmProvider: String,
     override val llmModel: String,
+    /** Metrics service for recording tool call telemetry. Null in tests that don't inject it. */
+    private val toolMetricsService: ToolMetricsService? = null,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -871,16 +875,29 @@ class AgentAdvanced(
         emitEvent(syntheticResponse)
         appendTo += syntheticResponse
 
-        return when {
+        val confirmationOutcome =
+            when {
+                confirmed && !executionFailed -> ConfirmationOutcome.APPLIED
+                !confirmed -> ConfirmationOutcome.REJECTED
+                else -> ConfirmationOutcome.ABORTED
+            }
+        toolMetricsService?.recordConfirmation(
+            toolName = pending.toolName,
+            agentName = name,
+            namespaceId = namespaceId,
+            outcome = confirmationOutcome,
+        )
+
+        return when (confirmationOutcome) {
             // User confirmed AND tool ran successfully → fall through, LLM can comment.
-            confirmed && !executionFailed -> ConfirmationResolution.Applied
+            ConfirmationOutcome.APPLIED -> ConfirmationResolution.Applied
 
             // User explicitly refused → fall through, LLM can produce a natural follow-up.
-            !confirmed -> ConfirmationResolution.Rejected
+            ConfirmationOutcome.REJECTED -> ConfirmationResolution.Rejected
 
             // Confirmed but the tool threw (executionFailed=true) → no useful continuation;
             // the user just got bitten by a real failure, don't push the LLM to retry.
-            else -> ConfirmationResolution.Aborted
+            ConfirmationOutcome.ABORTED -> ConfirmationResolution.Aborted
         }
     }
 
@@ -1260,6 +1277,11 @@ Output requirements:
             val message =
                 "Failed to generate valid JSON parameters for '${tool.name}' after $MAX_PARAMETER_ATTEMPTS attempts."
             emitEvent(WarnEvent(namespaceId = namespaceId, caseId = caseId, message = message))
+            toolMetricsService?.recordParameterGenerationFailure(
+                toolName = tool.name,
+                agentName = name,
+                namespaceId = namespaceId,
+            )
         }
 
         return result
@@ -1451,7 +1473,7 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
             }
 
             else -> {
-                val startMs = System.currentTimeMillis()
+                val sample = toolMetricsService?.startTimer()
                 try {
                     val filteredEvents = filterEventsByIntegration(toolRequest.toolName, caseEventsProvider())
                     val result: ToolExecutionResult =
@@ -1464,6 +1486,13 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
                                 caseEvents = filteredEvents,
                             ),
                         )
+                    val durationMs = toolMetricsService?.stopTimer(
+                        sample = sample,
+                        toolName = toolRequest.toolName,
+                        agentName = name,
+                        namespaceId = namespaceId,
+                        success = result.success,
+                    )
                     ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
@@ -1471,17 +1500,32 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
                         toolName = toolRequest.toolName,
                         output = MessageContent.Text(result.output),
                         success = result.success,
-                        durationMs = System.currentTimeMillis() - startMs,
+                        durationMs = durationMs,
                         toolMetadata = result.metadata,
                     )
                 } catch (e: AgentInterrupt) {
                     // Re-throw so handleToolExecution() can emit a proper ToolResponseEvent
                     // before the interrupt propagates to the run() catch block.
+                    // Stop the timer here so the sample is not leaked.
+                    toolMetricsService?.stopTimer(
+                        sample = sample,
+                        toolName = toolRequest.toolName,
+                        agentName = name,
+                        namespaceId = namespaceId,
+                        success = true,
+                    )
                     throw e
                 } catch (e: Exception) {
                     logger.warn(e) {
                         "[AgentAdvanced] error during tool execution for ${tool.name}"
                     }
+                    val durationMs = toolMetricsService?.stopTimer(
+                        sample = sample,
+                        toolName = toolRequest.toolName,
+                        agentName = name,
+                        namespaceId = namespaceId,
+                        success = false,
+                    )
                     ToolResponseEvent(
                         namespaceId = namespaceId,
                         caseId = caseId,
@@ -1489,7 +1533,7 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
                         toolName = toolRequest.toolName,
                         output = MessageContent.Text("Error executing tool: ${e.message}"),
                         success = false,
-                        durationMs = System.currentTimeMillis() - startMs,
+                        durationMs = durationMs,
                     )
                 }
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -8,6 +8,7 @@ import io.whozoss.agentos.aiProvider.AiProviderService
 import io.whozoss.agentos.chat.ChatClientProvider
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.namespace.NamespaceService
+import io.whozoss.agentos.metrics.ToolMetricsService
 import io.whozoss.agentos.reconciliation.ConfigMergeService
 import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.aiProvider.AiModel
@@ -45,6 +46,7 @@ class AgentServiceImpl(
     private val confirmationManager: ConfirmationManager,
     private val objectMapper: ObjectMapper,
     private val toolRegistryService: ToolRegistryService,
+    private val toolMetricsService: ToolMetricsService,
 ) : AgentService {
     override suspend fun findAgentByName(
         namePart: String,
@@ -280,6 +282,7 @@ class AgentServiceImpl(
                 caseEventsProvider = context.caseEventsProvider,
                 llmProvider = providerConfig.name,
                 llmModel = modelConfig.apiModelName,
+                toolMetricsService = toolMetricsService,
             )
         } else {
             AgentSimple(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.caseFlow
 
+import io.micrometer.tracing.Tracer
 import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.agent.AgentExecutionContext
 import io.whozoss.agentos.agent.AgentService
@@ -8,6 +9,8 @@ import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.caseEvent.lastUserIdOrNull
 import io.whozoss.agentos.exception.ResourceNotFoundException
 import io.whozoss.agentos.namespace.NamespaceService
+import io.whozoss.agentos.tracing.OtelCoroutineContext
+import io.whozoss.agentos.tracing.withSpan
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
@@ -42,6 +45,10 @@ class CaseServiceImpl(
     private val caseEventService: CaseEventService,
     private val userService: UserService,
     private val namespaceService: NamespaceService,
+    // Nullable: Spring Boot auto-configures a Tracer only when tracing is enabled.
+    // When management.tracing.enabled=false (the default) no Tracer bean is registered
+    // and the app starts normally without any tracing overhead.
+    private val tracer: Tracer? = null,
 ) : CaseService {
     /**
      * Coroutine scope used to run case execution loops in the background.
@@ -180,7 +187,9 @@ class CaseServiceImpl(
         val runtime = getCaseRuntime(caseId)
         runtime.addUserMessage(actor, content, answerToEventId, sessionContext)
         // run() is self-guarding via an AtomicBoolean — launch unconditionally.
-        scope.launch { runtime.run() }
+        // OtelCoroutineContext captures the current OTel span so the background coroutine
+        // remains a child of the originating HTTP request trace.
+        scope.launch(OtelCoroutineContext()) { runtime.run() }
     }
 
     // ======================================================
@@ -421,25 +430,35 @@ class CaseServiceImpl(
             }
         }
 
-        agent.run(events, shouldContinue)
-            .catch { error ->
-                logger.error(error) { "Error in agent $agentName for case $caseId" }
-                storeEvent(
-                    WarnEvent(
-                        namespaceId = runtime.namespaceId,
-                        caseId = caseId,
-                        message = "Agent $agentName error: ${error.message}",
-                    ),
-                ).also { saved ->
+        withSpan(
+            tracer,
+            "agent.run",
+            mapOf(
+                "agent.name" to agentName,
+                "case.id" to caseId.toString(),
+                "namespace.id" to runtime.namespaceId.toString(),
+            ),
+        ) {
+            agent.run(events, shouldContinue)
+                .catch { error ->
+                    logger.error(error) { "Error in agent $agentName for case $caseId" }
+                    storeEvent(
+                        WarnEvent(
+                            namespaceId = runtime.namespaceId,
+                            caseId = caseId,
+                            message = "Agent $agentName error: ${error.message}",
+                        ),
+                    ).also { saved ->
+                        runtime.emitEvent(saved)
+                    }
+                }.collect { event ->
+                    val saved = storeEvent(event)
+                    if (event.caseId == caseId && event !is TransientCaseEvent) {
+                        runtime.pushEvents(listOf(saved))
+                    }
                     runtime.emitEvent(saved)
                 }
-            }.collect { event ->
-                val saved = storeEvent(event)
-                if (event.caseId == caseId && event !is TransientCaseEvent) {
-                    runtime.pushEvents(listOf(saved))
-                }
-                runtime.emitEvent(saved)
-            }
+        }
         logger.info { "Agent $agentName finished for case $caseId" }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/metrics/ToolMetricsService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/metrics/ToolMetricsService.kt
@@ -1,0 +1,204 @@
+package io.whozoss.agentos.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.Timer
+import mu.KLogging
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * Records Micrometer metrics for agent tool calls and confirmation outcomes.
+ *
+ * All metrics are exported automatically to Datadog (or any other configured
+ * Micrometer registry) without additional wiring. Datadog export is opt-in:
+ * it requires DATADOG_API_KEY to be set and
+ * `management.datadog.metrics.export.enabled=true` in application configuration.
+ *
+ * ## Metrics produced
+ *
+ * ### `agentos.tool.calls.total` (Counter)
+ * Incremented once per tool execution (success or failure).
+ * Tags:
+ * - `tool.name`        — fully-qualified tool name, e.g. `FILES__read`
+ * - `integration.type` — integration prefix before `__`, e.g. `FILES` (or `unknown`
+ *                         when the name contains no `__` separator)
+ * - `agent.name`       — name of the agent that called the tool
+ * - `namespace.id`     — UUID of the namespace the case belongs to
+ * - `status`           — `success` or `failure`
+ *
+ * ### `agentos.tool.calls.duration` (Timer)
+ * Distribution of wall-clock tool execution durations, measured with [Timer.Sample]
+ * (nanosecond precision via [MeterRegistry.config().clock()]).
+ * Same tags as `agentos.tool.calls.total`.
+ * Use [startTimer] before execution and [stopTimer] after to record a sample.
+ *
+ * ### `agentos.tool.parameter_generation.failures` (Counter)
+ * Incremented when [AgentAdvanced] exhausts all retry attempts and falls back
+ * to `args = null` for a tool call.
+ * Tags:
+ * - `tool.name`    — fully-qualified tool name
+ * - `agent.name`   — name of the agent
+ * - `namespace.id` — UUID of the namespace
+ *
+ * ### `agentos.tool.confirmation.total` (Counter)
+ * Incremented once per confirmation resolution.
+ * Tags:
+ * - `tool.name`    — fully-qualified tool name
+ * - `agent.name`   — name of the agent
+ * - `namespace.id` — UUID of the namespace
+ * - `outcome`      — `applied`, `rejected`, or `aborted`
+ */
+@Service
+class ToolMetricsService(
+    private val meterRegistry: MeterRegistry,
+) {
+    /**
+     * Starts a [Timer.Sample] using the registry's clock.
+     *
+     * Call this immediately before the tool execution block, then pass the returned
+     * sample to [stopTimer] in both the success and error branches.
+     *
+     * Returns `null` only when the meter registry is unavailable (defensive — in
+     * practice the registry is always present when this service is instantiated).
+     */
+    fun startTimer(): Timer.Sample = Timer.start(meterRegistry)
+
+    /**
+     * Stops [sample], records the elapsed duration on the [METRIC_TOOL_CALLS_DURATION]
+     * timer, increments the [METRIC_TOOL_CALLS_TOTAL] counter, and returns the elapsed
+     * time in milliseconds (for attaching to [ToolResponseEvent.durationMs]).
+     *
+     * @param sample      The [Timer.Sample] returned by [startTimer].
+     * @param toolName    Fully-qualified tool name (e.g. `FILES__read`).
+     * @param agentName   Name of the agent that called the tool.
+     * @param namespaceId Namespace the case belongs to.
+     * @param success     Whether the tool reported a successful result.
+     * @return Elapsed duration in whole milliseconds.
+     */
+    fun stopTimer(
+        sample: Timer.Sample?,
+        toolName: String,
+        agentName: String,
+        namespaceId: UUID,
+        success: Boolean,
+    ): Long {
+        val tags = toolTags(toolName, agentName, namespaceId, if (success) STATUS_SUCCESS else STATUS_FAILURE)
+        val timer = meterRegistry.timer(METRIC_TOOL_CALLS_DURATION, tags)
+        val elapsedNanos = sample?.stop(timer) ?: 0L
+
+        meterRegistry
+            .counter(METRIC_TOOL_CALLS_TOTAL, tags)
+            .increment()
+
+        return elapsedNanos / 1_000_000L
+    }
+
+    /**
+     * Records a parameter-generation failure: all retry attempts were exhausted
+     * and [AgentAdvanced] fell back to `args = null`.
+     *
+     * @param toolName    Fully-qualified tool name.
+     * @param agentName   Name of the agent.
+     * @param namespaceId Namespace the case belongs to.
+     */
+    fun recordParameterGenerationFailure(
+        toolName: String,
+        agentName: String,
+        namespaceId: UUID,
+    ) {
+        val tags =
+            Tags.of(
+                TAG_TOOL_NAME, toolName,
+                TAG_AGENT_NAME, agentName,
+                TAG_NAMESPACE_ID, namespaceId.toString(),
+            )
+
+        meterRegistry
+            .counter(METRIC_TOOL_PARAM_FAILURES, tags)
+            .increment()
+    }
+
+    /**
+     * Records the outcome of a tool confirmation flow.
+     *
+     * @param toolName    Fully-qualified tool name.
+     * @param agentName   Name of the agent.
+     * @param namespaceId Namespace the case belongs to.
+     * @param outcome     One of [ConfirmationOutcome].
+     */
+    fun recordConfirmation(
+        toolName: String,
+        agentName: String,
+        namespaceId: UUID,
+        outcome: ConfirmationOutcome,
+    ) {
+        val tags =
+            Tags.of(
+                TAG_TOOL_NAME, toolName,
+                TAG_AGENT_NAME, agentName,
+                TAG_NAMESPACE_ID, namespaceId.toString(),
+                TAG_OUTCOME, outcome.tagValue,
+            )
+
+        meterRegistry
+            .counter(METRIC_TOOL_CONFIRMATION_TOTAL, tags)
+            .increment()
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun toolTags(
+        toolName: String,
+        agentName: String,
+        namespaceId: UUID,
+        status: String,
+    ): Tags =
+        Tags.of(
+            TAG_TOOL_NAME, toolName,
+            TAG_INTEGRATION_TYPE, toolName.substringBefore("__", missingDelimiterValue = INTEGRATION_TYPE_UNKNOWN),
+            TAG_AGENT_NAME, agentName,
+            TAG_NAMESPACE_ID, namespaceId.toString(),
+            TAG_STATUS, status,
+        )
+
+    // -------------------------------------------------------------------------
+    // Companion
+    // -------------------------------------------------------------------------
+
+    companion object : KLogging() {
+        const val METRIC_TOOL_CALLS_TOTAL = "agentos.tool.calls.total"
+        const val METRIC_TOOL_CALLS_DURATION = "agentos.tool.calls.duration"
+        const val METRIC_TOOL_PARAM_FAILURES = "agentos.tool.parameter_generation.failures"
+        const val METRIC_TOOL_CONFIRMATION_TOTAL = "agentos.tool.confirmation.total"
+
+        const val TAG_TOOL_NAME = "tool.name"
+        const val TAG_INTEGRATION_TYPE = "integration.type"
+        const val TAG_AGENT_NAME = "agent.name"
+        const val TAG_NAMESPACE_ID = "namespace.id"
+        const val TAG_STATUS = "status"
+        const val TAG_OUTCOME = "outcome"
+
+        const val STATUS_SUCCESS = "success"
+        const val STATUS_FAILURE = "failure"
+        const val INTEGRATION_TYPE_UNKNOWN = "unknown"
+    }
+}
+
+/**
+ * Outcome of a tool confirmation flow, used as a Datadog tag value.
+ */
+enum class ConfirmationOutcome(
+    val tagValue: String,
+) {
+    /** User confirmed and the tool executed successfully. */
+    APPLIED("applied"),
+
+    /** User declined (or implicit consent was absent). */
+    REJECTED("rejected"),
+
+    /** Tool threw after confirmation, or orphan pending detected. */
+    ABORTED("aborted"),
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/metrics/ToolMetricsService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/metrics/ToolMetricsService.kt
@@ -3,6 +3,8 @@ package io.whozoss.agentos.metrics
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tags
 import io.micrometer.core.instrument.Timer
+import io.whozoss.agentos.metrics.ToolMetricsService.Companion.METRIC_TOOL_CALLS_DURATION
+import io.whozoss.agentos.metrics.ToolMetricsService.Companion.METRIC_TOOL_CALLS_TOTAL
 import mu.KLogging
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -31,7 +33,7 @@ import java.util.UUID
  * Distribution of wall-clock tool execution durations, measured with [Timer.Sample]
  * (nanosecond precision via [MeterRegistry.config().clock()]).
  * Same tags as `agentos.tool.calls.total`.
- * Use [startTimer] before execution and [stopTimer] after to record a sample.
+ * Use [startTimer] before execution and [stopTimerAndSendMetrics] after to record a sample.
  *
  * ### `agentos.tool.parameter_generation.failures` (Counter)
  * Incremented when [AgentAdvanced] exhausts all retry attempts and falls back
@@ -57,7 +59,7 @@ class ToolMetricsService(
      * Starts a [Timer.Sample] using the registry's clock.
      *
      * Call this immediately before the tool execution block, then pass the returned
-     * sample to [stopTimer] in both the success and error branches.
+     * sample to [stopTimerAndSendMetrics] in both the success and error branches.
      *
      * Returns `null` only when the meter registry is unavailable (defensive — in
      * practice the registry is always present when this service is instantiated).
@@ -76,7 +78,7 @@ class ToolMetricsService(
      * @param success     Whether the tool reported a successful result.
      * @return Elapsed duration in whole milliseconds.
      */
-    fun stopTimer(
+    fun stopTimerAndSendMetrics(
         sample: Timer.Sample?,
         toolName: String,
         agentName: String,
@@ -109,9 +111,12 @@ class ToolMetricsService(
     ) {
         val tags =
             Tags.of(
-                TAG_TOOL_NAME, toolName,
-                TAG_AGENT_NAME, agentName,
-                TAG_NAMESPACE_ID, namespaceId.toString(),
+                TAG_TOOL_NAME,
+                toolName,
+                TAG_AGENT_NAME,
+                agentName,
+                TAG_NAMESPACE_ID,
+                namespaceId.toString(),
             )
 
         meterRegistry
@@ -135,10 +140,14 @@ class ToolMetricsService(
     ) {
         val tags =
             Tags.of(
-                TAG_TOOL_NAME, toolName,
-                TAG_AGENT_NAME, agentName,
-                TAG_NAMESPACE_ID, namespaceId.toString(),
-                TAG_OUTCOME, outcome.tagValue,
+                TAG_TOOL_NAME,
+                toolName,
+                TAG_AGENT_NAME,
+                agentName,
+                TAG_NAMESPACE_ID,
+                namespaceId.toString(),
+                TAG_OUTCOME,
+                outcome.tagValue,
             )
 
         meterRegistry
@@ -157,11 +166,16 @@ class ToolMetricsService(
         status: String,
     ): Tags =
         Tags.of(
-            TAG_TOOL_NAME, toolName,
-            TAG_INTEGRATION_TYPE, toolName.substringBefore("__", missingDelimiterValue = INTEGRATION_TYPE_UNKNOWN),
-            TAG_AGENT_NAME, agentName,
-            TAG_NAMESPACE_ID, namespaceId.toString(),
-            TAG_STATUS, status,
+            TAG_TOOL_NAME,
+            toolName,
+            TAG_INTEGRATION_TYPE,
+            toolName.substringBefore("__", missingDelimiterValue = INTEGRATION_TYPE_UNKNOWN),
+            TAG_AGENT_NAME,
+            agentName,
+            TAG_NAMESPACE_ID,
+            namespaceId.toString(),
+            TAG_STATUS,
+            status,
         )
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tracing/OtelCoroutineContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tracing/OtelCoroutineContext.kt
@@ -1,0 +1,38 @@
+package io.whozoss.agentos.tracing
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
+import kotlinx.coroutines.ThreadContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Propagates OpenTelemetry context across coroutine suspension points.
+ *
+ * Kotlin coroutines may resume on a different thread after each suspension point.
+ * OpenTelemetry stores the active span in a ThreadLocal, which is lost on thread switches.
+ * This [ThreadContextElement] captures the OTel context when the coroutine suspends and
+ * restores it on resume, ensuring spans remain correctly parented across the entire
+ * coroutine execution.
+ *
+ * Usage: include in the [CoroutineContext] when launching coroutines that should
+ * inherit the current trace:
+ * ```
+ * scope.launch(Dispatchers.IO + OtelCoroutineContext()) {
+ *     // OTel context is preserved across suspension points here
+ * }
+ * ```
+ */
+class OtelCoroutineContext(
+    private val otelContext: Context = Context.current(),
+) : ThreadContextElement<Scope> {
+    companion object Key : CoroutineContext.Key<OtelCoroutineContext>
+
+    override val key: CoroutineContext.Key<OtelCoroutineContext> = Key
+
+    override fun updateThreadContext(context: CoroutineContext): Scope = otelContext.makeCurrent()
+
+    override fun restoreThreadContext(
+        context: CoroutineContext,
+        oldState: Scope,
+    ) = oldState.close()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tracing/TracingHelper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tracing/TracingHelper.kt
@@ -1,0 +1,73 @@
+package io.whozoss.agentos.tracing
+
+import io.micrometer.tracing.Tracer
+
+/**
+ * Executes [block] within a new tracing span, or directly when [tracer] is null.
+ *
+ * Creates a child span of the current active span (if any), applies the given [tags],
+ * executes the block, and finishes the span. Errors are recorded on the span before
+ * being rethrown.
+ *
+ * Passing a null [tracer] is safe: the block runs as-is with no span overhead,
+ * which allows call sites to skip null checks when tracing is disabled.
+ *
+ * OTel context propagation across suspension points within [block] requires
+ * [OtelCoroutineContext] to be present in the coroutine context.
+ *
+ * @param tracer the Micrometer [Tracer] instance, or null when tracing is disabled
+ * @param spanName operation name for the span (e.g. "case.execution", "agent.run")
+ * @param tags key-value pairs to attach to the span as low-cardinality attributes
+ * @param block the work to execute within the span
+ */
+suspend inline fun <T> withSpan(
+    tracer: Tracer?,
+    spanName: String,
+    tags: Map<String, String> = emptyMap(),
+    crossinline block: suspend () -> T,
+): T {
+    if (tracer == null) return block()
+    val span = tracer.nextSpan().name(spanName)
+    tags.forEach { (k, v) -> span.tag(k, v) }
+    span.start()
+    val scope = tracer.withSpan(span)
+    return try {
+        block()
+    } catch (e: Exception) {
+        span.error(e)
+        throw e
+    } finally {
+        scope.close()
+        span.end()
+    }
+}
+
+/**
+ * Non-suspend variant of [withSpan] for use outside coroutine contexts.
+ *
+ * @param tracer the Micrometer [Tracer] instance, or null when tracing is disabled
+ * @param spanName operation name for the span
+ * @param tags key-value pairs to attach to the span as low-cardinality attributes
+ * @param block the work to execute within the span
+ */
+inline fun <T> withSpanSync(
+    tracer: Tracer?,
+    spanName: String,
+    tags: Map<String, String> = emptyMap(),
+    block: () -> T,
+): T {
+    if (tracer == null) return block()
+    val span = tracer.nextSpan().name(spanName)
+    tags.forEach { (k, v) -> span.tag(k, v) }
+    span.start()
+    val scope = tracer.withSpan(span)
+    return try {
+        block()
+    } catch (e: Exception) {
+        span.error(e)
+        throw e
+    } finally {
+        scope.close()
+        span.end()
+    }
+}

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -77,6 +77,17 @@ management:
       # 'always' so that Eureka can read the health status without credentials.
       # The health endpoint itself does not expose sensitive data.
       show-details: always
+  tracing:
+    # Disabled by default — enable with TRACING_ENABLED=true when a Datadog agent
+    # (or any OTLP-compatible collector) is reachable at OTEL_EXPORTER_OTLP_ENDPOINT.
+    enabled: ${TRACING_ENABLED:false}
+    sampling:
+      probability: ${TRACING_SAMPLING_PROBABILITY:1.0}
+  otlp:
+    tracing:
+      # OTLP HTTP endpoint for trace export. Override to point at a remote collector.
+      # Datadog agent default: http://localhost:4318/v1/traces
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
   # Datadog metrics export — disabled by default, opt-in via environment variables.
   # Set DATADOG_API_KEY (required) and DATADOG_METRICS_ENABLED=true to activate.
   # DATADOG_SITE defaults to the US endpoint; override to 'datadoghq.eu' for EU tenants.
@@ -98,7 +109,8 @@ management:
   metrics:
     tags:
       application: agentos
-      environment: ${SPRING_PROFILES_ACTIVE:local}
+      host: vico
+      env: version-rc
   # statsd configuration
   # declared here for test purpose, should be in whoz conf directories
   statsd:

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -80,6 +80,7 @@ management:
   # Datadog metrics export — disabled by default, opt-in via environment variables.
   # Set DATADOG_API_KEY (required) and DATADOG_METRICS_ENABLED=true to activate.
   # DATADOG_SITE defaults to the US endpoint; override to 'datadoghq.eu' for EU tenants.
+  # prefer statsd if possible
   datadog:
     metrics:
       export:
@@ -98,6 +99,23 @@ management:
     tags:
       application: agentos
       environment: ${SPRING_PROFILES_ACTIVE:local}
+  # statsd configuration
+  # declared here for test purpose, should be in whoz conf directories
+  statsd:
+    metrics:
+      export:
+        enabled: true
+        flavor: datadog
+        host: localhost
+        port: 8127
+# cmd line to run datadog container
+# docker run -d \
+# -e DD_API_KEY=xxxxxx \
+# -e DD_SITE=datadoghq.eu \
+# -e DD_HOSTNAME=thomas.martin \
+# -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
+# -p 8126:8126 -p 8127:8125 \
+# datadog/agent:latest
 
 agentos:
   defaults:

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -77,6 +77,23 @@ management:
       # 'always' so that Eureka can read the health status without credentials.
       # The health endpoint itself does not expose sensitive data.
       show-details: always
+  # Datadog metrics export — disabled by default, opt-in via environment variables.
+  # Set DATADOG_API_KEY (required) and DATADOG_METRICS_ENABLED=true to activate.
+  # DATADOG_SITE defaults to the US endpoint; override to 'datadoghq.eu' for EU tenants.
+  datadog:
+    metrics:
+      export:
+        enabled: ${DATADOG_METRICS_ENABLED:false}
+        api-key: ${DATADOG_API_KEY:}
+        application-key: ${DATADOG_APP_KEY:}
+        uri: https://api.${DATADOG_SITE:datadoghq.com}
+        # Push interval — 30s balances freshness against Datadog ingest costs.
+        step: 30s
+  # Common tags applied to all metrics exported by this service.
+  metrics:
+    tags:
+      application: agentos
+      environment: ${SPRING_PROFILES_ACTIVE:local}
 
 agentos:
   defaults:

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -86,9 +86,13 @@ management:
         enabled: ${DATADOG_METRICS_ENABLED:false}
         api-key: ${DATADOG_API_KEY:}
         application-key: ${DATADOG_APP_KEY:}
-        uri: https://api.${DATADOG_SITE:datadoghq.com}
+        uri: https://api.${DATADOG_SITE:datadoghq.eu}
         # Push interval — 30s balances freshness against Datadog ingest costs.
         step: 30s
+        # Disable metric metadata push — the /api/v1/metrics endpoint does not
+        # exist on datadoghq.eu and returns 404, logged misleadingly as Unauthorized.
+        # Metric data still flows correctly via /api/v1/series.
+        descriptions: false
   # Common tags applied to all metrics exported by this service.
   metrics:
     tags:
@@ -97,10 +101,10 @@ management:
 
 agentos:
   defaults:
-    # Environment-level fallback agent name. Consulted when a namespace has no
-    # defaultAgentName configured. The named agent must exist in the case's namespace.
-    # Override with env var: AGENTOS_DEFAULTS_AGENT_NAME
-    # agent-name: copilot
+  # Environment-level fallback agent name. Consulted when a namespace has no
+  # defaultAgentName configured. The named agent must exist in the case's namespace.
+  # Override with env var: AGENTOS_DEFAULTS_AGENT_NAME
+  # agent-name: copilot
   plugins:
     dir: ${PLUGINS_DIR:plugins/}
   security:

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -27,6 +27,7 @@ import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.aiProvider.AiProvider
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.tool.ToolPlugin
+import io.whozoss.agentos.metrics.ToolMetricsService
 import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.tool.ToolResolverService
 import io.whozoss.agentos.user.User
@@ -49,6 +50,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
     private val confirmationManager: ConfirmationManager = mockk(relaxed = true)
     private val testObjectMapper = ObjectMapper()
     private val toolRegistryService: ToolRegistryService = mockk(relaxed = true)
+    private val toolMetricsService: ToolMetricsService = mockk(relaxed = true)
     private val agentService =
         AgentServiceImpl(
             chatClientProvider,
@@ -64,6 +66,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             confirmationManager,
             testObjectMapper,
             toolRegistryService,
+            toolMetricsService,
         )
 
     private val namespaceId: UUID = UUID.randomUUID()
@@ -341,6 +344,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     confirmationManager,
                     testObjectMapper,
                     toolRegistryService,
+                    toolMetricsService,
                 )
             val configs =
                 listOf(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/metrics/ToolMetricsServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/metrics/ToolMetricsServiceUnitSpec.kt
@@ -1,0 +1,262 @@
+package io.whozoss.agentos.metrics
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.util.UUID
+
+class ToolMetricsServiceUnitSpec : StringSpec({
+
+    fun registry() = SimpleMeterRegistry()
+
+    // -------------------------------------------------------------------------
+    // startTimer / stopTimer
+    // -------------------------------------------------------------------------
+
+    "stopTimer increments counter with success tag and records timer" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+        val namespaceId = UUID.randomUUID()
+
+        val sample = service.startTimer()
+        service.stopTimer(
+            sample = sample,
+            toolName = "FILES__read",
+            agentName = "my-agent",
+            namespaceId = namespaceId,
+            success = true,
+        )
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+            .tag(ToolMetricsService.TAG_INTEGRATION_TYPE, "FILES")
+            .tag(ToolMetricsService.TAG_AGENT_NAME, "my-agent")
+            .tag(ToolMetricsService.TAG_NAMESPACE_ID, namespaceId.toString())
+            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+            .counter()
+
+        counter?.count() shouldBe 1.0
+
+        val timer = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_DURATION)
+            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+            .timer()
+
+        timer.shouldNotBeNull()
+        timer.count() shouldBe 1L
+    }
+
+    "stopTimer increments counter with failure tag" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+        val namespaceId = UUID.randomUUID()
+
+        val sample = service.startTimer()
+        service.stopTimer(
+            sample = sample,
+            toolName = "JIRA__getIssue",
+            agentName = "jira-agent",
+            namespaceId = namespaceId,
+            success = false,
+        )
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_FAILURE)
+            .counter()
+
+        counter?.count() shouldBe 1.0
+    }
+
+    "stopTimer returns elapsed milliseconds (non-negative)" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+
+        val sample = service.startTimer()
+        val elapsedMs = service.stopTimer(
+            sample = sample,
+            toolName = "FILES__read",
+            agentName = "agent",
+            namespaceId = UUID.randomUUID(),
+            success = true,
+        )
+
+        elapsedMs shouldBeGreaterThanOrEqualTo 0L
+    }
+
+    "stopTimer with null sample still increments counter and returns 0" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+
+        val elapsedMs = service.stopTimer(
+            sample = null,
+            toolName = "FILES__read",
+            agentName = "agent",
+            namespaceId = UUID.randomUUID(),
+            success = true,
+        )
+
+        elapsedMs shouldBe 0L
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+            .counter()
+
+        counter?.count() shouldBe 1.0
+    }
+
+    "stopTimer uses 'unknown' integration type for tools without __ separator" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+
+        val sample = service.startTimer()
+        service.stopTimer(
+            sample = sample,
+            toolName = "redirect",
+            agentName = "agent",
+            namespaceId = UUID.randomUUID(),
+            success = true,
+        )
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+            .tag(ToolMetricsService.TAG_INTEGRATION_TYPE, ToolMetricsService.INTEGRATION_TYPE_UNKNOWN)
+            .counter()
+
+        counter?.count() shouldBe 1.0
+    }
+
+    "stopTimer accumulates multiple calls" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+        val namespaceId = UUID.randomUUID()
+
+        repeat(3) {
+            val sample = service.startTimer()
+            service.stopTimer(
+                sample = sample,
+                toolName = "FILES__read",
+                agentName = "agent",
+                namespaceId = namespaceId,
+                success = true,
+            )
+        }
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+            .counter()
+
+        counter?.count() shouldBe 3.0
+
+        val timer = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_DURATION)
+            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+            .timer()
+
+        timer?.count() shouldBe 3L
+    }
+
+    // -------------------------------------------------------------------------
+    // recordParameterGenerationFailure
+    // -------------------------------------------------------------------------
+
+    "recordParameterGenerationFailure increments the dedicated counter" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+        val namespaceId = UUID.randomUUID()
+
+        service.recordParameterGenerationFailure(
+            toolName = "FILES__read",
+            agentName = "agent",
+            namespaceId = namespaceId,
+        )
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_PARAM_FAILURES)
+            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+            .tag(ToolMetricsService.TAG_AGENT_NAME, "agent")
+            .tag(ToolMetricsService.TAG_NAMESPACE_ID, namespaceId.toString())
+            .counter()
+
+        counter?.count() shouldBe 1.0
+    }
+
+    // -------------------------------------------------------------------------
+    // recordConfirmation
+    // -------------------------------------------------------------------------
+
+    "recordConfirmation increments counter with APPLIED outcome" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+
+        service.recordConfirmation(
+            toolName = "FILES__remove",
+            agentName = "agent",
+            namespaceId = UUID.randomUUID(),
+            outcome = ConfirmationOutcome.APPLIED,
+        )
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
+            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__remove")
+            .tag(ToolMetricsService.TAG_OUTCOME, "applied")
+            .counter()
+
+        counter?.count() shouldBe 1.0
+    }
+
+    "recordConfirmation increments counter with REJECTED outcome" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+
+        service.recordConfirmation(
+            toolName = "FILES__remove",
+            agentName = "agent",
+            namespaceId = UUID.randomUUID(),
+            outcome = ConfirmationOutcome.REJECTED,
+        )
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
+            .tag(ToolMetricsService.TAG_OUTCOME, "rejected")
+            .counter()
+
+        counter?.count() shouldBe 1.0
+    }
+
+    "recordConfirmation increments counter with ABORTED outcome" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+
+        service.recordConfirmation(
+            toolName = "FILES__remove",
+            agentName = "agent",
+            namespaceId = UUID.randomUUID(),
+            outcome = ConfirmationOutcome.ABORTED,
+        )
+
+        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
+            .tag(ToolMetricsService.TAG_OUTCOME, "aborted")
+            .counter()
+
+        counter?.count() shouldBe 1.0
+    }
+
+    "different namespaces produce distinct counter series" {
+        val meterRegistry = registry()
+        val service = ToolMetricsService(meterRegistry)
+        val ns1 = UUID.randomUUID()
+        val ns2 = UUID.randomUUID()
+
+        service.stopTimer(service.startTimer(), "FILES__read", "agent", ns1, success = true)
+        service.stopTimer(service.startTimer(), "FILES__read", "agent", ns2, success = true)
+        service.stopTimer(service.startTimer(), "FILES__read", "agent", ns1, success = true)
+
+        val counterNs1 = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+            .tag(ToolMetricsService.TAG_NAMESPACE_ID, ns1.toString())
+            .counter()
+        val counterNs2 = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+            .tag(ToolMetricsService.TAG_NAMESPACE_ID, ns2.toString())
+            .counter()
+
+        counterNs1?.count() shouldBe 2.0
+        counterNs2?.count() shouldBe 1.0
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/metrics/ToolMetricsServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/metrics/ToolMetricsServiceUnitSpec.kt
@@ -7,256 +7,285 @@ import io.kotest.matchers.shouldBe
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import java.util.UUID
 
-class ToolMetricsServiceUnitSpec : StringSpec({
+class ToolMetricsServiceUnitSpec :
+    StringSpec({
 
-    fun registry() = SimpleMeterRegistry()
+        fun registry() = SimpleMeterRegistry()
 
-    // -------------------------------------------------------------------------
-    // startTimer / stopTimer
-    // -------------------------------------------------------------------------
+        // -------------------------------------------------------------------------
+        // startTimer / stopTimer
+        // -------------------------------------------------------------------------
 
-    "stopTimer increments counter with success tag and records timer" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-        val namespaceId = UUID.randomUUID()
+        "stopTimer increments counter with success tag and records timer" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+            val namespaceId = UUID.randomUUID()
 
-        val sample = service.startTimer()
-        service.stopTimer(
-            sample = sample,
-            toolName = "FILES__read",
-            agentName = "my-agent",
-            namespaceId = namespaceId,
-            success = true,
-        )
-
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
-            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
-            .tag(ToolMetricsService.TAG_INTEGRATION_TYPE, "FILES")
-            .tag(ToolMetricsService.TAG_AGENT_NAME, "my-agent")
-            .tag(ToolMetricsService.TAG_NAMESPACE_ID, namespaceId.toString())
-            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
-            .counter()
-
-        counter?.count() shouldBe 1.0
-
-        val timer = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_DURATION)
-            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
-            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
-            .timer()
-
-        timer.shouldNotBeNull()
-        timer.count() shouldBe 1L
-    }
-
-    "stopTimer increments counter with failure tag" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-        val namespaceId = UUID.randomUUID()
-
-        val sample = service.startTimer()
-        service.stopTimer(
-            sample = sample,
-            toolName = "JIRA__getIssue",
-            agentName = "jira-agent",
-            namespaceId = namespaceId,
-            success = false,
-        )
-
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
-            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_FAILURE)
-            .counter()
-
-        counter?.count() shouldBe 1.0
-    }
-
-    "stopTimer returns elapsed milliseconds (non-negative)" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-
-        val sample = service.startTimer()
-        val elapsedMs = service.stopTimer(
-            sample = sample,
-            toolName = "FILES__read",
-            agentName = "agent",
-            namespaceId = UUID.randomUUID(),
-            success = true,
-        )
-
-        elapsedMs shouldBeGreaterThanOrEqualTo 0L
-    }
-
-    "stopTimer with null sample still increments counter and returns 0" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-
-        val elapsedMs = service.stopTimer(
-            sample = null,
-            toolName = "FILES__read",
-            agentName = "agent",
-            namespaceId = UUID.randomUUID(),
-            success = true,
-        )
-
-        elapsedMs shouldBe 0L
-
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
-            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
-            .counter()
-
-        counter?.count() shouldBe 1.0
-    }
-
-    "stopTimer uses 'unknown' integration type for tools without __ separator" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-
-        val sample = service.startTimer()
-        service.stopTimer(
-            sample = sample,
-            toolName = "redirect",
-            agentName = "agent",
-            namespaceId = UUID.randomUUID(),
-            success = true,
-        )
-
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
-            .tag(ToolMetricsService.TAG_INTEGRATION_TYPE, ToolMetricsService.INTEGRATION_TYPE_UNKNOWN)
-            .counter()
-
-        counter?.count() shouldBe 1.0
-    }
-
-    "stopTimer accumulates multiple calls" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-        val namespaceId = UUID.randomUUID()
-
-        repeat(3) {
             val sample = service.startTimer()
-            service.stopTimer(
+            service.stopTimerAndSendMetrics(
                 sample = sample,
                 toolName = "FILES__read",
-                agentName = "agent",
+                agentName = "my-agent",
                 namespaceId = namespaceId,
                 success = true,
             )
+
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+                    .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+                    .tag(ToolMetricsService.TAG_INTEGRATION_TYPE, "FILES")
+                    .tag(ToolMetricsService.TAG_AGENT_NAME, "my-agent")
+                    .tag(ToolMetricsService.TAG_NAMESPACE_ID, namespaceId.toString())
+                    .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+                    .counter()
+
+            counter?.count() shouldBe 1.0
+
+            val timer =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_DURATION)
+                    .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+                    .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+                    .timer()
+
+            timer.shouldNotBeNull()
+            timer.count() shouldBe 1L
         }
 
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
-            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
-            .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
-            .counter()
+        "stopTimer increments counter with failure tag" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+            val namespaceId = UUID.randomUUID()
 
-        counter?.count() shouldBe 3.0
+            val sample = service.startTimer()
+            service.stopTimerAndSendMetrics(
+                sample = sample,
+                toolName = "JIRA__getIssue",
+                agentName = "jira-agent",
+                namespaceId = namespaceId,
+                success = false,
+            )
 
-        val timer = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_DURATION)
-            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
-            .timer()
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+                    .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_FAILURE)
+                    .counter()
 
-        timer?.count() shouldBe 3L
-    }
+            counter?.count() shouldBe 1.0
+        }
 
-    // -------------------------------------------------------------------------
-    // recordParameterGenerationFailure
-    // -------------------------------------------------------------------------
+        "stopTimer returns elapsed milliseconds (non-negative)" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
 
-    "recordParameterGenerationFailure increments the dedicated counter" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-        val namespaceId = UUID.randomUUID()
+            val sample = service.startTimer()
+            val elapsedMs =
+                service.stopTimerAndSendMetrics(
+                    sample = sample,
+                    toolName = "FILES__read",
+                    agentName = "agent",
+                    namespaceId = UUID.randomUUID(),
+                    success = true,
+                )
 
-        service.recordParameterGenerationFailure(
-            toolName = "FILES__read",
-            agentName = "agent",
-            namespaceId = namespaceId,
-        )
+            elapsedMs shouldBeGreaterThanOrEqualTo 0L
+        }
 
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_PARAM_FAILURES)
-            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
-            .tag(ToolMetricsService.TAG_AGENT_NAME, "agent")
-            .tag(ToolMetricsService.TAG_NAMESPACE_ID, namespaceId.toString())
-            .counter()
+        "stopTimer with null sample still increments counter and returns 0" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
 
-        counter?.count() shouldBe 1.0
-    }
+            val elapsedMs =
+                service.stopTimerAndSendMetrics(
+                    sample = null,
+                    toolName = "FILES__read",
+                    agentName = "agent",
+                    namespaceId = UUID.randomUUID(),
+                    success = true,
+                )
 
-    // -------------------------------------------------------------------------
-    // recordConfirmation
-    // -------------------------------------------------------------------------
+            elapsedMs shouldBe 0L
 
-    "recordConfirmation increments counter with APPLIED outcome" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+                    .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+                    .counter()
 
-        service.recordConfirmation(
-            toolName = "FILES__remove",
-            agentName = "agent",
-            namespaceId = UUID.randomUUID(),
-            outcome = ConfirmationOutcome.APPLIED,
-        )
+            counter?.count() shouldBe 1.0
+        }
 
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
-            .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__remove")
-            .tag(ToolMetricsService.TAG_OUTCOME, "applied")
-            .counter()
+        "stopTimer uses 'unknown' integration type for tools without __ separator" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
 
-        counter?.count() shouldBe 1.0
-    }
+            val sample = service.startTimer()
+            service.stopTimerAndSendMetrics(
+                sample = sample,
+                toolName = "redirect",
+                agentName = "agent",
+                namespaceId = UUID.randomUUID(),
+                success = true,
+            )
 
-    "recordConfirmation increments counter with REJECTED outcome" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+                    .tag(ToolMetricsService.TAG_INTEGRATION_TYPE, ToolMetricsService.INTEGRATION_TYPE_UNKNOWN)
+                    .counter()
 
-        service.recordConfirmation(
-            toolName = "FILES__remove",
-            agentName = "agent",
-            namespaceId = UUID.randomUUID(),
-            outcome = ConfirmationOutcome.REJECTED,
-        )
+            counter?.count() shouldBe 1.0
+        }
 
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
-            .tag(ToolMetricsService.TAG_OUTCOME, "rejected")
-            .counter()
+        "stopTimer accumulates multiple calls" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+            val namespaceId = UUID.randomUUID()
 
-        counter?.count() shouldBe 1.0
-    }
+            repeat(3) {
+                val sample = service.startTimer()
+                service.stopTimerAndSendMetrics(
+                    sample = sample,
+                    toolName = "FILES__read",
+                    agentName = "agent",
+                    namespaceId = namespaceId,
+                    success = true,
+                )
+            }
 
-    "recordConfirmation increments counter with ABORTED outcome" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+                    .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+                    .tag(ToolMetricsService.TAG_STATUS, ToolMetricsService.STATUS_SUCCESS)
+                    .counter()
 
-        service.recordConfirmation(
-            toolName = "FILES__remove",
-            agentName = "agent",
-            namespaceId = UUID.randomUUID(),
-            outcome = ConfirmationOutcome.ABORTED,
-        )
+            counter?.count() shouldBe 3.0
 
-        val counter = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
-            .tag(ToolMetricsService.TAG_OUTCOME, "aborted")
-            .counter()
+            val timer =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_DURATION)
+                    .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+                    .timer()
 
-        counter?.count() shouldBe 1.0
-    }
+            timer?.count() shouldBe 3L
+        }
 
-    "different namespaces produce distinct counter series" {
-        val meterRegistry = registry()
-        val service = ToolMetricsService(meterRegistry)
-        val ns1 = UUID.randomUUID()
-        val ns2 = UUID.randomUUID()
+        // -------------------------------------------------------------------------
+        // recordParameterGenerationFailure
+        // -------------------------------------------------------------------------
 
-        service.stopTimer(service.startTimer(), "FILES__read", "agent", ns1, success = true)
-        service.stopTimer(service.startTimer(), "FILES__read", "agent", ns2, success = true)
-        service.stopTimer(service.startTimer(), "FILES__read", "agent", ns1, success = true)
+        "recordParameterGenerationFailure increments the dedicated counter" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+            val namespaceId = UUID.randomUUID()
 
-        val counterNs1 = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
-            .tag(ToolMetricsService.TAG_NAMESPACE_ID, ns1.toString())
-            .counter()
-        val counterNs2 = meterRegistry.find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
-            .tag(ToolMetricsService.TAG_NAMESPACE_ID, ns2.toString())
-            .counter()
+            service.recordParameterGenerationFailure(
+                toolName = "FILES__read",
+                agentName = "agent",
+                namespaceId = namespaceId,
+            )
 
-        counterNs1?.count() shouldBe 2.0
-        counterNs2?.count() shouldBe 1.0
-    }
-})
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_PARAM_FAILURES)
+                    .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__read")
+                    .tag(ToolMetricsService.TAG_AGENT_NAME, "agent")
+                    .tag(ToolMetricsService.TAG_NAMESPACE_ID, namespaceId.toString())
+                    .counter()
+
+            counter?.count() shouldBe 1.0
+        }
+
+        // -------------------------------------------------------------------------
+        // recordConfirmation
+        // -------------------------------------------------------------------------
+
+        "recordConfirmation increments counter with APPLIED outcome" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+
+            service.recordConfirmation(
+                toolName = "FILES__remove",
+                agentName = "agent",
+                namespaceId = UUID.randomUUID(),
+                outcome = ConfirmationOutcome.APPLIED,
+            )
+
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
+                    .tag(ToolMetricsService.TAG_TOOL_NAME, "FILES__remove")
+                    .tag(ToolMetricsService.TAG_OUTCOME, "applied")
+                    .counter()
+
+            counter?.count() shouldBe 1.0
+        }
+
+        "recordConfirmation increments counter with REJECTED outcome" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+
+            service.recordConfirmation(
+                toolName = "FILES__remove",
+                agentName = "agent",
+                namespaceId = UUID.randomUUID(),
+                outcome = ConfirmationOutcome.REJECTED,
+            )
+
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
+                    .tag(ToolMetricsService.TAG_OUTCOME, "rejected")
+                    .counter()
+
+            counter?.count() shouldBe 1.0
+        }
+
+        "recordConfirmation increments counter with ABORTED outcome" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+
+            service.recordConfirmation(
+                toolName = "FILES__remove",
+                agentName = "agent",
+                namespaceId = UUID.randomUUID(),
+                outcome = ConfirmationOutcome.ABORTED,
+            )
+
+            val counter =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CONFIRMATION_TOTAL)
+                    .tag(ToolMetricsService.TAG_OUTCOME, "aborted")
+                    .counter()
+
+            counter?.count() shouldBe 1.0
+        }
+
+        "different namespaces produce distinct counter series" {
+            val meterRegistry = registry()
+            val service = ToolMetricsService(meterRegistry)
+            val ns1 = UUID.randomUUID()
+            val ns2 = UUID.randomUUID()
+
+            service.stopTimerAndSendMetrics(service.startTimer(), "FILES__read", "agent", ns1, success = true)
+            service.stopTimerAndSendMetrics(service.startTimer(), "FILES__read", "agent", ns2, success = true)
+            service.stopTimerAndSendMetrics(service.startTimer(), "FILES__read", "agent", ns1, success = true)
+
+            val counterNs1 =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+                    .tag(ToolMetricsService.TAG_NAMESPACE_ID, ns1.toString())
+                    .counter()
+            val counterNs2 =
+                meterRegistry
+                    .find(ToolMetricsService.METRIC_TOOL_CALLS_TOTAL)
+                    .tag(ToolMetricsService.TAG_NAMESPACE_ID, ns2.toString())
+                    .counter()
+
+            counterNs1?.count() shouldBe 2.0
+            counterNs2?.count() shouldBe 1.0
+        }
+    })

--- a/agentos/docs/metrics.md
+++ b/agentos/docs/metrics.md
@@ -1,0 +1,84 @@
+# Metrics
+
+AgentOS exposes metrics via [Micrometer](https://micrometer.io/). Any Micrometer-compatible
+backend can be wired in; Datadog is supported out of the box.
+
+## Enabling Datadog export
+
+Export is **disabled by default**. Set the following environment variables to activate it:
+
+| Variable | Required | Description |
+|---|---|---|
+| `DATADOG_METRICS_ENABLED` | yes | Set to `true` to enable export |
+| `DATADOG_API_KEY` | yes | Datadog API key |
+| `DATADOG_APP_KEY` | no | Datadog application key (optional) |
+| `DATADOG_SITE` | no | Datadog site. Defaults to `datadoghq.com`; use `datadoghq.eu` for EU tenants |
+
+Metrics are pushed every **30 seconds**.
+
+All metrics are tagged with:
+- `application: agentos`
+- `environment: <active Spring profile>` (defaults to `local`)
+
+## Custom metrics
+
+All custom metrics are produced by `ToolMetricsService` and instrument tool execution
+inside `AgentAdvanced`.
+
+### `agentos.tool.calls.total` — Counter
+
+Incremented once per tool execution, whether it succeeds or fails.
+
+| Tag | Values | Description |
+|---|---|---|
+| `tool.name` | e.g. `FILES__read` | Fully-qualified tool name |
+| `integration.type` | e.g. `FILES`, `JIRA` | Prefix before `__`; `unknown` when absent |
+| `agent.name` | e.g. `copilot` | Name of the agent that called the tool |
+| `namespace.id` | UUID | Namespace the case belongs to |
+| `status` | `success` / `failure` | Outcome of the tool execution |
+
+### `agentos.tool.calls.duration` — Timer
+
+Wall-clock duration of each tool execution, measured with `Timer.Sample`
+(nanosecond precision). Always emitted alongside `agentos.tool.calls.total`.
+
+Same tags as `agentos.tool.calls.total`.
+
+Datadog exposes this as a distribution: `avg`, `p50`, `p95`, `p99`, `max`.
+
+### `agentos.tool.parameter_generation.failures` — Counter
+
+Incremented when `AgentAdvanced` exhausts all retry attempts and cannot produce
+valid JSON parameters for a tool call (`args = null`).
+
+| Tag | Values | Description |
+|---|---|---|
+| `tool.name` | e.g. `FILES__read` | Fully-qualified tool name |
+| `agent.name` | e.g. `copilot` | Name of the agent |
+| `namespace.id` | UUID | Namespace the case belongs to |
+
+### `agentos.tool.confirmation.total` — Counter
+
+Incremented once per confirmation flow resolution (tools with
+`ConfirmationMode.EVERY_TIME` or `ConfirmationMode.INFER`).
+
+| Tag | Values | Description |
+|---|---|---|
+| `tool.name` | e.g. `FILES__remove` | Fully-qualified tool name |
+| `agent.name` | e.g. `copilot` | Name of the agent |
+| `namespace.id` | UUID | Namespace the case belongs to |
+| `outcome` | `applied` / `rejected` / `aborted` | `applied`: user confirmed and tool succeeded; `rejected`: user declined; `aborted`: tool threw after confirmation |
+
+## Standard Spring Boot metrics
+
+Spring Boot auto-configures the following on top of the custom metrics above.
+They are exported to Datadog under the same `application`/`environment` tags.
+
+| Metric prefix | Description |
+|---|---|
+| `http.server.requests` | HTTP request durations and status codes (MVC) |
+| `jvm.*` | JVM memory, GC, threads, classes |
+| `process.*` | CPU usage, uptime |
+| `system.*` | System CPU |
+| `logback.*` | Log event counts by level |
+| `spring.ai.*` | Spring AI model call observations (when enabled) |

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -43,6 +43,10 @@ springCloudNetflixEureka = "4.3.1"
 # 8.1 is the last version compatible with Jackson 2.x (Spring Boot 3.x);
 # 9.0+ requires Jackson 3.x.
 logstashLogbackEncoder = "8.1"
+# Micrometer Datadog registry — exports metrics to Datadog via HTTP.
+# Version is managed by Spring Boot BOM; explicit declaration only needed
+# for the Datadog-specific registry artifact.
+micrometerDatadog = "1.15.0"
 # OkHttp — version aligned with Spring Cloud BOM constraint (spring-cloud-dependencies 2025.0.1)
 # and the transitive version pulled by com.google.genai:google-genai (Spring AI Gemini).
 okhttp = "4.12.0"
@@ -83,6 +87,9 @@ klogger = {module="io.github.microutils:kotlin-logging-jvm", version.ref="klogge
 
 # Logstash Logback Encoder — JSON structured logging
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstashLogbackEncoder" }
+# Micrometer Datadog registry — exports Micrometer metrics to the Datadog API.
+# Disabled at runtime unless DATADOG_API_KEY is set and datadog.metrics.export.enabled=true.
+micrometer-registry-datadog = { module = "io.micrometer:micrometer-registry-datadog", version.ref = "micrometerDatadog" }
 
 # OkHttp — HTTP client used by plugins (e.g. copilot) and optionally by Feign (whoz profile)
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -43,10 +43,8 @@ springCloudNetflixEureka = "4.3.1"
 # 8.1 is the last version compatible with Jackson 2.x (Spring Boot 3.x);
 # 9.0+ requires Jackson 3.x.
 logstashLogbackEncoder = "8.1"
-# Micrometer Datadog registry — exports metrics to Datadog via HTTP.
-# Version is managed by Spring Boot BOM; explicit declaration only needed
-# for the Datadog-specific registry artifact.
-micrometerDatadog = "1.15.0"
+# Micrometer Datadog registry — version intentionally omitted; managed by
+# the Spring Boot BOM to stay aligned with the rest of the Micrometer stack.
 # OkHttp — version aligned with Spring Cloud BOM constraint (spring-cloud-dependencies 2025.0.1)
 # and the transitive version pulled by com.google.genai:google-genai (Spring AI Gemini).
 okhttp = "4.12.0"
@@ -89,7 +87,8 @@ klogger = {module="io.github.microutils:kotlin-logging-jvm", version.ref="klogge
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstashLogbackEncoder" }
 # Micrometer Datadog registry — exports Micrometer metrics to the Datadog API.
 # Disabled at runtime unless DATADOG_API_KEY is set and datadog.metrics.export.enabled=true.
-micrometer-registry-datadog = { module = "io.micrometer:micrometer-registry-datadog", version.ref = "micrometerDatadog" }
+# Version managed by Spring Boot BOM.
+micrometer-registry-datadog = { module = "io.micrometer:micrometer-registry-datadog" }
 
 # OkHttp — HTTP client used by plugins (e.g. copilot) and optionally by Feign (whoz profile)
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ spring-cloud-starter-config = { module = "org.springframework.cloud:spring-cloud
 spring-cloud-starter-eureka-client = { module = "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client", version.ref = "springCloudNetflixEureka" }
 
 # Klogger
-klogger = {module="io.github.microutils:kotlin-logging-jvm", version.ref="klogger"}
+klogger = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "klogger" }
 
 # Logstash Logback Encoder — JSON structured logging
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstashLogbackEncoder" }
@@ -89,6 +89,7 @@ logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-enc
 # Disabled at runtime unless DATADOG_API_KEY is set and datadog.metrics.export.enabled=true.
 # Version managed by Spring Boot BOM.
 micrometer-registry-datadog = { module = "io.micrometer:micrometer-registry-datadog" }
+micrometer-registry-statsd = { module = "io.micrometer:micrometer-registry-statsd" }
 
 # OkHttp — HTTP client used by plugins (e.g. copilot) and optionally by Feign (whoz profile)
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ springCloudNetflixEureka = "4.3.1"
 logstashLogbackEncoder = "8.1"
 # Micrometer Datadog registry — version intentionally omitted; managed by
 # the Spring Boot BOM to stay aligned with the rest of the Micrometer stack.
+# Micrometer Tracing + OpenTelemetry — versions managed by Spring Boot BOM 3.5.7:
+#   micrometer-tracing 1.5.5, opentelemetry 1.49.0. No explicit version needed.
 # OkHttp — version aligned with Spring Cloud BOM constraint (spring-cloud-dependencies 2025.0.1)
 # and the transitive version pulled by com.google.genai:google-genai (Spring AI Gemini).
 okhttp = "4.12.0"
@@ -90,6 +92,9 @@ logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-enc
 # Version managed by Spring Boot BOM.
 micrometer-registry-datadog = { module = "io.micrometer:micrometer-registry-datadog" }
 micrometer-registry-statsd = { module = "io.micrometer:micrometer-registry-statsd" }
+# Micrometer Tracing — OTel bridge + OTLP exporter. Versions managed by Spring Boot BOM.
+micrometer-tracing-bridge-otel = { module = "io.micrometer:micrometer-tracing-bridge-otel" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp" }
 
 # OkHttp — HTTP client used by plugins (e.g. copilot) and optionally by Feign (whoz profile)
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
## What

Adds vendor-agnostic distributed tracing to AgentOS via Micrometer Tracing + OpenTelemetry bridge, exporting spans over OTLP to any compatible backend (Datadog agent, Jaeger, Tempo, …).

## Why

AgentOS had metrics but zero tracing. The core execution model launches agent runs in background coroutines via `scope.launch { runtime.run() }`, which silently drops the HTTP request's trace context — spans initiated from a REST call were never linked to the agent execution that followed.

## Changes

### New files

**`agentos-sdk/.../tool/Trace.kt`** — defines the `@Trace` annotation that was already applied to `StandardTool.executeWithJson` but had no definition (pre-existing broken reference, now fixed as a `SOURCE`-retention marker).

**`agentos-service/.../tracing/OtelCoroutineContext.kt`** — a `ThreadContextElement<Scope>` that captures the active OTel `Context` when a coroutine suspends and restores it on resume. Solves the thread-switch problem inherent to coroutines + ThreadLocal-based OTel context.

**`agentos-service/.../tracing/TracingHelper.kt`** — two inline helpers:
- `withSpan(tracer?, spanName, tags, block)` — suspend-compatible span wrapper; no-ops when `tracer` is null so call sites need no null checks.
- `withSpanSync(...)` — identical non-suspend variant for blocking contexts.

### Modified files

**`CaseServiceImpl`**
- Injects `Tracer?` (nullable, default `null`) — safe when tracing is disabled since Spring Boot does not register a `Tracer` bean in that case.
- `addMessage`: passes `OtelCoroutineContext()` to `scope.launch(...)` so the background coroutine inherits the HTTP request's trace.
- `runAgent`: wraps the agent flow collection in a `withSpan("agent.run", ...)` span tagged with `agent.name`, `case.id`, and `namespace.id`.

**`application.yml`** — adds tracing config under `management:`:
```yaml
management:
  tracing:
    enabled: ${TRACING_ENABLED:false}      # off by default
    sampling:
      probability: ${TRACING_SAMPLING_PROBABILITY:1.0}
  otlp:
    tracing:
      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
```

**`build.gradle.kts`** — adds two BOM-managed dependencies (no explicit versions):
```kotlin
implementation(libs.micrometer.tracing.bridge.otel)
implementation(libs.opentelemetry.exporter.otlp)
```

**`libs.versions.toml`** — adds catalog entries for the two new deps.

## Opt-in by default

Tracing is disabled by default (`TRACING_ENABLED=false`). To activate, set:
```
TRACING_ENABLED=true
OTEL_EXPORTER_OTLP_ENDPOINT=http://<datadog-agent>:4318/v1/traces
```

No Datadog-specific dependency is added — any OTLP-compatible collector works.