### PR TITLE
fix: add maven-publish configuration to agentos-mcp-plugin

### DIFF
--- a/agentos/agentos-mcp-plugin/build.gradle.kts
+++ b/agentos/agentos-mcp-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("dev.nx.gradle.project-graph") version ("0.1.10")
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.kapt) // Required for PF4J annotation processing
+    `maven-publish`
 }
 
 group = "whoz-oss.agentos"
@@ -13,6 +14,55 @@ java {
         languageVersion = JavaLanguageVersion.of(libs.versions.java.get().toInt())
     }
     targetCompatibility = JavaVersion.toVersion(libs.versions.kotlinJvmTarget.get())
+    withSourcesJar()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+
+            pom {
+                name.set("AgentOS MCP Plugin")
+                description.set("AgentOS MCP plugin - connects to local MCP servers and exposes their tools")
+                url.set("https://github.com/whoz-oss/coday")
+
+                licenses {
+                    license {
+                        name.set("Apache License 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("whoz-oss")
+                        name.set("Whoz OSS")
+                        email.set("oss@whoz.com")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:git://github.com/whoz-oss/coday.git")
+                    developerConnection.set("scm:git:ssh://github.com/whoz-oss/coday.git")
+                    url.set("https://github.com/whoz-oss/coday")
+                }
+            }
+        }
+    }
+
+    repositories {
+        mavenLocal()
+
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/whoz-oss/coday")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Problem

The CI release pipeline fails on `nx publish agentos-mcp-plugin` because Gradle cannot find a `publish` task for this project:

```
Cannot locate tasks that match ':agentos-mcp-plugin:publish' as task 'publish' not found in project ':agentos-mcp-plugin'.
```

The MCP plugin had the `platform:jvm` tag in its `project.json` (which includes it in the release pipeline), but its `build.gradle.kts` was missing the `maven-publish` plugin and publishing configuration that all other publishable plugins have.

## Fix

Added the missing publish configuration to `agentos/agentos-mcp-plugin/build.gradle.kts`, following the exact same pattern as the other plugins (e.g. `agentos-bash-plugin`):

1. **`maven-publish` Gradle plugin** in the `plugins {}` block
2. **`withSourcesJar()`** in the `java {}` block
3. **`publishing {}` block** with Maven publication, POM metadata, and GitHub Packages repository

All existing content (fat JAR configuration, kapt, dependencies, etc.) is unchanged.