### PR TITLE
fix: prevent thread data loss on tab close + server shutdown

### DIFF
--- a/apps/server/src/lib/thread-coday-manager.ts
+++ b/apps/server/src/lib/thread-coday-manager.ts
@@ -516,23 +516,22 @@ class ThreadCodayInstance {
     }
     this.connections.clear()
 
-    // Run post-processing before killing Coday.
-    // Coday.run() calls cleanup() which nullifies context, so we must grab the thread
-    // from aiThreadService (still alive at this point) rather than coday.context.
+    // Grab thread and AI client BEFORE killing Coday (kill() nullifies context)
+    let threadForPostProcessing: any | undefined
+    let aiClientForPostProcessing: any | undefined
     if (this.coday) {
       const aiThreadService = this.coday.aiThreadService
-      const thread = this.coday.context?.aiThread ?? aiThreadService?.getCurrentThread()
+      threadForPostProcessing = this.coday.context?.aiThread ?? aiThreadService?.getCurrentThread()
       const aiClientProvider: AiClientProvider | undefined = this.coday.aiClientProvider
-      const aiClient = aiClientProvider?.getClient(undefined, 'SMALL') ?? aiClientProvider?.getClient(undefined)
-      if (thread && aiClient) {
-        const processor = new ThreadPostProcessor(aiClient, this.threadService)
-        processor.process(thread, this.projectName)
-      } else {
-        debugLog('THREAD_CODAY', `Skipping post-processing for thread ${this.threadId}: no thread or AI client`)
-      }
+      aiClientForPostProcessing =
+        aiClientProvider?.getClient(undefined, 'SMALL') ?? aiClientProvider?.getClient(undefined)
+      debugLog(
+        'THREAD_CODAY',
+        `Pre-kill snapshot for ${this.threadId}: thread=${!!threadForPostProcessing} (${threadForPostProcessing?.messagesLength ?? 0} msgs), aiClient=${!!aiClientForPostProcessing}`
+      )
     }
 
-    // Kill Coday instance (this will trigger cleanup of agents and MCP servers)
+    // Kill Coday FIRST — this triggers autoSave, persisting the full thread to disk
     if (this.coday) {
       try {
         await this.coday.kill()
@@ -540,6 +539,34 @@ class ThreadCodayInstance {
         debugLog('THREAD_CODAY', `Error during Coday kill:`, error)
       }
       this.coday = undefined
+    }
+
+    // THEN run post-processing (reads from disk after autoSave, so no stale overwrite)
+    // Await with a 10s timeout to not block shutdown indefinitely
+    if (threadForPostProcessing && aiClientForPostProcessing) {
+      const processor = new ThreadPostProcessor(aiClientForPostProcessing, this.threadService)
+      try {
+        const postProcessStart = Date.now()
+        const result = await Promise.race([
+          processor.process(threadForPostProcessing, this.projectName).then(() => 'completed' as const),
+          new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 10_000)),
+        ])
+        if (result === 'timeout') {
+          debugLog(
+            'THREAD_CODAY',
+            `Post-processing TIMED OUT for thread ${this.threadId} after 10s (thread data is safe, only name/summary may be missing)`
+          )
+        } else {
+          debugLog(
+            'THREAD_CODAY',
+            `Post-processing completed for thread ${this.threadId} in ${Date.now() - postProcessStart}ms`
+          )
+        }
+      } catch (err) {
+        debugLog('THREAD_CODAY', `Post-processing error for thread ${this.threadId}:`, err)
+      }
+    } else {
+      debugLog('THREAD_CODAY', `Skipping post-processing for thread ${this.threadId}: no thread or AI client`)
     }
   }
 }

--- a/apps/server/src/lib/thread-post-processor.ts
+++ b/apps/server/src/lib/thread-post-processor.ts
@@ -18,13 +18,11 @@ export class ThreadPostProcessor {
   ) {}
 
   /**
-   * Entry point. Called after ThreadCodayInstance.cleanup().
-   * Returns immediately — processing is async and non-blocking.
+   * Entry point. Called after autoSave completes.
+   * Returns a promise — caller decides whether to await or fire-and-forget.
    */
