### PR TITLE
fix: #33235 platform integrations always read-only on namespace page

### DIFF
--- a/libs/agentos-ui/src/lib/components/integrations-all-scopes/integrations-all-scopes.component.html
+++ b/libs/agentos-ui/src/lib/components/integrations-all-scopes/integrations-all-scopes.component.html
@@ -19,7 +19,7 @@
     <agentos-integration-config-item
       [config]="resolved.config"
       [scope]="resolved.scope"
-      [readOnly]="(resolved.scope === 'namespace' || resolved.scope === 'platform') && !isAdmin()"
+      [readOnly]="resolved.scope === 'platform' || (resolved.scope === 'namespace' && !isAdmin())"
       (editRequested)="onEdit(resolved)"
       (deleteRequested)="onDelete(resolved)"
       (duplicateRequested)="onDuplicate(resolved)"


### PR DESCRIPTION
## Context

WZ-33235 — last remaining fix: `integrationConfig` entries with `scope === 'platform'` displayed on the namespace page were not properly protected.

## Problem

The previous `[readOnly]` expression:
```html
[readOnly]="(resolved.scope === 'namespace' || resolved.scope === 'platform') && !isAdmin()"
```
Made platform-scoped integrations editable for namespace admins — Edit and Delete buttons were visible and functional, even though only super-admins can mutate platform-level resources.

## Fix

```html
[readOnly]="resolved.scope === 'platform' || (resolved.scope === 'namespace' && !isAdmin())"
```

| Scope | Admin namespace | Non-admin |
|---|---|---|
| `platform` | ✅ read-only | ✅ read-only |
| `namespace` | ❌ editable | ✅ read-only |
| `userOnNs` / `userGlobal` | ❌ editable | ❌ editable |

Platform configs are now unconditionally read-only on the namespace page, regardless of the user's namespace role.

## Testing

- Build + lint pass cleanly (`pnpm nx run-many -t build lint -p client`)
