### PR TITLE
fix: #33273 case search flattens tree and matches on id

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
@@ -1,19 +1,35 @@
 <ds-entity-list
   title="Cases"
-  [items]="rootItems()"
+  [items]="displayItems()"
   [itemTemplate]="caseItemTpl"
   [showCreate]="true"
+  [disableInternalFilter]="true"
   emptyMessage="No cases yet. Start one below."
   searchPlaceholder="Filter cases…"
   cardMinWidth="220px"
   contentMaxWidth="100%"
   (itemSelected)="onItemSelected($event)"
   (createRequested)="onCreateRequested()"
+  (searchChanged)="onSearchChanged($event)"
 >
 </ds-entity-list>
 
 <ng-template #caseItemTpl let-item>
-  <ng-container *ngTemplateOutlet="caseRowTpl; context: { node: item, depth: 0 }" />
+  @if (isSearchActive()) {
+    <!-- Flat mode: render each match directly, no tree expand/collapse -->
+    <button
+      type="button"
+      class="case-tree-node__row"
+      [class.case-tree-node__row--active]="item.id === activeCaseId()"
+      (click)="onItemSelected(item.id)"
+    >
+      <span class="case-tree-node__expand-slot"></span>
+      <span class="case-tree-node__name">{{ item.name }}</span>
+    </button>
+  } @else {
+    <!-- Tree mode: hierarchical rendering -->
+    <ng-container *ngTemplateOutlet="caseRowTpl; context: { node: item, depth: 0 }" />
+  }
 </ng-template>
 
 <ng-template #caseRowTpl let-node="node" let-depth="depth">

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
@@ -163,18 +163,12 @@ function buildTree(cases: Case[]): CaseTreeItem[] {
  * Returns a flat list — hierarchy is not preserved in search results.
  */
 function collectMatching(nodes: CaseTreeItem[], query: string): CaseTreeItem[] {
-  const results: CaseTreeItem[] = []
-  for (const node of nodes) {
-    const matchesName = node.name.toLowerCase().includes(query)
-    const matchesId = node.id.toLowerCase().includes(query)
-    if (matchesName || matchesId) {
-      results.push(node)
-    }
-    if (node.children.length) {
-      results.push(...collectMatching(node.children, query))
-    }
-  }
-  return results
+  return nodes.reduce<CaseTreeItem[]>((acc, node) => {
+    const matches = node.name.toLowerCase().includes(query) || node.id.toLowerCase().includes(query)
+    if (matches) acc.push(node)
+    if (node.children.length) acc.push(...collectMatching(node.children, query))
+    return acc
+  }, [])
 }
 
 function findAndCollectAncestors(nodes: CaseTreeItem[], targetId: string, acc: Set<string>): boolean {

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
@@ -14,7 +14,7 @@ import { NgTemplateOutlet } from '@angular/common'
 
 /**
  * EntityListItem extended with a recursive children list.
- * Only root nodes are passed to ds-entity-list; children are rendered
+ * Only root nodes are passed to ds-entity-list in tree mode; children are rendered
  * inline by the itemTemplate.
  */
 export interface CaseTreeItem extends EntityListItem {
@@ -25,8 +25,11 @@ export interface CaseTreeItem extends EntityListItem {
  * CaseDrawerComponent — presentational drawer for the case list.
  *
  * Uses ds-entity-list for the chrome (toolbar, search, create button).
- * The itemTemplate handles hierarchical rendering: each root item renders
- * its sub-cases inline, collapsed by default.
+ *
+ * Two display modes:
+ * - **Tree mode** (no active search): root cases are shown with expandable sub-cases.
+ * - **Flat mode** (search active): all matching cases at every depth level are shown
+ *   as a flat list, including sub-cases. Matching is done on title AND case ID.
  */
 @Component({
   selector: 'agentos-case-drawer',
@@ -44,15 +47,41 @@ export class CaseDrawerComponent {
 
   @ViewChild('caseItemTpl', { static: true }) caseItemTpl!: TemplateRef<{ $implicit: CaseTreeItem }>
 
+  /** Current search query, driven by ds-entity-list's searchChanged output. */
+  protected readonly searchQuery = signal('')
+
+  protected readonly isSearchActive = computed(() => this.searchQuery().trim().length > 0)
+
   /**
-   * Arbre reconstruit automatiquement quand cases() change.
-   * Remplace OnChanges qui ne se déclenche pas avec les signal inputs.
+   * Tree rebuilt automatically when cases() changes.
+   * Used in tree mode (no active search).
    */
   protected readonly rootItems = computed(() => buildTree(this.cases()))
 
   /**
-   * Ancêtres du case actif à auto-expanded, recalculés quand
-   * rootItems() ou activeCaseId() change.
+   * Flat list of all cases matching the current search query.
+   * Traverses the full tree at every depth level.
+   * Matching is done on title AND case ID (case-insensitive).
+   * Used in flat mode (search active).
+   */
+  protected readonly flatFilteredItems = computed((): CaseTreeItem[] => {
+    const query = this.searchQuery().toLowerCase().trim()
+    if (!query) return []
+    return collectMatching(this.rootItems(), query)
+  })
+
+  /**
+   * Items passed to ds-entity-list:
+   * - flat filtered list when search is active
+   * - root tree nodes otherwise
+   */
+  protected readonly displayItems = computed((): CaseTreeItem[] =>
+    this.isSearchActive() ? this.flatFilteredItems() : this.rootItems()
+  )
+
+  /**
+   * Ancestors of the active case to auto-expand, recalculated when
+   * rootItems() or activeCaseId() changes.
    */
   private readonly autoExpandedIds = computed(() => {
     const id = this.activeCaseId()
@@ -62,7 +91,7 @@ export class CaseDrawerComponent {
     return expanded
   })
 
-  /** IDs des noeuds manuellement expand/collapse par l'utilisateur. */
+  /** IDs of nodes manually expanded/collapsed by the user. */
   protected readonly expandedIds = signal(new Set<string>())
 
   protected isExpanded(id: string): boolean {
@@ -76,6 +105,10 @@ export class CaseDrawerComponent {
       next.has(id) ? next.delete(id) : next.add(id)
       return next
     })
+  }
+
+  protected onSearchChanged(query: string): void {
+    this.searchQuery.set(query)
   }
 
   protected onItemSelected(id: string): void {
@@ -95,6 +128,8 @@ function buildTree(cases: Case[]): CaseTreeItem[] {
   const toNode = (c: Case): CaseTreeItem => ({
     id: c.id ?? '',
     name: c.title ?? c.id ?? '—',
+    // Store the case ID in description so ds-entity-list's built-in filter also matches on it
+    description: c.id ?? '',
     children: [],
   })
 
@@ -120,6 +155,26 @@ function buildTree(cases: Case[]): CaseTreeItem[] {
       .map((item) => ({ ...item, children: sortDesc(item.children) }))
 
   return sortDesc(roots)
+}
+
+/**
+ * Recursively collect all tree nodes (at any depth) whose name or id
+ * contains the given query string (case-insensitive).
+ * Returns a flat list — hierarchy is not preserved in search results.
+ */
+function collectMatching(nodes: CaseTreeItem[], query: string): CaseTreeItem[] {
+  const results: CaseTreeItem[] = []
+  for (const node of nodes) {
+    const matchesName = node.name.toLowerCase().includes(query)
+    const matchesId = node.id.toLowerCase().includes(query)
+    if (matchesName || matchesId) {
+      results.push(node)
+    }
+    if (node.children.length) {
+      results.push(...collectMatching(node.children, query))
+    }
+  }
+  return results
 }
 
 function findAndCollectAncestors(nodes: CaseTreeItem[], targetId: string, acc: Set<string>): boolean {

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.html
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.html
@@ -2,34 +2,36 @@
   <!-- Toolbar (full width) -->
   <div class="entity-list__toolbar">
     <ng-content select="[toolbar-start]" />
-    <h1 class="entity-list__title">{{ title }}</h1>
+    <h1 class="entity-list__title">{{ title() }}</h1>
     <div class="entity-list__search-wrap">
       <span class="entity-list__search-icon">&#128269;</span>
       <input
         #searchInput
         class="entity-list__search-input"
         type="search"
-        [placeholder]="searchPlaceholder"
+        [placeholder]="searchPlaceholder()"
         [value]="searchQuery()"
         (input)="onSearchChange($any($event.target).value)"
         (keydown.escape)="clearSearch()"
         autocomplete="off"
       />
       @if (isSearchActive()) {
-        <button class="entity-list__search-clear" type="button" aria-label="Clear" (click)="clearSearch()">✕</button>
+        <button class="entity-list__search-clear" type="button" aria-label="Clear" (click)="clearSearch()">
+          &#x2715;
+        </button>
       }
     </div>
     <!-- Optional toolbar extras projected by the consumer (filters, toggles…) -->
     <ng-content select="[toolbar-extras]" />
-    @if (showCreate) {
+    @if (showCreate()) {
       <button class="entity-list__create-btn" type="button" title="Create" (click)="onCreateRequested()">+</button>
     }
   </div>
 
   <!-- Content (max-width constrained) -->
-  <div class="entity-list__content" [style.max-width]="contentMaxWidth">
+  <div class="entity-list__content" [style.max-width]="contentMaxWidth()">
     @if (filteredItems().length === 0) {
-      <p class="entity-list__empty">{{ emptyMessage }}</p>
+      <p class="entity-list__empty">{{ emptyMessage() }}</p>
     } @else if (hasGroups()) {
       <!-- Grouped view (no active search) -->
       <mat-accordion [multi]="true">
@@ -40,9 +42,9 @@
                 <mat-panel-title class="entity-list__panel-title">{{ group.groupLabel }}</mat-panel-title>
               </mat-expansion-panel-header>
             }
-            <div class="entity-list__grid" [style.--card-min-width]="cardMinWidth">
+            <div class="entity-list__grid" [style.--card-min-width]="cardMinWidth()">
               @for (item of group.items; track item.id) {
-                <ng-container *ngTemplateOutlet="itemTemplate ?? defaultCard; context: { $implicit: item }" />
+                <ng-container *ngTemplateOutlet="itemTemplate() ?? defaultCard; context: { $implicit: item }" />
               }
             </div>
           </mat-expansion-panel>
@@ -50,9 +52,9 @@
       </mat-accordion>
     } @else {
       <!-- Flat: no groups, or search active -->
-      <div class="entity-list__grid" [style.--card-min-width]="cardMinWidth">
+      <div class="entity-list__grid" [style.--card-min-width]="cardMinWidth()">
         @for (item of filteredItems(); track item.id) {
-          <ng-container *ngTemplateOutlet="itemTemplate ?? defaultCard; context: { $implicit: item }" />
+          <ng-container *ngTemplateOutlet="itemTemplate() ?? defaultCard; context: { $implicit: item }" />
         }
       </div>
     }

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.ts
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.ts
@@ -3,12 +3,9 @@ import {
   Component,
   computed,
   ElementRef,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
+  input,
+  output,
   signal,
-  SimpleChanges,
   TemplateRef,
   ViewChild,
 } from '@angular/core'
@@ -34,9 +31,8 @@ export interface GroupedItems {
 /**
  * DsEntityList — a full-page generic list.
  *
- * `items` is bridged via `ngOnChanges` into an internal signal so that
- * `computed` derivations (filtering, grouping) re-evaluate reactively
- * whenever the parent updates the binding.
+ * Uses signal-based inputs throughout. `computed` derivations (filtering,
+ * grouping) re-evaluate reactively whenever `items` or the search query change.
  */
 @Component({
   selector: 'ds-entity-list',
@@ -45,32 +41,41 @@ export interface GroupedItems {
   templateUrl: './entity-list.component.html',
   styleUrl: './entity-list.component.scss',
 })
-export class EntityListComponent implements AfterViewInit, OnChanges {
-  @Input({ required: true }) title!: string
-  @Input() items: EntityListItem[] = []
-  @Input() searchPlaceholder: string = 'Filter…'
-  @Input() emptyMessage: string = 'No items found.'
-  @Input() autoFocusSearch: boolean = false
-  @Input() cardMinWidth: string = '260px'
-  @Input() contentMaxWidth: string = '900px'
-  @Input() showCreate: boolean = false
-  @Input() itemTemplate?: TemplateRef<{ $implicit: EntityListItem }>
+export class EntityListComponent implements AfterViewInit {
+  readonly title = input.required<string>()
+  readonly items = input<EntityListItem[]>([])
+  readonly searchPlaceholder = input<string>('Filter…')
+  readonly emptyMessage = input<string>('No items found.')
+  readonly autoFocusSearch = input<boolean>(false)
+  readonly cardMinWidth = input<string>('260px')
+  readonly contentMaxWidth = input<string>('900px')
+  readonly showCreate = input<boolean>(false)
+  readonly itemTemplate = input<TemplateRef<{ $implicit: EntityListItem }> | undefined>(undefined)
+  /**
+   * When true, the internal search filter is disabled — items are displayed as-is.
+   * Use this when the parent manages its own filtering logic and passes pre-filtered items.
+   * The search input remains visible; the parent receives the query via searchChanged.
+   */
+  readonly disableInternalFilter = input<boolean>(false)
 
-  @Output() itemSelected = new EventEmitter<string>()
-  @Output() createRequested = new EventEmitter<void>()
+  readonly itemSelected = output<string>()
+  readonly createRequested = output<void>()
+  /**
+   * Emitted on every keystroke and on clear.
+   * Primarily useful when disableInternalFilter is true and the parent owns the filter logic.
+   */
+  readonly searchChanged = output<string>()
 
   @ViewChild('searchInput') private searchInputRef?: ElementRef<HTMLInputElement>
-
-  /** Internal signal bridging the `items` @Input — makes computed() reactive. */
-  private readonly itemsSignal = signal<EntityListItem[]>([])
 
   protected readonly searchQuery = signal('')
 
   protected readonly isSearchActive = computed(() => this.searchQuery().trim().length > 0)
 
   protected readonly filteredItems = computed(() => {
+    const all = this.items()
+    if (this.disableInternalFilter()) return all
     const query = this.searchQuery().toLowerCase().trim()
-    const all = this.itemsSignal()
     if (!query) return all
     return all.filter(
       (item) => item.name.toLowerCase().includes(query) || (item.description?.toLowerCase().includes(query) ?? false)
@@ -109,24 +114,20 @@ export class EntityListComponent implements AfterViewInit, OnChanges {
     () => !this.isSearchActive() && this.groupedItems().some((g) => g.groupKey !== '')
   )
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['items']) {
-      this.itemsSignal.set(this.items)
-    }
-  }
-
   ngAfterViewInit(): void {
-    if (this.autoFocusSearch) {
+    if (this.autoFocusSearch()) {
       setTimeout(() => this.searchInputRef?.nativeElement.focus(), 0)
     }
   }
 
   protected onSearchChange(value: string): void {
     this.searchQuery.set(value)
+    this.searchChanged.emit(value)
   }
 
   protected clearSearch(): void {
     this.searchQuery.set('')
+    this.searchChanged.emit('')
     this.searchInputRef?.nativeElement.focus()
   }
 


### PR DESCRIPTION
## Problem

Two issues with case search in the sidebar drawer:

1. **Case IDs were not matched** — the search only filtered on the case title, not the ID.
2. **Sub-cases were invisible to search** — the filter operated on root tree nodes only; children at any depth were never reached.

## Solution

### `ds-entity-list` — migrated to signal-based API + new `disableInternalFilter` input

- All `@Input()` / `@Output()` replaced with `input()` / `output()` (signal-based, Angular 17.3+)
- Removed the `OnChanges` + internal `itemsSignal` bridge — `filteredItems` now reads `this.items()` directly, which is natively reactive
- Added `disableInternalFilter: boolean` input: when `true`, items are displayed as-is (no internal filtering). The search input remains visible and the query is emitted via `searchChanged`.
- Added `searchChanged` output: emits on every keystroke and on clear. Primarily useful when `disableInternalFilter` is true and the parent owns the filter logic.

### `CaseDrawerComponent` — two-mode rendering

- **Tree mode** (no active search): unchanged hierarchical rendering with expand/collapse.
- **Flat mode** (search active): `collectMatching()` traverses the full tree recursively at every depth and returns a flat list of all cases whose **title or ID** matches the query. The tree structure is not preserved in search results.
- Uses `disableInternalFilter="true"` + `(searchChanged)` — the drawer owns the filter state, `ds-entity-list` receives pre-filtered items.
- `buildTree()` now populates the `description` field with the case ID, as a secondary defence so the native filter also matches on ID if `disableInternalFilter` is ever removed.