### PR TITLE
feat: #1014 add soft-delete action to AgentOS case list

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
@@ -7,7 +7,6 @@
   searchPlaceholder="Filter cases…"
   cardMinWidth="220px"
   contentMaxWidth="100%"
-  (itemSelected)="onItemSelected($event)"
   (createRequested)="onCreateRequested()"
 >
   <!-- Inject the close button into the toolbar-start slot, before the title -->
@@ -20,14 +19,18 @@
   />
 </ds-entity-list>
 
-<!-- Minimal case item template: single-line row, active highlight -->
+<!-- Minimal case item template: single-line row, active highlight, delete action -->
 <ng-template #caseItemTpl let-item>
-  <button
-    type="button"
-    class="case-drawer-item"
-    [class.case-drawer-item--active]="item.id === activeCaseId"
-    (click)="onItemSelected(item.id)"
-  >
-    <span class="case-drawer-item__name">{{ item.name }}</span>
-  </button>
+  <div class="case-drawer-item" [class.case-drawer-item--active]="item.id === activeCaseId">
+    <button type="button" class="case-drawer-item__select" (click)="onItemSelected(item.id)">
+      <span class="case-drawer-item__name">{{ item.name }}</span>
+    </button>
+    <ds-icon-button
+      class="case-drawer-item__delete"
+      icon="delete"
+      variant="danger"
+      title="Delete case"
+      (action)="onDeleteRequested(item.id)"
+    />
+  </div>
 </ng-template>

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
@@ -8,19 +8,10 @@
 .case-drawer-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   width: 100%;
-  padding: 0.5rem 0.75rem;
   border-radius: 8px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-  font-family: inherit;
