### PR TITLE
feat: #1130 add questionType discriminant to QuestionEvent

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
@@ -279,6 +279,7 @@ data class QuestionEvent(
     val agentName: String,
     val question: String,
     val options: List<String>? = null,
+    val questionType: QuestionType = QuestionType.FREE_TEXT,
 ) : CaseEvent {
     override val type: CaseEventType = CaseEventType.QUESTION
 

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
@@ -269,6 +269,11 @@ data class ThinkingEvent(
 /**
  * Emitted when an agent asks a question to the user via a tool.
  * The user can respond asynchronously via an AnswerEvent.
+ *
+ * @param userId When non-null, identifies the specific user this question is directed at.
+ *   Null means the question is addressed to any user of the case.
+ * @param questionType Controls how the UI should render the response input.
+ *   [QuestionType.OPEN_CHOICE] requires [options] to be non-null and non-empty.
  */
 data class QuestionEvent(
     override val metadata: EntityMetadata = EntityMetadata(),
@@ -280,6 +285,8 @@ data class QuestionEvent(
     val question: String,
     val options: List<String>? = null,
     val questionType: QuestionType = QuestionType.FREE_TEXT,
+    /** Identifies the specific user this question is directed at. Null = any user. */
+    val userId: UUID? = null,
 ) : CaseEvent {
     override val type: CaseEventType = CaseEventType.QUESTION
 

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/QuestionType.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/QuestionType.kt
@@ -1,0 +1,11 @@
+package io.whozoss.agentos.sdk.caseEvent
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class QuestionType(
+    @JsonValue val value: String,
+) {
+    FREE_TEXT("FREE_TEXT"),
+    SINGLE_CHOICE("SINGLE_CHOICE"),
+    OAUTH_AUTHORIZE("OAUTH_AUTHORIZE"),
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/QuestionType.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/QuestionType.kt
@@ -7,5 +7,10 @@ enum class QuestionType(
 ) {
     FREE_TEXT("FREE_TEXT"),
     SINGLE_CHOICE("SINGLE_CHOICE"),
+    /**
+     * The user may either pick one of the provided [QuestionEvent.options] or enter free text.
+     * Requires [QuestionEvent.options] to be non-null and non-empty.
+     */
+    OPEN_CHOICE("OPEN_CHOICE"),
     OAUTH_AUTHORIZE("OAUTH_AUTHORIZE"),
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
@@ -227,6 +227,11 @@ class QuestionEventNode(
     val question: String,
     /** JSON-serialised [List]<[String]>?, null when no options */
     val options: String? = null,
+    /**
+     * Stored as a String for forward compatibility. Defaults to "FREE_TEXT" so that
+     * existing nodes written before this field was introduced deserialise correctly.
+     */
+    val questionType: String = "FREE_TEXT",
     created: Instant = Instant.now(),
     createdBy: String? = null,
     modified: Instant = Instant.now(),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
@@ -232,6 +232,11 @@ class QuestionEventNode(
      * existing nodes written before this field was introduced deserialise correctly.
      */
     val questionType: String = "FREE_TEXT",
+    /**
+     * UUID of the specific user this question is directed at, or null when addressed
+     * to any user of the case. Null default ensures backward compat with existing nodes.
+     */
+    val userId: String? = null,
     created: Instant = Instant.now(),
     createdBy: String? = null,
     modified: Instant = Instant.now(),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
@@ -14,6 +14,7 @@ import io.whozoss.agentos.sdk.caseEvent.IntentionGeneratedEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.PendingConfirmationEvent
 import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionType
 import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
@@ -271,6 +272,7 @@ class CaseEventNodeMapper(
                     node.agentName,
                     node.question,
                     node.options,
+                    node.questionType,
                     node.created,
                     node.createdBy,
                     node.modified,
@@ -500,6 +502,7 @@ class CaseEventNodeMapper(
             agentName = n.agentName,
             question = n.question,
             options = n.options?.let { serializer.deserializeStringList(it) },
+            questionType = try { QuestionType.valueOf(n.questionType) } catch (_: Exception) { QuestionType.FREE_TEXT },
         )
 
     private fun toDomain(n: AnswerEventNode) =
@@ -736,6 +739,7 @@ class CaseEventNodeMapper(
             agentName = e.agentName,
             question = e.question,
             options = e.options?.let { serializer.serializeStringList(it) },
+            questionType = e.questionType.name,
             created = e.metadata.created,
             createdBy = e.metadata.createdBy,
             modified = e.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
@@ -273,6 +273,7 @@ class CaseEventNodeMapper(
                     node.question,
                     node.options,
                     node.questionType,
+                    node.userId,
                     node.created,
                     node.createdBy,
                     node.modified,
@@ -503,6 +504,7 @@ class CaseEventNodeMapper(
             question = n.question,
             options = n.options?.let { serializer.deserializeStringList(it) },
             questionType = try { QuestionType.valueOf(n.questionType) } catch (_: Exception) { QuestionType.FREE_TEXT },
+            userId = n.userId?.let { UUID.fromString(it) },
         )
 
     private fun toDomain(n: AnswerEventNode) =
@@ -740,6 +742,7 @@ class CaseEventNodeMapper(
             question = e.question,
             options = e.options?.let { serializer.serializeStringList(it) },
             questionType = e.questionType.name,
+            userId = e.userId?.toString(),
             created = e.metadata.created,
             createdBy = e.metadata.createdBy,
             modified = e.metadata.modified,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperInteractionSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperInteractionSpec.kt
@@ -9,6 +9,7 @@ import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
 import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionType
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import java.time.Instant
 import java.util.UUID
@@ -48,6 +49,46 @@ class CaseEventNodeMapperInteractionSpec :
             roundTripped.agentName shouldBe "RouterAgent"
             roundTripped.question shouldBe "Which environment should I deploy to?"
             roundTripped.options shouldBe listOf("staging", "production")
+            roundTripped.questionType shouldBe QuestionType.FREE_TEXT
+        }
+
+        "QuestionEvent with OAUTH_AUTHORIZE questionType survives the round-trip" {
+            val original =
+                QuestionEvent(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = UUID.randomUUID(),
+                    caseId = UUID.randomUUID(),
+                    timestamp = Instant.parse("2026-05-19T15:03:00Z"),
+                    agentId = agentId,
+                    agentName = "RouterAgent",
+                    question = "Please authorise access.",
+                    options = null,
+                    questionType = QuestionType.OAUTH_AUTHORIZE,
+                )
+
+            val node = nodeMapper.fromDomain(original)
+            val roundTripped = nodeMapper.toDomain(node) as QuestionEvent
+
+            roundTripped.questionType shouldBe QuestionType.OAUTH_AUTHORIZE
+        }
+
+        "QuestionEvent with unknown questionType in node defaults to FREE_TEXT" {
+            val node =
+                QuestionEventNode(
+                    id = UUID.randomUUID().toString(),
+                    caseId = UUID.randomUUID().toString(),
+                    namespaceId = UUID.randomUUID().toString(),
+                    timestamp = Instant.parse("2026-05-19T15:04:00Z"),
+                    agentId = agentId.toString(),
+                    agentName = "LegacyAgent",
+                    question = "Old question from before the field existed.",
+                    options = null,
+                    questionType = "UNKNOWN_VALUE",
+                )
+
+            val roundTripped = nodeMapper.toDomain(node) as QuestionEvent
+
+            roundTripped.questionType shouldBe QuestionType.FREE_TEXT
         }
 
         "QuestionEvent with null options survives the round-trip" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperInteractionSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperInteractionSpec.kt
@@ -52,6 +52,50 @@ class CaseEventNodeMapperInteractionSpec :
             roundTripped.questionType shouldBe QuestionType.FREE_TEXT
         }
 
+        "QuestionEvent with OPEN_CHOICE questionType survives the round-trip" {
+            val original =
+                QuestionEvent(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = UUID.randomUUID(),
+                    caseId = UUID.randomUUID(),
+                    timestamp = Instant.parse("2026-05-19T15:05:00Z"),
+                    agentId = agentId,
+                    agentName = "RouterAgent",
+                    question = "Pick a template or describe your own.",
+                    options = listOf("blank", "standard", "advanced"),
+                    questionType = QuestionType.OPEN_CHOICE,
+                )
+
+            val node = nodeMapper.fromDomain(original)
+            val roundTripped = nodeMapper.toDomain(node) as QuestionEvent
+
+            roundTripped.questionType shouldBe QuestionType.OPEN_CHOICE
+            roundTripped.options shouldBe listOf("blank", "standard", "advanced")
+            roundTripped.userId shouldBe null
+        }
+
+        "QuestionEvent with userId survives the round-trip" {
+            val targetUserId = UUID.randomUUID()
+            val original =
+                QuestionEvent(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = UUID.randomUUID(),
+                    caseId = UUID.randomUUID(),
+                    timestamp = Instant.parse("2026-05-19T15:06:00Z"),
+                    agentId = agentId,
+                    agentName = "RouterAgent",
+                    question = "Hey Alice, which environment?",
+                    options = listOf("staging", "production"),
+                    questionType = QuestionType.SINGLE_CHOICE,
+                    userId = targetUserId,
+                )
+
+            val node = nodeMapper.fromDomain(original)
+            val roundTripped = nodeMapper.toDomain(node) as QuestionEvent
+
+            roundTripped.userId shouldBe targetUserId
+        }
+
         "QuestionEvent with OAUTH_AUTHORIZE questionType survives the round-trip" {
             val original =
                 QuestionEvent(

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -3298,6 +3298,12 @@ components:
               type: string
           question:
             type: string
+          questionType:
+            type: string
+            enum:
+            - FREE_TEXT
+            - SINGLE_CHOICE
+            - OAUTH_AUTHORIZE
       required:
       - agentId
       - agentName
@@ -3306,6 +3312,7 @@ components:
       - metadata
       - namespaceId
       - question
+      - questionType
       - timestamp
       - type
     Text:

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -3303,7 +3303,11 @@ components:
             enum:
             - FREE_TEXT
             - SINGLE_CHOICE
+            - OPEN_CHOICE
             - OAUTH_AUTHORIZE
+          userId:
+            type: string
+            format: uuid
       required:
       - agentId
       - agentName

--- a/libs/agentos-api-client/src/lib/model/question-event.ts
+++ b/libs/agentos-api-client/src/lib/model/question-event.ts
@@ -20,4 +20,11 @@ export interface QuestionEvent {
   agentName: string
   options?: Array<string>
   question: string
+  questionType: QuestionEventQuestionTypeEnum
+}
+
+export enum QuestionEventQuestionTypeEnum {
+  FREE_TEXT = 'FREE_TEXT',
+  SINGLE_CHOICE = 'SINGLE_CHOICE',
+  OAUTH_AUTHORIZE = 'OAUTH_AUTHORIZE',
 }

--- a/libs/agentos-api-client/src/lib/model/question-event.ts
+++ b/libs/agentos-api-client/src/lib/model/question-event.ts
@@ -21,10 +21,12 @@ export interface QuestionEvent {
   options?: Array<string>
   question: string
   questionType: QuestionEventQuestionTypeEnum
+  userId?: string
 }
 
 export enum QuestionEventQuestionTypeEnum {
   FREE_TEXT = 'FREE_TEXT',
   SINGLE_CHOICE = 'SINGLE_CHOICE',
+  OPEN_CHOICE = 'OPEN_CHOICE',
   OAUTH_AUTHORIZE = 'OAUTH_AUTHORIZE',
 }


### PR DESCRIPTION
## Summary

Adds a `questionType` discriminant field to `QuestionEvent`, enabling the frontend to distinguish between different types of user interaction requests (free text input, single choice selection, OAuth authorization popup).

Part of #1130 — prerequisite for the OAuth 2.1 interactive flow in AuthService.

## Changes

### SDK (`agentos-sdk`)
- New `QuestionType` enum: `FREE_TEXT`, `SINGLE_CHOICE`, `OAUTH_AUTHORIZE`
- `QuestionEvent.questionType` field with backward-compatible default (`FREE_TEXT`)

### Service (`agentos-service`)
- `QuestionEventNode.questionType` stored as string, defaults to `"FREE_TEXT"` for existing Neo4j nodes
- `CaseEventNodeMapper` handles round-trip conversion with fallback to `FREE_TEXT` for unknown values
- `withRemoved` preserves `questionType` through soft-delete copies

### Generated artifacts
- OpenAPI spec regenerated — `questionType` enum in `QuestionRequested` schema
- TypeScript API client regenerated — `QuestionEventQuestionTypeEnum` available in Angular

### Tests
- Existing round-trip test extended to verify default `questionType`
- New test: `OAUTH_AUTHORIZE` round-trip through `fromDomain`/`toDomain`
- New test: unknown `questionType` in node gracefully defaults to `FREE_TEXT`

## Backward compatibility

- All existing `QuestionEvent` construction sites compile unchanged (default parameter)
- Existing Neo4j nodes without `questionType` property deserialize as `FREE_TEXT`
- No changes to `CaseTranscriptFormatter`, `AgentIntentionGenerator`, or any other consumer