### PR TITLE
fix: wz-33145 cancel eviction watcher coroutine on idle eviction to p…

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -207,7 +207,7 @@ class CaseServiceImpl(
                             // combine(StateFlow, StateFlow) never completes naturally.
                             // Without cancel, the coroutine stays suspended forever,
                             // retaining the CaseRuntime in its closure — a memory leak.
-                            watcherJobs.remove(caseId)//?.cancel() <- the fix
+                            watcherJobs.remove(caseId)?.cancel()
                             logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
                         } else {
                             logger.debug {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImpl.kt
@@ -64,6 +64,15 @@ class CaseServiceImpl(
      */
     private val watcherJobs = ConcurrentHashMap<UUID, Job>()
 
+    /**
+     * Number of active coroutines running in the service scope.
+     * Counts all child jobs of the scope — watcher coroutines and any in-flight run() launches.
+     * Exposed for testing only: verifies that eviction watcher coroutines are properly
+     * cancelled after idle eviction and do not leak.
+     */
+    internal val activeCoroutineCount: Int
+        get() = scope.coroutineContext[Job]?.children?.count() ?: 0
+
     // ======================================================
     // EntityService
     // ======================================================
@@ -194,10 +203,11 @@ class CaseServiceImpl(
                             runtime.statusFlow.value == CaseStatus.IDLE
                         ) {
                             activeRuntimes.remove(caseId)
-                            // Remove from watcherJobs without cancelling: we are executing
-                            // inside this very coroutine, so cancel() would be a no-op and
-                            // is semantically misleading. The coroutine ends naturally here.
-                            watcherJobs.remove(caseId)
+                            // Cancel the watcher job: collect{} on the infinite
+                            // combine(StateFlow, StateFlow) never completes naturally.
+                            // Without cancel, the coroutine stays suspended forever,
+                            // retaining the CaseRuntime in its closure — a memory leak.
+                            watcherJobs.remove(caseId)//?.cancel() <- the fix
                             logger.info { "Case $caseId: evicted idle runtime (no SSE subscribers after ${idleEvictionGraceMs}ms grace)" }
                         } else {
                             logger.debug {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseServiceImplSpec.kt
@@ -1271,6 +1271,50 @@ class CaseServiceImplSpec :
             service.getById(case.id).status shouldBe CaseStatus.IDLE
         }
 
+        "eviction watcher coroutine is terminated after idle eviction" {
+            // Regression test for the coroutine-leak fix.
+            //
+            // Before the fix, the idle eviction path called watcherJobs.remove(caseId)
+            // without ?.cancel(). The comment claimed collect{} on the infinite
+            // combine(StateFlow, StateFlow) "ends naturally" — it does not. The remove
+            // cleared the map entry but left the coroutine suspended in collect forever,
+            // retaining the CaseRuntime in its closure — a memory leak.
+            //
+            // After the fix, watcherJobs.remove(caseId)?.cancel() is used, which is
+            // consistent with the terminal-status path in handleStatusChange and
+            // correctly terminates the coroutine.
+            //
+            // This test verifies that after eviction the service scope has no orphan
+            // coroutines left over from the watcher.
+
+            val service = buildService(idleEvictionGraceMs = 50L)
+            val case = service.create(Case(namespaceId = namespaceId))
+            val runtime = service.getCaseRuntime(case.id)
+            val scope = CoroutineScope(Dispatchers.IO)
+
+            // Subscribe, let the case reach IDLE, then unsubscribe.
+            val awaiter = scope.expectCaseStatus(runtime, CaseStatus.IDLE)
+            awaitSubscribers(runtime)
+            service.addMessage(
+                caseId = case.id,
+                actor = userActor,
+                content = listOf(MessageContent.Text("hello")),
+            )
+            awaiter.join()
+            // awaiter job ends -> subscriptionCount drops to 0.
+            // Also wait for run() to fully exit so its coroutine is not counted.
+            awaitNotRunning(runtime)
+
+            // Wait for grace period + margin for the watcher to fire and cancel itself.
+            delay(200)
+
+            // Runtime was evicted.
+            service.findActiveRuntime(case.id) shouldBe null
+            // The watcher coroutine must have been cancelled — no orphan coroutines
+            // should remain in the service scope for this case.
+            service.activeCoroutineCount shouldBe 0
+        }
+
         "idle runtime is NOT evicted while SSE subscribers remain connected" {
             // The eviction watcher only fires when subscriptionCount == 0.
             // We keep a subscriber alive so subscriptionCount never reaches 0.


### PR DESCRIPTION
…revent OOM

Décommenter le `//?.cancel() <- the fix` fait passer le test.