### PR TITLE
fix: agent name resolution uses exact match instead of substring contains

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -8,6 +8,7 @@ import io.whozoss.agentos.aiModel.AiModelService
 import io.whozoss.agentos.aiProvider.AiProviderService
 import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.chat.ChatClientProvider
+import io.whozoss.agentos.chat.CompressingChatClient
 import io.whozoss.agentos.delegation.DelegationTool
 import io.whozoss.agentos.delegation.SubCaseManager
 import io.whozoss.agentos.exchange.ExchangeCapabilityService
@@ -19,8 +20,6 @@ import io.whozoss.agentos.metrics.ToolMetricsService
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.permissions.EntityType
 import io.whozoss.agentos.redirect.globToRegex
-import io.whozoss.agentos.chat.CompressingChatClient
-import io.whozoss.agentos.util.IdCompressorService
 import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.aiProvider.AiProvider
@@ -31,6 +30,7 @@ import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.tool.ToolResolverService
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
+import io.whozoss.agentos.util.IdCompressorService
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import mu.KLogging
@@ -70,11 +70,11 @@ class AgentServiceImpl(
      *
      * **Matching semantics differ by path:**
      * - `userId != null` path: loads all accessible agents (platform + deployed) and filters
-     *   client-side with `.contains()` (case-insensitive substring). This is intentional for
-     *   interactive use cases where a partial name typed by a user should resolve loosely.
+     *   client-side with an exact case-insensitive match (`equals(ignoreCase = true)`).
      * - `userId == null` path: delegates to [AgentConfigServiceImpl.findByName] which performs
      *   a case-insensitive exact match, then falls back to platform agents.
-     * - [resolveAgentName] with `userId != null` uses a Cypher `STARTS WITH` prefix match.
+     * - [resolveAgentName] with `userId != null` uses a Cypher `STARTS WITH` prefix match
+     *   (autocomplete — a different call site from this method).
      *
      * **Scoping / shadowing rule (both paths):**
      * Platform agents (namespaceId = null) are shadowed by namespace-scoped agents with the
@@ -90,14 +90,13 @@ class AgentServiceImpl(
         require(namePart.isNotBlank()) { "Blank agent name, cannot resolve agent" }
         val agentConfig =
             if (context.userId != null) {
-                val namePartLowercase = namePart.lowercase()
                 val agentConfigs =
                     agentConfigService
                         .findDeployedByNamespaceIdAndUserIdAndName(
                             namespaceId = context.namespaceId,
                             userId = context.userId,
-                            agentName = null,
-                        ).filter { it.name.lowercase().contains(namePartLowercase) }
+                            agentName = namePart.lowercase(),
+                        ).filter { it.name.equals(namePart, ignoreCase = true) }
                 resolveWithShadowing(agentConfigs, namePart, context.namespaceId)
             } else {
                 agentConfigService.findByName(context.namespaceId, namePart)
@@ -629,7 +628,8 @@ class AgentServiceImpl(
             // the debug getDefinition endpoint) still creates an empty scope dir.
             Files.createDirectories(root)
             val cfg =
-                objectMapper.createObjectNode()
+                objectMapper
+                    .createObjectNode()
                     .put("rootPath", root.toAbsolutePath().toString())
                     .put("readOnly", readOnly)
                     // Align the agent read tool's size cap with the exchange's own read limit, so an
@@ -652,12 +652,13 @@ class AgentServiceImpl(
             // The agent gets read/write on the case exchange by design (it produces files during a run).
             // User-facing write is separately gated: the exchange upload/delete endpoints require Case
             // WRITE via @PreAuthorize, and the manifest exposes the computed ExchangeCapability.
-            tools += grant(
-                exchangeStorageService.caseRoot(context.namespaceId, caseId, caseCreatedAt),
-                readOnly = false,
-                configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
-                allowedTools = integrations[ExchangeIntegrationTypes.CASE],
-            )
+            tools +=
+                grant(
+                    exchangeStorageService.caseRoot(context.namespaceId, caseId, caseCreatedAt),
+                    readOnly = false,
+                    configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
+                    allowedTools = integrations[ExchangeIntegrationTypes.CASE],
+                )
         }
         if (integrations.containsKey(ExchangeIntegrationTypes.NAMESPACE)) {
             // The agent inherits the invoking user's namespace right: read/write for a namespace
@@ -670,12 +671,13 @@ class AgentServiceImpl(
                         context.namespaceId.toString(),
                     )
                 } ?: false
-            tools += grant(
-                exchangeStorageService.namespaceRoot(context.namespaceId),
-                readOnly = !userCanWriteNamespace,
-                configName = ExchangeIntegrationTypes.NAMESPACE_CONFIG_NAME,
-                allowedTools = integrations[ExchangeIntegrationTypes.NAMESPACE],
-            )
+            tools +=
+                grant(
+                    exchangeStorageService.namespaceRoot(context.namespaceId),
+                    readOnly = !userCanWriteNamespace,
+                    configName = ExchangeIntegrationTypes.NAMESPACE_CONFIG_NAME,
+                    allowedTools = integrations[ExchangeIntegrationTypes.NAMESPACE],
+                )
         }
         return tools
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -136,7 +136,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
     )
 
     init {
-        every { toolResolverService.resolveToolsForRun(agentIntegrations = any(), context = any(), allIntegrationConfigs = any()) } returns emptyList()
+        every { toolResolverService.resolveToolsForRun(agentIntegrations = any(), context = any(), allIntegrationConfigs = any()) } returns
+            emptyList()
         // dedupToolsByName is the shared collision-reconciler; identity is fine (no collisions in these tests).
         every { toolResolverService.dedupToolsByName(any()) } answers { firstArg() }
         // isToolAllowed gates the exchange grant's per-tool allowlist; allow all (tests use null allowlists).
@@ -202,7 +203,14 @@ class AgentServiceImplUnitSpec : StringSpec() {
             every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
             every { exchangeStorageService.namespaceRoot(namespaceId) } returns tmp
 
-            val config = agentConfig(name = "ns-agent", modelName = "sonnet").copy(integrations = mapOf("CASE_FILE_EXCHANGE" to null, "NAMESPACE_FILE_EXCHANGE" to null))
+            val config =
+                agentConfig(name = "ns-agent", modelName = "sonnet").copy(
+                    integrations =
+                        mapOf(
+                            "CASE_FILE_EXCHANGE" to null,
+                            "NAMESPACE_FILE_EXCHANGE" to null,
+                        ),
+                )
             every { agentConfigService.findById(config.metadata.id) } returns config
             every { aiModelService.findAiModel(namespaceId, "sonnet") } returns modelConfig(alias = "sonnet")
             every { aiProviderService.getById(aiProviderId) } returns providerConfig()
@@ -415,7 +423,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val chatClient = mockk<ChatClient>(relaxed = true)
 
             // userId != null => findAgentByName takes the findDeployedByNamespaceIdAndUserIdAndName path
-            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, null) } returns listOf(config)
+            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "my-agent") } returns listOf(config)
             every { aiModelService.findAiModel(namespaceId, "default") } returns platformModel
             every { aiProviderService.getById(platformProviderId) } returns platformProvider
             every { aiProviderService.resolveProvider(namespaceId, userId, "anthropic-platform") } returns platformProvider
