### PR TITLE
feat(agentos): add AGENTOS_EXTERNAL_USERID to server.ts

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -75,11 +75,15 @@ let promptExecutionService: PromptExecutionService
 // consuming the request body before it can be forwarded.
 const AGENTOS_PORT = process.env.AGENTOS_PORT ? parseInt(process.env.AGENTOS_PORT) : 8124
 const AGENTOS_HOSTNAME = process.env.AGENTOS_HOSTNAME ?? 'localhost'
+const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
 const AGENTOS_URL = `http://${AGENTOS_HOSTNAME}:${AGENTOS_PORT}`
 app.use(
   '/api/agentos',
   (req, _res, next) => {
     console.log(`[AGENTOS PROXY] ${req.method} ${req.path}`)
+    if (AGENTOS_EXTERNAL_USERID) {
+      req.headers['X-External-User-Id'] = AGENTOS_EXTERNAL_USERID
+    }
     next()
   },
   createProxyMiddleware({


### PR DESCRIPTION
Add support of AGENTOS_EXTERNAL_USERID on server.ts so you can use coday to connect to a remote agentos in auth mode using following env variables:
```
export AGENTOS_HOSTNAME='myagentoshostname.com'
export AGENTOS_PORT=80
export AGENTOS_EXTERNAL_USERID='your user external id on agentos database'
```