### PR TITLE
fix: prevent thread loss on Ctrl+C by saving before MCP cleanup

### DIFF
--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -246,15 +246,17 @@ export class Coday {
    */
   async cleanup(): Promise<void> {
     try {
+      // Save thread FIRST to prevent data loss if subsequent cleanup steps hang or fail
+      // (e.g. MCP process cleanup after SIGINT propagation).
+      // An in-flight tool response could still land after this save, but losing one
+      // response is far less damaging than losing the entire thread.
+      await this.aiThreadService.autoSave()
+
       if (this.services.agent) {
         await this.services.agent.kill()
       }
 
-      // Save thread AFTER agent.kill() to ensure all tool responses are written to the thread,
-      // and BEFORE aiThreadService.kill() which sets isKilled=true blocking autoSave.
-      await this.aiThreadService.autoSave()
-
-      this.aiThreadService.kill()
+      await this.aiThreadService.kill()
 
       // Reset AI client provider for fresh connections
       this.aiClientProvider.cleanup()


### PR DESCRIPTION
Reorders `Coday.cleanup()` so `autoSave()` runs before `agent.kill()`.

Previously, MCP child process cleanup could hang after SIGINT propagation, blocking thread persistence and losing the active thread.

Also adds missing `await` on `aiThreadService.kill()` which does a final safety-net save.