### PR TITLE
feat: readAsImage tool to let agents read images, PDFs and PPTX visually

### DIFF
--- a/agentos/agentos-file-plugin/build.gradle.kts
+++ b/agentos/agentos-file-plugin/build.gradle.kts
@@ -71,6 +71,16 @@ dependencies {
     // Kotlin coroutines for async file operations
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 
+    // PDFBox for PDF page rendering (readAsImage tool) — bundled into the plugin jar,
+    // the service classpath does not provide it
+    implementation(libs.pdfbox)
+
+    // POI for PPTX slide rendering (readAsImage tool) — bundled like PDFBox. Transitives
+    // (xmlbeans, poi-ooxml-lite, commons-*, curvesapi, log4j-api) are all Apache-2.0/BSD.
+    // log4j-api is also on the service classpath (log4j-to-slf4j) at the same version, so
+    // the APD parent-first copy wins harmlessly and POI logs route to Logback.
+    implementation(libs.poi.ooxml)
+
     // AgentOS SDK - Contains plugin interfaces
     compileOnly("whoz-oss.agentos:agentos-sdk:${libs.versions.agentosSdk.get()}")
 
@@ -101,6 +111,21 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict")
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.kotlinJvmTarget.get()))
+    }
+}
+
+tasks.jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    // Bundle PDFBox and POI with their transitive deps (fontbox, pdfbox-io, commons-logging,
+    // xmlbeans, poi-ooxml-lite, commons-compress/io/codec/collections4/math3, curvesapi) into
+    // the plugin JAR so the plugin classloader can resolve them independently of the service
+    // classpath (PF4J APD strategy). Jackson and the SDK are declared compileOnly and
+    // therefore NOT in runtimeClasspath -- they are provided by the service classloader
+    // at runtime. Same pattern as agentos-mcp-plugin; the descriptor stays in
+    // src/main/resources/plugin.properties (no manifest attributes here).
+    from(configurations.runtimeClasspath.map { fc -> fc.filter { it.name.endsWith(".jar") }.map { zipTree(it) } }) {
+        exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+        exclude("kotlin/**", "kotlinx/**")
     }
 }
 

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/FileToolProvider.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/FileToolProvider.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.plugins.file
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.whozoss.agentos.plugins.file.image.ImageProcessor
 import io.whozoss.agentos.plugins.file.tools.EditFilesTool
 import io.whozoss.agentos.plugins.file.tools.ListFilesTool
 import io.whozoss.agentos.plugins.file.tools.MoveFileTool
