### PR TITLE
feat(ci): add hotfix/* branch support to validate and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,18 @@ on:
   push:
     branches:
       - master
+      - 'hotfix/*'
   workflow_dispatch:
+    inputs:
+      specifier:
+        description: 'Force a version bump — bypasses conventional commits. Use to advance master past a hotfix line before cutting a hotfix branch.'
+        required: false
+        type: choice
+        options:
+          - ''
+          - minor
+          - major
+          - patch
 
 concurrency:
   group: release
@@ -65,7 +76,12 @@ jobs:
         env:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-        run: npx tsx scripts/release.ts
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.specifier }}" ]; then
+            ARGS="--specifier ${{ inputs.specifier }}"
+          fi
+          npx tsx scripts/release.ts $ARGS
 
       - name: Capture release commit SHA
         id: release_sha

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,9 @@ name: Validate Coday on pull requests
 on:
   pull_request:
     types: [opened, synchronize]
-    branches: [master]
+    branches:
+      - master
+      - 'hotfix/*'
 
 env:
   NX_MAX_WORKERS: 2

--- a/docs/06-guides/hotfix-branches.md
+++ b/docs/06-guides/hotfix-branches.md
@@ -1,0 +1,59 @@
+# Hotfix Branches
+
+Hotfix branches allow targeted fixes to be released on an older version line without impacting ongoing development on `master`.
+
+## How it works
+
+Hotfix branches follow the pattern `hotfix/<major>.<minor>` (e.g. `hotfix/0.183`). The CI pipeline detects them automatically:
+
+- PRs targeting a `hotfix/*` branch go through the full lint/test/JVM gate, same as PRs targeting `master`
+- Pushing to a `hotfix/*` branch triggers the release pipeline
+
+Version computation is handled by Nx out of the box. On a hotfix branch, git only sees tags reachable from that branch — so Nx naturally picks up `release/0.183.x` as the base and ignores master's newer tags entirely.
+
+## Prerequisites
+
+A hotfix branch for `0.183.x` is only safe to cut once master has moved to `0.184.0` or higher. If master is still releasing `0.183.x`, there is no need for a hotfix branch — just fix on master normally.
+
+If master hasn't moved past `0.183` yet, advance it first using the manual workflow trigger (see below).
+
+## Advancing master before cutting a hotfix branch
+
+Go to **GitHub → Actions → Release and Publish → Run workflow**, select `minor` from the specifier dropdown, and run it. This bypasses conventional commits and forces a minor bump — master moves from `0.183.x` to `0.184.0` immediately.
+
+Wait for the release workflow to complete before cutting the hotfix branch.
+
+## Creating a hotfix branch
+
+From the release tag you want to patch (e.g. the last `0.183.x` tag):
+
+```bash
+git checkout -b hotfix/0.183 release/0.183.4
+git push origin hotfix/0.183
+```
+
+## Applying fixes
+
+Fix on `master` first, then cherry-pick to the hotfix branch. Since `hotfix/*` branches are protected, changes must go through a PR:
+
+```bash
+# Create a local branch off the hotfix branch
+git checkout -b fix/my-fix hotfix/0.183
+git cherry-pick <commit-sha>
+git push origin fix/my-fix
+# Open a PR targeting hotfix/0.183
+```
+
+Once the PR is merged, the release pipeline triggers automatically. Nx finds `release/0.183.4` as the base, detects the `fix:` commit, and produces `0.183.5`. Subsequent fixes produce `0.183.6`, and so on.
+
+> Always fix on `master` first. This ensures the fix is captured in the primary codebase and prevents it from being lost when the hotfix branch is eventually deleted.
+
+## Deleting a hotfix branch
+
+When a newer minor line supersedes the hotfix line (e.g. `0.184.x` covers all the same fixes), delete the branch:
+
+```bash
+git push origin --delete hotfix/0.183
+```
+
+Release tags (`release/0.183.x`) and GitHub Releases are preserved permanently.

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -11,8 +11,18 @@ async function main(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run')
   if (dryRun) console.log('Dry run mode — no files will be written, no git operations performed')
 
+  const specifierIndex = process.argv.indexOf('--specifier')
+  const specifier = specifierIndex !== -1 ? process.argv[specifierIndex + 1] : undefined
+  if (specifier) {
+    console.log(`Forced specifier: ${specifier}`)
+  }
+
   // Step 1: Determine new version and update package.json files
-  const { projectsVersionData, releaseGraph, workspaceVersion } = await releaseVersion({ dryRun, verbose: false })
+  const { projectsVersionData, releaseGraph, workspaceVersion } = await releaseVersion({
+    dryRun,
+    verbose: false,
+    specifier,
+  })
 
   // workspaceVersion is null when conventional commits detected no changes, undefined would indicate a misconfiguration
   if (workspaceVersion === undefined) {


### PR DESCRIPTION
Enables CI support for hotfix branches and adds a manual specifier override for the release pipeline.

## Changes

- `validate.yml`: PR gate now also triggers on PRs targeting `hotfix/*` branches
- `release.yml`: release pipeline now also triggers on push to `hotfix/*` branches; adds an optional `specifier` dropdown (`minor`, `major`, `patch`) on manual runs to force a version bump bypassing conventional commits
- `scripts/release.ts`: forwards `--specifier` argument to `releaseVersion()` when provided
- `docs/06-guides/hotfix-branches.md`: documents the hotfix workflow

## How version computation works on hotfix branches

Nx resolves the base version using `git tag --merged`, which only sees tags reachable from the current branch. On `hotfix/0.183`, master's newer tags (`release/0.184.x`, etc.) are unreachable — Nx naturally picks `release/0.183.4` as the base and bumps to `0.183.5`. No custom logic needed.

## Hotfix workflow

### Prerequisites

A hotfix branch for `0.183.x` can only be cut once master has moved past `0.183`. If it hasn't, trigger **Actions → Release and Publish → Run workflow** with `specifier: minor` to force master to `0.184.0`.

### Create

```bash
git checkout -b hotfix/0.183 release/0.183.4
git push origin hotfix/0.183
```

### Apply fixes

Fix on `master` first, then cherry-pick:

```bash
git checkout hotfix/0.183
git cherry-pick <commit-sha>
git push origin hotfix/0.183
```

### Delete when obsolete

```bash
git push origin --delete hotfix/0.183
```

Tags and GitHub Releases are preserved.

<img width="1455" height="563" alt="image" src="https://github.com/user-attachments/assets/272f08cf-c612-4b83-90cf-af35e50ccbb2" />