### PR TITLE
fix: #33235 platform-level entities visible and read-only in namespace views

### DIFF
--- a/libs/agentos-ui/src/lib/components/agent-config-item/agent-config-item.component.html
+++ b/libs/agentos-ui/src/lib/components/agent-config-item/agent-config-item.component.html
@@ -15,7 +15,7 @@
       <ds-icon-button icon="check" variant="danger" title="Confirm deletion" (action)="onDeleteConfirmed()" />
       <ds-icon-button icon="close" title="Cancel deletion" (action)="onDeleteCancelled()" />
     } @else {
-      <ds-kebab-menu [items]="menuItems" (itemSelected)="onMenuAction($event)" />
+      <ds-kebab-menu [items]="readOnly() ? readOnlyMenuItems : menuItems" (itemSelected)="onMenuAction($event)" />
     }
   </div>
 </div>

--- a/libs/agentos-ui/src/lib/components/agent-config-item/agent-config-item.component.ts
+++ b/libs/agentos-ui/src/lib/components/agent-config-item/agent-config-item.component.ts
@@ -8,6 +8,9 @@ import { IconButtonComponent, KebabMenuComponent, KebabMenuItem } from '@whoz-os
  *
  * Displays the agent config name and optional description. Edit navigates to the
  * dedicated edit route; delete uses a two-step inline confirmation before emitting upward.