@@ -45,13 +46,27 @@ class FileToolProvider : ToolPlugin {
             ?.map { it.asText() }
             ?: emptyList()
 
+        val imageMaxDimension = config.get("imageMaxDimension")?.asInt() ?: ImageProcessor.MAX_DIMENSION
+        val imageJpegQuality = config.get("imageJpegQuality")?.asDouble()?.toFloat() ?: ImageProcessor.JPEG_QUALITY
+        val imageMaxSourcePixels = config.get("imageMaxSourcePixels")?.asLong() ?: ImageProcessor.MAX_SOURCE_PIXELS
+        val imagePassThroughMaxBytes = config.get("imagePassThroughMaxBytes")?.asLong() ?: ImageProcessor.PASS_THROUGH_MAX_BYTES
+
         val readMaxSizeBytes = readMaxSizeMb * 1024 * 1024
         val denyPatterns = SensitiveFilePatterns.DEFAULT_PATTERNS + extraDenyPatterns
 
         val readTools = listOf(
             ListFilesTool(rootPath, configName, denyPatterns),
             ReadFileTool(rootPath, configName, readMaxSizeBytes, denyPatterns),
-            ReadAsImageTool(rootPath, configName, readMaxSizeBytes, denyPatterns),
+            ReadAsImageTool(
+                rootPath,
+                configName,
+                readMaxSizeBytes,
+                denyPatterns,
+                imageMaxDimension = imageMaxDimension,
+                imageJpegQuality = imageJpegQuality,
+                imageMaxSourcePixels = imageMaxSourcePixels,
+                imagePassThroughMaxBytes = imagePassThroughMaxBytes,
+            ),
             SearchFilesTool(rootPath, configName, denyPatterns),
         )
 
@@ -88,6 +103,30 @@ class FileToolProvider : ToolPlugin {
                         "title": "Read Max Size (MB)",
                         "description": "Maximum file size in megabytes that ReadFileTool will read. Default is 10 MB.",
                         "default": 10
+                    },
+                    "imageMaxDimension": {
+                        "type": "integer",
+                        "title": "Image Max Dimension (px)",
+                        "description": "Longest-edge size, in pixels, that readAsImage sends to the LLM; larger images are downscaled. Default is 1024.",
+                        "default": 1024
+                    },
+                    "imageJpegQuality": {
+                        "type": "number",
+                        "title": "Image JPEG Quality",
+                        "description": "JPEG re-encoding quality for readAsImage, between 0 and 1. Default is 0.80.",
+                        "default": 0.80
+                    },
+                    "imageMaxSourcePixels": {
+                        "type": "integer",
+                        "title": "Image Max Source Pixels",
+                        "description": "Decode-bomb guard: readAsImage refuses to decode any source or embedded image above this pixel count. Default is 50000000.",
+                        "default": 50000000
+                    },
+                    "imagePassThroughMaxBytes": {
+                        "type": "integer",
+                        "title": "Image Pass-Through Max Size (bytes)",
+                        "description": "Originals at or below this byte size that already fit the max dimension are sent untouched instead of re-encoded. Default is 1048576 (1 MB).",
+                        "default": 1048576
                     },
                     "extraDenyPatterns": {
                         "type": "array",

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/FileToolProvider.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/FileToolProvider.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.whozoss.agentos.plugins.file.tools.EditFilesTool
 import io.whozoss.agentos.plugins.file.tools.ListFilesTool
 import io.whozoss.agentos.plugins.file.tools.MoveFileTool
+import io.whozoss.agentos.plugins.file.tools.ReadAsImageTool
 import io.whozoss.agentos.plugins.file.tools.ReadFileTool
 import io.whozoss.agentos.plugins.file.tools.RemoveFileTool
 import io.whozoss.agentos.plugins.file.tools.SearchFilesTool
@@ -22,9 +23,9 @@ import java.nio.file.Path
  * and instantiates file tools with the rootPath drawn from the persisted
  * IntegrationConfig parameters.
  *
- * When [readOnly] is true, only the read tools (list, read, search) are provided.
- * Write tools (edit, remove, move) are not included at all, so the agent
- * is never aware of their existence.
+ * When [readOnly] is true, only the read tools (list, read, readAsImage, search)
+ * are provided. Write tools (edit, remove, move) are not included at all, so the
+ * agent is never aware of their existence.
  */
 @Extension
 class FileToolProvider : ToolPlugin {
@@ -50,6 +51,7 @@ class FileToolProvider : ToolPlugin {
         val readTools = listOf(
             ListFilesTool(rootPath, configName, denyPatterns),
             ReadFileTool(rootPath, configName, readMaxSizeBytes, denyPatterns),
+            ReadAsImageTool(rootPath, configName, readMaxSizeBytes, denyPatterns),
             SearchFilesTool(rootPath, configName, denyPatterns),
         )
 

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessor.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessor.kt
@@ -5,6 +5,7 @@ import java.awt.Color
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.nio.file.Path
 import java.util.Base64
 import javax.imageio.IIOImage
@@ -34,23 +35,48 @@ object ImageProcessor {
     /** Original bytes below this size that already fit [MAX_DIMENSION] are passed through untouched. */
     const val PASS_THROUGH_MAX_BYTES = 1L * 1024 * 1024
 
+    /** Mime type by ImageIO reader format name — the format of the actual BYTES, not the file name. */
+    private val MIME_BY_FORMAT = mapOf(
+        "png" to "image/png",
+        "jpeg" to "image/jpeg",
+        "jpg" to "image/jpeg",
+        "gif" to "image/gif",
+        "bmp" to "image/bmp",
+    )
+
     /**
-     * Reads the dimensions (width x height) of an image file from its header,
+     * Image header sniffed without decoding any pixel data: dimensions plus the mime type
+     * of the actual content. [mimeType] is null when the detected format has no mime
+     * mapping (the content is readable but must go through the re-encoding path).
+     */
+    data class ImageHeader(val width: Int, val height: Int, val mimeType: String?)
+
+    /**
+     * Reads the header of an image file (dimensions and content-detected mime type)
      * without decoding the pixel data. Returns null when no installed reader
      * recognizes the format (e.g. corrupt or misnamed file).
      */
-    fun readDimensions(file: Path): Pair<Int, Int>? =
-        file.inputStream().use { input ->
-            ImageIO.createImageInputStream(input).use { imageInput ->
-                val readers = ImageIO.getImageReaders(imageInput)
-                if (!readers.hasNext()) return null
-                val reader = readers.next()
-                try {
-                    reader.input = imageInput
-                    reader.getWidth(0) to reader.getHeight(0)
-                } finally {
-                    reader.dispose()
-                }
+    fun readHeader(file: Path): ImageHeader? = file.inputStream().use { readHeader(it) }
+
+    /**
+     * Reads the header of an image stream (dimensions and content-detected mime type)
+     * without decoding the pixel data. Returns null when no installed reader
+     * recognizes the format. Only the header bytes are consumed.
+     */
+    fun readHeader(input: InputStream): ImageHeader? =
+        ImageIO.createImageInputStream(input).use { imageInput ->
+            val readers = ImageIO.getImageReaders(imageInput)
+            if (!readers.hasNext()) return null
+            val reader = readers.next()
+            try {
+                reader.input = imageInput
+                ImageHeader(
+                    width = reader.getWidth(0),
+                    height = reader.getHeight(0),
+                    mimeType = MIME_BY_FORMAT[reader.formatName.lowercase()],
+                )
+            } finally {
+                reader.dispose()
             }
         }
 

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessor.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessor.kt
@@ -1,0 +1,126 @@
+package io.whozoss.agentos.plugins.file.image
+
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import java.awt.Color
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.nio.file.Path
+import java.util.Base64
+import javax.imageio.IIOImage
+import javax.imageio.ImageIO
+import javax.imageio.ImageWriteParam
+import kotlin.io.path.inputStream
+
+/**
+ * Pure image processing helpers for the readAsImage tool.
+ *
+ * Everything is sized for LLM vision input: images are bounded to
+ * [MAX_DIMENSION] on their longest edge and re-encoded as JPEG at
+ * [JPEG_QUALITY] (alpha flattened onto white), matching the common
+ * denominator of the vision-capable providers.
+ */
+object ImageProcessor {
+
+    /** Maximum width/height sent to the LLM. Hard-coded for now, configurable later. */
+    const val MAX_DIMENSION = 1024
+
+    /** JPEG re-encoding quality. */
+    const val JPEG_QUALITY = 0.80f
+
+    /** Decode-bomb guard: refuse to decode sources above this pixel count. */
+    const val MAX_SOURCE_PIXELS = 50_000_000L
+
+    /** Original bytes below this size that already fit [MAX_DIMENSION] are passed through untouched. */
+    const val PASS_THROUGH_MAX_BYTES = 1L * 1024 * 1024
+
+    /**
+     * Reads the dimensions (width x height) of an image file from its header,
+     * without decoding the pixel data. Returns null when no installed reader
+     * recognizes the format (e.g. corrupt or misnamed file).
+     */
+    fun readDimensions(file: Path): Pair<Int, Int>? =
+        file.inputStream().use { input ->
+            ImageIO.createImageInputStream(input).use { imageInput ->
+                val readers = ImageIO.getImageReaders(imageInput)
+                if (!readers.hasNext()) return null
+                val reader = readers.next()
+                try {
+                    reader.input = imageInput
+                    reader.getWidth(0) to reader.getHeight(0)
+                } finally {
+                    reader.dispose()
+                }
+            }
+        }
+
+    /**
+     * True when the original file bytes can be sent as-is: the image already fits
+     * [MAX_DIMENSION] and the file is small enough that re-encoding would not
+     * meaningfully reduce the payload (also preserves GIF animation and PNG sharpness).
+     */
+    fun passThroughEligible(width: Int, height: Int, fileSizeBytes: Long): Boolean =
+        width <= MAX_DIMENSION && height <= MAX_DIMENSION && fileSizeBytes <= PASS_THROUGH_MAX_BYTES
+
+    /**
+     * Target dimensions scaled to fit [maxDimension] on the longest edge,
+     * preserving aspect ratio, never enlarging.
+     */
+    fun scaleDimensions(width: Int, height: Int, maxDimension: Int = MAX_DIMENSION): Pair<Int, Int> {
+        if (width <= maxDimension && height <= maxDimension) return width to height
+        val scale = minOf(maxDimension.toDouble() / width, maxDimension.toDouble() / height)
+        return maxOf(1, Math.round(width * scale).toInt()) to maxOf(1, Math.round(height * scale).toInt())
+    }
+
+    /**
+     * Renders [source] into an RGB image of [targetWidth] x [targetHeight]:
+     * bilinear scaling, alpha flattened onto a white background (JPEG has no alpha).
+     */
+    fun renderRgb(source: BufferedImage, targetWidth: Int, targetHeight: Int): BufferedImage {
+        val target = BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_RGB)
+        val graphics = target.createGraphics()
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+            graphics.color = Color.WHITE
+            graphics.fillRect(0, 0, targetWidth, targetHeight)
+            graphics.drawImage(source, 0, 0, targetWidth, targetHeight, null)
+        } finally {
+            graphics.dispose()
+        }
+        return target
+    }
+
+    /** Encodes [image] as JPEG at [quality]. */
+    fun encodeJpeg(image: BufferedImage, quality: Float = JPEG_QUALITY): ByteArray {
+        val writer = ImageIO.getImageWritersByFormatName("jpeg").next()
+        val params = writer.defaultWriteParam.apply {
+            compressionMode = ImageWriteParam.MODE_EXPLICIT
+            compressionQuality = quality
+        }
+        val output = ByteArrayOutputStream()
+        ImageIO.createImageOutputStream(output).use { imageOutput ->
+            writer.output = imageOutput
+            try {
+                writer.write(null, IIOImage(image, null, null), params)
+            } finally {
+                writer.dispose()
+            }
+        }
+        return output.toByteArray()
+    }
+
+    /**
+     * Scales [source] to fit [MAX_DIMENSION] (never enlarging), flattens alpha and
+     * encodes JPEG at [JPEG_QUALITY], as a ready-to-send [MessageContent.Image].
+     */
+    fun toJpegContent(source: BufferedImage): MessageContent.Image {
+        val (targetWidth, targetHeight) = scaleDimensions(source.width, source.height)
+        val bytes = encodeJpeg(renderRgb(source, targetWidth, targetHeight))
+        return MessageContent.Image(
+            content = Base64.getEncoder().encodeToString(bytes),
+            mimeType = "image/jpeg",
+            width = targetWidth,
+            height = targetHeight,
+        )
+    }
+}

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessor.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessor.kt
@@ -23,16 +23,16 @@ import kotlin.io.path.inputStream
  */
 object ImageProcessor {
 
-    /** Maximum width/height sent to the LLM. Hard-coded for now, configurable later. */
+    /** Default maximum width/height sent to the LLM; overridable per FILE_ACCESS integration (`imageMaxDimension`). */
     const val MAX_DIMENSION = 1024
 
-    /** JPEG re-encoding quality. */
+    /** Default JPEG re-encoding quality; overridable per FILE_ACCESS integration (`imageJpegQuality`). */
     const val JPEG_QUALITY = 0.80f
 
-    /** Decode-bomb guard: refuse to decode sources above this pixel count. */
+    /** Default decode-bomb guard: refuse to decode sources above this pixel count (`imageMaxSourcePixels`). */
     const val MAX_SOURCE_PIXELS = 50_000_000L
 
-    /** Original bytes below this size that already fit [MAX_DIMENSION] are passed through untouched. */
+    /** Default: original bytes below this size that already fit the max dimension are passed through untouched (`imagePassThroughMaxBytes`). */
     const val PASS_THROUGH_MAX_BYTES = 1L * 1024 * 1024
 
     /** Mime type by ImageIO reader format name — the format of the actual BYTES, not the file name. */
@@ -82,11 +82,17 @@ object ImageProcessor {
 
     /**
      * True when the original file bytes can be sent as-is: the image already fits
-     * [MAX_DIMENSION] and the file is small enough that re-encoding would not
+     * [maxDimension] and the file is small enough that re-encoding would not
      * meaningfully reduce the payload (also preserves GIF animation and PNG sharpness).
      */
-    fun passThroughEligible(width: Int, height: Int, fileSizeBytes: Long): Boolean =
-        width <= MAX_DIMENSION && height <= MAX_DIMENSION && fileSizeBytes <= PASS_THROUGH_MAX_BYTES
+    fun passThroughEligible(
+        width: Int,
+        height: Int,
+        fileSizeBytes: Long,
+        maxDimension: Int = MAX_DIMENSION,
+        passThroughMaxBytes: Long = PASS_THROUGH_MAX_BYTES,
+    ): Boolean =
+        width <= maxDimension && height <= maxDimension && fileSizeBytes <= passThroughMaxBytes
 
     /**
      * Target dimensions scaled to fit [maxDimension] on the longest edge,
@@ -136,12 +142,16 @@ object ImageProcessor {
     }
 
     /**
-     * Scales [source] to fit [MAX_DIMENSION] (never enlarging), flattens alpha and
-     * encodes JPEG at [JPEG_QUALITY], as a ready-to-send [MessageContent.Image].
+     * Scales [source] to fit [maxDimension] (never enlarging), flattens alpha and
+     * encodes JPEG at [quality], as a ready-to-send [MessageContent.Image].
      */
-    fun toJpegContent(source: BufferedImage): MessageContent.Image {
-        val (targetWidth, targetHeight) = scaleDimensions(source.width, source.height)
-        val bytes = encodeJpeg(renderRgb(source, targetWidth, targetHeight))
+    fun toJpegContent(
+        source: BufferedImage,
+        maxDimension: Int = MAX_DIMENSION,
+        quality: Float = JPEG_QUALITY,
+    ): MessageContent.Image {
+        val (targetWidth, targetHeight) = scaleDimensions(source.width, source.height, maxDimension)
+        val bytes = encodeJpeg(renderRgb(source, targetWidth, targetHeight), quality)
         return MessageContent.Image(
             content = Base64.getEncoder().encodeToString(bytes),
             mimeType = "image/jpeg",

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
@@ -7,11 +7,23 @@ import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withTimeout
 import mu.KLogging
 import org.apache.pdfbox.Loader
+import org.apache.pdfbox.cos.COSBase
+import org.apache.pdfbox.cos.COSName
+import org.apache.pdfbox.cos.COSStream
 import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDResources
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
+import org.apache.pdfbox.pdmodel.graphics.pattern.PDTilingPattern
 import org.apache.pdfbox.rendering.ImageType
 import org.apache.pdfbox.rendering.PDFRenderer
 import org.apache.poi.EncryptedDocumentException
@@ -29,6 +41,7 @@ import java.util.Base64
 import javax.imageio.ImageIO
 import kotlin.io.path.fileSize
 import kotlin.io.path.name
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Render an image, PDF or PPTX file into [MessageContent.Image] attachments so a
@@ -44,6 +57,11 @@ import kotlin.io.path.name
  * PPTX fidelity (POI rendering): text, shapes, tables and bitmap pictures render
  * well; fonts absent from the host are substituted (e.g. Calibri to DejaVu),
  * SmartArt is not rendered and embedded charts come out blank.
+ *
+ * Decompression-bomb guards: standalone images are rejected above
+ * [ImageProcessor.MAX_SOURCE_PIXELS]; images EMBEDDED in a PDF or PPTX are pre-checked
+ * against the same cap from their declared header dimensions before anything is decoded
+ * (PDFBox/POI otherwise decode embedded bitmaps at full source resolution).
  */
 class ReadAsImageTool(
     private val projectRoot: Path,
@@ -73,19 +91,30 @@ class ReadAsImageTool(
          */
         private const val RENDER_TARGET_PX = 2048
 
-        private val IMAGE_MIME_BY_EXTENSION = mapOf(
-            "png" to "image/png",
-            "jpg" to "image/jpeg",
-            "jpeg" to "image/jpeg",
-            "gif" to "image/gif",
-            "bmp" to "image/bmp",
-        )
+        /** Extensions routed to the standalone-image path. */
+        private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "bmp")
 
         /**
-         * Original bytes may be sent as-is only for these mime types: the vision APIs
-         * accept png/jpeg/gif but reject image/bmp, so bmp is always re-encoded JPEG.
+         * Original bytes may be sent as-is only for these mime types, DETECTED FROM THE
+         * CONTENT by [ImageProcessor.readHeader] (never from the file extension, which the
+         * provider would reject on a mismatched payload): the vision APIs accept
+         * png/jpeg/gif but reject image/bmp, so bmp is always re-encoded JPEG.
          */
         private val PASS_THROUGH_MIME_TYPES = setOf("image/png", "image/jpeg", "image/gif")
+
+        /** Maximum concurrent renders across all instances of this tool. */
+        private const val MAX_CONCURRENT_RENDERS = 4
+
+        /** Nesting bound for the embedded-image resource scan (form XObjects, patterns). */
+        private const val MAX_EMBEDDED_SCAN_DEPTH = 5
+
+        /**
+         * Bounded, abandonable pool for the blocking renders. Coroutine cancellation is
+         * cooperative and PDFBox/POI rendering never suspends, so a timed-out render
+         * cannot be stopped: it is left to finish here (result discarded) instead of
+         * pinning the caller or an unbounded share of the Dispatchers.IO workers.
+         */
+        private val renderScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_RENDERS))
     }
 
     override val name: String = if (configName != null) "${configName}__readAsImage" else "FILES__readAsImage"
@@ -141,9 +170,20 @@ class ReadAsImageTool(
         val params = input ?: Input()
 
         return try {
-            val (summary, images) = runIOWithTimeout(IO_TIMEOUT) { render(params) }
+            val (summary, images) =
+                withTimeout(IO_TIMEOUT.seconds) {
+                    // Rendering is blocking, CPU-bound PDFBox/POI work that ignores
+                    // cooperative cancellation: run it as an abandonable job on the bounded
+                    // [renderScope] pool so the timeout releases the caller immediately and a
+                    // runaway render pins at most [MAX_CONCURRENT_RENDERS] threads.
+                    renderScope.async { render(params) }.await()
+                }
             ToolExecutionResult.successWithImages(summary, images)
         } catch (e: TimeoutCancellationException) {
+            logger.warn {
+                "readAsImage timed out after ${IO_TIMEOUT}s on '${params.filePath}'; " +
+                    "the abandoned render keeps its pool slot until it completes"
+            }
             ToolExecutionResult.error(
                 "Operation timed out after $IO_TIMEOUT seconds",
                 errorType = "TIMEOUT",
@@ -188,11 +228,11 @@ class ReadAsImageTool(
         return when (val extension = resolved.name.substringAfterLast('.', "").lowercase()) {
             "pdf" -> renderPdf(resolved, params.pages)
             "pptx" -> renderPptx(resolved, params.pages)
-            in IMAGE_MIME_BY_EXTENSION.keys -> {
+            in IMAGE_EXTENSIONS -> {
                 if (params.pages != null) {
                     throw IllegalArgumentException("\"pages\" applies only to PDF and PPTX files: ${params.filePath}")
                 }
-                renderImage(resolved, IMAGE_MIME_BY_EXTENSION.getValue(extension))
+                renderImage(resolved)
             }
             else -> throw UnsupportedFormatException(
                 "Unsupported file type '.$extension'. Supported: png, jpg, jpeg, gif, bmp, pdf, pptx. " +
@@ -201,21 +241,29 @@ class ReadAsImageTool(
         }
     }
 
-    private fun renderImage(file: Path, mimeType: String): Pair<String, List<MessageContent.Image>> {
-        val (width, height) = ImageProcessor.readDimensions(file)
+    private fun renderImage(file: Path): Pair<String, List<MessageContent.Image>> {
+        val header = ImageProcessor.readHeader(file)
             ?: throw IllegalArgumentException("File does not contain a readable image: ${file.name}")
-        if (width.toLong() * height > ImageProcessor.MAX_SOURCE_PIXELS) {
+        if (header.width.toLong() * header.height > ImageProcessor.MAX_SOURCE_PIXELS) {
             throw IllegalArgumentException(
-                "Image is too large to decode (${width}x$height, max ${ImageProcessor.MAX_SOURCE_PIXELS} pixels): ${file.name}",
+                "Image is too large to decode (${header.width}x${header.height}," +
+                    " max ${ImageProcessor.MAX_SOURCE_PIXELS} pixels): ${file.name}",
             )
         }
 
-        val image = if (mimeType in PASS_THROUGH_MIME_TYPES && ImageProcessor.passThroughEligible(width, height, file.fileSize())) {
+        // The pass-through mime is the one detected from the bytes, never the extension:
+        // a JPEG named .png sent as image/png would be rejected by the provider.
+        val contentMime = header.mimeType
+        val image = if (
+            contentMime != null &&
+            contentMime in PASS_THROUGH_MIME_TYPES &&
+            ImageProcessor.passThroughEligible(header.width, header.height, file.fileSize())
+        ) {
             MessageContent.Image(
                 content = Base64.getEncoder().encodeToString(Files.readAllBytes(file)),
-                mimeType = mimeType,
-                width = width,
-                height = height,
+                mimeType = contentMime,
+                width = header.width,
+                height = header.height,
             )
         } else {
             val decoded = ImageIO.read(file.toFile())
@@ -234,8 +282,13 @@ class ReadAsImageTool(
                     throw IllegalArgumentException("PDF has no page: ${file.name}")
                 }
                 val selection = selectPages(pages, pageCount, file.name)
+                checkPdfEmbeddedImages(document, selection, file.name)
 
                 val renderer = PDFRenderer(document)
+                // Belt-and-braces behind the declared-dimension pre-scan above: subsampled
+                // decode keeps even a legitimate large embedded image from materializing
+                // at full resolution.
+                renderer.isSubsamplingAllowed = true
                 val images = selection.map { page ->
                     ImageProcessor.toJpegContent(
                         renderer.renderImageWithDPI(page - 1, pageRenderDpi(document, page), ImageType.RGB),
@@ -262,6 +315,88 @@ class ReadAsImageTool(
         return minOf(PDF_RENDER_DPI, RENDER_TARGET_PX * POINTS_PER_INCH / longestEdgePt)
     }
 
+    /**
+     * Decompression-bomb guard for images embedded in a PDF: walks the resources of the
+     * selected pages (nested form XObjects, tiling patterns and annotation appearances,
+     * depth-bounded) and rejects any image XObject whose DECLARED dimensions exceed
+     * [ImageProcessor.MAX_SOURCE_PIXELS], before anything is decoded. PDFBox decodes
+     * embedded images at full source resolution while drawing, so without this check a
+     * sub-cap file declaring a huge image would allocate a multi-GB raster (uncatchable
+     * OutOfMemoryError) — the same failure mode [pageRenderDpi] guards for the page buffer.
+     */
+    private fun checkPdfEmbeddedImages(document: PDDocument, selection: List<Int>, fileName: String) {
+        val visited = mutableSetOf<COSBase>()
+        selection.forEach { pageNumber ->
+            val page = document.getPage(pageNumber - 1)
+            checkPdfResources(page.resources, fileName, visited, depth = 0)
+            page.annotations.forEach { annotation ->
+                annotation.normalAppearanceStream?.let {
+                    checkPdfResources(it.resources, fileName, visited, depth = 1)
+                }
+            }
+        }
+    }
+
+    private fun checkPdfResources(
+        resources: PDResources?,
+        fileName: String,
+        visited: MutableSet<COSBase>,
+        depth: Int,
+    ) {
+        if (resources == null || depth > MAX_EMBEDDED_SCAN_DEPTH || !visited.add(resources.cosObject)) return
+        for (name in resources.xObjectNames) {
+            // An entry that cannot be materialized would not render either: skip it here
+            // and let the renderer apply its own tolerance for broken objects.
+            when (val xObject = runCatching { resources.getXObject(name) }.getOrNull()) {
+                is PDImageXObject -> {
+                    checkEmbeddedImageSize(xObject.width, xObject.height, fileName)
+                    checkImageMaskSize(xObject, COSName.SMASK, fileName)
+                    checkImageMaskSize(xObject, COSName.MASK, fileName)
+                }
+                is PDFormXObject -> checkPdfResources(xObject.resources, fileName, visited, depth + 1)
+                else -> {}
+            }
+        }
+        for (name in resources.patternNames) {
+            val pattern = runCatching { resources.getPattern(name) }.getOrNull()
+            if (pattern is PDTilingPattern) {
+                checkPdfResources(pattern.resources, fileName, visited, depth + 1)
+            }
+        }
+    }
+
+    /** Declared dimensions of an image's /SMask or /Mask stream, checked without decoding. */
+    private fun checkImageMaskSize(image: PDImageXObject, key: COSName, fileName: String) {
+        val mask = image.cosObject.getDictionaryObject(key) as? COSStream ?: return
+        checkEmbeddedImageSize(mask.getInt(COSName.WIDTH, 0), mask.getInt(COSName.HEIGHT, 0), fileName)
+    }
+
+    /**
+     * Decompression-bomb guard for pictures embedded in a PPTX: sniffs the header of every
+     * picture part in the package (slides, layouts, masters and backgrounds share the same
+     * part pool) and rejects the deck when a picture's declared dimensions exceed
+     * [ImageProcessor.MAX_SOURCE_PIXELS]. POI decodes pictures at full source resolution
+     * while drawing. Header-only sniff: no pixel data is decoded; unrecognized parts
+     * (vector metafiles, corrupt data) are skipped, as POI itself skips them.
+     */
+    private fun checkPptxEmbeddedImages(presentation: XMLSlideShow, fileName: String) {
+        presentation.pictureData.forEach { picture ->
+            val header = runCatching {
+                picture.inputStream.use { ImageProcessor.readHeader(it) }
+            }.getOrNull() ?: return@forEach
+            checkEmbeddedImageSize(header.width, header.height, fileName)
+        }
+    }
+
+    private fun checkEmbeddedImageSize(width: Int, height: Int, fileName: String) {
+        if (width.toLong() * height > ImageProcessor.MAX_SOURCE_PIXELS) {
+            throw IllegalArgumentException(
+                "Embedded image is too large to decode (${width}x$height," +
+                    " max ${ImageProcessor.MAX_SOURCE_PIXELS} pixels): $fileName",
+            )
+        }
+    }
+
     private fun renderPptx(file: Path, pages: List<Int>?): Pair<String, List<MessageContent.Image>> {
         try {
             // XMLSlideShow is constructed directly on purpose: SlideShowFactory resolves
@@ -275,6 +410,7 @@ class ReadAsImageTool(
                     }
                     sanitizeDanglingTableStyleRefs(presentation)
                     val selection = selectPages(pages, slideCount, file.name, unit = "slide")
+                    checkPptxEmbeddedImages(presentation, file.name)
 
                     val pageSize = presentation.pageSize
                     val scale = RENDER_TARGET_PX.toDouble() / maxOf(pageSize.width, pageSize.height)

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
@@ -1,0 +1,346 @@
+package io.whozoss.agentos.plugins.file.tools
+
+import io.whozoss.agentos.plugins.file.BoundaryPathResolver
+import io.whozoss.agentos.plugins.file.SensitiveFilePatterns
+import io.whozoss.agentos.plugins.file.image.ImageProcessor
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+import kotlinx.coroutines.TimeoutCancellationException
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException
+import org.apache.pdfbox.rendering.ImageType
+import org.apache.pdfbox.rendering.PDFRenderer
+import org.apache.poi.EncryptedDocumentException
+import org.apache.poi.openxml4j.exceptions.NotOfficeXmlFileException
+import org.apache.poi.xslf.usermodel.XMLSlideShow
+import java.awt.Color
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlin.io.path.fileSize
+import kotlin.io.path.name
+
+/**
+ * Render an image, PDF or PPTX file into [MessageContent.Image] attachments so a
+ * vision-capable model can see it.
+ *
+ * Images (png/jpg/jpeg/gif/bmp) are bounded to [ImageProcessor.MAX_DIMENSION] and
+ * re-encoded JPEG when needed; small originals pass through untouched. PDFs are
+ * rendered one image per page, PPTX presentations one image per slide (at most
+ * [MAX_PAGES_PER_CALL] per call, selectable via the `pages` parameter). The textual
+ * [ToolExecutionResult.output] summarizes what was rendered; the images ride in
+ * [ToolExecutionResult.images].
+ *
+ * PPTX fidelity (POI rendering): text, shapes, tables and bitmap pictures render
+ * well; fonts absent from the host are substituted (e.g. Calibri to DejaVu),
+ * SmartArt is not rendered and embedded charts come out blank.
+ */
+class ReadAsImageTool(
+    private val projectRoot: Path,
+    private val configName: String? = null,
+    private val readMaxSizeBytes: Long = DEFAULT_READ_MAX_SIZE,
+    private val denyPatterns: List<String> = SensitiveFilePatterns.DEFAULT_PATTERNS,
+) : StandardTool<ReadAsImageTool.Input> {
+    companion object {
+        /** PDF/PPTX rendering is significantly slower than a plain read: distinct, larger timeout. */
+        private const val IO_TIMEOUT = 60L
+        private const val DEFAULT_READ_MAX_SIZE = 10L * 1024 * 1024 // 10 MB
+
+        /** Maximum PDF pages / PPTX slides rendered in a single call. */
+        const val MAX_PAGES_PER_CALL = 10
+
+        /** Rendering resolution before downscaling: keeps text legible at 1024px. */
+        private const val PDF_RENDER_DPI = 150f
+
+        /**
+         * PPTX slides are rendered with their longest edge at this size (2x supersampling),
+         * then downscaled to [ImageProcessor.MAX_DIMENSION]: keeps slide text legible.
+         */
+        private const val SLIDE_RENDER_TARGET = 2048
+
+        private val IMAGE_MIME_BY_EXTENSION = mapOf(
+            "png" to "image/png",
+            "jpg" to "image/jpeg",
+            "jpeg" to "image/jpeg",
+            "gif" to "image/gif",
+            "bmp" to "image/bmp",
+        )
+    }
+
+    override val name: String = if (configName != null) "${configName}__readAsImage" else "FILES__readAsImage"
+
+    override val description: String =
+        """
+        Render an image, PDF or PowerPoint file VISUALLY, as image(s) attached to the
+        conversation, so you can SEE its content: photos, scans, screenshots, diagrams,
+        charts, PDF documents (one image per page) and PPTX presentations (one image per
+        slide). Requires a vision-capable model.
+        Supported: .png, .jpg, .jpeg, .gif (first frame when resized), .bmp, .pdf, .pptx.
+        Do NOT use for text-based files (source code, markdown, CSV, JSON, logs...):
+        use readFile instead, which returns the exact text and is far cheaper.
+        PDF/PPTX: at most $MAX_PAGES_PER_CALL pages/slides are rendered per call; pass
+        "pages" (1-based page or slide numbers) to view a specific subset of a longer document.
+        """.trimIndent()
+
+    override val version: String = "1.0.0"
+
+    override val paramType: Class<Input> = Input::class.java
+
+    // language=JSON
+    override val inputSchema: String =
+        """
+        {
+            "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "filePath": {
+                    "type": "string",
+                    "description": "Relative file path (e.g. \"cv.pdf\", \"decks/pitch.pptx\", \"diagrams/archi.png\")"
+                },
+                "pages": {
+                    "type": "array",
+                    "items": { "type": "integer", "minimum": 1 },
+                    "description": "1-based page numbers (PDF) or slide numbers (PPTX); max $MAX_PAGES_PER_CALL per call. Omit to render from the beginning up to the cap."
+                }
+            },
+            "required": ["filePath"],
+            "additionalProperties": false
+        }
+        """.trimIndent()
+
+    data class Input(
+        val filePath: String = "",
+        val pages: List<Int>? = null,
+    )
+
+    override suspend fun execute(
+        input: Input?,
+        context: ToolContext,
+    ): ToolExecutionResult {
+        val params = input ?: Input()
+
+        return try {
+            val (summary, images) = runIOWithTimeout(IO_TIMEOUT) { render(params) }
+            ToolExecutionResult.successWithImages(summary, images)
+        } catch (e: TimeoutCancellationException) {
+            ToolExecutionResult.error(
+                "Operation timed out after $IO_TIMEOUT seconds",
+                errorType = "TIMEOUT",
+                errorMessage = e.message,
+            )
+        } catch (e: UnsupportedFormatException) {
+            ToolExecutionResult.error(
+                e.message ?: "Unsupported file format",
+                errorType = "UNSUPPORTED_FORMAT",
+                errorMessage = e.message,
+            )
+        } catch (e: IllegalArgumentException) {
+            ToolExecutionResult.error(
+                e.message ?: "Invalid input",
+                errorType = "INVALID_INPUT",
+                errorMessage = e.message,
+            )
+        } catch (e: Exception) {
+            ToolExecutionResult.error(
+                "Error rendering file: ${e.message}",
+                errorType = "READ_ERROR",
+                errorMessage = e.message,
+            )
+        }
+    }
+
+    private fun render(params: Input): Pair<String, List<MessageContent.Image>> {
+        val resolver = BoundaryPathResolver(projectRoot, denyPatterns)
+        val resolved = resolver.resolve(params.filePath, createIntent = false)
+
+        // Size guard before anything is parsed. Also the first line of defense against
+        // decompression bombs; POI's built-in ZipSecureFile checks (inflate ratio cap,
+        // max entry size) cover the pptx zip itself.
+        val size = resolved.fileSize()
+        if (size > readMaxSizeBytes) {
+            throw IllegalArgumentException(
+                "File exceeds maximum size of ${readMaxSizeBytes / 1024 / 1024} MB: ${params.filePath}",
+            )
+        }
+
+        return when (val extension = resolved.name.substringAfterLast('.', "").lowercase()) {
+            "pdf" -> renderPdf(resolved, params.pages)
+            "pptx" -> renderPptx(resolved, params.pages)
+            in IMAGE_MIME_BY_EXTENSION.keys -> {
+                if (params.pages != null) {
+                    throw IllegalArgumentException("\"pages\" applies only to PDF and PPTX files: ${params.filePath}")
+                }
+                renderImage(resolved, IMAGE_MIME_BY_EXTENSION.getValue(extension))
+            }
+            else -> throw UnsupportedFormatException(
+                "Unsupported file type '.$extension'. Supported: png, jpg, jpeg, gif, bmp, pdf, pptx. " +
+                    "For text-based files use readFile.",
+            )
+        }
+    }
+
+    private fun renderImage(file: Path, mimeType: String): Pair<String, List<MessageContent.Image>> {
+        val (width, height) = ImageProcessor.readDimensions(file)
+            ?: throw IllegalArgumentException("File does not contain a readable image: ${file.name}")
+        if (width.toLong() * height > ImageProcessor.MAX_SOURCE_PIXELS) {
+            throw IllegalArgumentException(
+                "Image is too large to decode (${width}x$height, max ${ImageProcessor.MAX_SOURCE_PIXELS} pixels): ${file.name}",
+            )
+        }
+
+        val image = if (ImageProcessor.passThroughEligible(width, height, file.fileSize())) {
+            MessageContent.Image(
+                content = Base64.getEncoder().encodeToString(Files.readAllBytes(file)),
+                mimeType = mimeType,
+                width = width,
+                height = height,
+            )
+        } else {
+            val decoded = ImageIO.read(file.toFile())
+                ?: throw IllegalArgumentException("File does not contain a readable image: ${file.name}")
+            ImageProcessor.toJpegContent(decoded)
+        }
+
+        return "Loaded image ${file.name} (${image.width}x${image.height}, ${image.mimeType}, attached)." to listOf(image)
+    }
+
+    private fun renderPdf(file: Path, pages: List<Int>?): Pair<String, List<MessageContent.Image>> {
+        try {
+            Loader.loadPDF(file.toFile()).use { document ->
+                val pageCount = document.numberOfPages
+                val selection = selectPages(pages, pageCount, file.name)
+
+                val renderer = PDFRenderer(document)
+                val images = selection.map { page ->
+                    ImageProcessor.toJpegContent(
+                        renderer.renderImageWithDPI(page - 1, PDF_RENDER_DPI, ImageType.RGB),
+                    )
+                }
+
+                val summary = buildString {
+                    append("Rendered PDF ${file.name}: page(s) ${describePages(selection)} of $pageCount (one image per page, attached).")
+                    if (pages == null && pageCount > MAX_PAGES_PER_CALL) {
+                        append(
+                            " $pageCount pages total: call again with pages=[${MAX_PAGES_PER_CALL + 1},...]" +
+                                " to view the following pages.",
+                        )
+                    }
+                }
+                return summary to images
+            }
+        } catch (e: InvalidPasswordException) {
+            throw IllegalArgumentException("PDF is password-protected: ${file.name}")
+        }
+    }
+
+    private fun renderPptx(file: Path, pages: List<Int>?): Pair<String, List<MessageContent.Image>> {
+        try {
+            // XMLSlideShow is constructed directly on purpose: SlideShowFactory resolves
+            // providers through the thread context classloader, which under PF4J is the
+            // application classloader and does not see the bundled POI classes.
+            Files.newInputStream(file).use { input ->
+                XMLSlideShow(input).use { presentation ->
+                    val slideCount = presentation.slides.size
+                    if (slideCount == 0) {
+                        throw IllegalArgumentException("PPTX has no slide: ${file.name}")
+                    }
+                    val selection = selectPages(pages, slideCount, file.name, unit = "slide")
+
+                    val pageSize = presentation.pageSize
+                    val scale = SLIDE_RENDER_TARGET.toDouble() / maxOf(pageSize.width, pageSize.height)
+                    val width = Math.round(pageSize.width * scale).toInt()
+                    val height = Math.round(pageSize.height * scale).toInt()
+
+                    val images = selection.map { slide -> renderSlide(presentation, slide, width, height, scale) }
+
+                    val summary = buildString {
+                        append(
+                            "Rendered PPTX ${file.name}: slide(s) ${describePages(selection)} of $slideCount" +
+                                " (one image per slide, attached).",
+                        )
+                        if (pages == null && slideCount > MAX_PAGES_PER_CALL) {
+                            append(
+                                " $slideCount slides total: call again with pages=[${MAX_PAGES_PER_CALL + 1},...]" +
+                                    " to view the following slides.",
+                            )
+                        }
+                    }
+                    return summary to images
+                }
+            }
+        } catch (e: EncryptedDocumentException) {
+            throw IllegalArgumentException("PowerPoint file is password-protected: ${file.name}")
+        } catch (e: NotOfficeXmlFileException) {
+            // Also covers encrypted pptx (stored as an OLE2 container) and legacy .ppt
+            // files renamed to .pptx.
+            throw IllegalArgumentException(
+                "Not a valid .pptx file (corrupt, password-protected, or legacy .ppt; convert to .pptx): ${file.name}",
+            )
+        }
+    }
+
+    private fun renderSlide(
+        presentation: XMLSlideShow,
+        slideNumber: Int,
+        width: Int,
+        height: Int,
+        scale: Double,
+    ): MessageContent.Image {
+        val target = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+        val graphics = target.createGraphics()
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+            graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+            graphics.color = Color.WHITE
+            graphics.fillRect(0, 0, width, height)
+            graphics.scale(scale, scale)
+            presentation.slides[slideNumber - 1].draw(graphics)
+        } finally {
+            graphics.dispose()
+        }
+        return ImageProcessor.toJpegContent(target)
+    }
+
+    private fun selectPages(
+        pages: List<Int>?,
+        pageCount: Int,
+        fileName: String,
+        unit: String = "page",
+    ): List<Int> {
+        if (pages == null) return (1..minOf(pageCount, MAX_PAGES_PER_CALL)).toList()
+
+        val selection = pages.distinct().sorted()
+        if (selection.isEmpty()) {
+            throw IllegalArgumentException("\"pages\" must not be empty: $fileName")
+        }
+        if (selection.size > MAX_PAGES_PER_CALL) {
+            throw IllegalArgumentException(
+                "At most $MAX_PAGES_PER_CALL ${unit}s per call (got ${selection.size}): split into several calls.",
+            )
+        }
+        val outOfRange = selection.filter { it !in 1..pageCount }
+        if (outOfRange.isNotEmpty()) {
+            throw IllegalArgumentException(
+                "Page(s) $outOfRange out of range: $fileName has $pageCount ${unit}(s).",
+            )
+        }
+        return selection
+    }
+
+    private fun describePages(selection: List<Int>): String {
+        val contiguous = selection.size > 1 && selection.last() - selection.first() == selection.size - 1
+        return when {
+            selection.size == 1 -> "${selection.first()}"
+            contiguous -> "${selection.first()}-${selection.last()}"
+            else -> selection.joinToString(",")
+        }
+    }
+
+    private class UnsupportedFormatException(message: String) : IllegalArgumentException(message)
+}

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
@@ -8,6 +8,7 @@ import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
 import kotlinx.coroutines.TimeoutCancellationException
+import mu.KLogging
 import org.apache.pdfbox.Loader
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException
@@ -16,6 +17,9 @@ import org.apache.pdfbox.rendering.PDFRenderer
 import org.apache.poi.EncryptedDocumentException
 import org.apache.poi.openxml4j.exceptions.NotOfficeXmlFileException
 import org.apache.poi.xslf.usermodel.XMLSlideShow
+import org.apache.poi.xslf.usermodel.XSLFGroupShape
+import org.apache.poi.xslf.usermodel.XSLFShape
+import org.apache.poi.xslf.usermodel.XSLFTable
 import java.awt.Color
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
@@ -47,7 +51,7 @@ class ReadAsImageTool(
     private val readMaxSizeBytes: Long = DEFAULT_READ_MAX_SIZE,
     private val denyPatterns: List<String> = SensitiveFilePatterns.DEFAULT_PATTERNS,
 ) : StandardTool<ReadAsImageTool.Input> {
-    companion object {
+    companion object : KLogging() {
         /** PDF/PPTX rendering is significantly slower than a plain read: distinct, larger timeout. */
         private const val IO_TIMEOUT = 60L
         private const val DEFAULT_READ_MAX_SIZE = 10L * 1024 * 1024 // 10 MB
@@ -158,6 +162,7 @@ class ReadAsImageTool(
                 errorMessage = e.message,
             )
         } catch (e: Exception) {
+            logger.warn(e) { "readAsImage failed to render '${params.filePath}'" }
             ToolExecutionResult.error(
                 "Error rendering file: ${e.message}",
                 errorType = "READ_ERROR",
@@ -268,6 +273,7 @@ class ReadAsImageTool(
                     if (slideCount == 0) {
                         throw IllegalArgumentException("PPTX has no slide: ${file.name}")
                     }
+                    sanitizeDanglingTableStyleRefs(presentation)
                     val selection = selectPages(pages, slideCount, file.name, unit = "slide")
 
                     val pageSize = presentation.pageSize
@@ -288,6 +294,33 @@ class ReadAsImageTool(
             throw IllegalArgumentException(
                 "Not a valid .pptx file (corrupt, password-protected, or legacy .ppt; convert to .pptx): ${file.name}",
             )
+        }
+    }
+
+    /**
+     * Some generators emit tables referencing a table style by id without shipping the
+     * `ppt/tableStyles.xml` part. PowerPoint falls back to default formatting, but POI
+     * dereferences the absent part and throws an NPE while drawing the table
+     * (XSLFTable.getTableStyle, still unguarded in POI 5.5.1). When the part is missing,
+     * the dangling references are dropped from the in-memory model only (the file is
+     * never written back), so rendering matches the PowerPoint fallback.
+     */
+    private fun sanitizeDanglingTableStyleRefs(presentation: XMLSlideShow) {
+        if (presentation.tableStyles != null) return
+        presentation.slides.forEach { slide -> stripTableStyleIds(slide.shapes) }
+    }
+
+    private fun stripTableStyleIds(shapes: List<XSLFShape>) {
+        shapes.forEach { shape ->
+            when (shape) {
+                is XSLFTable -> {
+                    val ctTable = shape.ctTable
+                    if (ctTable.isSetTblPr && ctTable.tblPr.isSetTableStyleId) {
+                        ctTable.tblPr.unsetTableStyleId()
+                    }
+                }
+                is XSLFGroupShape -> stripTableStyleIds(shape.shapes)
+            }
         }
     }
 

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
@@ -45,7 +45,7 @@ import kotlin.time.Duration.Companion.seconds
  * Render an image, PDF or PPTX file into [MessageContent.Image] attachments so a
  * vision-capable model can see it.
  *
- * Images (png/jpg/jpeg/gif/bmp) are bounded to [ImageProcessor.MAX_DIMENSION] and
+ * Images (png/jpg/jpeg/gif/bmp) are bounded to [imageMaxDimension] and
  * re-encoded JPEG when needed; small originals pass through untouched. PDFs are
  * rendered one image per page, PPTX presentations one image per slide (at most
  * [MAX_PAGES_PER_CALL] per call, selectable via the `pages` parameter). The textual
@@ -57,7 +57,7 @@ import kotlin.time.Duration.Companion.seconds
  * SmartArt is not rendered and embedded charts come out blank.
  *
  * Decompression-bomb guards (PDFBox/POI decode embedded bitmaps at full source
- * resolution): standalone images are rejected above [ImageProcessor.MAX_SOURCE_PIXELS]
+ * resolution): standalone images are rejected above [imageMaxSourcePixels]
  * from their declared header before any decode. Inside a PDF every image is intercepted
  * at [PageDrawer.drawImage] ([BoundedPageDrawer]) and checked against the same cap before
  * PDFBox materializes it: that is the single decode point for XObjects, inline images
@@ -70,52 +70,11 @@ class ReadAsImageTool(
     private val readMaxSizeBytes: Long = DEFAULT_READ_MAX_SIZE,
     private val denyPatterns: List<String> = SensitiveFilePatterns.DEFAULT_PATTERNS,
     private val ioTimeoutSeconds: Long = IO_TIMEOUT,
+    private val imageMaxDimension: Int = ImageProcessor.MAX_DIMENSION,
+    private val imageJpegQuality: Float = ImageProcessor.JPEG_QUALITY,
+    private val imageMaxSourcePixels: Long = ImageProcessor.MAX_SOURCE_PIXELS,
+    private val imagePassThroughMaxBytes: Long = ImageProcessor.PASS_THROUGH_MAX_BYTES,
 ) : StandardTool<ReadAsImageTool.Input> {
-    companion object : KLogging() {
-        /** PDF/PPTX rendering is significantly slower than a plain read: distinct, larger timeout. */
-        private const val IO_TIMEOUT = 60L
-        private const val DEFAULT_READ_MAX_SIZE = 10L * 1024 * 1024 // 10 MB
-
-        /** Maximum PDF pages / PPTX slides rendered in a single call. */
-        const val MAX_PAGES_PER_CALL = 10
-
-        /** Nominal PDF rendering resolution before downscaling: keeps text legible at 1024px. */
-        private const val PDF_RENDER_DPI = 150f
-
-        /** PDF user-space unit: 72 points per inch. */
-        private const val POINTS_PER_INCH = 72f
-
-        /**
-         * PDF pages and PPTX slides are rendered with their longest edge capped at this
-         * size (2x supersampling), then downscaled to [ImageProcessor.MAX_DIMENSION].
-         * On PDFs this also bounds the render allocation: a page declaring a huge
-         * MediaBox at [PDF_RENDER_DPI] would otherwise allocate a multi-GB buffer.
-         */
-        private const val RENDER_TARGET_PX = 2048
-
-        /** Extensions routed to the standalone-image path. */
-        private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "bmp")
-
-        /**
-         * Original bytes may be sent as-is only for these mime types, DETECTED FROM THE
-         * CONTENT by [ImageProcessor.readHeader] (never from the file extension, which the
-         * provider would reject on a mismatched payload): the vision APIs accept
-         * png/jpeg/gif but reject image/bmp, so bmp is always re-encoded JPEG.
-         */
-        private val PASS_THROUGH_MIME_TYPES = setOf("image/png", "image/jpeg", "image/gif")
-
-        /** Maximum concurrent renders across all instances of this tool. */
-        private const val MAX_CONCURRENT_RENDERS = 4
-
-        /**
-         * Bounded, abandonable pool for the blocking renders. Coroutine cancellation is
-         * cooperative and PDFBox/POI rendering never suspends, so a timed-out render
-         * cannot be stopped: it is left to finish here (result discarded) instead of
-         * pinning the caller or an unbounded share of the Dispatchers.IO workers.
-         */
-        private val renderScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_RENDERS))
-    }
-
     override val name: String = if (configName != null) "${configName}__readAsImage" else "FILES__readAsImage"
 
     override val description: String =
@@ -248,10 +207,10 @@ class ReadAsImageTool(
     private fun renderImage(file: Path): Pair<String, List<MessageContent.Image>> {
         val header = ImageProcessor.readHeader(file)
             ?: throw IllegalArgumentException("File does not contain a readable image: ${file.name}")
-        if (header.width.toLong() * header.height > ImageProcessor.MAX_SOURCE_PIXELS) {
+        if (header.width.toLong() * header.height > imageMaxSourcePixels) {
             throw IllegalArgumentException(
                 "Image is too large to decode (${header.width}x${header.height}," +
-                    " max ${ImageProcessor.MAX_SOURCE_PIXELS} pixels): ${file.name}",
+                    " max $imageMaxSourcePixels pixels): ${file.name}",
             )
         }
 
@@ -261,7 +220,13 @@ class ReadAsImageTool(
         val image = if (
             contentMime != null &&
             contentMime in PASS_THROUGH_MIME_TYPES &&
-            ImageProcessor.passThroughEligible(header.width, header.height, file.fileSize())
+            ImageProcessor.passThroughEligible(
+                header.width,
+                header.height,
+                file.fileSize(),
+                imageMaxDimension,
+                imagePassThroughMaxBytes,
+            )
         ) {
             MessageContent.Image(
                 content = Base64.getEncoder().encodeToString(Files.readAllBytes(file)),
@@ -272,7 +237,7 @@ class ReadAsImageTool(
         } else {
             val decoded = ImageIO.read(file.toFile())
                 ?: throw IllegalArgumentException("File does not contain a readable image: ${file.name}")
-            ImageProcessor.toJpegContent(decoded)
+            ImageProcessor.toJpegContent(decoded, imageMaxDimension, imageJpegQuality)
         }
 
         return "Loaded image ${file.name} (${image.width}x${image.height}, ${image.mimeType}, attached)." to listOf(image)
@@ -295,6 +260,8 @@ class ReadAsImageTool(
                 val images = selection.map { page ->
                     ImageProcessor.toJpegContent(
                         renderer.renderImageWithDPI(page - 1, pageRenderDpi(document, page), ImageType.RGB),
+                        imageMaxDimension,
+                        imageJpegQuality,
                     )
                 }
 
@@ -328,7 +295,7 @@ class ReadAsImageTool(
     }
 
     /**
-     * Rejects any image over [ImageProcessor.MAX_SOURCE_PIXELS] from its DECLARED dimensions
+     * Rejects any image over [imageMaxSourcePixels] from its DECLARED dimensions
      * before PDFBox decodes it. [PageDrawer.drawImage] is the single decode entry point for
      * every image PDFBox draws — image XObjects, inline images (BI/ID/EI), Type3 glyph
      * images, and images reachable through forms/patterns/annotations at any nesting depth —
@@ -356,7 +323,7 @@ class ReadAsImageTool(
      * Decompression-bomb guard for pictures embedded in a PPTX: sniffs the header of every
      * picture part in the package (slides, layouts, masters and backgrounds share the same
      * part pool) and rejects the deck when a picture's declared dimensions exceed
-     * [ImageProcessor.MAX_SOURCE_PIXELS]. POI decodes pictures at full source resolution
+     * [imageMaxSourcePixels]. POI decodes pictures at full source resolution
      * while drawing. Header-only sniff: no pixel data is decoded; unrecognized parts
      * (vector metafiles, corrupt data) are skipped, as POI itself skips them.
      */
@@ -370,10 +337,10 @@ class ReadAsImageTool(
     }
 
     private fun checkEmbeddedImageSize(width: Int, height: Int, fileName: String) {
-        if (width.toLong() * height > ImageProcessor.MAX_SOURCE_PIXELS) {
+        if (width.toLong() * height > imageMaxSourcePixels) {
             throw IllegalArgumentException(
                 "Embedded image is too large to decode (${width}x$height," +
-                    " max ${ImageProcessor.MAX_SOURCE_PIXELS} pixels): $fileName",
+                    " max $imageMaxSourcePixels pixels): $fileName",
             )
         }
     }
@@ -461,7 +428,7 @@ class ReadAsImageTool(
         } finally {
             graphics.dispose()
         }
-        return ImageProcessor.toJpegContent(target)
+        return ImageProcessor.toJpegContent(target, imageMaxDimension, imageJpegQuality)
     }
 
     private fun selectPages(
@@ -525,4 +492,49 @@ class ReadAsImageTool(
     }
 
     private class UnsupportedFormatException(message: String) : IllegalArgumentException(message)
+
+    companion object : KLogging() {
+        /** PDF/PPTX rendering is significantly slower than a plain read: distinct, larger timeout. */
+        private const val IO_TIMEOUT = 60L
+        private const val DEFAULT_READ_MAX_SIZE = 10L * 1024 * 1024 // 10 MB
+
+        /** Maximum PDF pages / PPTX slides rendered in a single call. */
+        const val MAX_PAGES_PER_CALL = 10
+
+        /** Nominal PDF rendering resolution before downscaling: keeps text legible at 1024px. */
+        private const val PDF_RENDER_DPI = 150f
+
+        /** PDF user-space unit: 72 points per inch. */
+        private const val POINTS_PER_INCH = 72f
+
+        /**
+         * PDF pages and PPTX slides are rendered with their longest edge capped at this
+         * size (2x supersampling), then downscaled to [ImageProcessor.MAX_DIMENSION].
+         * On PDFs this also bounds the render allocation: a page declaring a huge
+         * MediaBox at [PDF_RENDER_DPI] would otherwise allocate a multi-GB buffer.
+         */
+        private const val RENDER_TARGET_PX = 2048
+
+        /** Extensions routed to the standalone-image path. */
+        private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "bmp")
+
+        /**
+         * Original bytes may be sent as-is only for these mime types, DETECTED FROM THE
+         * CONTENT by [ImageProcessor.readHeader] (never from the file extension, which the
+         * provider would reject on a mismatched payload): the vision APIs accept
+         * png/jpeg/gif but reject image/bmp, so bmp is always re-encoded JPEG.
+         */
+        private val PASS_THROUGH_MIME_TYPES = setOf("image/png", "image/jpeg", "image/gif")
+
+        /** Maximum concurrent renders across all instances of this tool. */
+        private const val MAX_CONCURRENT_RENDERS = 4
+
+        /**
+         * Bounded, abandonable pool for the blocking renders. Coroutine cancellation is
+         * cooperative and PDFBox/POI rendering never suspends, so a timed-out render
+         * cannot be stopped: it is left to finish here (result discarded) instead of
+         * pinning the caller or an unbounded share of the Dispatchers.IO workers.
+         */
+        private val renderScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_RENDERS))
+    }
 }

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
@@ -7,6 +7,7 @@ import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -15,17 +16,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.withTimeout
 import mu.KLogging
 import org.apache.pdfbox.Loader
-import org.apache.pdfbox.cos.COSBase
-import org.apache.pdfbox.cos.COSName
-import org.apache.pdfbox.cos.COSStream
 import org.apache.pdfbox.pdmodel.PDDocument
-import org.apache.pdfbox.pdmodel.PDResources
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException
-import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject
+import org.apache.pdfbox.pdmodel.graphics.image.PDImage
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
-import org.apache.pdfbox.pdmodel.graphics.pattern.PDTilingPattern
 import org.apache.pdfbox.rendering.ImageType
 import org.apache.pdfbox.rendering.PDFRenderer
+import org.apache.pdfbox.rendering.PageDrawer
+import org.apache.pdfbox.rendering.PageDrawerParameters
 import org.apache.poi.EncryptedDocumentException
 import org.apache.poi.openxml4j.exceptions.NotOfficeXmlFileException
 import org.apache.poi.xslf.usermodel.XMLSlideShow
@@ -58,16 +56,20 @@ import kotlin.time.Duration.Companion.seconds
  * well; fonts absent from the host are substituted (e.g. Calibri to DejaVu),
  * SmartArt is not rendered and embedded charts come out blank.
  *
- * Decompression-bomb guards: standalone images are rejected above
- * [ImageProcessor.MAX_SOURCE_PIXELS]; images EMBEDDED in a PDF or PPTX are pre-checked
- * against the same cap from their declared header dimensions before anything is decoded
- * (PDFBox/POI otherwise decode embedded bitmaps at full source resolution).
+ * Decompression-bomb guards (PDFBox/POI decode embedded bitmaps at full source
+ * resolution): standalone images are rejected above [ImageProcessor.MAX_SOURCE_PIXELS]
+ * from their declared header before any decode. Inside a PDF every image is intercepted
+ * at [PageDrawer.drawImage] ([BoundedPageDrawer]) and checked against the same cap before
+ * PDFBox materializes it: that is the single decode point for XObjects, inline images
+ * (BI/ID/EI), Type3 glyph images, forms at any nesting depth, patterns and annotations,
+ * so no path is missed. Inside a PPTX every embedded picture's header is pre-checked.
  */
 class ReadAsImageTool(
     private val projectRoot: Path,
     private val configName: String? = null,
     private val readMaxSizeBytes: Long = DEFAULT_READ_MAX_SIZE,
     private val denyPatterns: List<String> = SensitiveFilePatterns.DEFAULT_PATTERNS,
+    private val ioTimeoutSeconds: Long = IO_TIMEOUT,
 ) : StandardTool<ReadAsImageTool.Input> {
     companion object : KLogging() {
         /** PDF/PPTX rendering is significantly slower than a plain read: distinct, larger timeout. */
@@ -104,9 +106,6 @@ class ReadAsImageTool(
 
         /** Maximum concurrent renders across all instances of this tool. */
         private const val MAX_CONCURRENT_RENDERS = 4
-
-        /** Nesting bound for the embedded-image resource scan (form XObjects, patterns). */
-        private const val MAX_EMBEDDED_SCAN_DEPTH = 5
 
         /**
          * Bounded, abandonable pool for the blocking renders. Coroutine cancellation is
@@ -171,7 +170,7 @@ class ReadAsImageTool(
 
         return try {
             val (summary, images) =
-                withTimeout(IO_TIMEOUT.seconds) {
+                withTimeout(ioTimeoutSeconds.seconds) {
                     // Rendering is blocking, CPU-bound PDFBox/POI work that ignores
                     // cooperative cancellation: run it as an abandonable job on the bounded
                     // [renderScope] pool so the timeout releases the caller immediately and a
@@ -181,14 +180,19 @@ class ReadAsImageTool(
             ToolExecutionResult.successWithImages(summary, images)
         } catch (e: TimeoutCancellationException) {
             logger.warn {
-                "readAsImage timed out after ${IO_TIMEOUT}s on '${params.filePath}'; " +
+                "readAsImage timed out after ${ioTimeoutSeconds}s on '${params.filePath}'; " +
                     "the abandoned render keeps its pool slot until it completes"
             }
             ToolExecutionResult.error(
-                "Operation timed out after $IO_TIMEOUT seconds",
+                "Operation timed out after $ioTimeoutSeconds seconds",
                 errorType = "TIMEOUT",
                 errorMessage = e.message,
             )
+        } catch (e: CancellationException) {
+            // The tool coroutine was cancelled for an external reason (case aborted, stream
+            // closed). Never swallow it into a READ_ERROR: rethrow so cancellation propagates.
+            // Must sit after the TimeoutCancellationException catch (that one is our own timeout).
+            throw e
         } catch (e: UnsupportedFormatException) {
             ToolExecutionResult.error(
                 e.message ?: "Unsupported file format",
@@ -282,12 +286,11 @@ class ReadAsImageTool(
                     throw IllegalArgumentException("PDF has no page: ${file.name}")
                 }
                 val selection = selectPages(pages, pageCount, file.name)
-                checkPdfEmbeddedImages(document, selection, file.name)
 
-                val renderer = PDFRenderer(document)
-                // Belt-and-braces behind the declared-dimension pre-scan above: subsampled
-                // decode keeps even a legitimate large embedded image from materializing
-                // at full resolution.
+                // [BoundedRenderer] rejects any embedded image over the cap at the single
+                // decode point (see [BoundedPageDrawer]); subsampling is belt-and-braces so
+                // an in-cap-but-still-large image does not materialize at full resolution.
+                val renderer = BoundedRenderer(document, file.name)
                 renderer.isSubsamplingAllowed = true
                 val images = selection.map { page ->
                     ImageProcessor.toJpegContent(
@@ -316,59 +319,37 @@ class ReadAsImageTool(
     }
 
     /**
-     * Decompression-bomb guard for images embedded in a PDF: walks the resources of the
-     * selected pages (nested form XObjects, tiling patterns and annotation appearances,
-     * depth-bounded) and rejects any image XObject whose DECLARED dimensions exceed
-     * [ImageProcessor.MAX_SOURCE_PIXELS], before anything is decoded. PDFBox decodes
-     * embedded images at full source resolution while drawing, so without this check a
-     * sub-cap file declaring a huge image would allocate a multi-GB raster (uncatchable
-     * OutOfMemoryError) — the same failure mode [pageRenderDpi] guards for the page buffer.
+     * A [PDFRenderer] whose page drawer enforces the embedded-image cap. Overriding the
+     * renderer's single factory hook is what lets [BoundedPageDrawer] see every image.
      */
-    private fun checkPdfEmbeddedImages(document: PDDocument, selection: List<Int>, fileName: String) {
-        val visited = mutableSetOf<COSBase>()
-        selection.forEach { pageNumber ->
-            val page = document.getPage(pageNumber - 1)
-            checkPdfResources(page.resources, fileName, visited, depth = 0)
-            page.annotations.forEach { annotation ->
-                annotation.normalAppearanceStream?.let {
-                    checkPdfResources(it.resources, fileName, visited, depth = 1)
-                }
-            }
-        }
+    private inner class BoundedRenderer(document: PDDocument, private val fileName: String) : PDFRenderer(document) {
+        override fun createPageDrawer(parameters: PageDrawerParameters): PageDrawer =
+            BoundedPageDrawer(parameters, fileName)
     }
 
-    private fun checkPdfResources(
-        resources: PDResources?,
-        fileName: String,
-        visited: MutableSet<COSBase>,
-        depth: Int,
-    ) {
-        if (resources == null || depth > MAX_EMBEDDED_SCAN_DEPTH || !visited.add(resources.cosObject)) return
-        for (name in resources.xObjectNames) {
-            // An entry that cannot be materialized would not render either: skip it here
-            // and let the renderer apply its own tolerance for broken objects.
-            when (val xObject = runCatching { resources.getXObject(name) }.getOrNull()) {
-                is PDImageXObject -> {
-                    checkEmbeddedImageSize(xObject.width, xObject.height, fileName)
-                    checkImageMaskSize(xObject, COSName.SMASK, fileName)
-                    checkImageMaskSize(xObject, COSName.MASK, fileName)
-                }
-                is PDFormXObject -> checkPdfResources(xObject.resources, fileName, visited, depth + 1)
-                else -> {}
+    /**
+     * Rejects any image over [ImageProcessor.MAX_SOURCE_PIXELS] from its DECLARED dimensions
+     * before PDFBox decodes it. [PageDrawer.drawImage] is the single decode entry point for
+     * every image PDFBox draws — image XObjects, inline images (BI/ID/EI), Type3 glyph
+     * images, and images reachable through forms/patterns/annotations at any nesting depth —
+     * so this one check covers them all, where a resource-tree walk would miss inline and
+     * content-stream images. Without it a sub-cap file declaring a huge image would allocate
+     * a multi-GB raster and throw an uncatchable OutOfMemoryError in the shared service JVM.
+     */
+    private inner class BoundedPageDrawer(
+        parameters: PageDrawerParameters,
+        private val fileName: String,
+    ) : PageDrawer(parameters) {
+        override fun drawImage(pdImage: PDImage) {
+            checkEmbeddedImageSize(pdImage.width, pdImage.height, fileName)
+            if (pdImage is PDImageXObject) {
+                // A small base image can carry a huge /SMask or /Mask that PDFBox decodes at
+                // its own full resolution while compositing.
+                pdImage.softMask?.let { checkEmbeddedImageSize(it.width, it.height, fileName) }
+                pdImage.mask?.let { checkEmbeddedImageSize(it.width, it.height, fileName) }
             }
+            super.drawImage(pdImage)
         }
-        for (name in resources.patternNames) {
-            val pattern = runCatching { resources.getPattern(name) }.getOrNull()
-            if (pattern is PDTilingPattern) {
-                checkPdfResources(pattern.resources, fileName, visited, depth + 1)
-            }
-        }
-    }
-
-    /** Declared dimensions of an image's /SMask or /Mask stream, checked without decoding. */
-    private fun checkImageMaskSize(image: PDImageXObject, key: COSName, fileName: String) {
-        val mask = image.cosObject.getDictionaryObject(key) as? COSStream ?: return
-        checkEmbeddedImageSize(mask.getInt(COSName.WIDTH, 0), mask.getInt(COSName.HEIGHT, 0), fileName)
     }
 
     /**

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadAsImageTool.kt
@@ -9,6 +9,7 @@ import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
 import kotlinx.coroutines.TimeoutCancellationException
 import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException
 import org.apache.pdfbox.rendering.ImageType
 import org.apache.pdfbox.rendering.PDFRenderer
@@ -54,14 +55,19 @@ class ReadAsImageTool(
         /** Maximum PDF pages / PPTX slides rendered in a single call. */
         const val MAX_PAGES_PER_CALL = 10
 
-        /** Rendering resolution before downscaling: keeps text legible at 1024px. */
+        /** Nominal PDF rendering resolution before downscaling: keeps text legible at 1024px. */
         private const val PDF_RENDER_DPI = 150f
 
+        /** PDF user-space unit: 72 points per inch. */
+        private const val POINTS_PER_INCH = 72f
+
         /**
-         * PPTX slides are rendered with their longest edge at this size (2x supersampling),
-         * then downscaled to [ImageProcessor.MAX_DIMENSION]: keeps slide text legible.
+         * PDF pages and PPTX slides are rendered with their longest edge capped at this
+         * size (2x supersampling), then downscaled to [ImageProcessor.MAX_DIMENSION].
+         * On PDFs this also bounds the render allocation: a page declaring a huge
+         * MediaBox at [PDF_RENDER_DPI] would otherwise allocate a multi-GB buffer.
          */
-        private const val SLIDE_RENDER_TARGET = 2048
+        private const val RENDER_TARGET_PX = 2048
 
         private val IMAGE_MIME_BY_EXTENSION = mapOf(
             "png" to "image/png",
@@ -70,6 +76,12 @@ class ReadAsImageTool(
             "gif" to "image/gif",
             "bmp" to "image/bmp",
         )
+
+        /**
+         * Original bytes may be sent as-is only for these mime types: the vision APIs
+         * accept png/jpeg/gif but reject image/bmp, so bmp is always re-encoded JPEG.
+         */
+        private val PASS_THROUGH_MIME_TYPES = setOf("image/png", "image/jpeg", "image/gif")
     }
 
     override val name: String = if (configName != null) "${configName}__readAsImage" else "FILES__readAsImage"
@@ -193,7 +205,7 @@ class ReadAsImageTool(
             )
         }
 
-        val image = if (ImageProcessor.passThroughEligible(width, height, file.fileSize())) {
+        val image = if (mimeType in PASS_THROUGH_MIME_TYPES && ImageProcessor.passThroughEligible(width, height, file.fileSize())) {
             MessageContent.Image(
                 content = Base64.getEncoder().encodeToString(Files.readAllBytes(file)),
                 mimeType = mimeType,
@@ -213,29 +225,36 @@ class ReadAsImageTool(
         try {
             Loader.loadPDF(file.toFile()).use { document ->
                 val pageCount = document.numberOfPages
+                if (pageCount == 0) {
+                    throw IllegalArgumentException("PDF has no page: ${file.name}")
+                }
                 val selection = selectPages(pages, pageCount, file.name)
 
                 val renderer = PDFRenderer(document)
                 val images = selection.map { page ->
                     ImageProcessor.toJpegContent(
-                        renderer.renderImageWithDPI(page - 1, PDF_RENDER_DPI, ImageType.RGB),
+                        renderer.renderImageWithDPI(page - 1, pageRenderDpi(document, page), ImageType.RGB),
                     )
                 }
 
-                val summary = buildString {
-                    append("Rendered PDF ${file.name}: page(s) ${describePages(selection)} of $pageCount (one image per page, attached).")
-                    if (pages == null && pageCount > MAX_PAGES_PER_CALL) {
-                        append(
-                            " $pageCount pages total: call again with pages=[${MAX_PAGES_PER_CALL + 1},...]" +
-                                " to view the following pages.",
-                        )
-                    }
-                }
-                return summary to images
+                return buildRenderSummary("PDF", file.name, selection, pageCount, "page", pages) to images
             }
         } catch (e: InvalidPasswordException) {
             throw IllegalArgumentException("PDF is password-protected: ${file.name}")
         }
+    }
+
+    /**
+     * DPI for one page: nominal [PDF_RENDER_DPI], reduced when the page geometry would
+     * push the rendered longest edge past [RENDER_TARGET_PX]. Bounds the render buffer
+     * (a spec-max 14400pt MediaBox at 150 DPI would allocate a ~3.4GB image and throw
+     * an uncatchable OutOfMemoryError in the service JVM).
+     */
+    private fun pageRenderDpi(document: PDDocument, page: Int): Float {
+        val box = document.getPage(page - 1).mediaBox
+        val longestEdgePt = maxOf(box.width, box.height)
+        if (longestEdgePt <= 0f) return PDF_RENDER_DPI
+        return minOf(PDF_RENDER_DPI, RENDER_TARGET_PX * POINTS_PER_INCH / longestEdgePt)
     }
 
     private fun renderPptx(file: Path, pages: List<Int>?): Pair<String, List<MessageContent.Image>> {
@@ -252,25 +271,13 @@ class ReadAsImageTool(
                     val selection = selectPages(pages, slideCount, file.name, unit = "slide")
 
                     val pageSize = presentation.pageSize
-                    val scale = SLIDE_RENDER_TARGET.toDouble() / maxOf(pageSize.width, pageSize.height)
+                    val scale = RENDER_TARGET_PX.toDouble() / maxOf(pageSize.width, pageSize.height)
                     val width = Math.round(pageSize.width * scale).toInt()
                     val height = Math.round(pageSize.height * scale).toInt()
 
                     val images = selection.map { slide -> renderSlide(presentation, slide, width, height, scale) }
 
-                    val summary = buildString {
-                        append(
-                            "Rendered PPTX ${file.name}: slide(s) ${describePages(selection)} of $slideCount" +
-                                " (one image per slide, attached).",
-                        )
-                        if (pages == null && slideCount > MAX_PAGES_PER_CALL) {
-                            append(
-                                " $slideCount slides total: call again with pages=[${MAX_PAGES_PER_CALL + 1},...]" +
-                                    " to view the following slides.",
-                            )
-                        }
-                    }
-                    return summary to images
+                    return buildRenderSummary("PPTX", file.name, selection, slideCount, "slide", pages) to images
                 }
             }
         } catch (e: EncryptedDocumentException) {
@@ -332,6 +339,31 @@ class ReadAsImageTool(
         }
         return selection
     }
+
+    /**
+     * Summary shown to the model. When the default selection was truncated by
+     * [MAX_PAGES_PER_CALL], it also doubles as the pagination affordance.
+     */
+    private fun buildRenderSummary(
+        kind: String,
+        fileName: String,
+        selection: List<Int>,
+        total: Int,
+        unit: String,
+        requestedPages: List<Int>?,
+    ): String =
+        buildString {
+            append(
+                "Rendered $kind $fileName: ${unit}(s) ${describePages(selection)} of $total" +
+                    " (one image per $unit, attached).",
+            )
+            if (requestedPages == null && total > MAX_PAGES_PER_CALL) {
+                append(
+                    " $total ${unit}s total: call again with pages=[${MAX_PAGES_PER_CALL + 1},...]" +
+                        " to view the following ${unit}s.",
+                )
+            }
+        }
 
     private fun describePages(selection: List<Int>): String {
         val contiguous = selection.size > 1 && selection.last() - selection.first() == selection.size - 1

--- a/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadFileTool.kt
+++ b/agentos/agentos-file-plugin/src/main/kotlin/io/whozoss/agentos/plugins/file/tools/ReadFileTool.kt
@@ -15,8 +15,8 @@ import kotlin.io.path.fileSize
 /**
  * Read content from a text file.
  *
- * V1: Text files only (UTF-8). Binary files return "[binary or unreadable file]".
- * V2 planned: PDF and image support via MessageContent polymorphism.
+ * Text files only (UTF-8). Binary files return "[binary or unreadable file]".
+ * For images and PDFs use [ReadAsImageTool].
  */
 class ReadFileTool(
     private val projectRoot: Path,
@@ -34,7 +34,7 @@ class ReadFileTool(
     override val description: String =
         """
         Read content from a text file. Use searchFiles to find files.
-        V1: text files only (UTF-8). PDF and image support planned for V2.
+        Text files only (UTF-8). For images and PDFs use readAsImage.
         """.trimIndent()
 
     override val version: String = "1.0.0"

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/FileToolProviderSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/FileToolProviderSpec.kt
@@ -30,14 +30,15 @@ class FileToolProviderSpec : StringSpec() {
             provider.provideTools(null) shouldBe emptyList()
         }
 
-        "read-write config produces 6 tools" {
+        "read-write config produces 7 tools" {
             val config = jacksonObjectMapper().readTree("""{"rootPath": "${tempDir.pathString}"}"""
             .trimIndent())
             val tools = FileToolProvider().provideTools(config, "TEST")
-            tools.size shouldBe 6
+            tools.size shouldBe 7
             tools.map { it.name } shouldContainAll listOf(
                 "TEST__listFiles",
                 "TEST__readFile",
+                "TEST__readAsImage",
                 "TEST__searchFiles",
                 "TEST__editFiles",
                 "TEST__remove",
@@ -45,15 +46,16 @@ class FileToolProviderSpec : StringSpec() {
             )
         }
 
-        "read-only config produces 3 tools" {
+        "read-only config produces 4 tools" {
             val config = jacksonObjectMapper().readTree(
                 """{"rootPath": "${tempDir.pathString}", "readOnly": true}""",
             )
             val tools = FileToolProvider().provideTools(config, "TEST")
-            tools.size shouldBe 3
+            tools.size shouldBe 4
             tools.map { it.name } shouldContainAll listOf(
                 "TEST__listFiles",
                 "TEST__readFile",
+                "TEST__readAsImage",
                 "TEST__searchFiles",
             )
         }
@@ -91,7 +93,35 @@ class FileToolProviderSpec : StringSpec() {
                 """{"rootPath": "${tempDir.pathString}", "extraDenyPatterns": null}""",
             )
             val tools = FileToolProvider().provideTools(config, "TEST")
-            tools.size shouldBe 6
+            tools.size shouldBe 7
+        }
+
+        "readMaxSizeMb propagation to ReadAsImageTool" {
+            val bigFile = tempDir.resolve("big.png")
+            bigFile.toFile().writeBytes(ByteArray(2 * 1024 * 1024))
+
+            val config = jacksonObjectMapper().readTree(
+                """{"rootPath": "${tempDir.pathString}", "readMaxSizeMb": 1}""",
+            )
+            val tools = FileToolProvider().provideTools(config, "TEST")
+            val readAsImageTool = tools.first { it.name.contains("readAsImage") }
+
+            val result = readAsImageTool.executeWithJson("""{"filePath": "big.png"}""", ctx)
+            result.output shouldContain "exceeds maximum size"
+        }
+
+        "extraDenyPatterns propagation to ReadAsImageTool" {
+            val secretFile = tempDir.resolve("scan.secret-png")
+            secretFile.writeText("not really an image")
+
+            val config = jacksonObjectMapper().readTree(
+                """{"rootPath": "${tempDir.pathString}", "extraDenyPatterns": ["*.secret-png"]}""",
+            )
+            val tools = FileToolProvider().provideTools(config, "TEST")
+            val readAsImageTool = tools.first { it.name.contains("readAsImage") }
+
+            val result = readAsImageTool.executeWithJson("""{"filePath": "scan.secret-png"}""", ctx)
+            result.output shouldContain "Access denied"
         }
     }
 }

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
@@ -1,0 +1,345 @@
+package io.whozoss.agentos.plugins.file
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.whozoss.agentos.plugins.file.tools.ReadAsImageTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.encryption.AccessPermission
+import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy
+import org.apache.poi.poifs.crypt.EncryptionInfo
+import org.apache.poi.poifs.crypt.EncryptionMode
+import org.apache.poi.poifs.filesystem.POIFSFileSystem
+import org.apache.poi.xslf.usermodel.XMLSlideShow
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+import java.util.UUID
+import javax.imageio.ImageIO
+import kotlin.io.path.writeBytes
+import kotlin.io.path.writeText
+
+class ReadAsImageToolSpec : StringSpec() {
+    private val ctx = ToolContext(UUID.randomUUID(), null, null, emptyList())
+    private lateinit var tempDir: Path
+
+    private fun writePng(name: String, width: Int, height: Int, type: Int = BufferedImage.TYPE_INT_RGB): Path {
+        val file = tempDir.resolve(name)
+        ImageIO.write(BufferedImage(width, height, type), "png", file.toFile())
+        return file
+    }
+
+    private fun writePdf(name: String, pageCount: Int, protection: StandardProtectionPolicy? = null): Path {
+        val file = tempDir.resolve(name)
+        PDDocument().use { document ->
+            repeat(pageCount) { document.addPage(PDPage()) }
+            protection?.let { document.protect(it) }
+            document.save(file.toFile())
+        }
+        return file
+    }
+
+    private fun writePptx(name: String, slideCount: Int): Path {
+        val file = tempDir.resolve(name)
+        XMLSlideShow().use { presentation ->
+            repeat(slideCount) { index ->
+                val box = presentation.createSlide().createTextBox()
+                box.setAnchor(Rectangle(50, 50, 400, 100))
+                box.text = "Slide ${index + 1}"
+            }
+            Files.newOutputStream(file).use { presentation.write(it) }
+        }
+        return file
+    }
+
+    private fun writeProtectedPptx(name: String, password: String): Path {
+        val clearBytes = ByteArrayOutputStream().use { buffer ->
+            XMLSlideShow().use { presentation ->
+                presentation.createSlide()
+                presentation.write(buffer)
+            }
+            buffer.toByteArray()
+        }
+
+        val file = tempDir.resolve(name)
+        POIFSFileSystem().use { fs ->
+            val encryptor = EncryptionInfo(EncryptionMode.agile).encryptor
+            encryptor.confirmPassword(password)
+            encryptor.getDataStream(fs).use { it.write(clearBytes) }
+            Files.newOutputStream(file).use { fs.writeFilesystem(it) }
+        }
+        return file
+    }
+
+    init {
+        beforeEach {
+            tempDir = Files.createTempDirectory("read-as-image-test")
+        }
+
+        afterEach {
+            tempDir.toFile().deleteRecursively()
+        }
+
+        "small PNG passes through untouched with original mime type" {
+            val file = writePng("small.png", 100, 80)
+            val originalBytes = Files.readAllBytes(file)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("small.png"), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 1
+            val image = result.images.single()
+            image.mimeType shouldBe "image/png"
+            image.width shouldBe 100
+            image.height shouldBe 80
+            Base64.getDecoder().decode(image.content) shouldBe originalBytes
+            result.output shouldContain "small.png"
+        }
+
+        "large PNG is resized to fit max dimension and re-encoded as JPEG" {
+            writePng("large.png", 2200, 1600)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("large.png"), ctx)
+
+            result.success shouldBe true
+            val image = result.images.single()
+            image.mimeType shouldBe "image/jpeg"
+            image.width shouldBe 1024
+            image.height shouldBe 745
+
+            val decoded = ImageIO.read(ByteArrayInputStream(Base64.getDecoder().decode(image.content)))
+            decoded.width shouldBe 1024
+            decoded.height shouldBe 745
+        }
+
+        "large PNG with alpha is flattened and encoded as JPEG" {
+            writePng("alpha.png", 1500, 1200, BufferedImage.TYPE_INT_ARGB)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("alpha.png"), ctx)
+
+            result.success shouldBe true
+            result.images.single().mimeType shouldBe "image/jpeg"
+        }
+
+        "text file is rejected with UNSUPPORTED_FORMAT pointing to readFile" {
+            tempDir.resolve("notes.txt").writeText("plain text")
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("notes.txt"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "UNSUPPORTED_FORMAT"
+            result.output shouldContain "readFile"
+        }
+
+        "webp file is rejected with UNSUPPORTED_FORMAT" {
+            tempDir.resolve("img.webp").writeBytes(byteArrayOf(0x52, 0x49, 0x46, 0x46))
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("img.webp"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "UNSUPPORTED_FORMAT"
+            result.output shouldContain "Supported: png, jpg, jpeg, gif, bmp, pdf"
+        }
+
+        "missing file returns an error" {
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("absent.png"), ctx)
+
+            result.success shouldBe false
+            result.output shouldContain "Path does not exist"
+        }
+
+        "corrupt png content is rejected as unreadable image" {
+            tempDir.resolve("corrupt.png").writeBytes(byteArrayOf(0x00, 0x01, 0x02, 0x03))
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("corrupt.png"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "readable image"
+        }
+
+        "file exceeding size cap is rejected before decoding" {
+            val file = writePng("big.png", 50, 50)
+            val tool = ReadAsImageTool(tempDir, readMaxSizeBytes = Files.size(file) - 1)
+
+            val result = tool.execute(ReadAsImageTool.Input("big.png"), ctx)
+
+            result.success shouldBe false
+            result.output shouldContain "exceeds maximum size"
+        }
+
+        "sensitive file patterns are enforced" {
+            tempDir.resolve("secret.pem").writeText("---KEY---")
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("secret.pem"), ctx)
+
+            result.success shouldBe false
+            result.output shouldContain "Access denied"
+        }
+
+        "path traversal is rejected" {
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("../outside.png"), ctx)
+
+            result.success shouldBe false
+        }
+
+        "3-page PDF renders one JPEG per page" {
+            writePdf("cv.pdf", 3)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("cv.pdf"), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 3
+            result.output shouldContain "page(s) 1-3 of 3"
+            result.images.forEach { image ->
+                image.mimeType shouldBe "image/jpeg"
+                image.width!! shouldBeLessThanOrEqual 1024
+                image.height!! shouldBeLessThanOrEqual 1024
+            }
+        }
+
+        "pages parameter selects a single PDF page" {
+            writePdf("cv.pdf", 3)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("cv.pdf", pages = listOf(2)), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 1
+            result.output shouldContain "page(s) 2 of 3"
+        }
+
+        "page out of range is rejected with the actual page count" {
+            writePdf("cv.pdf", 3)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("cv.pdf", pages = listOf(9)), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "3 page(s)"
+        }
+
+        "PDF over the page cap renders the first pages and hints at continuation" {
+            writePdf("long.pdf", 12)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("long.pdf"), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 10
+            result.output shouldContain "page(s) 1-10 of 12"
+            result.output shouldContain "12 pages total"
+        }
+
+        "explicit selection above the page cap is rejected" {
+            writePdf("long.pdf", 12)
+            val pages = (1..11).toList()
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("long.pdf", pages = pages), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "At most 10 pages"
+        }
+
+        "empty pages selection is rejected" {
+            writePdf("cv.pdf", 3)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("cv.pdf", pages = emptyList()), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+        }
+
+        "password-protected PDF is rejected" {
+            writePdf("locked.pdf", 1, StandardProtectionPolicy("owner", "user", AccessPermission()))
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("locked.pdf"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "password-protected"
+        }
+
+        "pages parameter on an image file is rejected" {
+            writePng("photo.png", 100, 100)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("photo.png", pages = listOf(1)), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "PDF"
+        }
+
+        "3-slide PPTX renders one JPEG per slide" {
+            writePptx("pitch.pptx", 3)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("pitch.pptx"), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 3
+            result.output shouldContain "slide(s) 1-3 of 3"
+            result.images.forEach { image ->
+                image.mimeType shouldBe "image/jpeg"
+                image.width!! shouldBeLessThanOrEqual 1024
+                image.height!! shouldBeLessThanOrEqual 1024
+            }
+        }
+
+        "pages parameter selects a single PPTX slide" {
+            writePptx("pitch.pptx", 3)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("pitch.pptx", pages = listOf(2)), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 1
+            result.output shouldContain "slide(s) 2 of 3"
+        }
+
+        "slide out of range is rejected with the actual slide count" {
+            writePptx("pitch.pptx", 3)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("pitch.pptx", pages = listOf(9)), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "3 slide(s)"
+        }
+
+        "PPTX over the page cap renders the first slides and hints at continuation" {
+            writePptx("long.pptx", 12)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("long.pptx"), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 10
+            result.output shouldContain "slide(s) 1-10 of 12"
+            result.output shouldContain "12 slides total"
+        }
+
+        "password-protected PPTX is rejected" {
+            writeProtectedPptx("locked.pptx", "secret")
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("locked.pptx"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "password-protected"
+        }
+
+        "corrupt bytes named .pptx are rejected as invalid" {
+            tempDir.resolve("corrupt.pptx").writeBytes(byteArrayOf(0x00, 0x01, 0x02, 0x03))
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("corrupt.pptx"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+        }
+    }
+}

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
@@ -8,24 +8,33 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.whozoss.agentos.plugins.file.tools.ReadAsImageTool
 import io.whozoss.agentos.sdk.tool.ToolContext
+import org.apache.pdfbox.cos.COSName
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.PDPageContentStream
 import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.apache.pdfbox.pdmodel.common.PDStream
 import org.apache.pdfbox.pdmodel.encryption.AccessPermission
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
 import org.apache.poi.poifs.crypt.EncryptionInfo
 import org.apache.poi.poifs.crypt.EncryptionMode
 import org.apache.poi.poifs.filesystem.POIFSFileSystem
+import org.apache.poi.sl.usermodel.PictureData
 import org.apache.poi.xslf.usermodel.XMLSlideShow
 import java.awt.Rectangle
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Base64
 import java.util.UUID
+import java.util.zip.CRC32
+import java.util.zip.DeflaterOutputStream
 import javax.imageio.ImageIO
 import kotlin.io.path.writeBytes
 import kotlin.io.path.writeText
@@ -58,6 +67,71 @@ class ReadAsImageToolSpec : StringSpec() {
                 box.setAnchor(Rectangle(50, 50, 400, 100))
                 box.text = "Slide ${index + 1}"
             }
+            Files.newOutputStream(file).use { presentation.write(it) }
+        }
+        return file
+    }
+
+    /**
+     * Minimal valid PNG header (signature + IHDR with correct CRC, no pixel data):
+     * enough for the header sniff to report the declared dimensions, tiny on disk.
+     */
+    private fun pngHeaderBytes(width: Int, height: Int): ByteArray {
+        val ihdr = ByteBuffer.allocate(13)
+            .putInt(width)
+            .putInt(height)
+            .put(8.toByte()) // bit depth
+            .put(2.toByte()) // color type: truecolor
+            .put(0.toByte()) // compression
+            .put(0.toByte()) // filter
+            .put(0.toByte()) // interlace
+            .array()
+        val crc = CRC32().apply {
+            update("IHDR".toByteArray(Charsets.US_ASCII))
+            update(ihdr)
+        }
+        return ByteBuffer.allocate(33)
+            .put(byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A))
+            .putInt(13)
+            .put("IHDR".toByteArray(Charsets.US_ASCII))
+            .put(ihdr)
+            .putInt(crc.value.toInt())
+            .array()
+    }
+
+    /**
+     * PDF whose single page draws an image XObject DECLARING huge dimensions (the Flate
+     * payload is garbage: the pre-scan must reject on the declared header, before any
+     * decode is attempted).
+     */
+    private fun writePdfWithHugeEmbeddedImage(name: String): Path {
+        val file = tempDir.resolve(name)
+        PDDocument().use { document ->
+            val page = PDPage()
+            document.addPage(page)
+            val deflated = ByteArrayOutputStream().also { buffer ->
+                DeflaterOutputStream(buffer).use { it.write(ByteArray(64)) }
+            }.toByteArray()
+            val stream = PDStream(document, ByteArrayInputStream(deflated), COSName.FLATE_DECODE)
+            val dictionary = stream.cosObject
+            dictionary.setItem(COSName.TYPE, COSName.XOBJECT)
+            dictionary.setItem(COSName.SUBTYPE, COSName.IMAGE)
+            dictionary.setInt(COSName.WIDTH, 30_000)
+            dictionary.setInt(COSName.HEIGHT, 30_000)
+            dictionary.setInt(COSName.BITS_PER_COMPONENT, 8)
+            dictionary.setItem(COSName.COLORSPACE, COSName.DEVICEGRAY)
+            val image = PDImageXObject(stream, null)
+            PDPageContentStream(document, page).use { it.drawImage(image, 50f, 50f, 100f, 100f) }
+            document.save(file.toFile())
+        }
+        return file
+    }
+
+    private fun writePptxWithPicture(name: String, pictureBytes: ByteArray): Path {
+        val file = tempDir.resolve(name)
+        XMLSlideShow().use { presentation ->
+            val picture = presentation.addPicture(pictureBytes, PictureData.PictureType.PNG)
+            presentation.createSlide().createPicture(picture)
             Files.newOutputStream(file).use { presentation.write(it) }
         }
         return file
@@ -212,6 +286,33 @@ class ReadAsImageToolSpec : StringSpec() {
             result.output shouldContain "readable image"
         }
 
+        "image declaring more pixels than the decode cap is rejected before decoding" {
+            // 30000x30000 = 900M pixels, way over MAX_SOURCE_PIXELS; the file is a
+            // 33-byte header, so any attempt to actually decode would fail differently.
+            tempDir.resolve("huge.png").writeBytes(pngHeaderBytes(30_000, 30_000))
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("huge.png"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "too large to decode"
+        }
+
+        "image content wins over the file extension for the pass-through mime type" {
+            // A JPEG named .png must be labeled image/jpeg (the content), not image/png
+            // (the extension): providers reject a mismatched declared media type.
+            val file = tempDir.resolve("fake.png")
+            ImageIO.write(BufferedImage(100, 80, BufferedImage.TYPE_INT_RGB), "jpg", file.toFile())
+            val originalBytes = Files.readAllBytes(file)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("fake.png"), ctx)
+
+            result.success shouldBe true
+            val image = result.images.single()
+            image.mimeType shouldBe "image/jpeg"
+            Base64.getDecoder().decode(image.content) shouldBe originalBytes
+        }
+
         "file exceeding size cap is rejected before decoding" {
             val file = writePng("big.png", 50, 50)
             val tool = ReadAsImageTool(tempDir, readMaxSizeBytes = Files.size(file) - 1)
@@ -260,6 +361,16 @@ class ReadAsImageToolSpec : StringSpec() {
             result.success shouldBe true
             result.images shouldHaveSize 1
             result.output shouldContain "page(s) 2 of 3"
+        }
+
+        "pages selection with duplicates and gaps is deduplicated, sorted and summarized as a list" {
+            writePdf("cv.pdf", 5)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("cv.pdf", pages = listOf(3, 1, 3)), ctx)
+
+            result.success shouldBe true
+            result.images shouldHaveSize 2
+            result.output shouldContain "page(s) 1,3 of 5"
         }
 
         "page out of range is rejected with the actual page count" {
@@ -338,6 +449,37 @@ class ReadAsImageToolSpec : StringSpec() {
             result.success shouldBe false
             result.errorType shouldBe "INVALID_INPUT"
             result.output shouldContain "password-protected"
+        }
+
+        "PDF embedding an image larger than the decode cap is rejected before rendering" {
+            // PDFBox decodes embedded image XObjects at full declared resolution while
+            // drawing: the pre-scan must reject on the declared dimensions, before the
+            // (garbage) payload is ever decoded.
+            writePdfWithHugeEmbeddedImage("bomb.pdf")
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("bomb.pdf"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "Embedded image is too large"
+        }
+
+        "PDF with a small embedded image still renders" {
+            val file = tempDir.resolve("photo.pdf")
+            PDDocument().use { document ->
+                val page = PDPage()
+                document.addPage(page)
+                val image = LosslessFactory.createFromImage(document, BufferedImage(60, 40, BufferedImage.TYPE_INT_RGB))
+                PDPageContentStream(document, page).use { it.drawImage(image, 50f, 50f, 120f, 80f) }
+                document.save(file.toFile())
+            }
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("photo.pdf"), ctx)
+
+            withClue(result.output) {
+                result.success shouldBe true
+            }
+            result.images shouldHaveSize 1
         }
 
         "pages parameter on an image file is rejected" {
@@ -427,6 +569,32 @@ class ReadAsImageToolSpec : StringSpec() {
 
             result.success shouldBe false
             result.errorType shouldBe "INVALID_INPUT"
+        }
+
+        "PPTX embedding a picture larger than the decode cap is rejected before rendering" {
+            // POI decodes embedded pictures at full source resolution while drawing: the
+            // header pre-scan must reject on the declared dimensions before any decode.
+            writePptxWithPicture("bomb.pptx", pngHeaderBytes(30_000, 30_000))
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("bomb.pptx"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "Embedded image is too large"
+        }
+
+        "PPTX with a small embedded picture still renders" {
+            val pngBytes = ByteArrayOutputStream().also { buffer ->
+                ImageIO.write(BufferedImage(60, 40, BufferedImage.TYPE_INT_RGB), "png", buffer)
+            }.toByteArray()
+            writePptxWithPicture("photo.pptx", pngBytes)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("photo.pptx"), ctx)
+
+            withClue(result.output) {
+                result.success shouldBe true
+            }
+            result.images shouldHaveSize 1
         }
     }
 }

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
@@ -249,6 +249,20 @@ class ReadAsImageToolSpec : StringSpec() {
             decoded.height shouldBe 745
         }
 
+        "a custom imageMaxDimension from config bounds the rendered image" {
+            writePng("large.png", 2200, 1600)
+
+            val result =
+                ReadAsImageTool(tempDir, imageMaxDimension = 512)
+                    .execute(ReadAsImageTool.Input("large.png"), ctx)
+
+            result.success shouldBe true
+            val image = result.images.single()
+            image.mimeType shouldBe "image/jpeg"
+            image.width shouldBe 512
+            image.height shouldBe 372
+        }
+
         "large PNG with alpha is flattened and encoded as JPEG" {
             writePng("alpha.png", 1500, 1200, BufferedImage.TYPE_INT_ARGB)
 

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
@@ -9,6 +9,7 @@ import io.whozoss.agentos.plugins.file.tools.ReadAsImageTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.common.PDRectangle
 import org.apache.pdfbox.pdmodel.encryption.AccessPermission
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy
 import org.apache.poi.poifs.crypt.EncryptionInfo
@@ -124,6 +125,18 @@ class ReadAsImageToolSpec : StringSpec() {
             writePng("alpha.png", 1500, 1200, BufferedImage.TYPE_INT_ARGB)
 
             val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("alpha.png"), ctx)
+
+            result.success shouldBe true
+            result.images.single().mimeType shouldBe "image/jpeg"
+        }
+
+        "small BMP is re-encoded as JPEG, never passed through as image/bmp" {
+            // Vision providers reject the image/bmp media type, so bmp must not use
+            // the pass-through path even when small.
+            val file = tempDir.resolve("scan.bmp")
+            ImageIO.write(BufferedImage(100, 80, BufferedImage.TYPE_INT_RGB), "bmp", file.toFile())
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("scan.bmp"), ctx)
 
             result.success shouldBe true
             result.images.single().mimeType shouldBe "image/jpeg"
@@ -255,6 +268,33 @@ class ReadAsImageToolSpec : StringSpec() {
 
             result.success shouldBe false
             result.errorType shouldBe "INVALID_INPUT"
+        }
+
+        "zero-page PDF is rejected as invalid input" {
+            writePdf("empty.pdf", 0)
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("empty.pdf"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "no page"
+        }
+
+        "PDF with a huge MediaBox renders with a capped resolution instead of exploding memory" {
+            // A spec-max 14400x14400pt page at the nominal 150 DPI would allocate a
+            // ~3.4GB buffer; the per-page DPI cap bounds the render to RENDER_TARGET_PX.
+            val file = tempDir.resolve("poster.pdf")
+            PDDocument().use { document ->
+                document.addPage(PDPage(PDRectangle(14400f, 14400f)))
+                document.save(file.toFile())
+            }
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("poster.pdf"), ctx)
+
+            result.success shouldBe true
+            val image = result.images.single()
+            image.width!! shouldBeLessThanOrEqual 1024
+            image.height!! shouldBeLessThanOrEqual 1024
         }
 
         "password-protected PDF is rejected" {

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.plugins.file
 
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.ints.shouldBeLessThanOrEqual
@@ -20,6 +21,7 @@ import java.awt.Rectangle
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Base64
@@ -59,6 +61,37 @@ class ReadAsImageToolSpec : StringSpec() {
             Files.newOutputStream(file).use { presentation.write(it) }
         }
         return file
+    }
+
+    /**
+     * Writes a deck whose slide holds a table referencing a table style by id while the
+     * package ships no `ppt/tableStyles.xml` — the (PowerPoint-tolerated) shape produced
+     * by some third-party generators. POI's empty template always includes the part, so
+     * it is stripped from the zip after writing, along with its relationship and
+     * content-type override.
+     */
+    private fun writePptxWithDanglingTableStyle(name: String): Path {
+        val file = tempDir.resolve(name)
+        XMLSlideShow().use { presentation ->
+            val table = presentation.createSlide().createTable(2, 2)
+            table.setAnchor(Rectangle(50, 50, 400, 200))
+            table.setColumnWidth(0, 150.0)
+            table.setColumnWidth(1, 150.0)
+            (0..1).forEach { row -> (0..1).forEach { col -> table.getCell(row, col).text = "R${row}C$col" } }
+            val tblPr = table.ctTable.let { if (it.isSetTblPr) it.tblPr else it.addNewTblPr() }
+            tblPr.tableStyleId = "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"
+            Files.newOutputStream(file).use { presentation.write(it) }
+        }
+        FileSystems.newFileSystem(file).use { zip ->
+            Files.delete(zip.getPath("ppt", "tableStyles.xml"))
+            stripZipEntryTag(zip.getPath("ppt", "_rels", "presentation.xml.rels"), Regex("<Relationship[^>]*tableStyles\\.xml[^>]*/>"))
+            stripZipEntryTag(zip.getPath("[Content_Types].xml"), Regex("<Override[^>]*tableStyles[^>]*/>"))
+        }
+        return file
+    }
+
+    private fun stripZipEntryTag(entry: Path, tag: Regex) {
+        Files.writeString(entry, Files.readString(entry).replace(tag, ""))
     }
 
     private fun writeProtectedPptx(name: String, password: String): Path {
@@ -361,6 +394,20 @@ class ReadAsImageToolSpec : StringSpec() {
             result.images shouldHaveSize 10
             result.output shouldContain "slide(s) 1-10 of 12"
             result.output shouldContain "12 slides total"
+        }
+
+        "PPTX table referencing a style without a tableStyles part renders with default formatting" {
+            // Some generators emit a tableStyleId while omitting ppt/tableStyles.xml;
+            // PowerPoint falls back to default formatting, POI 5.5.1 still NPEs on it
+            // (XSLFTable.getTableStyle dereferences the absent part).
+            writePptxWithDanglingTableStyle("report.pptx")
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("report.pptx"), ctx)
+
+            withClue(result.output) {
+                result.success shouldBe true
+            }
+            result.images shouldHaveSize 1
         }
 
         "password-protected PPTX is rejected" {

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/ReadAsImageToolSpec.kt
@@ -127,6 +127,27 @@ class ReadAsImageToolSpec : StringSpec() {
         return file
     }
 
+    /**
+     * PDF whose page content stream draws an INLINE image (BI/ID/EI) DECLARING huge
+     * dimensions. Inline images live in the content stream, not in the resources dictionary,
+     * so a resource-tree scan would miss them entirely — only the per-image decode
+     * interception catches this. The ASCIIHex payload is a single byte: the guard must reject
+     * on the declared /W /H before any decode.
+     */
+    private fun writePdfWithHugeInlineImage(name: String): Path {
+        val file = tempDir.resolve(name)
+        PDDocument().use { document ->
+            val page = PDPage(PDRectangle(200f, 200f))
+            document.addPage(page)
+            val content = "q 100 0 0 100 0 0 cm\nBI /W 30000 /H 30000 /BPC 8 /CS /G /F /AHx ID\n00>\nEI\nQ\n"
+            val stream = PDStream(document)
+            stream.createOutputStream().use { it.write(content.toByteArray(Charsets.US_ASCII)) }
+            page.setContents(stream)
+            document.save(file.toFile())
+        }
+        return file
+    }
+
     private fun writePptxWithPicture(name: String, pictureBytes: ByteArray): Path {
         val file = tempDir.resolve(name)
         XMLSlideShow().use { presentation ->
@@ -480,6 +501,31 @@ class ReadAsImageToolSpec : StringSpec() {
                 result.success shouldBe true
             }
             result.images shouldHaveSize 1
+        }
+
+        "PDF with a huge INLINE image (content stream, not a resource) is rejected before rendering" {
+            // Inline images bypass any resource-tree scan; the per-image decode interception
+            // catches them at the same point as XObjects.
+            writePdfWithHugeInlineImage("inline-bomb.pdf")
+
+            val result = ReadAsImageTool(tempDir).execute(ReadAsImageTool.Input("inline-bomb.pdf"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "INVALID_INPUT"
+            result.output shouldContain "Embedded image is too large"
+        }
+
+        "render exceeding the timeout returns a TIMEOUT error and releases the caller" {
+            // ioTimeoutSeconds=0 makes withTimeout fire at the first suspension (the render
+            // await), exercising the abandonable-render timeout path deterministically.
+            writePdf("cv.pdf", 1)
+            val tool = ReadAsImageTool(tempDir, ioTimeoutSeconds = 0)
+
+            val result = tool.execute(ReadAsImageTool.Input("cv.pdf"), ctx)
+
+            result.success shouldBe false
+            result.errorType shouldBe "TIMEOUT"
+            result.output shouldContain "timed out"
         }
 
         "pages parameter on an image file is rejected" {

--- a/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessorSpec.kt
+++ b/agentos/agentos-file-plugin/src/test/kotlin/io/whozoss/agentos/plugins/file/image/ImageProcessorSpec.kt
@@ -1,0 +1,90 @@
+package io.whozoss.agentos.plugins.file.image
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.util.Base64
+import javax.imageio.ImageIO
+
+class ImageProcessorSpec : StringSpec() {
+    init {
+        "scaleDimensions never enlarges an image that already fits" {
+            ImageProcessor.scaleDimensions(800, 600) shouldBe (800 to 600)
+            ImageProcessor.scaleDimensions(10, 10) shouldBe (10 to 10)
+            ImageProcessor.scaleDimensions(1024, 1024) shouldBe (1024 to 1024)
+        }
+
+        "scaleDimensions fits landscape image inside max dimension preserving ratio" {
+            val (width, height) = ImageProcessor.scaleDimensions(2200, 1600)
+            width shouldBe 1024
+            height shouldBe 745
+        }
+
+        "scaleDimensions fits portrait image inside max dimension preserving ratio" {
+            val (width, height) = ImageProcessor.scaleDimensions(1600, 3200)
+            width shouldBe 512
+            height shouldBe 1024
+        }
+
+        "scaleDimensions caps a square image at max dimension" {
+            ImageProcessor.scaleDimensions(5000, 5000) shouldBe (1024 to 1024)
+        }
+
+        "passThroughEligible accepts small file fitting max dimension" {
+            ImageProcessor.passThroughEligible(1000, 800, 200L * 1024) shouldBe true
+        }
+
+        "passThroughEligible rejects oversized dimensions" {
+            ImageProcessor.passThroughEligible(2000, 800, 200L * 1024) shouldBe false
+            ImageProcessor.passThroughEligible(800, 2000, 200L * 1024) shouldBe false
+        }
+
+        "passThroughEligible rejects heavy file even when dimensions fit" {
+            ImageProcessor.passThroughEligible(1000, 800, 5L * 1024 * 1024) shouldBe false
+        }
+
+        "renderRgb flattens alpha onto white background" {
+            val source = BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB) // fully transparent
+            val rendered = ImageProcessor.renderRgb(source, 10, 10)
+
+            val pixel = Color(rendered.getRGB(5, 5))
+            pixel.red shouldBe 255
+            pixel.green shouldBe 255
+            pixel.blue shouldBe 255
+        }
+
+        "encodeJpeg produces a decodable JPEG" {
+            val source = BufferedImage(20, 10, BufferedImage.TYPE_INT_RGB)
+            val bytes = ImageProcessor.encodeJpeg(source)
+
+            val decoded = ImageIO.read(ByteArrayInputStream(bytes))
+            decoded.width shouldBe 20
+            decoded.height shouldBe 10
+        }
+
+        "toJpegContent resizes and reports final dimensions" {
+            val source = BufferedImage(2048, 1024, BufferedImage.TYPE_INT_RGB)
+            val content = ImageProcessor.toJpegContent(source)
+
+            content.mimeType shouldBe "image/jpeg"
+            content.width shouldBe 1024
+            content.height shouldBe 512
+
+            val decoded = ImageIO.read(ByteArrayInputStream(Base64.getDecoder().decode(content.content)))
+            decoded.width shouldBe 1024
+            decoded.height shouldBe 512
+        }
+
+        "toJpegContent keeps small images at their original size" {
+            val source = BufferedImage(300, 200, BufferedImage.TYPE_INT_RGB)
+            val content = ImageProcessor.toJpegContent(source)
+
+            content.width shouldBe 300
+            content.height shouldBe 200
+            content.width!! shouldBeLessThanOrEqual ImageProcessor.MAX_DIMENSION
+        }
+    }
+}

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/CaseEvent.kt
@@ -234,6 +234,11 @@ data class ToolRequestEvent(
  * [io.whozoss.agentos.sdk.tool.ToolContext.caseEvents] to perform coherence checks
  * (e.g. verifying that a referenced entity was fetched before being mutated).
  * The map is empty when the tool returned no metadata.
+ *
+ * [images] carries the visual attachments produced by the tool (see
+ * [io.whozoss.agentos.sdk.tool.ToolExecutionResult.images]). [output] stays the textual
+ * summary of the execution; provider tool responses are text-only, so images are delivered
+ * to the LLM separately at prompt-build time.
  */
 data class ToolResponseEvent(
     override val metadata: EntityMetadata = EntityMetadata(),
@@ -248,6 +253,8 @@ data class ToolResponseEvent(
     val durationMs: Long? = null,
     /** Opaque metadata returned by the tool. Empty map when the tool produced no metadata. */
     val toolMetadata: Map<String, Any?> = emptyMap(),
+    /** Images produced by the tool. Empty list when the tool produced no image. */
+    val images: List<MessageContent.Image> = emptyList(),
 ) : CaseEvent {
     override val type: CaseEventType = CaseEventType.TOOL_RESPONSE
 }

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/MessageContent.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/caseEvent/MessageContent.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.sdk.caseEvent
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * Structured content for messages.
@@ -22,7 +23,12 @@ sealed interface MessageContent {
 
     /**
      * Image content (base64 encoded).
+     *
+     * The explicit allOf keeps the OpenAPI composition with [MessageContent] (and its
+     * `type` discriminator) even though the type is also referenced directly (outside
+     * the sealed-interface oneOf) by [ToolResponseEvent.images].
      */
+    @Schema(allOf = [MessageContent::class])
     data class Image(
         val content: String, // base64 encoded
         val mimeType: String,

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolExecutionResult.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/tool/ToolExecutionResult.kt
@@ -1,5 +1,7 @@
 package io.whozoss.agentos.sdk.tool
 
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+
 /**
  * Result of a [StandardTool] execution.
  *
@@ -13,6 +15,14 @@ package io.whozoss.agentos.sdk.tool
  * so that later tool invocations in the same case can read it back via
  * [ToolContext.caseEvents].
  *
+ * [images] carries visual attachments produced by the tool (e.g. an image file read for
+ * vision, a PDF rendered page by page). Provider tool responses are text-only, so the
+ * service layer delivers [images] to the LLM as a follow-up user message at prompt-build
+ * time. When returning images, [output] MUST still contain a short textual summary of what
+ * the images are: it is what transcripts, non-vision paths and the tool-response wire
+ * message show. [MessageContent.Image] is an SDK class, hence classloader-safe across the
+ * PF4J plugin boundary.
+ *
  * Use the companion factory methods for the common cases:
  * ```kotlin
  * // happy path, no metadata
@@ -20,6 +30,9 @@ package io.whozoss.agentos.sdk.tool
  *
  * // happy path, with metadata
  * return ToolExecutionResult.success("result text", mapOf("entityId" to id))
+ *
+ * // happy path, with images
+ * return ToolExecutionResult.successWithImages("Rendered cv.pdf: 3 pages", images)
  *
  * // error
  * return ToolExecutionResult.error("Something went wrong", errorType = "NOT_FOUND")
@@ -31,6 +44,7 @@ data class ToolExecutionResult(
     val metadata: Map<String, Any?> = emptyMap(),
     val errorType: String? = null,
     val errorMessage: String? = null,
+    val images: List<MessageContent.Image> = emptyList(),
 ) {
     companion object {
         fun success(
@@ -41,6 +55,18 @@ data class ToolExecutionResult(
                 output = output,
                 success = true,
                 metadata = metadata,
+            )
+
+        fun successWithImages(
+            output: String,
+            images: List<MessageContent.Image>,
+            metadata: Map<String, Any?> = emptyMap(),
+        ): ToolExecutionResult =
+            ToolExecutionResult(
+                output = output,
+                success = true,
+                metadata = metadata,
+                images = images,
             )
 
         fun error(

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -347,9 +347,19 @@ openApi {
     apiDocsUrl.set("http://localhost:$agentosPort/v3/api-docs.yaml")
     // Wait up to 60s for the app to be ready
     waitTimeInSeconds.set(60)
-    // Activate the openapi profile so the app starts without real AI API keys
+    // Activate the openapi profile so the app starts without real AI API keys.
+    // embedded-bolt-port=0 (random OS-assigned port) as a command-line arg because it must
+    // beat application-embedded-neo4j.yml (last active profile wins over the openapi one):
+    // spec generation must not fail when a locally running dev stack already binds the
+    // default embedded port 7688. The driver resolves the actual port at runtime.
     customBootRun {
-        args.set(listOf("--spring.profiles.active=openapi,embedded-neo4j", "--server.port=$agentosPort"))
+        args.set(
+            listOf(
+                "--spring.profiles.active=openapi,embedded-neo4j",
+                "--server.port=$agentosPort",
+                "--agentos.persistence.embedded-bolt-port=0",
+            ),
+        )
     }
 }
 

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -304,6 +304,15 @@ configurations.all {
             useVersion(libs.versions.netty.get())
             because("neo4j-embedded 2026.x requires Netty 4.2.x; Spring Boot BOM pins 4.1.x")
         }
+        // The file plugin's ReadAsImageTool compiles against kotlinx-coroutines from the version
+        // catalog, whose CoroutineDispatcher.limitedParallelism(parallelism, name) overload only
+        // exists since 1.9. Spring Boot's BOM downgrades coroutines to 1.8.x at runtime, so the
+        // compiled call resolves to a method missing at runtime -> NoSuchMethodError when the
+        // plugin is loaded under PF4J. Pin coroutines to the compiled-against version.
+        if (requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-coroutines")) {
+            useVersion(libs.versions.kotlinCoroutines.get())
+            because("code compiles against coroutines ${libs.versions.kotlinCoroutines.get()}; Spring Boot BOM downgrades it to 1.8.x at runtime")
+        }
     }
 }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -587,6 +587,7 @@ class AgentAdvanced(
                     success = result.success,
                     durationMs = durationMs,
                     toolMetadata = result.metadata,
+                    images = result.images,
                 )
             } catch (e: Exception) {
                 logger.warn(e) {
@@ -1529,6 +1530,7 @@ Generate ONLY the JSON object matching the input schema above, Output requiremen
                         success = result.success,
                         durationMs = durationMs,
                         toolMetadata = result.metadata,
+                        images = result.images,
                     )
                 } catch (e: AgentInterrupt) {
                     // Re-throw so handleToolExecution() can emit a proper ToolResponseEvent

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -24,6 +24,13 @@ data class AgentAdvancedContext(
     val confirmationManager: ConfirmationManager,
     /** Namespace context block sent as a privileged system message, prepended before event history. */
     val systemPrompt: String? = null,
+    /**
+     * Char-equivalent cost of one attached image against the detailed-tool budget.
+     * Default mirrors [AgentConfigProperties.imageCharCost].
+     */
+    val imageCharCost: Int = 6_000,
+    /** Maximum images attached as Media across the whole prompt, newest first. Default mirrors [AgentConfigProperties.maxAttachedImages]. */
+    val maxAttachedImages: Int = 20,
 ) {
     /**
      * Build the complete message list for a single LLM call.
@@ -64,7 +71,11 @@ data class AgentAdvancedContext(
     ): List<Message> {
         val responsesByRequestId = indexToolResponses(events)
         val (detailedRequestIds, mediaRequestIds) =
-            selectDetailedToolRequestIds(events, responsesByRequestId, maxDetailedChars)
+            selectDetailedToolRequestIds(
+                events = events,
+                responsesByRequestId = responsesByRequestId,
+                maxDetailedChars = maxDetailedChars,
+            )
 
         val lastUserMsgIndex =
             events.indexOfLast {
@@ -84,7 +95,12 @@ data class AgentAdvancedContext(
                 }
 
                 is ToolRequestEvent -> {
-                    toToolMessages(event, detailedRequestIds, mediaRequestIds, responsesByRequestId)
+                    toToolMessages(
+                        event = event,
+                        detailedRequestIds = detailedRequestIds,
+                        mediaRequestIds = mediaRequestIds,
+                        responsesByRequestId = responsesByRequestId,
+                    )
                 }
 
                 is IntentionGeneratedEvent -> {
@@ -113,8 +129,8 @@ data class AgentAdvancedContext(
     /**
      * Single newest-first walk deciding both selections coherently:
      * - a request is detailed while its cumulated char cost fits [maxDetailedChars];
-     * - its images are attached while they fit [MAX_ATTACHED_IMAGES], and only attached
-     *   images are charged [IMAGE_CHAR_COST] against the budget. Responses whose images
+     * - its images are attached while they fit [maxAttachedImages], and only attached
+     *   images are charged [imageCharCost] against the budget. Responses whose images
      *   are not attached keep their text summary plus a marker (see
      *   [toDetailedToolMessages]) and cost only that text.
      */
@@ -133,13 +149,9 @@ data class AgentAdvancedContext(
 
             val response = responsesByRequestId[event.toolRequestId]
             val images = response?.images ?: emptyList()
-            val attachMedia = images.isNotEmpty() && imagesAttached + images.size <= MAX_ATTACHED_IMAGES
+            val attachMedia = images.isNotEmpty() && imagesAttached + images.size <= maxAttachedImages
 
-            val argsCost = event.args?.length ?: 0
-            val responseCost = response?.let { extractText(it.output).length } ?: 0
-            val imagesCost = if (attachMedia) images.size * IMAGE_CHAR_COST else 0
-            val cost = argsCost + responseCost + imagesCost
-
+            val cost = detailedCharCost(event, response, attachMedia)
             if (charsCollected + cost > maxDetailedChars) break
 
             detailed.add(event.toolRequestId)
@@ -150,6 +162,22 @@ data class AgentAdvancedContext(
             }
         }
         return ToolReplaySelection(detailed, withMedia)
+    }
+
+    /**
+     * Char-equivalent cost charged against the detailed-tool budget for one request/response:
+     * the request args, the response text, and — only when [attachMedia] is true — the attached
+     * images at [imageCharCost] each.
+     */
+    private fun detailedCharCost(
+        event: ToolRequestEvent,
+        response: ToolResponseEvent?,
+        attachMedia: Boolean,
+    ): Int {
+        val argsCost = event.args?.length ?: 0
+        val responseCost = response?.let { extractText(it.output).length } ?: 0
+        val imagesCost = if (attachMedia) (response?.images?.size ?: 0) * imageCharCost else 0
+        return argsCost + responseCost + imagesCost
     }
 
     private fun toToolMessages(
@@ -232,17 +260,4 @@ data class AgentAdvancedContext(
             is MessageContent.Text -> content.content
             is MessageContent.Image -> "[image ${content.mimeType} ${content.width}x${content.height}]"
         }
-
-    companion object {
-        /**
-         * Char-equivalent cost of one attached image against the detailed-tool budget.
-         * Derived from the legacy Coday estimate: (width * height) / 750 tokens at
-         * ~3.5 chars per token, ~4 900 chars for a full-size 1024x1024 image,
-         * rounded up to 6 000.
-         */
-        internal const val IMAGE_CHAR_COST = 6_000
-
-        /** Maximum images attached as Media across the whole prompt, newest first. */
-        internal const val MAX_ATTACHED_IMAGES = 20
-    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -65,6 +65,8 @@ data class AgentAdvancedContext(
         val responsesByRequestId = indexToolResponses(events)
         val detailedRequestIds =
             selectDetailedToolRequestIds(events, responsesByRequestId, maxDetailedChars)
+        val mediaRequestIds =
+            selectMediaToolRequestIds(events, responsesByRequestId, detailedRequestIds)
 
         val lastUserMsgIndex =
             events.indexOfLast {
@@ -84,7 +86,7 @@ data class AgentAdvancedContext(
                 }
 
                 is ToolRequestEvent -> {
-                    toToolMessages(event, detailedRequestIds, responsesByRequestId)
+                    toToolMessages(event, detailedRequestIds, mediaRequestIds, responsesByRequestId)
                 }
 
                 is IntentionGeneratedEvent -> {
@@ -129,22 +131,52 @@ data class AgentAdvancedContext(
     ): Int {
         val argsCost = request.args?.length ?: 0
         val responseCost = response?.let { extractText(it.output).length } ?: 0
-        return argsCost + responseCost
+        val imagesCost = (response?.images?.size ?: 0) * IMAGE_CHAR_COST
+        return argsCost + responseCost + imagesCost
+    }
+
+    /**
+     * Select the tool requests whose response images are actually attached as [Media],
+     * newest first, bounded by [MAX_ATTACHED_IMAGES] so a long history of image reads
+     * cannot flood the prompt. Older image responses keep their text summary and get a
+     * marker instead (see [toDetailedToolMessages]).
+     */
+    private fun selectMediaToolRequestIds(
+        events: List<CaseEvent>,
+        responsesByRequestId: Map<String, ToolResponseEvent>,
+        detailedRequestIds: Set<String>,
+    ): Set<String> {
+        val result = mutableSetOf<String>()
+        var imagesAttached = 0
+
+        for (event in events.reversed()) {
+            if (event !is ToolRequestEvent || event.toolRequestId !in detailedRequestIds) continue
+
+            val images = responsesByRequestId[event.toolRequestId]?.images ?: continue
+            if (images.isEmpty()) continue
+            if (imagesAttached + images.size > MAX_ATTACHED_IMAGES) break
+
+            result.add(event.toolRequestId)
+            imagesAttached += images.size
+        }
+        return result
     }
 
     private fun toToolMessages(
         event: ToolRequestEvent,
         detailedRequestIds: Set<String>,
+        mediaRequestIds: Set<String>,
         responsesByRequestId: Map<String, ToolResponseEvent>,
     ): List<Message> =
         if (event.toolRequestId in detailedRequestIds) {
-            toDetailedToolMessages(event, responsesByRequestId)
+            toDetailedToolMessages(event, mediaRequestIds, responsesByRequestId)
         } else {
             listOf(toToolSummaryMessage(event, responsesByRequestId))
         }
 
     private fun toDetailedToolMessages(
         event: ToolRequestEvent,
+        mediaRequestIds: Set<String>,
         responsesByRequestId: Map<String, ToolResponseEvent>,
     ): List<Message> {
         val args = normalizeArgs(event.args)
@@ -155,9 +187,12 @@ data class AgentAdvancedContext(
         // Every AssistantMessage with tool_calls MUST be followed by a ToolResponseMessage
         // for each tool_call_id — OpenAI returns 400 otherwise. Use the real response if
         // available, or synthesize a placeholder so the message list stays well-formed.
-        val responseText =
-            responsesByRequestId[event.toolRequestId]?.let { extractText(it.output) }
-                ?: "[No response recorded]"
+        val response = responsesByRequestId[event.toolRequestId]
+        val attachMedia = response != null && response.images.isNotEmpty() && event.toolRequestId in mediaRequestIds
+        var responseText = response?.let { extractText(it.output) } ?: "[No response recorded]"
+        if (response != null && response.images.isNotEmpty() && !attachMedia) {
+            responseText += "\n[${response.images.size} image(s) no longer attached, call the tool again if needed]"
+        }
 
         messages.add(
             ToolResponseMessage
@@ -172,6 +207,11 @@ data class AgentAdvancedContext(
                     ),
                 ).build(),
         )
+        // Provider tool responses are text-only: the images ride in a follow-up user
+        // message with Media attachments right after the tool response.
+        if (attachMedia) {
+            messages.add(toolImagesUserMessage(event.toolName, response!!.images))
+        }
         return messages
     }
 
@@ -185,7 +225,9 @@ data class AgentAdvancedContext(
                 response == null || response.success -> "Success"
                 else -> "Failed: ${extractText(response.output)}"
             }
-        return AssistantMessage("[Step summary] Tool: ${event.toolName} | $status")
+        val imagesSuffix =
+            response?.images?.size?.takeIf { it > 0 }?.let { " | $it image(s) (not shown)" } ?: ""
+        return AssistantMessage("[Step summary] Tool: ${event.toolName} | $status$imagesSuffix")
     }
 
     private fun toIntentionMessage(event: IntentionGeneratedEvent): List<Message> =
@@ -198,6 +240,19 @@ data class AgentAdvancedContext(
     private fun extractText(content: MessageContent): String =
         when (content) {
             is MessageContent.Text -> content.content
-            else -> content.toString()
+            is MessageContent.Image -> "[image ${content.mimeType} ${content.width}x${content.height}]"
         }
+
+    companion object {
+        /**
+         * Char-equivalent cost of one attached image against the detailed-tool budget.
+         * Derived from the legacy Coday estimate: (width * height) / 750 tokens at
+         * ~3.5 chars per token, ~4 900 chars for a full-size 1024x1024 image,
+         * rounded up to 6 000.
+         */
+        internal const val IMAGE_CHAR_COST = 6_000
+
+        /** Maximum images attached as Media across the whole prompt, newest first. */
+        internal const val MAX_ATTACHED_IMAGES = 20
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -63,10 +63,8 @@ data class AgentAdvancedContext(
         maxDetailedChars: Int = 300_000,
     ): List<Message> {
         val responsesByRequestId = indexToolResponses(events)
-        val detailedRequestIds =
+        val (detailedRequestIds, mediaRequestIds) =
             selectDetailedToolRequestIds(events, responsesByRequestId, maxDetailedChars)
-        val mediaRequestIds =
-            selectMediaToolRequestIds(events, responsesByRequestId, detailedRequestIds)
 
         val lastUserMsgIndex =
             events.indexOfLast {
@@ -103,63 +101,55 @@ data class AgentAdvancedContext(
     private fun indexToolResponses(events: List<CaseEvent>): Map<String, ToolResponseEvent> =
         events.filterIsInstance<ToolResponseEvent>().associateBy { it.toolRequestId }
 
+    /**
+     * Selection of the tool requests replayed in detail, and among them the ones whose
+     * response images are actually attached as [Media].
+     */
+    private data class ToolReplaySelection(
+        val detailedRequestIds: Set<String>,
+        val mediaRequestIds: Set<String>,
+    )
+
+    /**
+     * Single newest-first walk deciding both selections coherently:
+     * - a request is detailed while its cumulated char cost fits [maxDetailedChars];
+     * - its images are attached while they fit [MAX_ATTACHED_IMAGES], and only attached
+     *   images are charged [IMAGE_CHAR_COST] against the budget. Responses whose images
+     *   are not attached keep their text summary plus a marker (see
+     *   [toDetailedToolMessages]) and cost only that text.
+     */
     private fun selectDetailedToolRequestIds(
         events: List<CaseEvent>,
         responsesByRequestId: Map<String, ToolResponseEvent>,
         maxDetailedChars: Int,
-    ): Set<String> {
-        val result = mutableSetOf<String>()
+    ): ToolReplaySelection {
+        val detailed = mutableSetOf<String>()
+        val withMedia = mutableSetOf<String>()
         var charsCollected = 0
+        var imagesAttached = 0
 
         for (event in events.reversed()) {
             if (event !is ToolRequestEvent) continue
 
             val response = responsesByRequestId[event.toolRequestId]
-            val cost = estimateDetailedCharCost(event, response)
+            val images = response?.images ?: emptyList()
+            val attachMedia = images.isNotEmpty() && imagesAttached + images.size <= MAX_ATTACHED_IMAGES
+
+            val argsCost = event.args?.length ?: 0
+            val responseCost = response?.let { extractText(it.output).length } ?: 0
+            val imagesCost = if (attachMedia) images.size * IMAGE_CHAR_COST else 0
+            val cost = argsCost + responseCost + imagesCost
 
             if (charsCollected + cost > maxDetailedChars) break
 
-            result.add(event.toolRequestId)
+            detailed.add(event.toolRequestId)
             charsCollected += cost
+            if (attachMedia) {
+                withMedia.add(event.toolRequestId)
+                imagesAttached += images.size
+            }
         }
-        return result
-    }
-
-    private fun estimateDetailedCharCost(
-        request: ToolRequestEvent,
-        response: ToolResponseEvent?,
-    ): Int {
-        val argsCost = request.args?.length ?: 0
-        val responseCost = response?.let { extractText(it.output).length } ?: 0
-        val imagesCost = (response?.images?.size ?: 0) * IMAGE_CHAR_COST
-        return argsCost + responseCost + imagesCost
-    }
-
-    /**
-     * Select the tool requests whose response images are actually attached as [Media],
-     * newest first, bounded by [MAX_ATTACHED_IMAGES] so a long history of image reads
-     * cannot flood the prompt. Older image responses keep their text summary and get a
-     * marker instead (see [toDetailedToolMessages]).
-     */
-    private fun selectMediaToolRequestIds(
-        events: List<CaseEvent>,
-        responsesByRequestId: Map<String, ToolResponseEvent>,
-        detailedRequestIds: Set<String>,
-    ): Set<String> {
-        val result = mutableSetOf<String>()
-        var imagesAttached = 0
-
-        for (event in events.reversed()) {
-            if (event !is ToolRequestEvent || event.toolRequestId !in detailedRequestIds) continue
-
-            val images = responsesByRequestId[event.toolRequestId]?.images ?: continue
-            if (images.isEmpty()) continue
-            if (imagesAttached + images.size > MAX_ATTACHED_IMAGES) break
-
-            result.add(event.toolRequestId)
-            imagesAttached += images.size
-        }
-        return result
+        return ToolReplaySelection(detailed, withMedia)
     }
 
     private fun toToolMessages(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentConfigProperties.kt
@@ -5,9 +5,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 /**
  * Platform-level agent configuration properties.
  *
- * Bound from the `agentos.agent` prefix in application.yml.
+ * Bound from the `agentos.defaults` prefix in application.yml.
  *
- * [defaultAgentName] is the environment-level fallback agent name. It is consulted
+ * [agentName] is the environment-level fallback agent name. It is consulted
  * when a namespace has no [io.whozoss.agentos.namespace.Namespace.defaultAgentName]
  * configured, and is resolved in the same way — by name against the [AgentConfig]
  * entries of the case's namespace. This means the named agent must exist in each
@@ -15,20 +15,36 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *
  * Fallback resolution order when routing a conversation:
  * 1. Namespace default agent ([Namespace.defaultAgentName]), if configured
- * 2. Environment default agent ([defaultAgentName]), if configured
+ * 2. Environment default agent ([agentName]), if configured
  * 3. Silent fail (WarnEvent emitted, no agent selected)
  *
- * Override with environment variable (Spring Boot relaxed binding):
+ * [imageCharCost] and [maxAttachedImages] bound how tool-response images are replayed
+ * into an agent's LLM context (see [AgentAdvancedContext]).
+ *
+ * Override with environment variables (Spring Boot relaxed binding):
  * - AGENTOS_DEFAULTS_AGENT_NAME
+ * - AGENTOS_DEFAULTS_IMAGE_CHAR_COST
+ * - AGENTOS_DEFAULTS_MAX_ATTACHED_IMAGES
  *
  * Example (application.yml):
  * ```yaml
  * agentos:
  *   defaults:
  *     agent-name: copilot
+ *     image-char-cost: 6000
+ *     max-attached-images: 20
  * ```
  */
 @ConfigurationProperties(prefix = "agentos.defaults")
 data class AgentConfigProperties(
     val agentName: String? = null,
+    /**
+     * Char-equivalent cost of one attached image against the detailed-tool budget.
+     * Derived from the legacy Coday estimate: (width * height) / 750 tokens at
+     * ~3.5 chars per token, ~4 900 chars for a full-size 1024x1024 image,
+     * rounded up to 6 000.
+     */
+    val imageCharCost: Int = 6_000,
+    /** Maximum images attached as Media across the whole prompt, newest first. */
+    val maxAttachedImages: Int = 20,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -64,6 +64,7 @@ class AgentServiceImpl(
     private val exchangeStorageService: ExchangeStorageService,
     private val exchangeCapabilityService: ExchangeCapabilityService,
     private val agentDocumentResolver: AgentDocumentResolver,
+    private val agentConfigProperties: AgentConfigProperties,
 ) : AgentService {
     /**
      * Resolves an agent by name for a given [context].
@@ -376,6 +377,8 @@ class AgentServiceImpl(
                     agentId = agentId,
                     confirmationManager = confirmationManager,
                     systemPrompt = resolvedSystemPrompt,
+                    imageCharCost = agentConfigProperties.imageCharCost,
+                    maxAttachedImages = agentConfigProperties.maxAttachedImages,
                 )
             AgentAdvanced(
                 metadata = EntityMetadata(id = agentId),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -318,13 +318,7 @@ class AgentSimple(
                         val toolResponseMessages =
                             toolCallsForCurrentMessage.map { toolCall ->
                                 val response = toolResponses[toolCall.id()]
-                                val output =
-                                    response?.let {
-                                        when (val content = it.output) {
-                                            is MessageContent.Text -> content.content
-                                            else -> content.toString()
-                                        }
-                                    } ?: "[No response recorded]"
+                                val output = response?.let { toolResponseText(it) } ?: "[No response recorded]"
                                 ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
                             }
 
@@ -375,13 +369,7 @@ class AgentSimple(
             val toolResponseMessages =
                 toolCallsForCurrentMessage.map { toolCall ->
                     val response = toolResponses[toolCall.id()]
-                    val output =
-                        response?.let {
-                            when (val content = it.output) {
-                                is MessageContent.Text -> content.content
-                                else -> content.toString()
-                            }
-                        } ?: "[No response recorded]"
+                    val output = response?.let { toolResponseText(it) } ?: "[No response recorded]"
                     ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
                 }
 
@@ -389,6 +377,23 @@ class AgentSimple(
         }
 
         return messages
+    }
+
+    /**
+     * Textual rendering of a tool response for the LLM prompt. Never stringifies
+     * non-text content (a raw data-class toString would dump base64 payloads).
+     *
+     * AgentSimple does not support image attachments (its Spring AI tool loop is
+     * text-only), so when the response carries images the model is explicitly told
+     * they are not viewable here instead of being led to believe they are attached.
+     */
+    private fun toolResponseText(response: ToolResponseEvent): String {
+        val text =
+            when (val content = response.output) {
+                is MessageContent.Text -> content.content
+                is MessageContent.Image -> "[image ${content.mimeType} ${content.width}x${content.height}]"
+            }
+        return if (response.images.isEmpty()) text else text + "\n" + imagesNotSupportedNote(response.images.size)
     }
 
     /**
@@ -559,12 +564,28 @@ class AgentSimple(
                         success = executionResult.success,
                         durationMs = toolDuration.inWholeMilliseconds,
                         toolMetadata = executionResult.metadata,
+                        // Preserved on the event (persistence, SSE) even though this
+                        // runtime cannot deliver them to the LLM.
+                        images = executionResult.images,
                     ),
                 )
 
-                return executionResult.output
+                return if (executionResult.images.isEmpty()) {
+                    executionResult.output
+                } else {
+                    executionResult.output + "\n" + imagesNotSupportedNote(executionResult.images.size)
+                }
             }
         }
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        /**
+         * Appended to a tool response whose result carries images: AgentSimple's
+         * Spring AI tool loop is text-only, so the model must not be led to believe
+         * the images are attached (image delivery is an AgentAdvanced feature).
+         */
+        internal fun imagesNotSupportedNote(count: Int): String =
+            "[Note: $count image(s) were produced but this agent runtime does not support image attachments;" +
+                " only this text summary is available. Image viewing requires an advanced-execution agent.]"
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
@@ -7,6 +7,10 @@ import org.springframework.web.util.HtmlUtils
 import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
 import org.springframework.ai.chat.messages.UserMessage
+import org.springframework.ai.content.Media
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.util.MimeType
+import java.util.Base64
 
 /**
  * Regex patterns for the XML conversation tags injected by [MessageEvent.toSpringAiMessage].
@@ -61,6 +65,34 @@ private fun escapeXml(value: String): String = HtmlUtils.htmlEscape(value)
  * The XML tagging convention (`<agent=Name>`, `<user name="...">`) is deliberately kept
  * consistent with the Coday `AiClient.convertAgentMessages` implementation.
  */
+/**
+ * Convert a [MessageContent.Image] (base64 payload) to a Spring AI [Media],
+ * mapped by every supported ChatModel to its native image block format.
+ */
+internal fun MessageContent.Image.toSpringAiMedia(): Media =
+    Media
+        .builder()
+        .mimeType(MimeType.valueOf(mimeType))
+        .data(ByteArrayResource(Base64.getDecoder().decode(content)))
+        .build()
+
+/**
+ * Build the follow-up [UserMessage] carrying the [images] produced by a tool.
+ *
+ * Provider tool responses are text-only (Spring AI [org.springframework.ai.chat.messages.ToolResponseMessage]
+ * carries a String), so images are delivered right after the tool response as a user
+ * message with [Media] attachments, which all supported ChatModels map natively.
+ */
+internal fun toolImagesUserMessage(
+    toolName: String,
+    images: List<MessageContent.Image>,
+): UserMessage =
+    UserMessage
+        .builder()
+        .text("[Attached: ${images.size} image(s) produced by tool $toolName, see tool result above]")
+        .media(images.map { it.toSpringAiMedia() })
+        .build()
+
 internal fun MessageEvent.toSpringAiMessage(currentAgentId: String): Message {
     val textContent =
         content

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNode.kt
@@ -196,6 +196,12 @@ class ToolResponseEventNode(
      */
     val metadataJson: String? = null,
     val durationMs: Long? = null,
+    /**
+     * JSON-serialised [List]<[io.whozoss.agentos.sdk.caseEvent.MessageContent.Image]> of images
+     * produced by the tool, or null when the tool produced no image. Stored as a nullable
+     * string for backward compatibility with existing nodes that pre-date this field.
+     */
+    val imagesJson: String? = null,
     created: Instant = Instant.now(),
     createdBy: String? = null,
     modified: Instant = Instant.now(),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapper.kt
@@ -11,6 +11,7 @@ import io.whozoss.agentos.sdk.caseEvent.CaseStatusEvent
 import io.whozoss.agentos.sdk.caseEvent.ConfirmationResolvedEvent
 import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
 import io.whozoss.agentos.sdk.caseEvent.IntentionGeneratedEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.PendingConfirmationEvent
 import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
@@ -240,6 +241,7 @@ class CaseEventNodeMapper(
                     node.success,
                     node.metadataJson,
                     node.durationMs,
+                    node.imagesJson,
                     node.created,
                     node.createdBy,
                     node.modified,
@@ -483,6 +485,9 @@ class CaseEventNodeMapper(
             success = n.success,
             durationMs = n.durationMs,
             toolMetadata = n.metadataJson?.let { serializer.deserializeMetadata(it) } ?: emptyMap(),
+            images = n.imagesJson
+                ?.let { serializer.deserialize(it).filterIsInstance<MessageContent.Image>() }
+                ?: emptyList(),
         )
 
     private fun toDomain(n: ThinkingEventNode) =
@@ -711,6 +716,7 @@ class CaseEventNodeMapper(
             success = e.success,
             metadataJson = e.toolMetadata.takeIf { it.isNotEmpty() }?.let { serializer.serializeMetadata(it) },
             durationMs = e.durationMs,
+            imagesJson = e.images.takeIf { it.isNotEmpty() }?.let { serializer.serialize(it) },
             created = e.metadata.created,
             createdBy = e.metadata.createdBy,
             modified = e.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatter.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatter.kt
@@ -84,7 +84,8 @@ object CaseTranscriptFormatter {
                 } else {
                     raw
                 }
-                "TOOL_RESPONSE: [$status, $duration] $text"
+                val imagesSuffix = event.images.size.takeIf { it > 0 }?.let { " [+$it image(s)]" } ?: ""
+                "TOOL_RESPONSE: [$status, $duration] $text$imagesSuffix"
             }
             is IntentionGeneratedEvent -> {
                 if (includesTechnicalEvents) "INTENTION (${event.agentId}): ${event.intention} → ${event.toolName}" else null

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/CompressingChatClient.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/CompressingChatClient.kt
@@ -214,7 +214,10 @@ class CompressingChatClient(
      */
     private fun Message.compress(buffer: MessageCompressorBuffer): Message {
         return when (this) {
-            is UserMessage -> UserMessage(compressorService.compress(this.text, buffer))
+            // mutate() preserves media (image attachments) and metadata: rebuilding with
+            // UserMessage(text) would silently strip them. Media byte arrays are never
+            // regex-scanned; only the text goes through the compressor.
+            is UserMessage -> this.mutate().text(compressorService.compress(this.text, buffer)).build()
             is SystemMessage -> SystemMessage(compressorService.compress(this.text, buffer))
             is AssistantMessage -> {
                 val toolCalls = this.toolCalls

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -116,6 +116,12 @@ agentos:
   # defaultAgentName configured. The named agent must exist in the case's namespace.
   # Override with env var: AGENTOS_DEFAULTS_AGENT_NAME
   # agent-name: copilot
+  # Char-equivalent cost of one tool-response image against the agent's detailed-context budget.
+  # Override with env var: AGENTOS_DEFAULTS_IMAGE_CHAR_COST
+  # image-char-cost: 6000
+  # Maximum tool-response images attached as Media across a whole prompt (newest first).
+  # Override with env var: AGENTOS_DEFAULTS_MAX_ATTACHED_IMAGES
+  # max-attached-images: 20
   plugins:
     dir: ${PLUGINS_DIR:plugins/}
   security:

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
@@ -667,6 +667,31 @@ class AgentAdvancedContextSpec :
             mediaMessages shouldHaveSize 1
         }
 
+        "responses with evicted media pay no image cost against the budget" {
+            // 3 responses of 10 images each: the 20-image cap attaches media for the 2
+            // newest only. The oldest must NOT be charged IMAGE_CHAR_COST for images it
+            // does not attach, so it stays detailed (with the marker) instead of being
+            // evicted from the budget by phantom cost.
+            val events =
+                (1..3).flatMap { i ->
+                    listOf(
+                        toolRequest("r$i", "FILES__readAsImage"),
+                        toolResponseWithImages("r$i", "FILES__readAsImage", "read $i", List(10) { image() }),
+                    )
+                }
+            val budget = 20 * AgentAdvancedContext.IMAGE_CHAR_COST + 500
+
+            val messages = context.convertEventsToMessages(events, maxDetailedChars = budget)
+
+            // No pair summarized: the oldest costs only its text since its media are evicted
+            val summaries = messages.filterIsInstance<AssistantMessage>().filter { it.text?.contains("[Step summary]") == true }
+            summaries shouldHaveSize 0
+            val mediaMessages = messages.filterIsInstance<UserMessage>()
+            mediaMessages shouldHaveSize 2
+            val evictedResponse = messages[1].shouldBeInstanceOf<ToolResponseMessage>()
+            evictedResponse.responses[0].responseData() shouldContain "no longer attached"
+        }
+
         "extractText never dumps base64 for image output" {
             val events =
                 listOf(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
@@ -576,4 +576,114 @@ class AgentAdvancedContextSpec :
             messages shouldHaveSize 1
             messages[0].shouldBeInstanceOf<UserMessage>()
         }
+
+        // -------------------------------------------------------------------------
+        // Tool response images (readAsImage)
+        // -------------------------------------------------------------------------
+
+        fun image(width: Int = 1024, height: Int = 745) =
+            MessageContent.Image(content = "aGVsbG8=", mimeType = "image/jpeg", width = width, height = height)
+
+        fun toolResponseWithImages(
+            reqId: String,
+            toolName: String,
+            output: String,
+            images: List<MessageContent.Image>,
+        ) = ToolResponseEvent(
+            namespaceId = ns,
+            caseId = case,
+            toolRequestId = reqId,
+            toolName = toolName,
+            output = MessageContent.Text(output),
+            success = true,
+            images = images,
+        )
+
+        "tool response images are attached as a follow-up UserMessage with Media" {
+            val events =
+                listOf(
+                    toolRequest("r1", "FILES__readAsImage"),
+                    toolResponseWithImages("r1", "FILES__readAsImage", "Rendered PDF cv.pdf", List(3) { image() }),
+                )
+            val messages = context.convertEventsToMessages(events)
+
+            messages shouldHaveSize 3
+            messages[0].shouldBeInstanceOf<AssistantMessage>()
+            val toolRespMsg = messages[1].shouldBeInstanceOf<ToolResponseMessage>()
+            toolRespMsg.responses[0].responseData() shouldBe "Rendered PDF cv.pdf"
+            val mediaMsg = messages[2].shouldBeInstanceOf<UserMessage>()
+            mediaMsg.media shouldHaveSize 3
+            mediaMsg.text shouldContain "3 image(s)"
+            mediaMsg.text shouldContain "FILES__readAsImage"
+        }
+
+        "tool response without images does not add a media message" {
+            val events =
+                listOf(
+                    toolRequest("r1", "FILES__read"),
+                    toolResponse("r1", "FILES__read", "content"),
+                )
+            val messages = context.convertEventsToMessages(events)
+
+            messages shouldHaveSize 2
+        }
+
+        "image tool responses beyond MAX_ATTACHED_IMAGES lose their media, newest kept" {
+            // 3 reads of 10 images each: only the 2 most recent fit the 20-image cap
+            val events =
+                (1..3).flatMap { i ->
+                    listOf(
+                        toolRequest("r$i", "FILES__readAsImage"),
+                        toolResponseWithImages("r$i", "FILES__readAsImage", "read $i", List(10) { image() }),
+                    )
+                }
+            val messages = context.convertEventsToMessages(events)
+
+            // 3 x (assistant + tool response) + 2 media messages
+            messages shouldHaveSize 8
+            val mediaMessages = messages.filterIsInstance<UserMessage>()
+            mediaMessages shouldHaveSize 2
+            val evictedResponse = messages[1].shouldBeInstanceOf<ToolResponseMessage>()
+            evictedResponse.responses[0].responseData() shouldContain "no longer attached"
+        }
+
+        "image cost counts against the detailed-tool budget" {
+            // Image response costs IMAGE_CHAR_COST each: with a tiny budget the older
+            // pair is summarized while the newest stays detailed.
+            val events =
+                listOf(
+                    toolRequest("r1", "FILES__readAsImage"),
+                    toolResponseWithImages("r1", "FILES__readAsImage", "read 1", List(2) { image() }),
+                    toolRequest("r2", "FILES__readAsImage"),
+                    toolResponseWithImages("r2", "FILES__readAsImage", "read 2", List(2) { image() }),
+                )
+            val messages =
+                context.convertEventsToMessages(events, maxDetailedChars = 2 * AgentAdvancedContext.IMAGE_CHAR_COST + 100)
+
+            val summaries = messages.filterIsInstance<AssistantMessage>().filter { it.text?.contains("[Step summary]") == true }
+            summaries shouldHaveSize 1
+            summaries[0].text shouldContain "2 image(s) (not shown)"
+            val mediaMessages = messages.filterIsInstance<UserMessage>()
+            mediaMessages shouldHaveSize 1
+        }
+
+        "extractText never dumps base64 for image output" {
+            val events =
+                listOf(
+                    toolRequest("r1", "FILES__readAsImage"),
+                    ToolResponseEvent(
+                        namespaceId = ns,
+                        caseId = case,
+                        toolRequestId = "r1",
+                        toolName = "FILES__readAsImage",
+                        output = image(width = 100, height = 80),
+                        success = true,
+                    ),
+                )
+            val messages = context.convertEventsToMessages(events)
+
+            val toolRespMsg = messages[1].shouldBeInstanceOf<ToolResponseMessage>()
+            toolRespMsg.responses[0].responseData() shouldBe "[image image/jpeg 100x80]"
+            toolRespMsg.responses[0].responseData() shouldNotContain "aGVsbG8="
+        }
     })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
@@ -628,7 +628,7 @@ class AgentAdvancedContextSpec :
             messages shouldHaveSize 2
         }
 
-        "image tool responses beyond MAX_ATTACHED_IMAGES lose their media, newest kept" {
+        "image tool responses beyond maxAttachedImages lose their media, newest kept" {
             // 3 reads of 10 images each: only the 2 most recent fit the 20-image cap
             val events =
                 (1..3).flatMap { i ->
@@ -648,7 +648,7 @@ class AgentAdvancedContextSpec :
         }
 
         "image cost counts against the detailed-tool budget" {
-            // Image response costs IMAGE_CHAR_COST each: with a tiny budget the older
+            // Image response costs imageCharCost each: with a tiny budget the older
             // pair is summarized while the newest stays detailed.
             val events =
                 listOf(
@@ -658,7 +658,7 @@ class AgentAdvancedContextSpec :
                     toolResponseWithImages("r2", "FILES__readAsImage", "read 2", List(2) { image() }),
                 )
             val messages =
-                context.convertEventsToMessages(events, maxDetailedChars = 2 * AgentAdvancedContext.IMAGE_CHAR_COST + 100)
+                context.convertEventsToMessages(events, maxDetailedChars = 2 * context.imageCharCost + 100)
 
             val summaries = messages.filterIsInstance<AssistantMessage>().filter { it.text?.contains("[Step summary]") == true }
             summaries shouldHaveSize 1
@@ -669,7 +669,7 @@ class AgentAdvancedContextSpec :
 
         "responses with evicted media pay no image cost against the budget" {
             // 3 responses of 10 images each: the 20-image cap attaches media for the 2
-            // newest only. The oldest must NOT be charged IMAGE_CHAR_COST for images it
+            // newest only. The oldest must NOT be charged imageCharCost for images it
             // does not attach, so it stays detailed (with the marker) instead of being
             // evicted from the budget by phantom cost.
             val events =
@@ -679,7 +679,7 @@ class AgentAdvancedContextSpec :
                         toolResponseWithImages("r$i", "FILES__readAsImage", "read $i", List(10) { image() }),
                     )
                 }
-            val budget = 20 * AgentAdvancedContext.IMAGE_CHAR_COST + 500
+            val budget = 20 * context.imageCharCost + 500
 
             val messages = context.convertEventsToMessages(events, maxDetailedChars = budget)
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedSpec.kt
@@ -550,6 +550,78 @@ class AgentAdvancedSpec :
             events.filterIsInstance<AgentFinishedEvent>() shouldHaveSize 1
         }
 
+        "tool result images are copied onto the emitted ToolResponseEvent" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val images = listOf(
+                MessageContent.Image(content = "aGVsbG8=", mimeType = "image/jpeg", width = 791, height = 1024),
+                MessageContent.Image(content = "d29ybGQ=", mimeType = "image/jpeg", width = 791, height = 1024),
+            )
+
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+            every { mockStreamSpec.chatResponse() } returns chatResponseFlux("The CV shows...")
+            every { mockChatClient.prompt(any<Prompt>()).call().content() } returns "{}"
+
+            val readAsImageTool = mockk<StandardTool<String>>(relaxed = true)
+            every { readAsImageTool.name } returns "FILES__readAsImage"
+            every { readAsImageTool.description } returns "Render an image or PDF file visually"
+            every { readAsImageTool.inputSchema } returns "{}"
+            every { readAsImageTool.paramType } returns String::class.java
+            coEvery { readAsImageTool.executeWithJson(any(), any()) } returns
+                ToolExecutionResult.successWithImages("Rendered PDF cv.pdf: page(s) 1-2 of 2", images)
+
+            val agentId = UUID.randomUUID()
+            val mockGenerator = mockk<AgentIntentionGenerator>()
+            every {
+                mockGenerator.generate(any(), any(), any(), any(), any())
+            } returnsMany
+                listOf(
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "Read the CV visually.",
+                        toolName = "FILES__readAsImage",
+                    ),
+                    IntentionGeneratedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentId,
+                        intention = "Answer with what the CV shows.",
+                        toolName = "Answer",
+                    ),
+                )
+
+            val context =
+                AgentAdvancedContext(
+                    chatClient = mockChatClient,
+                    tools = listOf(readAsImageTool),
+                    instructions = null,
+                    agentId = agentId,
+                    confirmationManager = mockk(relaxed = true),
+                )
+            val agent =
+                AgentAdvanced(
+                    metadata = EntityMetadata(id = agentId),
+                    name = "VisionAgent",
+                    context = context,
+                    intentionGenerator = mockGenerator,
+                    objectMapper = testObjectMapper,
+                    maxIterations = 5,
+                    llmProvider = "test-provider",
+                    llmModel = "test-model",
+                )
+
+            val events = agent.run(makeInitialEvents(namespaceId, caseId)).toList()
+
+            val toolResponse = events.filterIsInstance<ToolResponseEvent>().single()
+            toolResponse.success shouldBe true
+            toolResponse.images shouldBe images
+            toolResponse.output shouldBe MessageContent.Text("Rendered PDF cv.pdf: page(s) 1-2 of 2")
+        }
+
         // -------------------------------------------------------------------------
         // detectRepetitionLoop unit tests
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -82,6 +82,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             exchangeCapabilityService = exchangeCapabilityService,
             agentDocumentResolver = agentDocumentResolver,
             idCompressorService = IdCompressorService(),
+            agentConfigProperties = AgentConfigProperties(),
         )
 
     private val namespaceId: UUID = UUID.randomUUID()
@@ -531,6 +532,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     exchangeCapabilityService = exchangeCapabilityService,
                     agentDocumentResolver = agentDocumentResolver,
                     idCompressorService = IdCompressorService(),
+                    agentConfigProperties = AgentConfigProperties(),
                 )
             val configs =
                 listOf(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -353,6 +354,103 @@ class AgentSimpleToolCallbackUnitSpec :
 
             events shouldHaveAtLeastSize 3
             events.filterIsInstance<AgentFinishedEvent>().firstOrNull() shouldNotBe null
+        }
+
+        "image-producing tool: images are kept on the event and the LLM sees the not-supported note" {
+            // AgentSimple cannot deliver image attachments to the LLM. The images must
+            // still be preserved on the ToolResponseEvent (persistence, SSE), and the
+            // text handed back to the LLM must say the images are NOT viewable here,
+            // instead of letting the tool summary claim they are attached.
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+            val images = listOf(
+                MessageContent.Image(content = "aGVsbG8=", mimeType = "image/jpeg", width = 791, height = 1024),
+            )
+
+            val fakeTool =
+                object : StandardTool<Nothing> {
+                    override val name = "FILES__readAsImage"
+                    override val description = "Render a file visually"
+                    override val inputSchema = """{"type":"object","properties":{}}"""
+                    override val version = "1.0.0"
+                    override val paramType: Class<Nothing>? = null
+
+                    override suspend fun execute(
+                        input: Nothing?,
+                        context: ToolContext,
+                    ): ToolExecutionResult = ToolExecutionResult.successWithImages("Rendered PDF cv.pdf: page(s) 1 of 1", images)
+                }
+
+            var callbackReturn: String? = null
+            val toolCallbackSlot = slot<List<ToolCallback>>()
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(any<Prompt>()).toolCallbacks(capture(toolCallbackSlot)).stream() } answers {
+                val cb = toolCallbackSlot.captured.first { it.toolDefinition.name() == "FILES__readAsImage" }
+                callbackReturn = cb.call("{}")
+                mockStreamSpec
+            }
+            every { mockStreamSpec.content() } returns Flux.just("done")
+
+            val agent = makeAgent(agentId, mockChatClient, listOf(fakeTool))
+            val events = agent.run(listOf(userMessage(namespaceId, caseId, "read my cv"))).toList()
+
+            val toolResponse = events.filterIsInstance<ToolResponseEvent>().single()
+            toolResponse.images shouldBe images
+            (toolResponse.output as MessageContent.Text).content shouldBe "Rendered PDF cv.pdf: page(s) 1 of 1"
+
+            callbackReturn shouldNotBe null
+            callbackReturn!! shouldContain "does not support image attachments"
+            callbackReturn!! shouldContain "Rendered PDF cv.pdf"
+        }
+
+        "history replay renders image tool responses as text with the note, never base64" {
+            val namespaceId = UUID.randomUUID()
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.randomUUID()
+
+            val promptSlot = slot<Prompt>()
+            val mockChatClient = mockk<ChatClient>(relaxed = true)
+            val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { mockChatClient.prompt(capture(promptSlot)).stream() } returns mockStreamSpec
+            every { mockStreamSpec.content() } returns Flux.just("response")
+
+            val agent = makeAgent(agentId, mockChatClient, emptyList())
+
+            val history =
+                listOf(
+                    userMessage(namespaceId, caseId, "read my cv"),
+                    ToolRequestEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        toolRequestId = "req-img-1",
+                        toolName = "FILES__readAsImage",
+                        args = """{"filePath":"cv.pdf"}""",
+                    ),
+                    ToolResponseEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        toolRequestId = "req-img-1",
+                        toolName = "FILES__readAsImage",
+                        output = MessageContent.Text("Rendered PDF cv.pdf: page(s) 1 of 1"),
+                        images = listOf(
+                            MessageContent.Image(content = "aGVsbG8=", mimeType = "image/jpeg", width = 10, height = 10),
+                        ),
+                    ),
+                    userMessage(namespaceId, caseId, "so what does it say?"),
+                )
+
+            agent.run(history).toList()
+
+            val toolResponseMessage =
+                promptSlot.captured.instructions
+                    .filterIsInstance<org.springframework.ai.chat.messages.ToolResponseMessage>()
+                    .single()
+            val responseData = toolResponseMessage.responses.single().responseData()
+            responseData shouldContain "Rendered PDF cv.pdf"
+            responseData shouldContain "does not support image attachments"
+            responseData shouldNotContain "aGVsbG8="
         }
 
         "NonTransientAiException from LLM provider surfaces as ErrorEvent + AgentFinishedEvent, no generic error" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperToolSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseEvent/CaseEventNodeMapperToolSpec.kt
@@ -243,6 +243,51 @@ class CaseEventNodeMapperToolSpec :
             roundTripped.durationMs shouldBe null
         }
 
+        "ToolResponseEvent with images survives the round-trip" {
+            val images = listOf(
+                MessageContent.Image(content = "aGVsbG8=", mimeType = "image/jpeg", width = 1024, height = 745),
+                MessageContent.Image(content = "d29ybGQ=", mimeType = "image/png", width = 100, height = 80),
+            )
+            val original =
+                ToolResponseEvent(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = UUID.randomUUID(),
+                    caseId = UUID.randomUUID(),
+                    timestamp = Instant.parse("2026-05-19T15:11:00Z"),
+                    toolRequestId = "req-10",
+                    toolName = "FILES__readAsImage",
+                    output = MessageContent.Text("Rendered PDF cv.pdf: page(s) 1-2 of 2"),
+                    success = true,
+                    images = images,
+                )
+
+            val node = nodeMapper.fromDomain(original)
+            val roundTripped = nodeMapper.toDomain(node) as ToolResponseEvent
+
+            roundTripped.images shouldBe images
+            roundTripped.output shouldBe original.output
+        }
+
+        "ToolResponseEvent without images round-trips to an empty list (legacy nodes)" {
+            val original =
+                ToolResponseEvent(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    namespaceId = UUID.randomUUID(),
+                    caseId = UUID.randomUUID(),
+                    timestamp = Instant.parse("2026-05-19T15:12:00Z"),
+                    toolRequestId = "req-11",
+                    toolName = "FILES__readFile",
+                    output = MessageContent.Text("text"),
+                    success = true,
+                )
+
+            val node = nodeMapper.fromDomain(original)
+            (node as ToolResponseEventNode).imagesJson shouldBe null
+
+            val roundTripped = nodeMapper.toDomain(node) as ToolResponseEvent
+            roundTripped.images shouldBe emptyList()
+        }
+
         // ─── ToolSelectedEvent ───────────────────────────────────────────────────────
 
         "ToolSelectedEvent survives the fromDomain/toDomain round-trip" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatterUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/casePlugin/CaseTranscriptFormatterUnitSpec.kt
@@ -284,6 +284,28 @@ class CaseTranscriptFormatterUnitSpec : StringSpec({
         result shouldContain "TOOL_RESPONSE: [error, ?ms] not found"
     }
 
+    "full mode: ToolResponseEvent with images renders a count, not the base64" {
+        val events = listOf(
+            ToolResponseEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                timestamp = t0,
+                toolRequestId = "req-1",
+                toolName = "FILES__readAsImage",
+                output = MessageContent.Text("Rendered PDF cv.pdf: page(s) 1-2 of 2"),
+                success = true,
+                durationMs = 42,
+                images = listOf(
+                    MessageContent.Image(content = "aGVsbG8=", mimeType = "image/jpeg", width = 800, height = 600),
+                    MessageContent.Image(content = "d29ybGQ=", mimeType = "image/jpeg", width = 800, height = 600),
+                ),
+            ),
+        )
+        val result = CaseTranscriptFormatter.format(events, includesTechnicalEvents = true)
+        result shouldContain "TOOL_RESPONSE: [success, 42ms] Rendered PDF cv.pdf: page(s) 1-2 of 2 [+2 image(s)]"
+        result shouldNotContain "aGVsbG8="
+    }
+
     "full mode: includes IntentionGeneratedEvent" {
         val events = listOf(
             IntentionGeneratedEvent(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/chat/CompressingChatClientSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/chat/CompressingChatClientSpec.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.chat
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -12,12 +13,16 @@ import io.mockk.verify
 import io.whozoss.agentos.util.IdCompressorService
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.Message
 import org.springframework.ai.chat.messages.SystemMessage
 import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.model.Generation
 import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.content.Media
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.util.MimeTypeUtils
 import reactor.core.publisher.Flux
 
 // ---------------------------------------------------------------------------
@@ -565,5 +570,33 @@ class CompressingChatClientSpec :
 
             val sentText = captured.captured.instructions.joinToString("") { it.text ?: "" }
             sentText shouldBe "hello world"
+        }
+
+        "UserMessage media survives compression while its text is compressed" {
+            val service = IdCompressorService()
+            val captured = slot<Prompt>()
+            val delegate = mockk<ChatClient>(relaxed = true)
+            val reqSpec = mockk<ChatClient.ChatClientRequestSpec>(relaxed = true)
+            val callSpec = mockk<ChatClient.CallResponseSpec>(relaxed = true)
+            every { delegate.prompt(capture(captured)) } returns reqSpec
+            every { reqSpec.call() } returns callSpec
+            every { callSpec.content() } returns "ok"
+
+            val media =
+                Media
+                    .builder()
+                    .mimeType(MimeTypeUtils.IMAGE_JPEG)
+                    .data(ByteArrayResource(byteArrayOf(1, 2, 3)))
+                    .build()
+            val message = UserMessage.builder().text("image for id=$REAL_UUID").media(media).build()
+
+            val client = CompressingChatClient(delegate, service)
+            client.prompt(Prompt(listOf<Message>(message))).call().content()
+
+            val sent = captured.captured.instructions.single() as UserMessage
+            sent.text shouldNotContain REAL_UUID
+            sent.text shouldContain IdCompressorService.UUID_COMPRESSED_VALUE_PREFIX
+            sent.media shouldHaveSize 1
+            sent.media[0].dataAsByteArray shouldBe byteArrayOf(1, 2, 3)
         }
     })

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ mcpSdk = "2.0.0"
 
 # Apache PDFBox — PDF page rendering for the file plugin's readAsImage tool.
 # Bundled fat-jar style in agentos-file-plugin (not on the service classpath).
-pdfbox = "3.0.7"
+pdfbox = "3.0.8"
 
 # Apache POI — PPTX slide rendering for the file plugin's readAsImage tool.
 # Bundled fat-jar style in agentos-file-plugin (not on the service classpath).

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -53,6 +53,14 @@ okhttp = "4.12.0"
 # The parent artifact 'mcp' pulls mcp-json-jackson3 by default — use mcp-core + mcp-json-jackson2 instead.
 mcpSdk = "2.0.0"
 
+# Apache PDFBox — PDF page rendering for the file plugin's readAsImage tool.
+# Bundled fat-jar style in agentos-file-plugin (not on the service classpath).
+pdfbox = "3.0.7"
+
+# Apache POI — PPTX slide rendering for the file plugin's readAsImage tool.
+# Bundled fat-jar style in agentos-file-plugin (not on the service classpath).
+poi = "5.5.1"
+
 # AgentOS modules versions
 agentosSdk = "0.216.0"
 agentosService = "0.216.0"
@@ -143,6 +151,12 @@ testcontainers-junit = { module = "org.testcontainers:junit-jupiter", version.re
 # MCP Java SDK
 mcp-core = { module = "io.modelcontextprotocol.sdk:mcp-core", version.ref = "mcpSdk" }
 mcp-json-jackson2 = { module = "io.modelcontextprotocol.sdk:mcp-json-jackson2", version.ref = "mcpSdk" }
+
+# Apache PDFBox — PDF page rendering (agentos-file-plugin readAsImage)
+pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
+
+# Apache POI — PPTX slide rendering (agentos-file-plugin readAsImage)
+poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
 
 # Testing
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -3125,6 +3125,7 @@ components:
       required:
       - externalIds
     Image:
+      type: object
       allOf:
       - $ref: "#/components/schemas/MessageContent"
       - type: object
@@ -3609,6 +3610,10 @@ components:
           durationMs:
             type: integer
             format: int64
+          images:
+            type: array
+            items:
+              $ref: "#/components/schemas/Image"
           output:
             oneOf:
             - $ref: "#/components/schemas/Image"
@@ -3625,6 +3630,7 @@ components:
       required:
       - caseId
       - id
+      - images
       - metadata
       - namespaceId
       - output


### PR DESCRIPTION
## What

New `readAsImage` file tool so agents can visually read binary documents from the file exchange (or any FILE_ACCESS root): images, PDFs (one image per page) and PPTX presentations (one image per slide). The rendered pages ride as base64 `MessageContent.Image` attachments next to the textual tool summary, and reach the model as native image blocks.

Follows the team decision to start with the simple case (a few-page document) and to unify image and PDF reading behind a single dedicated tool, separate from `readFile`.

## How it works

- SDK (additive): `ToolExecutionResult.images` plus a `successWithImages` factory, and `ToolResponseEvent.images`. Existing factories keep their binary signature, legacy Neo4j nodes deserialize to an empty list, the OpenAPI change is additive.
- Plugin: `ReadAsImageTool` joins `readTools`, so it is exposed on FILE_ACCESS configs and on the case/namespace exchange grants with the usual per-agent allowlist, `BoundaryPathResolver`, deny patterns and size caps. Images are bounded to 1024px and re-encoded JPEG q80 (small originals pass through untouched). PDF pages are rendered with PDFBox at 150 DPI with lazy parsing; PPTX slides are rendered directly with POI at 2x supersampling. At most 10 pages/slides per call; the 1-based `pages` parameter selects a subset and the summary tells the model how to continue on longer documents.
- Delivery to the LLM (AgentAdvanced only): Spring AI tool responses are text-only, so images are injected at prompt-build time as a follow-up user message carrying `Media`, which the four chat models map natively. Context cost stays bounded: images are costed inside the 300k-char detailed-tool budget and only the 20 most recent images stay attached, older responses keep a text marker. `CompressingChatClient` now preserves media while compressing text, and base64 never enters any text field by construction.
- Packaging: pdfbox 3.0.7 and poi-ooxml 5.5.1 are bundled in the plugin jar (PF4J APD, same pattern as the MCP plugin); the jar grows to ~23 MB, with no Jackson or Kotlin classes bundled. `XMLSlideShow` is constructed directly on purpose: `SlideShowFactory` resolves providers through the TCCL, which cannot see bundled classes under PF4J.

## Known limitations

- AgentSimple is not wired: a simple agent calling the tool gets the textual summary only (its Spring AI ToolCallback contract returns a plain string). Follow-up work.
- webp/svg are rejected with a typed error; the exchange upload allowlist accepts them, so users can hit it. Legacy .ppt, docx/xlsx and large-file strategies (chunking, sub-agents) are out of scope as agreed.
- POI slide fidelity: fonts missing on the host are substituted, SmartArt is not rendered, embedded charts come out blank. Text, shapes, tables and pictures render fine.
- No vision-capability flag on AiModel: a non-vision model fails with the existing provider ErrorEvent.
- The SSE payload now carries the base64 images; the current frontend ignores the new field (rendering them in the UI is a separate topic).

## Tests

- Plugin: 24 kotest cases covering resize/pass-through/alpha flattening, typed errors, traversal and deny patterns, PDF and PPTX paging, password-protected and corrupt files. Fixtures are generated in-test, nothing binary is committed.
- Service: media injection and eviction, image budget costing, compression media pass-through, Neo4j round-trip, transcript rendering.
- Full agentos-service suite green; plugin jar content verified (PDFBox and POI present, no Jackson); no POI transitive collides with the service classpath.
- Still to run before merge: smoke tests against real provider APIs (Anthropic, OpenAI) with a PDF, a PNG and a PPTX through the case exchange, including the non-vision model failure path.

Side fix: `generateOpenApiDocs` now forces a random embedded Bolt port so spec generation no longer fails when a local dev stack already binds 7688.