@@ -782,7 +790,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             // Both namespace and platform agent returned by the query
             every {
-                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, null)
+                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "my-agent")
             } returns listOf(nsAgent, platformAgentNullNs)
             every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
             every { aiProviderService.getById(aiProviderId) } returns provider
@@ -796,18 +804,65 @@ class AgentServiceImplUnitSpec : StringSpec() {
         }
 
         "findAgentByName with userId throws when two namespace-level agents match the name" {
+            // Two distinct configs sharing the same name at namespace level is an error —
+            // resolveWithShadowing enforces uniqueness per level.
             val userId = UUID.randomUUID()
             val ns1 = agentConfig(name = "my-agent", modelName = "sonnet")
-            val ns2 = agentConfig(name = "my-agent-extra", modelName = "sonnet")
+            val ns2 = agentConfig(name = "my-agent", modelName = "sonnet") // same name, different id
             val contextWithUser = AgentExecutionContext(namespaceId = namespaceId, caseId = caseId, userId = userId)
 
             every {
-                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, null)
+                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "my-agent")
             } returns listOf(ns1, ns2)
 
             io.kotest.assertions.throwables.shouldThrow<IllegalArgumentException> {
                 agentService.findAgentByName("my-agent", contextWithUser)
             }
+        }
+
+        "findAgentByName with userId does not match agent whose name contains the search term as substring" {
+            // Regression test for the contains() bug: searching for "Archay" must not match
+            // "Searchay" even though "archay" is a substring of "searchay".
+            val userId = UUID.randomUUID()
+            val archay = agentConfig(name = "Archay", modelName = "sonnet")
+            val searchay = agentConfig(name = "Searchay", modelName = "sonnet")
+            val contextWithUser = AgentExecutionContext(namespaceId = namespaceId, caseId = caseId, userId = userId)
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+
+            every {
+                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "archay")
+            } returns listOf(archay, searchay)
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { aiProviderService.resolveProvider(namespaceId, userId, "anthropic-prod") } returns provider
+            every { chatClientProvider.getChatClient(model, provider, any()) } returns chatClient
+            every { userService.findById(userId) } returns null
+
+            val agent = agentService.findAgentByName("Archay", contextWithUser)
+            agent.name shouldBe "Archay"
+        }
+
+        "findAgentByName with userId exact match is case-insensitive" {
+            val userId = UUID.randomUUID()
+            val myAgent = agentConfig(name = "MyAgent", modelName = "sonnet")
+            val contextWithUser = AgentExecutionContext(namespaceId = namespaceId, caseId = caseId, userId = userId)
+            val model = modelConfig(alias = "sonnet")
+            val provider = providerConfig()
+            val chatClient = mockk<ChatClient>(relaxed = true)
+
+            every {
+                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "myagent")
+            } returns listOf(myAgent)
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
+            every { aiProviderService.getById(aiProviderId) } returns provider
+            every { aiProviderService.resolveProvider(namespaceId, userId, "anthropic-prod") } returns provider
+            every { chatClientProvider.getChatClient(model, provider, any()) } returns chatClient
+            every { userService.findById(userId) } returns null
+
+            val agent = agentService.findAgentByName("myagent", contextWithUser)
+            agent.name shouldBe "MyAgent"
         }
 
         "findAgentByName with userId resolves single platform agent when no namespace agent matches" {
@@ -825,7 +880,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val chatClient = mockk<ChatClient>(relaxed = true)
 
             every {
-                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, null)
+                agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "platform-agent")
             } returns listOf(platformAgent)
             every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
             every { aiProviderService.getById(aiProviderId) } returns provider