+ *
+ * When readOnly is true (platform-level configs shown in namespace context), all
+ * mutation actions (edit, delete) are hidden.
  */
 @Component({
   selector: 'agentos-agent-config-item',
@@ -27,6 +30,11 @@ export class AgentConfigItemComponent {
   readonly namespaceId = input<string | undefined>(undefined)
   /** Set to true for platform-level configs (no namespace scope). */
   readonly platformMode = input(false)
+  /**
+   * When true, edit and delete actions are hidden.
+   * Used for platform-level configs displayed in a namespace context (read-only visibility).
+   */
+  readonly readOnly = input(false)
 
   readonly deleteRequested = output<AgentConfig>()
 
@@ -36,6 +44,10 @@ export class AgentConfigItemComponent {
     { key: 'edit', label: 'Edit agent config', icon: 'edit' },
     { key: 'inspect', label: 'Inspect definition', icon: 'search' },
     { key: 'delete', label: 'Delete agent config', icon: 'delete', variant: 'danger' },
+  ]
+
+  protected readonly readOnlyMenuItems: KebabMenuItem[] = [
+    { key: 'inspect', label: 'Inspect definition', icon: 'search' },
   ]
 
   protected onMenuAction(key: string): void {

--- a/libs/agentos-ui/src/lib/components/ai-model-item/ai-model-item.component.html
+++ b/libs/agentos-ui/src/lib/components/ai-model-item/ai-model-item.component.html
@@ -12,7 +12,7 @@
       <span class="ai-model-item__confirm-label">Delete?</span>
       <ds-icon-button icon="check" variant="danger" title="Confirm deletion" (action)="onDeleteConfirmed()" />
       <ds-icon-button icon="close" title="Cancel deletion" (action)="onDeleteCancelled()" />
-    } @else {
+    } @else if (!readOnly()) {
       <ds-kebab-menu [items]="menuItems" (itemSelected)="onMenuAction($event)" />
     }
   </div>

--- a/libs/agentos-ui/src/lib/components/ai-model-item/ai-model-item.component.ts
+++ b/libs/agentos-ui/src/lib/components/ai-model-item/ai-model-item.component.ts
@@ -20,6 +20,11 @@ import { IconButtonComponent, KebabMenuComponent, KebabMenuItem } from '@whoz-os
 export class AiModelItemComponent {
   readonly model = input.required<AiModel>()
   readonly namespaceId = input<string | undefined>(undefined)
+  /**
+   * When true, edit and delete actions are hidden.
+   * Used for platform-level models displayed in a namespace context (read-only visibility).
+   */
+  readonly readOnly = input(false)
 
   readonly deleteRequested = output<AiModel>()
   readonly editRequested = output<AiModel>()
@@ -30,6 +35,8 @@ export class AiModelItemComponent {
     { key: 'edit', label: 'Edit model', icon: 'edit' },
     { key: 'delete', label: 'Delete model', icon: 'delete', variant: 'danger' },
   ]
+
+  protected readonly readOnlyMenuItems: KebabMenuItem[] = []
 
   protected get displayTitle(): string {
     return this.model().alias ?? this.model().apiModelName

--- a/libs/agentos-ui/src/lib/components/ai-model-item/ai-model-item.component.ts
+++ b/libs/agentos-ui/src/lib/components/ai-model-item/ai-model-item.component.ts
@@ -36,8 +36,6 @@ export class AiModelItemComponent {
     { key: 'delete', label: 'Delete model', icon: 'delete', variant: 'danger' },
   ]
 
-  protected readonly readOnlyMenuItems: KebabMenuItem[] = []
-
   protected get displayTitle(): string {
     return this.model().alias ?? this.model().apiModelName
   }

--- a/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/ai-provider-form/ai-provider-form.component.ts
@@ -6,9 +6,11 @@ import { AiProvider, AiProviderApiTypeEnum } from '@whoz-oss/agentos-api-client'
 import { AiProviderConfigStateService, AiProviderScope } from '../../services/ai-provider-config-state.service'
 import { NamespaceRoleStateService } from '../../services/namespace-role-state.service'
 
+/** Scopes available for creation/editing — platform is read-only, never selectable in a form. */
 const VALID_SCOPES: ReadonlySet<AiProviderScope> = new Set(['namespace', 'userOnNs', 'userGlobal'])
 
 const SCOPE_LABEL: Readonly<Record<AiProviderScope, string>> = Object.freeze({
+  platform: 'Configuration de niveau plateforme',
   namespace: 'Configuration du namespace',
   userOnNs: 'Pour moi sur ce namespace',
   userGlobal: 'Pour moi globalement',

--- a/libs/agentos-ui/src/lib/components/ai-provider-item/ai-provider-item.component.ts
+++ b/libs/agentos-ui/src/lib/components/ai-provider-item/ai-provider-item.component.ts
@@ -17,6 +17,7 @@ interface ScopeBadge {
  * Same convention as story 6.5 IntegrationConfigItemComponent.
  */
 const SCOPE_BADGES: Readonly<Record<AiProviderScope, ScopeBadge>> = Object.freeze({
+  platform: { label: 'PLATFORM', ariaLabel: 'Configuration de niveau plateforme (lecture seule)', variant: 'neutral' },
   namespace: { label: 'NS', ariaLabel: 'Configuration partagée du namespace', variant: 'neutral' },
   userOnNs: { label: 'USER × NS', ariaLabel: 'Configuration utilisateur sur ce namespace', variant: 'info' },
   userGlobal: { label: 'USER GLOBAL', ariaLabel: 'Configuration utilisateur globale', variant: 'warning' },
@@ -35,7 +36,8 @@ const SCOPE_BADGES: Readonly<Record<AiProviderScope, ScopeBadge>> = Object.freez
  * any destination via the radio in the form. The apiKey is intentionally NOT carried into
  * the duplicate (NFR-SEC-1: credentials never migrate across resources).
  *
- * Read-only mode hides edit/delete (used for users without write permission on the NS).
+ * Read-only mode hides edit/delete (used for users without write permission on the NS,
+ * and for platform-level providers shown in a namespace context).
  *
  * The `apiKey` is never displayed on this row — credentials are only visible in the form
  * (and even there, masked unless the user types a new value). NFR-SEC-1.

--- a/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.html
+++ b/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.html
@@ -19,7 +19,7 @@
     <agentos-ai-provider-item
       [config]="resolved.config"
       [scope]="resolved.scope"
-      [readOnly]="resolved.scope === 'namespace' && !isAdmin()"
+      [readOnly]="resolved.scope === 'platform' || (resolved.scope === 'namespace' && !isAdmin())"
       (editRequested)="onEdit(resolved)"
       (deleteRequested)="onDelete(resolved)"
       (duplicateRequested)="onDuplicate(resolved)"

--- a/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.ts
+++ b/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.ts
@@ -15,6 +15,7 @@ import { defaultCreateScope } from '../_shared/default-create-scope'
 import { AiProviderItemComponent } from '../ai-provider-item/ai-provider-item.component'
 
 const SECTION_LABEL: Readonly<Record<AiProviderScope, string>> = Object.freeze({
+  platform: 'Platform (read-only)',
   namespace: 'AI Providers du namespace',
   userOnNs: 'Mes overrides sur ce namespace',
   userGlobal: 'Mes overrides globaux',
@@ -88,6 +89,9 @@ export class AiProvidersAllScopesComponent implements OnInit {
 
     this.state.vm$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((vm) => {
       const next = new Map<string, ResolvedItem>()
+      vm.platform.forEach((c) => {
+        if (c.id) next.set(this.itemKey('platform', c.id), { config: c, scope: 'platform' })
+      })
       vm.namespace.forEach((c) => {
         if (c.id) next.set(this.itemKey('namespace', c.id), { config: c, scope: 'namespace' })
       })
@@ -159,6 +163,7 @@ export class AiProvidersAllScopesComponent implements OnInit {
 
   private toListItems(vm: AiProviderConfigViewModel): EntityListItem[] {
     const items: EntityListItem[] = []
+    items.push(...this.sectionItems('platform', vm.platform))
     items.push(...this.sectionItems('namespace', vm.namespace))
     items.push(...this.sectionItems('userOnNs', vm.userOnNs))
     items.push(...this.sectionItems('userGlobal', vm.userGlobal))

--- a/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.html
@@ -15,6 +15,11 @@
 <!-- Item template: renders AgentConfigItemComponent for each entity-list card slot -->
 <ng-template #agentConfigItemTpl let-item>
   @if (resolveConfig(item.id); as config) {
-    <agentos-agent-config-item [config]="config" [namespaceId]="namespaceId" (deleteRequested)="deleteConfig($event)" />
+    <agentos-agent-config-item
+      [config]="config"
+      [namespaceId]="namespaceId"
+      [readOnly]="isPlatformConfig(item.id)"
+      (deleteRequested)="deleteConfig($event)"
+    />
   }
 </ng-template>

--- a/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
@@ -4,14 +4,19 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import { AgentConfig, AgentConfigControllerService } from '@whoz-oss/agentos-api-client'
 import { EntityListComponent, EntityListItem } from '@whoz-oss/design-system'
-import { BehaviorSubject, map, switchMap } from 'rxjs'
+import { BehaviorSubject, forkJoin, map, switchMap } from 'rxjs'
 import { AgentConfigItemComponent } from '../agent-config-item/agent-config-item.component'
+
+const GROUP_NAMESPACE = 'namespace'
+const GROUP_PLATFORM = 'platform'
 
 /**
  * NamespaceAgentConfigsComponent — list view for agent configs of a namespace.
  *
  * Loaded at /:namespaceId/agent-configs. Responsibilities:
- * - Load and display the list of AgentConfig via ds-entity-list
+ * - Load and display namespace-level AND platform-level agent configs
+ * - Merge both levels into a grouped ds-entity-list (namespace / platform)
+ * - Platform-level configs are displayed read-only (no edit/delete actions)
  * - Navigate back to the namespace list
  * - Navigate to the create form (/:namespaceId/agent-configs/new)
  * - Deletion with inline confirmation (delegated to AgentConfigItemComponent)
@@ -35,30 +40,52 @@ export class NamespaceAgentConfigsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
-  /** Raw configs, kept for delete lookups. */
-  private readonly configs$ = this.refresh$.pipe(
-    switchMap(() => this.agentConfigController.listByNamespaceAgentConfig(this.namespaceId))
+  /**
+   * Fetches both namespace-level and platform-level configs in parallel.
+   * Platform configs are appended with a groupKey so ds-entity-list renders them
+   * in a separate collapsed-by-default group.
+   */
+  private readonly allConfigs$ = this.refresh$.pipe(
+    switchMap(() =>
+      forkJoin({
+        namespace: this.agentConfigController.listByNamespaceAgentConfig(this.namespaceId),
+        platform: this.agentConfigController.listPlatformAgentsAgentConfig(),
+      })
+    )
   )
 
-  /** Mapped to EntityListItem[] for ds-entity-list. */
-  protected readonly configItems$ = this.configs$.pipe(
-    map((configs) =>
-      configs.map(
+  /** Mapped to EntityListItem[] for ds-entity-list, grouped by level. */
+  protected readonly configItems$ = this.allConfigs$.pipe(
+    map(({ namespace, platform }) => [
+      ...platform.map(
         (c: AgentConfig): EntityListItem => ({
           id: c.id ?? '',
           name: c.name,
           description: c.description,
+          groupKey: GROUP_PLATFORM,
+          groupLabel: 'Platform (read-only)',
         })
-      )
-    )
+      ),
+      ...namespace.map(
+        (c: AgentConfig): EntityListItem => ({
+          id: c.id ?? '',
+          name: c.name,
+          description: c.description,
+          groupKey: GROUP_NAMESPACE,
+          groupLabel: 'Namespace',
+        })
+      ),
+    ])
   )
 
   /** Full config objects indexed by id — used to resolve itemTemplate events. */
-  private configsById = new Map<string, AgentConfig>()
+  private namespaceConfigsById = new Map<string, AgentConfig>()
+  private platformConfigsById = new Map<string, AgentConfig>()
 
   constructor() {
-    this.configs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((configs: AgentConfig[]) => {
-      this.configsById = new Map(configs.map((c: AgentConfig) => [c.id ?? '', c]))
+    this.allConfigs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ namespace, platform }) => {
+      this.namespaceConfigsById = new Map(namespace.map((c: AgentConfig) => [c.id ?? '', c]))
+      this.platformConfigsById = new Map(platform.map((c: AgentConfig) => [c.id ?? '', c]))
     })
   }
 
@@ -78,6 +105,10 @@ export class NamespaceAgentConfigsComponent {
   }
 
   protected resolveConfig(id: string): AgentConfig | null {
-    return this.configsById.get(id) ?? null
+    return this.namespaceConfigsById.get(id) ?? this.platformConfigsById.get(id) ?? null
+  }
+
+  protected isPlatformConfig(id: string): boolean {
+    return this.platformConfigsById.has(id)
   }
 }

--- a/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import { AgentConfig, AgentConfigControllerService } from '@whoz-oss/agentos-api-client'
 import { EntityListComponent, EntityListItem } from '@whoz-oss/design-system'
-import { BehaviorSubject, forkJoin, map, switchMap } from 'rxjs'
+import { BehaviorSubject, catchError, forkJoin, map, of, switchMap } from 'rxjs'
 import { AgentConfigItemComponent } from '../agent-config-item/agent-config-item.component'
 
 const GROUP_NAMESPACE = 'namespace'
@@ -49,7 +49,9 @@ export class NamespaceAgentConfigsComponent {
     switchMap(() =>
       forkJoin({
         namespace: this.agentConfigController.listByNamespaceAgentConfig(this.namespaceId),
-        platform: this.agentConfigController.listPlatformAgentsAgentConfig(),
+        platform: this.agentConfigController
+          .listPlatformAgentsAgentConfig()
+          .pipe(catchError(() => of([] as AgentConfig[]))),
       })
     )
   )

--- a/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.html
@@ -13,6 +13,11 @@
 <!-- Item template: renders AiModelItemComponent for each entity-list card slot -->
 <ng-template #aiModelItemTpl let-item>
   @if (resolveModel(item.id); as model) {
-    <agentos-ai-model-item [model]="model" [namespaceId]="namespaceId" (deleteRequested)="deleteModel($event)" />
+    <agentos-ai-model-item
+      [model]="model"
+      [namespaceId]="namespaceId"
+      [readOnly]="isPlatformModel(item.id)"
+      (deleteRequested)="deleteModel($event)"
+    />
   }
 </ng-template>

--- a/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.html
@@ -18,6 +18,7 @@
       [namespaceId]="namespaceId"
       [readOnly]="isPlatformModel(item.id)"
       (deleteRequested)="deleteModel($event)"
+      (editRequested)="editModel($event)"
     />
   }
 </ng-template>

--- a/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
@@ -110,6 +110,10 @@ export class NamespaceAiModelsComponent {
     this.router.navigate(['/agentos', this.namespaceId, 'ai-models', 'new'])
   }
 
+  protected editModel(model: AiModel): void {
+    this.router.navigate(['/agentos', this.namespaceId, 'ai-models', model.id, 'edit'])
+  }
+
   protected deleteModel(model: AiModel): void {
     this.aiModelController
       .deleteAiModel(model.id ?? '')

--- a/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
@@ -9,7 +9,7 @@ import {
   AiModelControllerService,
 } from '@whoz-oss/agentos-api-client'
 import { EntityListComponent, EntityListItem, IconButtonComponent } from '@whoz-oss/design-system'
-import { BehaviorSubject, forkJoin, Observable, switchMap, map } from 'rxjs'
+import { BehaviorSubject, catchError, forkJoin, Observable, of, switchMap, map } from 'rxjs'
 import { AiModelItemComponent } from '../ai-model-item/ai-model-item.component'
 
 const PLATFORM_GROUP_KEY = '__platform__'
@@ -57,7 +57,7 @@ export class NamespaceAiModelsComponent {
       switchMap(() =>
         forkJoin({
           namespace: this.aiModelController.listByNamespaceIdAiModel(this.namespaceId),
-          platform: this.aiModelController.listPlatformLevelAiModel(),
+          platform: this.aiModelController.listPlatformLevelAiModel().pipe(catchError(() => of([] as AiModel[]))),
           providers: this.aiProviderController.listAiProvider(this.namespaceId),
         })
       )

--- a/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
@@ -9,16 +9,20 @@ import {
   AiModelControllerService,
 } from '@whoz-oss/agentos-api-client'
 import { EntityListComponent, EntityListItem, IconButtonComponent } from '@whoz-oss/design-system'
-import { BehaviorSubject, combineLatest, Observable, switchMap, map } from 'rxjs'
+import { BehaviorSubject, forkJoin, Observable, switchMap, map } from 'rxjs'
 import { AiModelItemComponent } from '../ai-model-item/ai-model-item.component'
+
+const PLATFORM_GROUP_KEY = '__platform__'
+const PLATFORM_GROUP_LABEL = 'Platform (read-only)'
 
 /**
  * NamespaceLlmModelsComponent — list view for AI models of a namespace.
  *
  * Loaded at /:namespaceId/ai-models. Responsibilities:
- * - Load all AiModel for the namespace in a single call
- * - Load AiProvider providers in parallel to resolve group labels
- * - Display models grouped by provider name via ds-entity-list grouping
+ * - Load namespace-level AND platform-level AI models in parallel
+ * - Load AiProvider providers to resolve group labels for namespace models
+ * - Display namespace models grouped by provider name, platform models in a dedicated group
+ * - Platform-level models are displayed read-only (no edit/delete actions)
  * - Navigate back to the namespace list
  * - Navigate to the create form (/:namespaceId/ai-models/new)
  * - Deletion with inline confirmation (delegated to AiModelItemComponent)
@@ -45,40 +49,56 @@ export class NamespaceAiModelsComponent {
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
   /**
-   * Raw models, kept for delete lookups.
-   * Loaded in parallel with providers to resolve group labels without sequential calls.
+   * Fetches namespace models, platform models, and providers in parallel.
+   * Providers are needed to resolve group labels for namespace-level models.
    */
-  private readonly data$: Observable<[AiModel[], AiProvider[]]> = this.refresh$.pipe(
-    switchMap(() =>
-      combineLatest([
-        this.aiModelController.listByNamespaceIdAiModel(this.namespaceId),
-        this.aiProviderController.listAiProvider(this.namespaceId),
-      ])
-    )
-  )
-
-  /** Mapped to EntityListItem[] with groupKey/groupLabel for ds-entity-list grouping. */
-  protected readonly modelItems$ = this.data$.pipe(
-    map(([models, providers]) => {
-      const providerNames = new Map(providers.map((p: AiProvider) => [p.id ?? '', p.name]))
-      return models.map(
-        (m: AiModel): EntityListItem => ({
-          id: m.id ?? '',
-          name: m.alias ?? m.apiModelName,
-          description: m.apiModelName,
-          groupKey: m.aiProviderId,
-          groupLabel: providerNames.get(m.aiProviderId) ?? m.aiProviderId,
+  private readonly data$: Observable<{ namespace: AiModel[]; platform: AiModel[]; providers: AiProvider[] }> =
+    this.refresh$.pipe(
+      switchMap(() =>
+        forkJoin({
+          namespace: this.aiModelController.listByNamespaceIdAiModel(this.namespaceId),
+          platform: this.aiModelController.listPlatformLevelAiModel(),
+          providers: this.aiProviderController.listAiProvider(this.namespaceId),
         })
       )
+    )
+
+  /** Mapped to EntityListItem[] with groupKey/groupLabel for ds-entity-list grouping.
+   * Platform models appear first in their own group; namespace models follow, grouped by provider. */
+  protected readonly modelItems$ = this.data$.pipe(
+    map(({ namespace, platform, providers }) => {
+      const providerNames = new Map(providers.map((p: AiProvider) => [p.id ?? '', p.name]))
+      return [
+        ...platform.map(
+          (m: AiModel): EntityListItem => ({
+            id: m.id ?? '',
+            name: m.alias ?? m.apiModelName,
+            description: m.apiModelName,
+            groupKey: PLATFORM_GROUP_KEY,
+            groupLabel: PLATFORM_GROUP_LABEL,
+          })
+        ),
+        ...namespace.map(
+          (m: AiModel): EntityListItem => ({
+            id: m.id ?? '',
+            name: m.alias ?? m.apiModelName,
+            description: m.apiModelName,
+            groupKey: m.aiProviderId,
+            groupLabel: providerNames.get(m.aiProviderId) ?? m.aiProviderId,
+          })
+        ),
+      ]
     })
   )
 
   /** Full model objects indexed by id — used to resolve itemTemplate events. */
-  private modelsById = new Map<string, AiModel>()
+  private namespaceModelsById = new Map<string, AiModel>()
+  private platformModelsById = new Map<string, AiModel>()
 
   constructor() {
-    this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(([models]) => {
-      this.modelsById = new Map(models.map((m: AiModel) => [m.id ?? '', m]))
+    this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ namespace, platform }) => {
+      this.namespaceModelsById = new Map(namespace.map((m: AiModel) => [m.id ?? '', m]))
+      this.platformModelsById = new Map(platform.map((m: AiModel) => [m.id ?? '', m]))
     })
   }
 
@@ -98,6 +118,10 @@ export class NamespaceAiModelsComponent {
   }
 
   protected resolveModel(id: string): AiModel | null {
-    return this.modelsById.get(id) ?? null
+    return this.namespaceModelsById.get(id) ?? this.platformModelsById.get(id) ?? null
+  }
+
+  protected isPlatformModel(id: string): boolean {
+    return this.platformModelsById.has(id)
   }
 }

--- a/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.html
@@ -13,6 +13,11 @@
 <!-- Item template: renders PromptItemComponent for each entity-list card slot -->
 <ng-template #promptItemTpl let-item>
   @if (resolvePrompt(item.id); as prompt) {
-    <agentos-prompt-item [prompt]="prompt" [namespaceId]="namespaceId" (deleteRequested)="deletePrompt($event)" />
+    <agentos-prompt-item
+      [prompt]="prompt"
+      [namespaceId]="namespaceId"
+      [readOnly]="isPlatformPrompt(item.id)"
+      (deleteRequested)="deletePrompt($event)"
+    />
   }
 </ng-template>

--- a/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import { Prompt } from '@whoz-oss/agentos-api-client'
 import { EntityListComponent, EntityListItem } from '@whoz-oss/design-system'
-import { BehaviorSubject, forkJoin, map, switchMap } from 'rxjs'
+import { BehaviorSubject, catchError, forkJoin, map, of, switchMap } from 'rxjs'
 import { PromptStateService } from '../../services/prompt-state.service'
 import { PromptItemComponent } from '../prompt-item/prompt-item.component'
 
@@ -45,7 +45,7 @@ export class NamespacePromptsComponent {
   private readonly allPrompts$ = this.refresh$.pipe(
     switchMap(() =>
       forkJoin({
-        platform: this.promptState.listPlatform(),
+        platform: this.promptState.listPlatform().pipe(catchError(() => of([] as Prompt[]))),
         namespace: this.promptState.listByNamespace(this.namespaceId),
       })
     )

--- a/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.ts
@@ -4,15 +4,20 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import { Prompt } from '@whoz-oss/agentos-api-client'
 import { EntityListComponent, EntityListItem } from '@whoz-oss/design-system'
-import { BehaviorSubject, map, switchMap } from 'rxjs'
+import { BehaviorSubject, forkJoin, map, switchMap } from 'rxjs'
 import { PromptStateService } from '../../services/prompt-state.service'
 import { PromptItemComponent } from '../prompt-item/prompt-item.component'
+
+const GROUP_PLATFORM = 'platform'
+const GROUP_NAMESPACE = 'namespace'
 
 /**
  * NamespacePromptsComponent — list view for prompts of a namespace.
  *
  * Loaded at /:namespaceId/prompts. Responsibilities:
- * - Load and display the list of Prompt via ds-entity-list
+ * - Load and display namespace-level AND platform-level prompts
+ * - Merge both levels into a grouped ds-entity-list (platform first, then namespace)
+ * - Platform-level prompts are displayed read-only (no edit/delete actions)
  * - Navigate back to the namespace list
  * - Navigate to the create form (/:namespaceId/prompts/new)
  * - Deletion with inline two-step confirmation (delegated to PromptItemComponent)
@@ -36,28 +41,48 @@ export class NamespacePromptsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
-  /** Raw prompts, kept for delete lookups. */
-  private readonly prompts$ = this.refresh$.pipe(switchMap(() => this.promptState.listByNamespace(this.namespaceId)))
+  /** Fetches both namespace-level and platform-level prompts in parallel. */
+  private readonly allPrompts$ = this.refresh$.pipe(
+    switchMap(() =>
+      forkJoin({
+        platform: this.promptState.listPlatform(),
+        namespace: this.promptState.listByNamespace(this.namespaceId),
+      })
+    )
+  )
 
-  /** Mapped to EntityListItem[] for ds-entity-list. */
-  protected readonly promptItems$ = this.prompts$.pipe(
-    map((prompts) =>
-      prompts.map(
+  /** Mapped to EntityListItem[] for ds-entity-list, platform group first. */
+  protected readonly promptItems$ = this.allPrompts$.pipe(
+    map(({ platform, namespace }) => [
+      ...platform.map(
         (p: Prompt): EntityListItem => ({
           id: p.id ?? '',
           name: p.name,
           description: p.description,
+          groupKey: GROUP_PLATFORM,
+          groupLabel: 'Platform (read-only)',
         })
-      )
-    )
+      ),
+      ...namespace.map(
+        (p: Prompt): EntityListItem => ({
+          id: p.id ?? '',
+          name: p.name,
+          description: p.description,
+          groupKey: GROUP_NAMESPACE,
+          groupLabel: 'Namespace',
+        })
+      ),
+    ])
   )
 
   /** Full prompt objects indexed by id — used to resolve itemTemplate events. */
-  private promptsById = new Map<string, Prompt>()
+  private namespacePromptsById = new Map<string, Prompt>()
+  private platformPromptsById = new Map<string, Prompt>()
 
   constructor() {
-    this.prompts$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((prompts: Prompt[]) => {
-      this.promptsById = new Map(prompts.map((p: Prompt) => [p.id ?? '', p]))
+    this.allPrompts$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ platform, namespace }) => {
+      this.platformPromptsById = new Map(platform.map((p: Prompt) => [p.id ?? '', p]))
+      this.namespacePromptsById = new Map(namespace.map((p: Prompt) => [p.id ?? '', p]))
     })
   }
 
@@ -77,6 +102,10 @@ export class NamespacePromptsComponent {
   }
 
   protected resolvePrompt(id: string): Prompt | null {
-    return this.promptsById.get(id) ?? null
+    return this.platformPromptsById.get(id) ?? this.namespacePromptsById.get(id) ?? null
+  }
+
+  protected isPlatformPrompt(id: string): boolean {
+    return this.platformPromptsById.has(id)
   }
 }

--- a/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.html
+++ b/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.html
@@ -12,7 +12,9 @@
       <ds-icon-button icon="check" variant="danger" title="Confirm deletion" (action)="onDeleteConfirmed()" />
       <ds-icon-button icon="close" title="Cancel deletion" (action)="onDeleteCancelled()" />
     } @else {
-      <ds-kebab-menu [items]="menuItems" (itemSelected)="onMenuAction($event)" />
+      @if (!readOnly) {
+        <ds-kebab-menu [items]="menuItems" (itemSelected)="onMenuAction($event)" />
+      }
     }
   </div>
 </div>

--- a/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.html
+++ b/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.html
@@ -1,8 +1,8 @@
 <div class="prompt-item" role="listitem" [class.prompt-item--pending-delete]="pendingDelete()">
   <div class="prompt-item__body">
-    <span class="prompt-item__name">{{ prompt.name }}</span>
-    @if (prompt.description) {
-      <span class="prompt-item__description">{{ prompt.description }}</span>
+    <span class="prompt-item__name">{{ prompt().name }}</span>
+    @if (prompt().description) {
+      <span class="prompt-item__description">{{ prompt().description }}</span>
     }
   </div>
 
@@ -11,10 +11,8 @@
       <span class="prompt-item__confirm-label">Delete?</span>
       <ds-icon-button icon="check" variant="danger" title="Confirm deletion" (action)="onDeleteConfirmed()" />
       <ds-icon-button icon="close" title="Cancel deletion" (action)="onDeleteCancelled()" />
-    } @else {
-      @if (!readOnly) {
-        <ds-kebab-menu [items]="menuItems" (itemSelected)="onMenuAction($event)" />
-      }
+    } @else if (!readOnly()) {
+      <ds-kebab-menu [items]="menuItems" (itemSelected)="onMenuAction($event)" />
     }
   </div>
 </div>

--- a/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.ts
+++ b/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject, signal } from '@angular/core'
+import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core'
 import { Router } from '@angular/router'
 import { Prompt } from '@whoz-oss/agentos-api-client'
 import { IconButtonComponent, KebabMenuComponent, KebabMenuItem } from '@whoz-oss/design-system'
@@ -9,6 +9,9 @@ import { IconButtonComponent, KebabMenuComponent, KebabMenuItem } from '@whoz-os
  * Displays the prompt name and optional description. Edit navigates to the
  * dedicated edit route; delete uses a two-step inline confirmation before
  * emitting upward to the parent list component.
+ *
+ * When readOnly is true (platform-level prompts shown in namespace context),
+ * all mutation actions (edit, delete) are hidden.
  */
 @Component({
   selector: 'agentos-prompt-item',
@@ -20,17 +23,17 @@ import { IconButtonComponent, KebabMenuComponent, KebabMenuItem } from '@whoz-os
 export class PromptItemComponent {
   private readonly router = inject(Router)
 
-  @Input({ required: true }) prompt!: Prompt
-  @Input() namespaceId?: string
+  readonly prompt = input.required<Prompt>()
+  readonly namespaceId = input<string | undefined>(undefined)
   /** When true, edit navigates to the admin platform route instead of the namespace route. */
-  @Input() platformMode = false
+  readonly platformMode = input(false)
   /**
    * When true, edit and delete actions are hidden.
    * Used for platform-level prompts displayed in a namespace context (read-only visibility).
    */
-  @Input() readOnly = false
+  readonly readOnly = input(false)
 
-  @Output() deleteRequested = new EventEmitter<Prompt>()
+  readonly deleteRequested = output<Prompt>()
 
   protected readonly pendingDelete = signal(false)
 
@@ -42,10 +45,10 @@ export class PromptItemComponent {
   protected onMenuAction(key: string): void {
     switch (key) {
       case 'edit':
-        if (this.platformMode) {
-          this.router.navigate(['/agentos', 'admin', 'prompts', this.prompt.id, 'edit'])
+        if (this.platformMode()) {
+          this.router.navigate(['/agentos', 'admin', 'prompts', this.prompt().id, 'edit'])
         } else {
-          this.router.navigate(['/agentos', this.namespaceId, 'prompts', this.prompt.id, 'edit'])
+          this.router.navigate(['/agentos', this.namespaceId(), 'prompts', this.prompt().id, 'edit'])
         }
         break
       case 'delete':
@@ -56,7 +59,7 @@ export class PromptItemComponent {
 
   protected onDeleteConfirmed(): void {
     this.pendingDelete.set(false)
-    this.deleteRequested.emit(this.prompt)
+    this.deleteRequested.emit(this.prompt())
   }
 
   protected onDeleteCancelled(): void {

--- a/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.ts
+++ b/libs/agentos-ui/src/lib/components/prompt-item/prompt-item.component.ts
@@ -24,6 +24,11 @@ export class PromptItemComponent {
   @Input() namespaceId?: string
   /** When true, edit navigates to the admin platform route instead of the namespace route. */
   @Input() platformMode = false
+  /**
+   * When true, edit and delete actions are hidden.
+   * Used for platform-level prompts displayed in a namespace context (read-only visibility).
+   */
+  @Input() readOnly = false
 
   @Output() deleteRequested = new EventEmitter<Prompt>()
 

--- a/libs/agentos-ui/src/lib/services/ai-provider-config-state.service.ts
+++ b/libs/agentos-ui/src/lib/services/ai-provider-config-state.service.ts
@@ -6,13 +6,15 @@ import { UserStateService } from './user-state.service'
 
 /**
  * Scope of an AI provider row in the unified 3-section view.
+ * - `platform`  : provider defined at platform level (read-only for namespace admins)
  * - `namespace` : provider shared at the namespace level
  * - `userOnNs`  : the caller's personal override scoped to the current namespace
  * - `userGlobal`: the caller's personal override that applies cross-namespace
  */
-export type AiProviderScope = 'namespace' | 'userOnNs' | 'userGlobal'
+export type AiProviderScope = 'platform' | 'namespace' | 'userOnNs' | 'userGlobal'
 
 export interface AiProviderConfigViewModel {
+  platform: AiProvider[]
   namespace: AiProvider[]
   userOnNs: AiProvider[]
   userGlobal: AiProvider[]
@@ -83,17 +85,27 @@ export class AiProviderConfigStateService {
    */
   readonly vm$: Observable<AiProviderConfigViewModel> = combineLatest([this.namespaceId$, this.refresh$]).pipe(
     switchMap(([namespaceId]) => {
+      const platform$ = this.loadPlatformProviders().pipe(catchError(() => of([] as AiProvider[])))
       if (!namespaceId) {
         return combineLatest([
+          platform$,
           this.loadNamespaceProviders('').pipe(catchError(() => of([] as AiProvider[]))),
           this.loadUserProviders('global').pipe(catchError(() => of([] as AiProvider[]))),
-        ]).pipe(map(([namespace, userGlobal]) => ({ namespace, userOnNs: [] as AiProvider[], userGlobal })))
+        ]).pipe(
+          map(([platform, namespace, userGlobal]) => ({
+            platform,
+            namespace,
+            userOnNs: [] as AiProvider[],
+            userGlobal,
+          }))
+        )
       }
       return combineLatest([
+        platform$,
         this.loadNamespaceProviders(namespaceId).pipe(catchError(() => of([] as AiProvider[]))),
         this.loadUserProviders(namespaceId).pipe(catchError(() => of([] as AiProvider[]))),
         this.loadUserProviders('global').pipe(catchError(() => of([] as AiProvider[]))),
-      ]).pipe(map(([namespace, userOnNs, userGlobal]) => ({ namespace, userOnNs, userGlobal })))
+      ]).pipe(map(([platform, namespace, userOnNs, userGlobal]) => ({ platform, namespace, userOnNs, userGlobal })))
     }),
     shareReplay({ bufferSize: 1, refCount: true })
   )
@@ -124,6 +136,11 @@ export class AiProviderConfigStateService {
     () => this.loadUserProviders('global'),
     [] as AiProvider[]
   )
+
+  /** Platform-level providers: namespaceId IS NULL, no userId. */
+  loadPlatformProviders(): Observable<AiProvider[]> {
+    return this.nsController.listAiProvider(NAMESPACE_NONE_SENTINEL)
+  }
 
   loadNamespaceProviders(namespaceId: string): Observable<AiProvider[]> {
     if (!namespaceId) return of([])

--- a/libs/agentos-ui/src/lib/services/prompt-state.service.ts
+++ b/libs/agentos-ui/src/lib/services/prompt-state.service.ts
@@ -24,6 +24,10 @@ export class PromptStateService {
     return this.promptController.listByNamespacePrompt(namespaceId)
   }
 
+  listPlatform(): Observable<Prompt[]> {
+    return this.promptController.listPlatformPrompt()
+  }
+
   create(payload: Prompt): Observable<Prompt> {
     return this.promptController.createPrompt(payload)
   }


### PR DESCRIPTION
## WZ-33235 — Platform-level config visibility in namespace views

### Problem

Platform-level entities (agent configs, AI models, AI providers) were invisible to namespace admins. Only namespace-scoped entities were shown in the listing views.

### Solution

Fetch both namespace-level and platform-level entities in parallel and merge them into grouped `ds-entity-list` views. Platform entries appear first in a dedicated "Platform (read-only)" group with all mutation actions hidden.

### Changes

#### `namespace-agent-configs`
- Parallel fetch via `forkJoin`: namespace configs + platform configs (`listPlatformAgentsAgentConfig`)
- Two separate Maps to track origin; `isPlatformConfig(id)` drives `[readOnly]` on the item

#### `agent-config-item`
- New `readOnly` input: when true, only the "Inspect" action is available (edit/delete hidden)

#### `namespace-ai-models`
- Parallel fetch via `forkJoin`: namespace models + platform models (`listPlatformLevelAiModel`) + providers
- Platform models grouped first; `isPlatformModel(id)` drives `[readOnly]` on the item

#### `ai-model-item`
- New `readOnly` input: when true, the kebab menu is hidden entirely

#### `ai-providers-all-scopes` + `AiProviderConfigStateService`
- `AiProviderScope` extended with `'platform'`
- `AiProviderConfigViewModel` gains a `platform` field
- `vm$` adds a 4th parallel call (`listAiProvider('none')`) for platform providers
- Platform section rendered first; `readOnly` applies on `scope === 'platform'`

#### `ai-provider-item`
- `SCOPE_BADGES` completed with `platform` entry

#### `ai-provider-form`
- `SCOPE_LABEL` completed with `platform` (exhaustive `Record<AiProviderScope, string>`)
- `VALID_SCOPES` does **not** include `platform` — it is never selectable in a form


#### `prompt`
same: show platform entities as read-only on the namespace dedicated page.