-  process(thread: AiThread, projectName: string): void {
-    this.run(thread, projectName).catch((err) =>
-      debugLog('POST_PROCESSOR', `Unhandled error for thread ${thread.id}:`, err)
-    )
+  process(thread: AiThread, projectName: string): Promise<void> {
+    return this.run(thread, projectName)
   }
 
   private async run(thread: AiThread, projectName: string): Promise<void> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -469,15 +469,26 @@ PORT_PROMISE.catch((error) => {
 })
 
 // Graceful shutdown with proper cleanup
-let isShuttingDown = false
+// Counter-based guard: 1st signal starts shutdown, 2nd is tolerated (MCP child cascading),
+// 3rd force-exits. This prevents data loss from SIGINT propagating to child processes
+// in the same process group (e.g. MCP FETCH via uvx) which cascades back as a second signal.
+let shutdownSignalCount = 0
 
 async function gracefulShutdown(signal: string) {
-  if (isShuttingDown) {
-    console.log(`Received ${signal} during shutdown, forcing exit...`)
+  shutdownSignalCount++
+
+  if (shutdownSignalCount === 2) {
+    console.log(
+      `Received ${signal} during shutdown (likely from child process cascade) — shutdown in progress, press Ctrl+C again to force exit`
+    )
+    return
+  }
+
+  if (shutdownSignalCount >= 3) {
+    console.log(`Received ${signal} — forcing exit`)
     process.exit(1)
   }
 
-  isShuttingDown = true
   console.log(`Received ${signal}, shutting down gracefully...`)
 
   try {
@@ -520,7 +531,7 @@ process.on('uncaughtException', (error) => {
     return // Don't shutdown for this specific error
   }
 
-  if (!isShuttingDown) {
+  if (shutdownSignalCount === 0) {
     gracefulShutdown('uncaughtException')
   }
 })
@@ -551,7 +562,7 @@ process.on('unhandledRejection', (reason, promise) => {
 
   // Only shutdown for critical unhandled rejections
   console.error('Critical unhandled rejection detected')
-  if (!isShuttingDown) {
+  if (shutdownSignalCount === 0) {
     gracefulShutdown('unhandledRejection')
   }
 })

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -35,6 +35,7 @@ export class Coday {
   initialPrompts: string[] = []
   aiThreadService: ThreadStateService
   private killed: boolean = false
+  private cleanedUp: boolean = false
   private isReplaying: boolean = false
   private pendingQuestionEvent: QuestionEvent | null = null
   private messageQueue: Array<{ username: string; message: string }> = []
@@ -245,18 +246,27 @@ export class Coday {
    * - Called when conversation ends normally (exit, oneshot completion)
    */
   async cleanup(): Promise<void> {
+    if (this.cleanedUp) {
+      console.log('[CODAY] cleanup: already cleaned up, skipping (double-cleanup prevented)')
+      return
+    }
+    this.cleanedUp = true
     try {
       // Save thread FIRST to prevent data loss if subsequent cleanup steps hang or fail
       // (e.g. MCP process cleanup after SIGINT propagation).
       // An in-flight tool response could still land after this save, but losing one
       // response is far less damaging than losing the entire thread.
+      console.log('[CODAY] cleanup: starting autoSave...')
       await this.aiThreadService.autoSave()
+      console.log('[CODAY] cleanup: autoSave done, killing agent...')
 
       if (this.services.agent) {
         await this.services.agent.kill()
       }
+      console.log('[CODAY] cleanup: agent killed, killing thread service...')
 
       await this.aiThreadService.kill()
+      console.log('[CODAY] cleanup: thread service killed')
 
       // Reset AI client provider for fresh connections
       this.aiClientProvider.cleanup()

--- a/libs/service/src/lib/thread-state.service.ts
+++ b/libs/service/src/lib/thread-state.service.ts
@@ -41,9 +41,14 @@ export class ThreadStateService implements Killable {
     if (thread && thread.messagesLength > 0) {
       try {
         await this.threadRepository.save(this.projectId, thread)
+        console.log(`[THREAD_STATE] Kill-save succeeded for thread ${thread.id} (${thread.messagesLength} messages)`)
       } catch (error) {
         console.log('Kill-save failed:', error instanceof Error ? error.message : error)
       }
+    } else {
+      console.log(
+        `[THREAD_STATE] Kill-save skipped: ${thread ? `thread ${thread.id} has ${thread.messagesLength} messages` : 'no active thread'}`
+      )
     }
     this.isKilled = true
     this.activeThread$.complete()
@@ -107,14 +112,17 @@ export class ThreadStateService implements Killable {
   async autoSave(newName?: string): Promise<void> {
     // Check if service has been killed
     if (this.isKilled) {
-      console.log('Autosave skipped: service has been killed')
+      console.warn(
+        `[AUTOSAVE] SKIPPED for project ${this.projectId}: service already killed (thread data may be lost if no prior save succeeded)`
+      )
       return
     }
 
     const thread = this.activeThread$.value
     if (!thread || thread.messagesLength == 0) {
-      // skip saving a thread that has no messages
-      console.warn(`Autosave of an empty or falsy thread aborted, threadId: ${thread?.id}, user: ${this.username}`)
+      console.warn(
+        `[AUTOSAVE] Skipped: ${!thread ? 'no active thread' : `thread ${thread.id} has 0 messages`} (project: ${this.projectId}, user: ${this.username})`
+      )
       return
     }
 
@@ -123,6 +131,9 @@ export class ThreadStateService implements Killable {
         thread.name = newName
       }
       await this.threadRepository.save(this.projectId, thread)
+      console.log(
+        `[AUTOSAVE] Thread ${thread.id} saved (${thread.messagesLength} messages, project: ${this.projectId})`
+      )
 
       // Emit thread update event whenever we save
       // Always include the current name to ensure frontend list stays in sync


### PR DESCRIPTION
Fixes thread data loss (full or partial) when browser tab is closed and server is shut down with CTRL+C.

**Root cause 1 — cascading SIGINT force-exit:** CTRL+C sends SIGINT to the entire process group, including MCP child processes (FETCH via uvx, GITHUB via docker). When they die, the OS delivers a second SIGINT to the Node process, which hit the `isShuttingDown` guard and called `process.exit(1)` — before `autoSave()` even started. Replaced the boolean guard with a counter: 1st signal starts graceful shutdown, 2nd is tolerated (child cascade), 3rd force-exits.

**Root cause 2 — double cleanup:** `Coday.kill()` calls `cleanup()` which saves the thread, then kills the interactor causing `run()` to unwind and call `cleanup()` a second time. The second call found `aiThreadService.isKilled === true` and skipped the save. Added a `cleanedUp` guard flag.

**Root cause 3 — post-processor race:** `ThreadPostProcessor` ran fire-and-forget *before* `coday.kill()`. Its `updateThread()` read-modify-write from disk could overwrite the full thread saved by `autoSave()` with a stale snapshot. Reordered cleanup to run post-processing *after* `kill()` (so it reads the freshly saved version), awaited with a 10s timeout.

Added diagnostic logging at critical persistence decision points.

<img width="1141" height="438" alt="image" src="https://github.com/user-attachments/assets/3d19432a-3cca-43c9-a12a-20175848799b" />