@@ -858,7 +913,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val provider = providerConfig()
             val chatClient = mockk<ChatClient>(relaxed = true)
 
-            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, null) } returns listOf(config)
+            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "my-agent") } returns listOf(config)
             every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
 
             every { aiProviderService.getById(aiProviderId) } returns provider
@@ -894,7 +949,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val provider = providerConfig()
             val chatClient = mockk<ChatClient>(relaxed = true)
 
-            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, null) } returns listOf(config)
+            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "my-agent") } returns listOf(config)
             every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
 
             every { aiProviderService.getById(aiProviderId) } returns provider
@@ -947,7 +1002,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val provider = providerConfig()
             val chatClient = mockk<ChatClient>(relaxed = true)
 
-            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, null) } returns listOf(config)
+            every { agentConfigService.findDeployedByNamespaceIdAndUserIdAndName(namespaceId, userId, "my-agent") } returns listOf(config)
             every { aiModelService.findAiModel(namespaceId, "sonnet") } returns model
             every { aiProviderService.getById(aiProviderId) } returns provider
             every { aiProviderService.resolveProvider(namespaceId, userId, "anthropic-prod") } returns provider


### PR DESCRIPTION
## Problem

`AgentServiceImpl.findAgentByName()` (userId path) used `.contains()` for agent name matching. This caused substring collisions: searching for "Archay" also matched "Searchay" because "archay" is contained in "searchay". This triggered `resolveWithShadowing` to see multiple candidates and throw an error.

## Fix

Two-layer correction:

1. **Cypher pre-filter**: pass `agentName = namePart.lowercase()` to `findDeployedByNamespaceIdAndUserIdAndName` instead of `null`. The Cypher query uses `STARTS WITH` to reduce the result set at the database level.

2. **Java exact match**: replace `.contains()` with `.equals(namePart, ignoreCase = true)` to eliminate prefix false positives (e.g. "Archay" vs "Archay-Extra").

## Tests

- **Fixed**: existing test for duplicate-at-same-level now uses two agents with the same name (was relying on the `contains` bug to produce two matches)
- **Added**: regression test with "Archay" / "Searchay" scenario — the exact bug case
- **Added**: case-insensitive exact match test ("myagent" resolves "MyAgent")
- **Updated**: all existing userId-path test mocks aligned with the new `agentName` parameter