-  font-size: 0.875rem;
   color: var(--color-text, #1d1d1f);
   transition: background 0.12s ease;
-  gap: 0.5rem;
 
   &:hover {
     background: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
@@ -30,22 +21,40 @@
     background: var(--color-primary, #007aff);
     color: var(--color-text-inverse, #fff);
 
-    .case-drawer-item__status {
-      color: color-mix(in srgb, var(--color-text-inverse, #fff) 70%, transparent);
-    }
-
     &:hover {
       background: var(--color-primary-hover, #0051d5);
     }
   }
 
+  // Clickable area that selects the case (fills the row, leaving room for actions)
+  &__select {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    font-family: inherit;
+    font-size: 0.875rem;
+    color: inherit;
+  }
+
   &__name {
     flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-weight: 500;
     font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
     font-size: 0.8rem;
+  }
+
+  &__delete {
+    flex: none;
+    margin-inline-end: 0.25rem;
   }
 }

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.spec.ts
@@ -1,0 +1,13 @@
+import { CaseDrawerComponent } from './case-drawer.component'
+
+describe('CaseDrawerComponent', () => {
+  it('emits deleteRequested with the case id when a delete is requested', () => {
+    const component = new CaseDrawerComponent()
+    const emitted: string[] = []
+    component.deleteRequested.subscribe((id) => emitted.push(id))
+
+    component['onDeleteRequested']('case-42')
+
+    expect(emitted).toEqual(['case-42'])
+  })
+})

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
@@ -37,6 +37,7 @@ export class CaseDrawerComponent implements OnChanges {
   @Output() caseSelected = new EventEmitter<string>()
   @Output() createRequested = new EventEmitter<void>()
   @Output() closeRequested = new EventEmitter<void>()
+  @Output() deleteRequested = new EventEmitter<string>()
 
   @ViewChild('caseItemTpl', { static: true }) caseItemTpl!: TemplateRef<{ $implicit: EntityListItem }>
 
@@ -54,5 +55,9 @@ export class CaseDrawerComponent implements OnChanges {
 
   protected onCreateRequested(): void {
     this.createRequested.emit()
+  }
+
+  protected onDeleteRequested(id: string): void {
+    this.deleteRequested.emit(id)
   }
 }

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.html
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.html
@@ -11,6 +11,7 @@
           (caseSelected)="onCaseSelected($event)"
           (createRequested)="onCreateRequested()"
           (closeRequested)="toggleDrawer()"
+          (deleteRequested)="onDeleteRequested($event)"
         />
       </div>
 

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.spec.ts
@@ -1,0 +1,114 @@
+import { TestBed } from '@angular/core/testing'
+import { ActivatedRoute, Router } from '@angular/router'
+import { Case, CaseControllerService } from '@whoz-oss/agentos-api-client'
+import { EMPTY, Observable, of, throwError } from 'rxjs'
+import { CaseShellComponent } from './case-shell.component'
+
+describe('CaseShellComponent', () => {
+  const NS_ID = 'ns-1'
+
+  const caseWith = (id: string, title?: string): Case => ({ id, namespaceId: NS_ID, title }) as unknown as Case
+
+  let routerMock: { url: string; events: Observable<unknown>; navigate: jest.Mock }
+  let routeMock: { snapshot: { params: Record<string, string> } }
+  let caseControllerMock: { listByParentCase: jest.Mock; deleteCase: jest.Mock }
+
+  function makeComponent(url: string, cases: Case[] = []): CaseShellComponent {
+    routerMock = { url, events: EMPTY, navigate: jest.fn() }
+    routeMock = { snapshot: { params: { namespaceId: NS_ID } } }
+    caseControllerMock = {
+      listByParentCase: jest.fn().mockReturnValue(of(cases)),
+      deleteCase: jest.fn().mockReturnValue(of(undefined)),
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: routerMock },
+        { provide: ActivatedRoute, useValue: routeMock },
+        { provide: CaseControllerService, useValue: caseControllerMock },
+      ],
+    })
+
+    return TestBed.runInInjectionContext(() => new CaseShellComponent())
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    TestBed.resetTestingModule()
+  })
+
+  describe('soft-delete', () => {
+    it('does not delete the case when the user cancels the confirmation', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(false)
+      const component = makeComponent(`/agentos/${NS_ID}/cases`)
+
+      component['onDeleteRequested']('case-1')
+
+      expect(caseControllerMock.deleteCase).not.toHaveBeenCalled()
+    })
+
+    it('soft-deletes the case and refreshes the list once confirmed', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(true)
+      const component = makeComponent(`/agentos/${NS_ID}/cases`)
+      // Initial list load happens once at construction.
+      expect(caseControllerMock.listByParentCase).toHaveBeenCalledTimes(1)
+
+      component['onDeleteRequested']('case-1')
+
+      expect(caseControllerMock.deleteCase).toHaveBeenCalledWith('case-1')
+      // The list is refreshed after a successful delete.
+      expect(caseControllerMock.listByParentCase).toHaveBeenCalledTimes(2)
+    })
+
+    it('navigates back to the case section home when the deleted case is the active one', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(true)
+      const component = makeComponent(`/agentos/${NS_ID}/cases/active-1`)
+      expect(component['activeCaseId']()).toBe('active-1')
+
+      component['onDeleteRequested']('active-1')
+
+      expect(routerMock.navigate).toHaveBeenCalledWith(['.'], { relativeTo: routeMock })
+    })
+
+    it('stays on the current view when the deleted case is not the active one', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(true)
+      const component = makeComponent(`/agentos/${NS_ID}/cases/active-1`)
+
+      component['onDeleteRequested']('other-2')
+
+      expect(routerMock.navigate).not.toHaveBeenCalled()
+    })
+
+    it('names the case in the confirmation prompt when it has a title', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
+      const component = makeComponent(`/agentos/${NS_ID}/cases`, [caseWith('case-1', 'My Case')])
+
+      component['onDeleteRequested']('case-1')
+
+      expect(confirmSpy).toHaveBeenCalledWith('Delete case "My Case"?')
+    })
+
+    it('falls back to a generic prompt when the case has no title', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
+      const component = makeComponent(`/agentos/${NS_ID}/cases`, [caseWith('case-1')])
+
+      component['onDeleteRequested']('case-1')
+
+      expect(confirmSpy).toHaveBeenCalledWith('Delete this case?')
+    })
+
+    it('does not navigate or refresh, and logs, when the delete request fails', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(true)
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      const component = makeComponent(`/agentos/${NS_ID}/cases/active-1`)
+      caseControllerMock.deleteCase.mockReturnValue(throwError(() => new Error('boom')))
+
+      component['onDeleteRequested']('active-1')
+
+      expect(routerMock.navigate).not.toHaveBeenCalled()
+      // No refresh: listByParentCase stays at its single construction-time call.
+      expect(caseControllerMock.listByParentCase).toHaveBeenCalledTimes(1)
+      expect(errorSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.spec.ts
@@ -79,27 +79,31 @@ describe('CaseShellComponent', () => {
       expect(routerMock.navigate).not.toHaveBeenCalled()
     })
 
-    it('names the case in the confirmation prompt when it has a title', () => {
+    it('confirms with the same label the drawer row shows (the case id, not the title)', () => {
+      // The drawer renders CaseItemComponent.toListItem(c).name, which is c.id today
+      // (titles are not user-facing yet). The confirm must use that same label so the
+      // dialog identifies the row the user clicked.
       const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
       const component = makeComponent(`/agentos/${NS_ID}/cases`, [caseWith('case-1', 'My Case')])
 
       component['onDeleteRequested']('case-1')
 
-      expect(confirmSpy).toHaveBeenCalledWith('Delete case "My Case"?')
+      expect(confirmSpy).toHaveBeenCalledWith('Delete "case-1"?')
     })
 
-    it('falls back to a generic prompt when the case has no title', () => {
+    it('confirms with the case id when the case is not in the current list', () => {
       const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
-      const component = makeComponent(`/agentos/${NS_ID}/cases`, [caseWith('case-1')])
+      const component = makeComponent(`/agentos/${NS_ID}/cases`, [])
 
-      component['onDeleteRequested']('case-1')
+      component['onDeleteRequested']('gone-9')
 
-      expect(confirmSpy).toHaveBeenCalledWith('Delete this case?')
+      expect(confirmSpy).toHaveBeenCalledWith('Delete "gone-9"?')
     })
 
-    it('does not navigate or refresh, and logs, when the delete request fails', () => {
+    it('logs and alerts the user, and does not navigate or refresh, when the delete request fails', () => {
       jest.spyOn(window, 'confirm').mockReturnValue(true)
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined)
       const component = makeComponent(`/agentos/${NS_ID}/cases/active-1`)
       caseControllerMock.deleteCase.mockReturnValue(throwError(() => new Error('boom')))
 
@@ -109,6 +113,8 @@ describe('CaseShellComponent', () => {
       // No refresh: listByParentCase stays at its single construction-time call.
       expect(caseControllerMock.listByParentCase).toHaveBeenCalledTimes(1)
       expect(errorSpy).toHaveBeenCalled()
+      // The failure is surfaced to the user, not just the console.
+      expect(alertSpy).toHaveBeenCalled()
     })
   })
 })

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
@@ -83,6 +83,30 @@ export class CaseShellComponent {
 
   protected onCreateRequested(): void {
     // Navigate to the home view where the user can start a new case
+    this.navigateToSectionHome()
+  }
+
+  protected onDeleteRequested(caseId: string): void {
+    const title = this.cases().find((c) => c.id === caseId)?.title
+    const label = title ? `case "${title}"` : 'this case'
+    if (!confirm(`Delete ${label}?`)) {
+      return
+    }
+    // Soft-delete (the backend flips a `removed` flag); refresh the list on success.
+    this.caseController.deleteCase(caseId).subscribe({
+      next: () => {
+        // If the active case was deleted, leave its (now removed) chat view.
+        if (caseId === this.activeCaseId()) {
+          this.navigateToSectionHome()
+        }
+        this.refreshCases()
+      },
+      error: (err) => console.error(`[CaseShell] Failed to delete case ${caseId}:`, err),
+    })
+  }
+
+  /** Navigate to the case section home (the list / create view). */
+  private navigateToSectionHome(): void {
     this.router.navigate(['.'], { relativeTo: this.route })
   }
 

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
@@ -5,6 +5,7 @@ import { Case, CaseControllerService } from '@whoz-oss/agentos-api-client'
 import { DrawerComponent, IconButtonComponent } from '@whoz-oss/design-system'
 import { BehaviorSubject, filter, map, merge, of, switchMap } from 'rxjs'
 import { CaseDrawerComponent } from '../case-drawer/case-drawer.component'
+import { CaseItemComponent } from '../case-item/case-item.component'
 import { HeaderComponent } from '../header/header.component'
 
 /**
@@ -87,9 +88,11 @@ export class CaseShellComponent {
   }
 
   protected onDeleteRequested(caseId: string): void {
-    const title = this.cases().find((c) => c.id === caseId)?.title
-    const label = title ? `case "${title}"` : 'this case'
-    if (!confirm(`Delete ${label}?`)) {
+    // Confirm with the same label the drawer row shows (CaseItemComponent.toListItem),
+    // so the dialog identifies the exact case the user clicked.
+    const target = this.cases().find((c) => c.id === caseId)
+    const label = target ? CaseItemComponent.toListItem(target).name : caseId
+    if (!confirm(`Delete "${label}"?`)) {
       return
     }
     // Soft-delete (the backend flips a `removed` flag); refresh the list on success.
@@ -101,7 +104,10 @@ export class CaseShellComponent {
         }
         this.refreshCases()
       },
-      error: (err) => console.error(`[CaseShell] Failed to delete case ${caseId}:`, err),
+      error: (err) => {
+        console.error(`[CaseShell] Failed to delete case ${caseId}:`, err)
+        alert('Could not delete the case. Please try again.')
+      },
     })
   }
 


### PR DESCRIPTION
## What

First slice of #1014 (**AgentOS case management**): the **soft-delete** action in the case drawer.

Each case row now has a delete button. It soft-deletes the case through the **existing** `DELETE /api/cases/{id}` endpoint (which already flips a `removed` flag server-side), so this PR is front-only.

## How

- `CaseDrawerComponent` (presentational) gets a `deleteRequested` output. The row template is restructured into a flex container with a **select button** and a **danger `ds-icon-button`**, avoiding a `<button>` nested inside a `<button>`.
- `CaseShellComponent` (smart) handles the flow in `onDeleteRequested`: confirm (naming the case when it has a title), call `deleteCase`, navigate away if the **active** case was deleted, then refresh the list. Delete failures are logged and leave state intact.
- Removed a dead `(itemSelected)` binding on `ds-entity-list` (selection flows through the row's select button) and extracted a `navigateToSectionHome()` helper.

## Tests

- `case-drawer.component.spec.ts`: `deleteRequested` emits the case id.
- `case-shell.component.spec.ts`: confirm gating, delete + refresh, navigate-away-when-active, no navigate/refresh + log on failure, and the confirmation label (titled vs generic).

Verified: `nx test agentos-ui` (80/80), `nx lint agentos-ui`, and `nx build-angular client` (strictTemplates).

## Out of scope (rest of #1014)

- **rename**: coupled to the automatic case-naming work (#1010, needs a `titleManuallySet`-style guard) and will ship with that PR.
- **star / favorite**: separate PR (edge property on the user/case relation, toggle endpoint, favorite attribute on the list DTO + client regen).
