### PR TITLE
fix: build angular post-merge

### DIFF
--- a/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
@@ -48,7 +48,7 @@ export class NamespaceAgentConfigsComponent {
   private readonly allConfigs$ = this.refresh$.pipe(
     switchMap(() =>
       forkJoin({
-        namespace: this.agentConfigController.listByNamespaceAgentConfig(this.namespaceId),
+        namespace: this.agentConfigController.listByParentAgentConfig(this.namespaceId),
         platform: this.agentConfigController
           .listPlatformAgentsAgentConfig()
           .pipe(catchError(() => of([] as AgentConfig[]))),

--- a/libs/agentos-ui/src/lib/services/prompt-state.service.ts
+++ b/libs/agentos-ui/src/lib/services/prompt-state.service.ts
@@ -28,10 +28,6 @@ export class PromptStateService {
     return this.promptController.listPrompt('NAMESPACE', namespaceId)
   }
 
-  listPlatform(): Observable<Prompt[]> {
-    return this.promptController.listPlatformPrompt()
-  }
-
   create(payload: Prompt): Observable<Prompt> {
     return this.promptController.createPrompt(payload)
   }
@@ -49,6 +45,6 @@ export class PromptStateService {
    * Used for slash-command autocomplete in the chat composer.
    */
   listEffective(namespaceId: string): Observable<Prompt[]> {
-    return this.promptController.effectivePrompt(namespaceId)
+    return this.promptController.findEffectiveByNamespaceIdPrompt(namespaceId)
   }
 }


### PR DESCRIPTION
## What

Fixes two Angular compilation errors introduced by a merge conflict.

### `prompt-state.service.ts` — duplicate method after merge conflict

- Duplicate `listPlatform()` implementation removed
- `listPlatformPrompt()` (non-existent) → deleted (first impl using `listPrompt('PLATFORM')` is correct)
- `effectivePrompt()` (non-existent) → replaced with `findEffectiveByNamespaceIdPrompt()` (actual generated method name)

### `namespace-agent-configs.component.ts` — wrong method name

- `listByNamespaceAgentConfig()` (non-existent) → replaced with `listByParentAgentConfig()` (actual generated method name)

## Verification

Production build passes cleanly: `pnpm nx build client` ✅