### PR TITLE
feat: chat composer file attachments (drag & drop, + button, exchange upload)

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
@@ -2,7 +2,20 @@
   <agentos-exchange-shell dsDrawerSide (closeRequested)="exchangeOpen.set(false)" />
 
   <div dsDrawerContent class="case-chat__host">
-    <div class="case-chat">
+    <div
+      #dropzone
+      class="case-chat"
+      (dragenter)="canAttach() && attachments.onDragEnter($event)"
+      (dragover)="canAttach() && attachments.onDragOver($event)"
+      (dragleave)="attachments.onDragLeave($event, dropzone)"
+      (drop)="canAttach() && attachments.onDrop($event)"
+    >
+      @if (attachments.isDragOver()) {
+        <div class="case-chat__drop-overlay" aria-hidden="true">
+          <span class="material-icons">upload_file</span>
+          <span>Drop files to attach</span>
+        </div>
+      }
       <div class="case-chat__exchange-toggle">
         <ds-icon-button
           [icon]="exchangeOpen() ? 'chevron_right' : 'folder'"
@@ -166,37 +179,57 @@
             />
           </div>
         }
-        <textarea
-          #composerInput
-          class="case-chat__input"
-          placeholder="Reply…"
-          rows="3"
-          [value]="inputValue()"
-          [disabled]="isRunning() || isTerminal()"
-          (input)="onInput($event)"
-          (keydown)="onKeydown($event)"
-        ></textarea>
-        <div class="case-chat__actions">
-          <ds-icon-button
-            [icon]="showTechnical() ? 'visibility_off' : 'bug_report'"
-            variant="default"
-            [title]="showTechnical() ? 'Hide technical events' : 'Show technical events'"
-            (action)="toggleShowTechnical()"
-          />
-
-          @if (isRunning()) {
-            <ds-icon-button icon="stop" variant="danger" title="Interrupt" (action)="interrupt()" />
-          } @else {
+        <agentos-composer-attachments
+          #attachmentsUi
+          [attachments]="attachments.attachments()"
+          [namespaceBadge]="namespaceTargeted()"
+          [limitError]="attachments.limitError()"
+          [disabled]="attachments.isUploading()"
+          (removed)="attachments.remove($event)"
+          (filesSelected)="attachments.addFiles($event)"
+        />
+        <div class="case-chat__composer-row">
+          @if (canAttach()) {
             <ds-icon-button
-              icon="send"
-              variant="primary"
-              [title]="preferences.composerHint()"
-              [disabled]="!canSend"
-              (action)="submit()"
+              icon="add"
+              variant="default"
+              title="Attach files"
+              [disabled]="isRunning() || isTerminal()"
+              (action)="attachmentsUi.openPicker()"
             />
           }
+          <textarea
+            #composerInput
+            class="case-chat__input"
+            placeholder="Reply…"
+            rows="3"
+            [value]="inputValue()"
+            [disabled]="isRunning() || isTerminal()"
+            (input)="onInput($event)"
+            (keydown)="onKeydown($event)"
+          ></textarea>
+          <div class="case-chat__actions">
+            <ds-icon-button
+              [icon]="showTechnical() ? 'visibility_off' : 'bug_report'"
+              variant="default"
+              [title]="showTechnical() ? 'Hide technical events' : 'Show technical events'"
+              (action)="toggleShowTechnical()"
+            />
 
-          <ds-icon-button icon="cancel" variant="danger" title="Kill" [disabled]="isTerminal()" (action)="kill()" />
+            @if (isRunning()) {
+              <ds-icon-button icon="stop" variant="danger" title="Interrupt" (action)="interrupt()" />
+            } @else {
+              <ds-icon-button
+                icon="send"
+                variant="primary"
+                [title]="preferences.composerHint()"
+                [disabled]="!canSend"
+                (action)="submit()"
+              />
+            }
+
+            <ds-icon-button icon="cancel" variant="danger" title="Kill" [disabled]="isTerminal()" (action)="kill()" />
+          </div>
         </div>
       </div>
     </div>

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
@@ -3,12 +3,11 @@
 
   <div dsDrawerContent class="case-chat__host">
     <div
-      #dropzone
       class="case-chat"
-      (dragenter)="canAttach() && attachments.onDragEnter($event)"
-      (dragover)="canAttach() && attachments.onDragOver($event)"
-      (dragleave)="attachments.onDragLeave($event, dropzone)"
-      (drop)="canAttach() && attachments.onDrop($event)"
+      (dragenter)="canStageFiles() && attachments.onDragEnter($event)"
+      (dragover)="canStageFiles() && attachments.onDragOver($event)"
+      (dragleave)="attachments.onDragLeave()"
+      (drop)="canStageFiles() && attachments.onDrop($event)"
     >
       @if (attachments.isDragOver()) {
         <div class="case-chat__drop-overlay" aria-hidden="true">
@@ -194,7 +193,7 @@
               icon="add"
               variant="default"
               title="Attach files"
-              [disabled]="isRunning() || isTerminal()"
+              [disabled]="!canStageFiles()"
               (action)="attachmentsUi.openPicker()"
             />
           }
@@ -204,7 +203,7 @@
             placeholder="Reply…"
             rows="3"
             [value]="inputValue()"
-            [disabled]="isRunning() || isTerminal()"
+            [disabled]="isRunning() || isTerminal() || attachments.isUploading()"
             (input)="onInput($event)"
             (keydown)="onKeydown($event)"
           ></textarea>

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -508,7 +508,7 @@
     flex-shrink: 0;
     position: relative;
     display: flex;
-    align-items: flex-end;
+    flex-direction: column;
     gap: 0.5rem;
     background: var(--glass-bg, rgba(255, 255, 255, 0.72));
     border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.18));
@@ -516,6 +516,32 @@
     -webkit-backdrop-filter: var(--glass-backdrop-blur, blur(20px));
     border-radius: 16px;
     padding: 0.5rem 0.5rem 0.5rem 1rem;
+  }
+
+  &__composer-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  &__drop-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    // pointer-events: none so the drop lands on the container and dragging over the
+    // overlay itself never triggers a flickering dragleave.
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border: 2px dashed var(--color-primary, #0071e3);
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--color-primary, #0071e3) 8%, transparent);
+    color: var(--color-primary, #0071e3);
+    font-weight: 600;
   }
 
   &__input {

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
@@ -1,0 +1,161 @@
+import { HttpClient } from '@angular/common/http'
+import { ComponentRef, createComponent, EnvironmentInjector, signal } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { ActivatedRoute } from '@angular/router'
+import { Configuration, ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
+import { of } from 'rxjs'
+import { CaseStateService } from '../../services/case-state.service'
+import { ExchangeStateService } from '../../services/exchange-state.service'
+import { PromptStateService } from '../../services/prompt-state.service'
+import { USER_PREFERENCES_PORT } from '../../services/user-preferences.service'
+import { UserStateService } from '../../services/user-state.service'
+import { ComposerAttachmentsService } from '../composer-attachments/composer-attachments.service'
+import { CaseChatComponent } from './case-chat.component'
+
+/**
+ * The component is created WITHOUT rendering (no attachView / detectChanges): ngOnInit never
+ * runs, so no SSE connection is opened and the template tree (drawer, exchange shell) stays
+ * out of the picture. The submit orchestration is exercised directly on the instance; the
+ * component-provided ComposerAttachmentsService is the real one, backed by the mocked
+ * ExchangeStateService.
+ */
+describe('CaseChatComponent — submit with attachments', () => {
+  let http: { post: jest.Mock }
+  let exchangeState: {
+    uploadFile: jest.Mock
+    canWriteCase: ReturnType<typeof signal<boolean>>
+    canWriteNamespace: ReturnType<typeof signal<boolean>>
+    fileCount: ReturnType<typeof signal<number>>
+    refreshManifest: jest.Mock
+    refreshCase: jest.Mock
+    refreshNamespace: jest.Mock
+  }
+  let calls: string[]
+
+  function makeComponent(): ComponentRef<CaseChatComponent> {
+    const environmentInjector = TestBed.inject(EnvironmentInjector)
+    return createComponent(CaseChatComponent, { environmentInjector })
+  }
+
+  function attachments(ref: ComponentRef<CaseChatComponent>): ComposerAttachmentsService {
+    return ref.injector.get(ComposerAttachmentsService)
+  }
+
+  beforeEach(() => {
+    calls = []
+    http = {
+      post: jest.fn().mockImplementation(() => {
+        calls.push('post')
+        return of({})
+      }),
+    }
+    exchangeState = {
+      uploadFile: jest.fn().mockImplementation(async () => {
+        calls.push('upload')
+        return { success: true }
+      }),
+      canWriteCase: signal(true),
+      canWriteNamespace: signal(false),
+      fileCount: signal(0),
+      refreshManifest: jest.fn(),
+      refreshCase: jest.fn(),
+      refreshNamespace: jest.fn(),
+    }
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpClient, useValue: http },
+        { provide: Configuration, useValue: { basePath: '' } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParams: { case: 'c-1', ns: 'ns-1' } }, queryParams: of({}) },
+        },
+        { provide: ExchangeStateService, useValue: exchangeState },
+        { provide: CaseStateService, useValue: { addCase: jest.fn(), updateCaseTitle: jest.fn() } },
+        { provide: PromptStateService, useValue: { listEffective: jest.fn().mockReturnValue(of([])) } },
+        { provide: UserStateService, useValue: { currentUser: () => ({ id: 'u-1' }) } },
+        {
+          provide: USER_PREFERENCES_PORT,
+          useValue: { shouldSend: jest.fn().mockReturnValue(false), composerHint: () => 'hint' },
+        },
+      ],
+    })
+  })
+
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('uploads the attachments before sending, and appends the mention to the message', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('analyse this file')
+    attachments(ref).addFiles([new File(['x'], 'report.pdf')])
+
+    await ref.instance['submit']()
+
+    expect(calls).toEqual(['upload', 'post'])
+    expect(exchangeState.uploadFile).toHaveBeenCalledWith(ExchangeFileEntryScopeEnum.CASE, expect.any(File))
+    expect(http.post).toHaveBeenCalledWith('/api/cases/c-1/messages', {
+      content: 'analyse this file\n\n[Files attached to the case exchange: report.pdf]',
+      userId: 'default-user',
+    })
+    expect(ref.instance['inputValue']()).toBe('')
+    expect(attachments(ref).attachments()).toEqual([])
+  })
+
+  it('blocks the send when an upload fails, keeping the input and the failed chip', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('analyse this file')
+    attachments(ref).addFiles([new File(['x'], 'dup.pdf')])
+    exchangeState.uploadFile.mockResolvedValue({ success: false, error: 'A file with this name already exists.' })
+
+    await ref.instance['submit']()
+
+    expect(http.post).not.toHaveBeenCalled()
+    expect(ref.instance['inputValue']()).toBe('analyse this file')
+    expect(attachments(ref).attachments()[0]!.status).toBe('error')
+  })
+
+  it('routes the upload to the namespace when the message asks for it and the user can write it', async () => {
+    const ref = makeComponent()
+    exchangeState.canWriteNamespace.set(true)
+    ref.instance['inputValue'].set('please store this in the namespace')
+    attachments(ref).addFiles([new File(['x'], 'shared.md')])
+
+    await ref.instance['submit']()
+
+    expect(exchangeState.uploadFile).toHaveBeenCalledWith(ExchangeFileEntryScopeEnum.NAMESPACE, expect.any(File))
+    const content = (http.post.mock.calls[0]![1] as { content: string }).content
+    expect(content).toContain('[Files attached to the namespace exchange: shared.md]')
+  })
+
+  it('keeps the case target when the namespace is mentioned without write rights', async () => {
+    const ref = makeComponent()
+    exchangeState.canWriteNamespace.set(false)
+    ref.instance['inputValue'].set('please store this in the namespace')
+    attachments(ref).addFiles([new File(['x'], 'shared.md')])
+
+    await ref.instance['submit']()
+
+    expect(exchangeState.uploadFile).toHaveBeenCalledWith(ExchangeFileEntryScopeEnum.CASE, expect.any(File))
+  })
+
+  it('allows an attachment-only send: the content is the mention block', async () => {
+    const ref = makeComponent()
+    attachments(ref).addFiles([new File(['x'], 'alone.pdf')])
+
+    await ref.instance['submit']()
+
+    expect(http.post).toHaveBeenCalledWith('/api/cases/c-1/messages', {
+      content: '[Files attached to the case exchange: alone.pdf]',
+      userId: 'default-user',
+    })
+  })
+
+  it('sends a plain message untouched when nothing is attached', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('hello')
+
+    await ref.instance['submit']()
+
+    expect(http.post).toHaveBeenCalledWith('/api/cases/c-1/messages', { content: 'hello', userId: 'default-user' })
+    expect(exchangeState.uploadFile).not.toHaveBeenCalled()
+  })
+})

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
@@ -198,6 +198,22 @@ describe('CaseChatComponent — submit with attachments', () => {
     expect(http.post).not.toHaveBeenCalled()
   })
 
+  it('is not re-entrant: a second submit while one is in flight does not double-send', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('analyse this file')
+    attachments(ref).addFiles([new File(['x'], 'report.pdf')])
+    let resolveUpload!: (v: { success: boolean }) => void
+    exchangeState.uploadFile.mockReturnValue(new Promise<{ success: boolean }>((resolve) => (resolveUpload = resolve)))
+
+    const first = ref.instance['submit']()
+    await ref.instance['submit']() // fired while the first is still awaiting the upload
+    resolveUpload({ success: true })
+    await first
+
+    expect(exchangeState.uploadFile).toHaveBeenCalledTimes(1)
+    expect(http.post).toHaveBeenCalledTimes(1)
+  })
+
   it('canSend is false while uploading or on a terminal case, even with attachments staged', () => {
     const ref = makeComponent()
     attachments(ref).addFiles([new File(['x'], 'a.pdf')])

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentRef, createComponent, EnvironmentInjector, signal } from '@ang
 import { TestBed } from '@angular/core/testing'
 import { ActivatedRoute } from '@angular/router'
 import { Configuration, ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { CaseStateService } from '../../services/case-state.service'
 import { ExchangeStateService } from '../../services/exchange-state.service'
 import { PromptStateService } from '../../services/prompt-state.service'
@@ -157,5 +157,57 @@ describe('CaseChatComponent — submit with attachments', () => {
 
     expect(http.post).toHaveBeenCalledWith('/api/cases/c-1/messages', { content: 'hello', userId: 'default-user' })
     expect(exchangeState.uploadFile).not.toHaveBeenCalled()
+  })
+
+  it('a failed message send keeps the text and the uploaded chips for a retry', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('analyse this file')
+    attachments(ref).addFiles([new File(['x'], 'report.pdf')])
+    http.post.mockImplementationOnce(() => {
+      calls.push('post')
+      return throwError(() => new Error('network down'))
+    })
+
+    await ref.instance['submit']()
+
+    expect(ref.instance['inputValue']()).toBe('analyse this file')
+    expect(attachments(ref).attachments()[0]!.status).toBe('uploaded')
+
+    await ref.instance['submit']()
+
+    // The retry does not re-upload (chip already uploaded) and sends the same content.
+    expect(exchangeState.uploadFile).toHaveBeenCalledTimes(1)
+    expect(http.post).toHaveBeenCalledTimes(2)
+    expect(ref.instance['inputValue']()).toBe('')
+    expect(attachments(ref).attachments()).toEqual([])
+  })
+
+  it('a case switch during the upload aborts the send', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('draft written for the old case')
+    attachments(ref).addFiles([new File(['x'], 'a.pdf')])
+    exchangeState.uploadFile.mockImplementation(async () => {
+      // Simulates reinitialise() firing on a sidebar case switch mid-upload.
+      ref.instance['caseId'] = 'c-2'
+      attachments(ref).reset()
+      return { success: true }
+    })
+
+    await ref.instance['submit']()
+
+    expect(http.post).not.toHaveBeenCalled()
+  })
+
+  it('canSend is false while uploading or on a terminal case, even with attachments staged', () => {
+    const ref = makeComponent()
+    attachments(ref).addFiles([new File(['x'], 'a.pdf')])
+    expect(ref.instance['canSend']).toBe(true)
+
+    attachments(ref).isUploading.set(true)
+    expect(ref.instance['canSend']).toBe(false)
+
+    attachments(ref).isUploading.set(false)
+    ref.instance['isTerminal'].set(true)
+    expect(ref.instance['canSend']).toBe(false)
   })
 })

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -29,6 +29,7 @@ import {
   Configuration,
   EnrichmentPhaseTrace,
   ErrorEvent,
+  ExchangeFileEntryScopeEnum,
   IntentionGeneratedEvent,
   MessageEvent as CaseMessageEvent,
   ToolRequestEvent,
@@ -47,6 +48,9 @@ import { UserStateService } from '../../services/user-state.service'
 import { ExchangeStateService } from '../../services/exchange-state.service'
 import { exchangeMutationScope } from '../../services/exchange-content.utils'
 import { ExchangeShellComponent } from '../exchange-shell/exchange-shell.component'
+import { ComposerAttachmentsComponent } from '../composer-attachments/composer-attachments.component'
+import { ComposerAttachmentsService } from '../composer-attachments/composer-attachments.service'
+import { resolveUploadScope } from '../composer-attachments/composer-attachments.utils'
 
 export interface ToolCall {
   requestId: string
@@ -97,7 +101,15 @@ const SCROLL_BOTTOM_THRESHOLD = 64
  */
 @Component({
   selector: 'agentos-case-chat',
-  imports: [IconButtonComponent, JsonPipe, DrawerComponent, ExchangeShellComponent, PromptAutocompleteComponent],
+  imports: [
+    IconButtonComponent,
+    JsonPipe,
+    DrawerComponent,
+    ExchangeShellComponent,
+    PromptAutocompleteComponent,
+    ComposerAttachmentsComponent,
+  ],
+  providers: [ComposerAttachmentsService],
   templateUrl: './case-chat.component.html',
   styleUrl: './case-chat.component.scss',
 })
@@ -118,6 +130,11 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   /** Right-side file-exchange drawer open state + entry-point badge count. */
   protected readonly exchangeOpen = signal(false)
   protected readonly exchangeFileCount = this.exchangeState.fileCount
+
+  /** Files staged on the next message (component-scoped instance, see providers). */
+  protected readonly attachments = inject(ComposerAttachmentsService)
+  /** Attaching goes through the case exchange: same write gate as the drawer's upload button. */
+  protected readonly canAttach = this.exchangeState.canWriteCase
 
   protected toggleExchange(): void {
     this.exchangeOpen.update((v) => !v)
@@ -203,6 +220,13 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     if (!text) return ''
     return this.renderMarkdown(text)
   })
+
+  /** True when the message text targets the namespace exchange (previewed on the chips). */
+  protected readonly namespaceTargeted = computed(
+    () =>
+      resolveUploadScope(this.inputValue(), this.exchangeState.canWriteNamespace()) ===
+      ExchangeFileEntryScopeEnum.NAMESPACE
+  )
 
   /** Collapsed state per toolRequestId */
   protected readonly collapsedTools = signal<Set<string>>(new Set())
@@ -370,7 +394,12 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   }
 
   protected get canSend(): boolean {
-    return !!this.inputValue().trim() && !this.isRunning() && !this.isTerminal()
+    return (
+      (!!this.inputValue().trim() || this.attachments.hasAttachments()) &&
+      !this.isRunning() &&
+      !this.isTerminal() &&
+      !this.attachments.isUploading()
+    )
   }
 
   ngOnInit(): void {
@@ -703,12 +732,24 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     this.slashSuggestions.set([])
     this.effectivePrompts = []
     this.promptsLoaded = false
+    this.attachments.reset()
     this.connectSse()
   }
 
-  protected submit(): void {
+  protected async submit(): Promise<void> {
     if (!this.canSend) return
     const content = this.inputValue().trim()
+    if (this.attachments.hasAttachments()) {
+      const scope = resolveUploadScope(content, this.exchangeState.canWriteNamespace())
+      const mention = await this.attachments.uploadAllAndBuildMention(scope)
+      // Any upload failure blocks the send: the chips carry the mapped errors, the input
+      // stays intact so the user can fix and retry (already-uploaded files are skipped).
+      if (mention === null) return
+      this.inputValue.set('')
+      this.attachments.reset()
+      this.sendMessage(content ? `${content}\n\n${mention}` : mention)
+      return
+    }
     this.inputValue.set('')
     this.sendMessage(content)
   }

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http'
 import { JsonPipe } from '@angular/common'
-import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs'
+import { catchError, debounceTime, firstValueFrom, map, of, Subject, switchMap } from 'rxjs'
 import {
   afterNextRender,
   Component,
@@ -29,7 +29,6 @@ import {
   Configuration,
   EnrichmentPhaseTrace,
   ErrorEvent,
-  ExchangeFileEntryScopeEnum,
   IntentionGeneratedEvent,
   MessageEvent as CaseMessageEvent,
   ToolRequestEvent,
@@ -50,7 +49,7 @@ import { exchangeMutationScope } from '../../services/exchange-content.utils'
 import { ExchangeShellComponent } from '../exchange-shell/exchange-shell.component'
 import { ComposerAttachmentsComponent } from '../composer-attachments/composer-attachments.component'
 import { ComposerAttachmentsService } from '../composer-attachments/composer-attachments.service'
-import { resolveUploadScope } from '../composer-attachments/composer-attachments.utils'
+import { isNamespaceTargeted, resolveUploadScope } from '../composer-attachments/composer-attachments.utils'
 
 export interface ToolCall {
   requestId: string
@@ -135,6 +134,14 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   protected readonly attachments = inject(ComposerAttachmentsService)
   /** Attaching goes through the case exchange: same write gate as the drawer's upload button. */
   protected readonly canAttach = this.exchangeState.canWriteCase
+  /**
+   * Files can be staged (picker + drop) only when the composer itself is usable: staging on
+   * a terminal case would be a dead end, and staging during an upload batch would be
+   * silently skipped by the in-flight loop.
+   */
+  protected readonly canStageFiles = computed(
+    () => this.canAttach() && !this.isRunning() && !this.isTerminal() && !this.attachments.isUploading()
+  )
 
   protected toggleExchange(): void {
     this.exchangeOpen.update((v) => !v)
@@ -222,10 +229,8 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   })
 
   /** True when the message text targets the namespace exchange (previewed on the chips). */
-  protected readonly namespaceTargeted = computed(
-    () =>
-      resolveUploadScope(this.inputValue(), this.exchangeState.canWriteNamespace()) ===
-      ExchangeFileEntryScopeEnum.NAMESPACE
+  protected readonly namespaceTargeted = computed(() =>
+    isNamespaceTargeted(this.inputValue(), this.exchangeState.canWriteNamespace())
   )
 
   /** Collapsed state per toolRequestId */
@@ -740,14 +745,19 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     if (!this.canSend) return
     const content = this.inputValue().trim()
     if (this.attachments.hasAttachments()) {
+      const caseIdAtSubmit = this.caseId
       const scope = resolveUploadScope(content, this.exchangeState.canWriteNamespace())
       const mention = await this.attachments.uploadAllAndBuildMention(scope)
-      // Any upload failure blocks the send: the chips carry the mapped errors, the input
-      // stays intact so the user can fix and retry (already-uploaded files are skipped).
-      if (mention === null) return
-      this.inputValue.set('')
-      this.attachments.reset()
-      this.sendMessage(content ? `${content}\n\n${mention}` : mention)
+      // An upload failure or a mid-flight case switch blocks the send: failed chips carry
+      // the mapped errors (or the switch reset the batch), the input stays intact.
+      if (mention === null || this.caseId !== caseIdAtSubmit) return
+      const sent = await this.postMessage(content ? `${content}\n\n${mention}` : mention)
+      // Only a confirmed send clears the composer: on failure the text and the uploaded
+      // chips stay, and a retry rebuilds the mention without re-uploading anything.
+      if (sent && this.caseId === caseIdAtSubmit) {
+        this.inputValue.set('')
+        this.attachments.reset()
+      }
       return
     }
     this.inputValue.set('')
@@ -755,20 +765,26 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   }
 
   private sendMessage(content: string): void {
+    void this.postMessage(content)
+  }
+
+  private postMessage(content: string): Promise<boolean> {
     this.isRunning.set(true)
     this.streamingText.set('')
 
-    this.http
-      .post(`${this.config.basePath}/api/cases/${this.caseId}/messages`, {
+    return firstValueFrom(
+      this.http.post(`${this.config.basePath}/api/cases/${this.caseId}/messages`, {
         content,
         userId: 'default-user',
       })
-      .subscribe({
-        error: (err) => {
-          console.error('[CaseChat] Failed to send message', err)
-          this.isRunning.set(false)
-        },
-      })
+    ).then(
+      () => true,
+      (err) => {
+        console.error('[CaseChat] Failed to send message', err)
+        this.isRunning.set(false)
+        return false
+      }
+    )
   }
 
   protected interrupt(): void {

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -741,22 +741,35 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     this.connectSse()
   }
 
+  /**
+   * Re-entrancy guard for the async attachment path. canSend alone is not enough: it goes
+   * false during the upload (isUploading), but that flag is cleared by the service before
+   * postMessage sets isRunning, leaving a window where a second submit() could pass the
+   * guard and post the same message twice. Set synchronously, cleared in a finally.
+   */
+  private submitting = false
+
   protected async submit(): Promise<void> {
-    if (!this.canSend) return
+    if (this.submitting || !this.canSend) return
     const content = this.inputValue().trim()
     if (this.attachments.hasAttachments()) {
-      const caseIdAtSubmit = this.caseId
-      const scope = resolveUploadScope(content, this.exchangeState.canWriteNamespace())
-      const mention = await this.attachments.uploadAllAndBuildMention(scope)
-      // An upload failure or a mid-flight case switch blocks the send: failed chips carry
-      // the mapped errors (or the switch reset the batch), the input stays intact.
-      if (mention === null || this.caseId !== caseIdAtSubmit) return
-      const sent = await this.postMessage(content ? `${content}\n\n${mention}` : mention)
-      // Only a confirmed send clears the composer: on failure the text and the uploaded
-      // chips stay, and a retry rebuilds the mention without re-uploading anything.
-      if (sent && this.caseId === caseIdAtSubmit) {
-        this.inputValue.set('')
-        this.attachments.reset()
+      this.submitting = true
+      try {
+        const caseIdAtSubmit = this.caseId
+        const scope = resolveUploadScope(content, this.exchangeState.canWriteNamespace())
+        const mention = await this.attachments.uploadAllAndBuildMention(scope)
+        // An upload failure or a mid-flight case switch blocks the send: failed chips carry
+        // the mapped errors (or the switch reset the batch), the input stays intact.
+        if (mention === null || this.caseId !== caseIdAtSubmit) return
+        const sent = await this.postMessage(content ? `${content}\n\n${mention}` : mention)
+        // Only a confirmed send clears the composer: on failure the text and the uploaded
+        // chips stay, and a retry rebuilds the mention without re-uploading anything.
+        if (sent && this.caseId === caseIdAtSubmit) {
+          this.inputValue.set('')
+          this.attachments.reset()
+        }
+      } finally {
+        this.submitting = false
       }
       return
     }

--- a/libs/agentos-ui/src/lib/components/case-home/case-home.component.html
+++ b/libs/agentos-ui/src/lib/components/case-home/case-home.component.html
@@ -1,4 +1,17 @@
-<div class="case-home">
+<div
+  #dropzone
+  class="case-home"
+  (dragenter)="attachments.onDragEnter($event)"
+  (dragover)="attachments.onDragOver($event)"
+  (dragleave)="attachments.onDragLeave($event, dropzone)"
+  (drop)="attachments.onDrop($event)"
+>
+  @if (attachments.isDragOver()) {
+    <div class="case-home__drop-overlay" aria-hidden="true">
+      <span class="material-icons">upload_file</span>
+      <span>Drop files to attach</span>
+    </div>
+  }
   <div class="case-home__hero">
     <h1 class="case-home__headline">What can I help you with?</h1>
 
@@ -12,6 +25,16 @@
           />
         </div>
       }
+      <agentos-composer-attachments
+        #attachmentsUi
+        class="case-home__attachments"
+        [attachments]="attachments.attachments()"
+        [namespaceBadge]="namespaceTargeted()"
+        [limitError]="attachments.limitError()"
+        [disabled]="attachments.isUploading()"
+        (removed)="attachments.remove($event)"
+        (filesSelected)="attachments.addFiles($event)"
+      />
       <textarea
         #composerInput
         class="case-home__input"
@@ -23,7 +46,16 @@
         (keydown)="onKeydown($event)"
       ></textarea>
       <div class="case-home__composer-footer">
-        <span class="case-home__hint">{{ preferences.composerHint() }}</span>
+        <div class="case-home__footer-left">
+          <ds-icon-button
+            icon="add"
+            variant="default"
+            title="Attach files"
+            [disabled]="isCreating()"
+            (action)="attachmentsUi.openPicker()"
+          />
+          <span class="case-home__hint">{{ preferences.composerHint() }}</span>
+        </div>
         <ds-icon-button icon="send" variant="primary" title="Start case" [disabled]="!canSend" (action)="submit()" />
       </div>
     </div>

--- a/libs/agentos-ui/src/lib/components/case-home/case-home.component.html
+++ b/libs/agentos-ui/src/lib/components/case-home/case-home.component.html
@@ -1,10 +1,9 @@
 <div
-  #dropzone
   class="case-home"
-  (dragenter)="attachments.onDragEnter($event)"
-  (dragover)="attachments.onDragOver($event)"
-  (dragleave)="attachments.onDragLeave($event, dropzone)"
-  (drop)="attachments.onDrop($event)"
+  (dragenter)="!isCreating() && attachments.onDragEnter($event)"
+  (dragover)="!isCreating() && attachments.onDragOver($event)"
+  (dragleave)="attachments.onDragLeave()"
+  (drop)="!isCreating() && attachments.onDrop($event)"
 >
   @if (attachments.isDragOver()) {
     <div class="case-home__drop-overlay" aria-hidden="true">

--- a/libs/agentos-ui/src/lib/components/case-home/case-home.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-home/case-home.component.scss
@@ -6,6 +6,8 @@
   height: 100%;
   align-items: center;
   justify-content: center;
+  // Anchor for the drag & drop overlay.
+  position: relative;
 
   &__hero {
     display: flex;
@@ -92,7 +94,37 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.5rem 0.5rem 0.5rem 1.25rem;
+    padding: 0.5rem 0.5rem 0.5rem 0.5rem;
+  }
+
+  &__footer-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  &__attachments {
+    display: block;
+    padding: 0.75rem 0.75rem 0;
+  }
+
+  &__drop-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    // pointer-events: none so the drop lands on the container and dragging over the
+    // overlay itself never triggers a flickering dragleave.
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border: 2px dashed var(--color-primary, #0071e3);
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--color-primary, #0071e3) 8%, transparent);
+    color: var(--color-primary, #0071e3);
+    font-weight: 600;
   }
 
   &__hint {

--- a/libs/agentos-ui/src/lib/components/case-home/case-home.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-home/case-home.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentRef, createComponent, EnvironmentInjector, signal } from '@ang
 import { TestBed } from '@angular/core/testing'
 import { ActivatedRoute, Router } from '@angular/router'
 import { Configuration, ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
-import { of } from 'rxjs'
+import { of, Subject } from 'rxjs'
 import { CaseStateService } from '../../services/case-state.service'
 import { ExchangeStateService } from '../../services/exchange-state.service'
 import { PromptStateService } from '../../services/prompt-state.service'
@@ -26,6 +26,7 @@ describe('CaseHomeComponent — first message with attachments', () => {
     initializeForCase: jest.Mock
     canWriteNamespace: ReturnType<typeof signal<boolean>>
   }
+  let queryParams$: Subject<Record<string, string>>
   let calls: string[]
 
   function makeComponent(): ComponentRef<CaseHomeComponent> {
@@ -39,6 +40,7 @@ describe('CaseHomeComponent — first message with attachments', () => {
 
   beforeEach(() => {
     calls = []
+    queryParams$ = new Subject<Record<string, string>>()
     http = {
       post: jest.fn().mockImplementation((url: string) => {
         if (url.endsWith('/api/cases')) {
@@ -64,7 +66,7 @@ describe('CaseHomeComponent — first message with attachments', () => {
         { provide: HttpClient, useValue: http },
         { provide: Router, useValue: router },
         { provide: Configuration, useValue: { basePath: '' } },
-        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: { ns: 'ns-1' } }, queryParams: of({}) } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: { ns: 'ns-1' } }, queryParams: queryParams$ } },
         { provide: ExchangeStateService, useValue: exchangeState },
         { provide: CaseStateService, useValue: { addCase: jest.fn() } },
         { provide: PromptStateService, useValue: { listEffective: jest.fn().mockReturnValue(of([])) } },
@@ -129,6 +131,22 @@ describe('CaseHomeComponent — first message with attachments', () => {
     expect(calls.filter((c) => c === 'create-case')).toHaveLength(1)
     expect(calls).toContain('send-message')
     expect(router.navigate).toHaveBeenCalled()
+  })
+
+  it('a namespace switch clears the staged files and the pending case id', async () => {
+    const ref = makeComponent()
+    ref.instance.ngOnInit()
+    ref.instance['inputValue'].set('summarize this')
+    attachments(ref).addFiles([new File(['x'], 'dup.pdf')])
+    exchangeState.uploadFile.mockResolvedValueOnce({ success: false, error: 'A file with this name already exists.' })
+    await ref.instance['submit']()
+    expect(ref.instance['pendingCaseId']()).toBe('case-9')
+
+    queryParams$.next({ ns: 'ns-2' })
+
+    expect(exchangeState.initializeForNamespace).toHaveBeenCalledWith('ns-2')
+    expect(attachments(ref).attachments()).toEqual([])
+    expect(ref.instance['pendingCaseId']()).toBeNull()
   })
 
   it('routes the upload to the namespace when asked for with write rights', async () => {

--- a/libs/agentos-ui/src/lib/components/case-home/case-home.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-home/case-home.component.spec.ts
@@ -1,0 +1,148 @@
+import { HttpClient } from '@angular/common/http'
+import { ComponentRef, createComponent, EnvironmentInjector, signal } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { ActivatedRoute, Router } from '@angular/router'
+import { Configuration, ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
+import { of } from 'rxjs'
+import { CaseStateService } from '../../services/case-state.service'
+import { ExchangeStateService } from '../../services/exchange-state.service'
+import { PromptStateService } from '../../services/prompt-state.service'
+import { USER_PREFERENCES_PORT } from '../../services/user-preferences.service'
+import { UserStateService } from '../../services/user-state.service'
+import { ComposerAttachmentsService } from '../composer-attachments/composer-attachments.service'
+import { CaseHomeComponent } from './case-home.component'
+
+/**
+ * Created WITHOUT rendering (no attachView / detectChanges); ngOnInit is invoked manually
+ * where the test needs it. The component-provided ComposerAttachmentsService is real,
+ * backed by the mocked ExchangeStateService.
+ */
+describe('CaseHomeComponent — first message with attachments', () => {
+  let http: { post: jest.Mock }
+  let router: { navigate: jest.Mock }
+  let exchangeState: {
+    uploadFile: jest.Mock
+    initializeForNamespace: jest.Mock
+    initializeForCase: jest.Mock
+    canWriteNamespace: ReturnType<typeof signal<boolean>>
+  }
+  let calls: string[]
+
+  function makeComponent(): ComponentRef<CaseHomeComponent> {
+    const environmentInjector = TestBed.inject(EnvironmentInjector)
+    return createComponent(CaseHomeComponent, { environmentInjector })
+  }
+
+  function attachments(ref: ComponentRef<CaseHomeComponent>): ComposerAttachmentsService {
+    return ref.injector.get(ComposerAttachmentsService)
+  }
+
+  beforeEach(() => {
+    calls = []
+    http = {
+      post: jest.fn().mockImplementation((url: string) => {
+        if (url.endsWith('/api/cases')) {
+          calls.push('create-case')
+          return of({ id: 'case-9' })
+        }
+        calls.push('send-message')
+        return of({})
+      }),
+    }
+    router = { navigate: jest.fn() }
+    exchangeState = {
+      uploadFile: jest.fn().mockImplementation(async () => {
+        calls.push('upload')
+        return { success: true }
+      }),
+      initializeForNamespace: jest.fn(),
+      initializeForCase: jest.fn().mockImplementation(() => calls.push('init-case')),
+      canWriteNamespace: signal(false),
+    }
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpClient, useValue: http },
+        { provide: Router, useValue: router },
+        { provide: Configuration, useValue: { basePath: '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: { ns: 'ns-1' } }, queryParams: of({}) } },
+        { provide: ExchangeStateService, useValue: exchangeState },
+        { provide: CaseStateService, useValue: { addCase: jest.fn() } },
+        { provide: PromptStateService, useValue: { listEffective: jest.fn().mockReturnValue(of([])) } },
+        { provide: UserStateService, useValue: { currentUser: () => ({ id: 'u-1' }) } },
+        {
+          provide: USER_PREFERENCES_PORT,
+          useValue: { shouldSend: jest.fn().mockReturnValue(false), composerHint: () => 'hint' },
+        },
+      ],
+    })
+  })
+
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('initialises the namespace-only exchange on init so the badge gating can work', () => {
+    const ref = makeComponent()
+    ref.instance.ngOnInit()
+    expect(exchangeState.initializeForNamespace).toHaveBeenCalledWith('ns-1')
+  })
+
+  it('creates the case, uploads, sends the mention-bearing message, then navigates', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('summarize this')
+    attachments(ref).addFiles([new File(['x'], 'report.pdf')])
+
+    await ref.instance['submit']()
+
+    expect(calls).toEqual(['create-case', 'init-case', 'upload', 'send-message'])
+    expect(exchangeState.initializeForCase).toHaveBeenCalledWith('ns-1', 'case-9')
+    expect(http.post).toHaveBeenCalledWith('/api/cases/case-9/messages', {
+      content: 'summarize this\n\n[Files attached to the case exchange: report.pdf]',
+      userId: 'default-user',
+    })
+    expect(router.navigate).toHaveBeenCalledWith(['/agentos/home'], {
+      queryParams: { ns: 'ns-1', case: 'case-9' },
+    })
+    expect(attachments(ref).attachments()).toEqual([])
+    expect(ref.instance['inputValue']()).toBe('')
+  })
+
+  it('on upload failure: keeps the created case, does not send nor navigate, and a retry reuses it', async () => {
+    const ref = makeComponent()
+    ref.instance['inputValue'].set('summarize this')
+    attachments(ref).addFiles([new File(['x'], 'dup.pdf')])
+    exchangeState.uploadFile.mockResolvedValueOnce({ success: false, error: 'A file with this name already exists.' })
+
+    await ref.instance['submit']()
+
+    expect(calls.filter((c) => c === 'create-case')).toHaveLength(1)
+    expect(calls).not.toContain('send-message')
+    expect(router.navigate).not.toHaveBeenCalled()
+    expect(ref.instance['isCreating']()).toBe(false)
+    expect(ref.instance['inputValue']()).toBe('summarize this')
+    expect(attachments(ref).attachments()[0]!.status).toBe('error')
+
+    exchangeState.uploadFile.mockImplementation(async () => {
+      calls.push('upload')
+      return { success: true }
+    })
+    await ref.instance['submit']()
+
+    expect(calls.filter((c) => c === 'create-case')).toHaveLength(1)
+    expect(calls).toContain('send-message')
+    expect(router.navigate).toHaveBeenCalled()
+  })
+
+  it('routes the upload to the namespace when asked for with write rights', async () => {
+    const ref = makeComponent()
+    exchangeState.canWriteNamespace.set(true)
+    ref.instance['inputValue'].set('add this to the namespace documents')
+    attachments(ref).addFiles([new File(['x'], 'shared.md')])
+
+    await ref.instance['submit']()
+
+    expect(exchangeState.uploadFile).toHaveBeenCalledWith(ExchangeFileEntryScopeEnum.NAMESPACE, expect.any(File))
+    const messageCall = http.post.mock.calls.find(([url]) => (url as string).includes('/messages'))!
+    expect((messageCall[1] as { content: string }).content).toContain(
+      '[Files attached to the namespace exchange: shared.md]'
+    )
+  })
+})

--- a/libs/agentos-ui/src/lib/components/case-home/case-home.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-home/case-home.component.ts
@@ -1,30 +1,49 @@
 import { HttpClient } from '@angular/common/http'
-import { afterNextRender, Component, DestroyRef, ElementRef, inject, OnInit, signal, ViewChild } from '@angular/core'
+import {
+  afterNextRender,
+  Component,
+  computed,
+  DestroyRef,
+  ElementRef,
+  inject,
+  OnInit,
+  signal,
+  ViewChild,
+} from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
-import { Case, Configuration, Prompt } from '@whoz-oss/agentos-api-client'
+import { Case, Configuration, ExchangeFileEntryScopeEnum, Prompt } from '@whoz-oss/agentos-api-client'
 import { CaseStateService } from '../../services/case-state.service'
 import { IconButtonComponent } from '@whoz-oss/design-system'
-import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs'
+import { catchError, debounceTime, firstValueFrom, map, of, Subject, switchMap } from 'rxjs'
 import { PromptStateService } from '../../services/prompt-state.service'
 import { PromptAutocompleteComponent } from '../prompt-autocomplete/prompt-autocomplete.component'
 import { USER_PREFERENCES_PORT } from '../../services/user-preferences.service'
 import { UserStateService } from '../../services/user-state.service'
+import { ExchangeStateService } from '../../services/exchange-state.service'
+import { ComposerAttachmentsComponent } from '../composer-attachments/composer-attachments.component'
+import { ComposerAttachmentsService } from '../composer-attachments/composer-attachments.service'
+import { resolveUploadScope } from '../composer-attachments/composer-attachments.utils'
 
 /**
  * CaseHomeComponent — landing page for a namespace.
  *
  * Flow:
- * 1. User types a message and presses Enter (or clicks Send)
+ * 1. User types a message (optionally attaching files) and presses Enter (or clicks Send)
  * 2. POST /api/cases creates the case
- * 3. POST /api/cases/:id/messages sends the first message
- * 4. Only then does the app navigate to the case chat
+ * 3. Attached files are uploaded to the new case's exchange (or the namespace's, on
+ *    explicit request) and referenced in the message content
+ * 4. POST /api/cases/:id/messages sends the first message
+ * 5. Only then does the app navigate to the case chat
  *
  * The first message is never stored in router state to avoid re-sending on refresh.
+ * The created case id is remembered in [pendingCaseId] so a failed upload/send retries
+ * against the same case instead of creating a duplicate.
  */
 @Component({
   selector: 'agentos-case-home',
-  imports: [IconButtonComponent, PromptAutocompleteComponent],
+  imports: [IconButtonComponent, PromptAutocompleteComponent, ComposerAttachmentsComponent],
+  providers: [ComposerAttachmentsService],
   templateUrl: './case-home.component.html',
   styleUrl: './case-home.component.scss',
 })
@@ -38,6 +57,10 @@ export class CaseHomeComponent implements OnInit {
   protected readonly preferences = inject(USER_PREFERENCES_PORT)
   private readonly promptState = inject(PromptStateService)
   private readonly userState = inject(UserStateService)
+  private readonly exchangeState = inject(ExchangeStateService)
+
+  /** Files staged on the first message (component-scoped instance, see providers). */
+  protected readonly attachments = inject(ComposerAttachmentsService)
 
   @ViewChild('composerInput') private composerInput?: ElementRef<HTMLTextAreaElement>
   @ViewChild(PromptAutocompleteComponent) private autocompleteRef?: PromptAutocompleteComponent
@@ -46,6 +69,16 @@ export class CaseHomeComponent implements OnInit {
 
   protected readonly inputValue = signal('')
   protected readonly isCreating = signal(false)
+
+  /** Case created by a previous failed submit — reused on retry, never duplicated. */
+  private readonly pendingCaseId = signal<string | null>(null)
+
+  /** True when the message text targets the namespace exchange (previewed on the chips). */
+  protected readonly namespaceTargeted = computed(
+    () =>
+      resolveUploadScope(this.inputValue(), this.exchangeState.canWriteNamespace()) ===
+      ExchangeFileEntryScopeEnum.NAMESPACE
+  )
 
   // ---------------------------------------------------------------------------
   // Slash-command autocomplete
@@ -58,7 +91,13 @@ export class CaseHomeComponent implements OnInit {
   protected readonly slashSuggestions = signal<Prompt[]>([])
 
   ngOnInit(): void {
+    // Namespace-only exchange init: no case exists yet, but canWriteNamespace() gating
+    // (namespace-intent badge and upload target) needs the namespace manifest.
+    this.exchangeState.initializeForNamespace(this.namespaceId)
+
     // React to ?ns query param changes — the component is reused across namespace switches.
+    // The handler skips the initial emission (newNs === this.namespaceId), hence the
+    // explicit init above.
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       const newNs = params['ns'] as string
       if (newNs && newNs !== this.namespaceId) {
@@ -68,6 +107,9 @@ export class CaseHomeComponent implements OnInit {
         this.promptsLoaded = false
         this.slashSuggestions.set([])
         this.inputValue.set('')
+        this.attachments.reset()
+        this.pendingCaseId.set(null)
+        this.exchangeState.initializeForNamespace(newNs)
       }
     })
   }
@@ -98,7 +140,7 @@ export class CaseHomeComponent implements OnInit {
   }
 
   protected get canSend(): boolean {
-    return !!this.inputValue().trim() && !this.isCreating()
+    return (!!this.inputValue().trim() || this.attachments.hasAttachments()) && !this.isCreating()
   }
 
   protected onInput(event: Event): void {
@@ -166,41 +208,59 @@ export class CaseHomeComponent implements OnInit {
     this.slashPrefix$.next(withoutSlash)
   }
 
-  protected submit(): void {
+  protected async submit(): Promise<void> {
     if (!this.canSend) return
     const firstMessage = this.inputValue().trim()
-    this.inputValue.set('')
     this.isCreating.set(true)
 
-    // Step 1: create the case
-    this.http
-      .post<Case>(`${this.config.basePath}/api/cases`, {
-        namespaceId: this.namespaceId,
-        metadata: {},
-      })
-      .pipe(
-        // Step 2: send the first message before navigating, carry the case id through
-        switchMap((createdCase) => {
-          this.caseState.addCase(createdCase)
-          return this.http
-            .post(`${this.config.basePath}/api/cases/${createdCase.id}/messages`, {
-              content: firstMessage,
-              userId: 'default-user',
-            })
-            .pipe(map(() => createdCase))
-        }),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe({
-        next: (createdCase) => {
-          // Step 3: navigate — no firstMessage in state, the message is already posted
-          this.router.navigate(['/agentos/home'], { queryParams: { ns: this.namespaceId, case: createdCase.id ?? '' } })
-        },
-        error: (err) => {
-          console.error('[CaseHome] Failed to create case or send first message', err)
+    try {
+      // Step 1: create the case — once. A previous failed attempt is retried against the
+      // same case (pendingCaseId), so a duplicate is never created.
+      let caseId = this.pendingCaseId()
+      if (!caseId) {
+        const createdCase = await firstValueFrom(
+          this.http.post<Case>(`${this.config.basePath}/api/cases`, {
+            namespaceId: this.namespaceId,
+            metadata: {},
+          })
+        )
+        this.caseState.addCase(createdCase)
+        caseId = createdCase.id ?? ''
+        this.pendingCaseId.set(caseId)
+      }
+
+      // Step 2: upload the attachments to the fresh case (or the namespace on explicit
+      // request) and reference them in the message content.
+      let content = firstMessage
+      if (this.attachments.hasAttachments()) {
+        this.exchangeState.initializeForCase(this.namespaceId, caseId)
+        const scope = resolveUploadScope(firstMessage, this.exchangeState.canWriteNamespace())
+        const mention = await this.attachments.uploadAllAndBuildMention(scope)
+        if (mention === null) {
+          // Partial failure: stay on home with the failed chips and the intact text; a
+          // retry reuses the created case and skips the files already uploaded.
           this.isCreating.set(false)
-          this.inputValue.set(firstMessage)
-        },
-      })
+          return
+        }
+        content = content ? `${content}\n\n${mention}` : mention
+      }
+
+      // Step 3: send the first message before navigating.
+      await firstValueFrom(
+        this.http.post(`${this.config.basePath}/api/cases/${caseId}/messages`, {
+          content,
+          userId: 'default-user',
+        })
+      )
+
+      // Step 4: navigate — no firstMessage in state, the message is already posted.
+      this.attachments.reset()
+      this.inputValue.set('')
+      this.pendingCaseId.set(null)
+      this.router.navigate(['/agentos/home'], { queryParams: { ns: this.namespaceId, case: caseId } })
+    } catch (err) {
+      console.error('[CaseHome] Failed to create case or send first message', err)
+      this.isCreating.set(false)
+    }
   }
 }

--- a/libs/agentos-ui/src/lib/components/case-home/case-home.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-home/case-home.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
-import { Case, Configuration, ExchangeFileEntryScopeEnum, Prompt } from '@whoz-oss/agentos-api-client'
+import { Case, Configuration, Prompt } from '@whoz-oss/agentos-api-client'
 import { CaseStateService } from '../../services/case-state.service'
 import { IconButtonComponent } from '@whoz-oss/design-system'
 import { catchError, debounceTime, firstValueFrom, map, of, Subject, switchMap } from 'rxjs'
@@ -23,7 +23,7 @@ import { UserStateService } from '../../services/user-state.service'
 import { ExchangeStateService } from '../../services/exchange-state.service'
 import { ComposerAttachmentsComponent } from '../composer-attachments/composer-attachments.component'
 import { ComposerAttachmentsService } from '../composer-attachments/composer-attachments.service'
-import { resolveUploadScope } from '../composer-attachments/composer-attachments.utils'
+import { isNamespaceTargeted, resolveUploadScope } from '../composer-attachments/composer-attachments.utils'
 
 /**
  * CaseHomeComponent — landing page for a namespace.
@@ -73,11 +73,12 @@ export class CaseHomeComponent implements OnInit {
   /** Case created by a previous failed submit — reused on retry, never duplicated. */
   private readonly pendingCaseId = signal<string | null>(null)
 
+  /** The async submit chain must stop touching state or navigating once the view is gone. */
+  private destroyed = false
+
   /** True when the message text targets the namespace exchange (previewed on the chips). */
-  protected readonly namespaceTargeted = computed(
-    () =>
-      resolveUploadScope(this.inputValue(), this.exchangeState.canWriteNamespace()) ===
-      ExchangeFileEntryScopeEnum.NAMESPACE
+  protected readonly namespaceTargeted = computed(() =>
+    isNamespaceTargeted(this.inputValue(), this.exchangeState.canWriteNamespace())
   )
 
   // ---------------------------------------------------------------------------
@@ -115,6 +116,8 @@ export class CaseHomeComponent implements OnInit {
   }
 
   constructor() {
+    this.destroyRef.onDestroy(() => (this.destroyed = true))
+
     afterNextRender(() => {
       this.composerInput?.nativeElement.focus()
     })
@@ -208,9 +211,14 @@ export class CaseHomeComponent implements OnInit {
     this.slashPrefix$.next(withoutSlash)
   }
 
+  // NOTE: this file exceeds the ~200-line guideline. The submit orchestration is kept
+  // inline for now: extracting a shared case-creation/composer service (which should also
+  // deduplicate the slash-autocomplete logic copied from case-chat) is follow-up work.
   protected async submit(): Promise<void> {
     if (!this.canSend) return
     const firstMessage = this.inputValue().trim()
+    // Captured for the whole chain: a namespace switch mid-flight abandons the submit.
+    const namespaceId = this.namespaceId
     this.isCreating.set(true)
 
     try {
@@ -220,7 +228,7 @@ export class CaseHomeComponent implements OnInit {
       if (!caseId) {
         const createdCase = await firstValueFrom(
           this.http.post<Case>(`${this.config.basePath}/api/cases`, {
-            namespaceId: this.namespaceId,
+            namespaceId,
             metadata: {},
           })
         )
@@ -228,17 +236,22 @@ export class CaseHomeComponent implements OnInit {
         caseId = createdCase.id ?? ''
         this.pendingCaseId.set(caseId)
       }
+      if (this.abandoned(namespaceId)) {
+        this.isCreating.set(false)
+        return
+      }
 
       // Step 2: upload the attachments to the fresh case (or the namespace on explicit
       // request) and reference them in the message content.
       let content = firstMessage
       if (this.attachments.hasAttachments()) {
-        this.exchangeState.initializeForCase(this.namespaceId, caseId)
+        this.exchangeState.initializeForCase(namespaceId, caseId)
         const scope = resolveUploadScope(firstMessage, this.exchangeState.canWriteNamespace())
         const mention = await this.attachments.uploadAllAndBuildMention(scope)
-        if (mention === null) {
-          // Partial failure: stay on home with the failed chips and the intact text; a
-          // retry reuses the created case and skips the files already uploaded.
+        if (mention === null || this.abandoned(namespaceId)) {
+          // Partial failure (or an abandoned submit): stay on home with the failed chips
+          // and the intact text; a retry reuses the created case and skips the files
+          // already uploaded.
           this.isCreating.set(false)
           return
         }
@@ -252,15 +265,24 @@ export class CaseHomeComponent implements OnInit {
           userId: 'default-user',
         })
       )
+      if (this.abandoned(namespaceId)) {
+        this.isCreating.set(false)
+        return
+      }
 
       // Step 4: navigate — no firstMessage in state, the message is already posted.
       this.attachments.reset()
       this.inputValue.set('')
       this.pendingCaseId.set(null)
-      this.router.navigate(['/agentos/home'], { queryParams: { ns: this.namespaceId, case: caseId } })
+      this.router.navigate(['/agentos/home'], { queryParams: { ns: namespaceId, case: caseId } })
     } catch (err) {
       console.error('[CaseHome] Failed to create case or send first message', err)
       this.isCreating.set(false)
     }
+  }
+
+  /** True when the in-flight submit no longer matches the live view (destroyed or ns switch). */
+  private abandoned(namespaceId: string): boolean {
+    return this.destroyed || this.namespaceId !== namespaceId
   }
 }

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.html
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.html
@@ -1,0 +1,49 @@
+@if (attachments().length > 0 || limitError()) {
+  <div class="composer-attachments">
+    @if (attachments().length > 0) {
+      <div class="composer-attachments__chips">
+        @for (attachment of attachments(); track attachment.id) {
+          <div
+            class="composer-attachments__chip"
+            [class.composer-attachments__chip--error]="attachment.status === 'error'"
+          >
+            <span
+              class="composer-attachments__icon material-icons"
+              [class.composer-attachments__icon--spinning]="attachment.status === 'uploading'"
+              aria-hidden="true"
+              >{{ attachment.status === 'uploading' ? 'progress_activity' : getFileIcon(attachment.file.name) }}</span
+            >
+            <span class="composer-attachments__name" [title]="attachment.file.name">{{
+              middleTruncate(attachment.file.name)
+            }}</span>
+            <span class="composer-attachments__kind">{{ kindLabel(attachment.file.name) }}</span>
+            @if (namespaceBadge()) {
+              <span class="composer-attachments__badge">namespace</span>
+            }
+            <ds-icon-button
+              icon="close"
+              title="Remove attachment"
+              [disabled]="disabled()"
+              (action)="removed.emit(attachment.id)"
+            />
+            @if (attachment.status === 'error' && attachment.error) {
+              <span class="composer-attachments__error">{{ attachment.error }}</span>
+            }
+          </div>
+        }
+      </div>
+    }
+    @if (limitError(); as limit) {
+      <p class="composer-attachments__limit">{{ limit }}</p>
+    }
+  </div>
+}
+<input
+  #fileInput
+  type="file"
+  multiple
+  class="composer-attachments__file-input"
+  aria-hidden="true"
+  tabindex="-1"
+  (change)="onFileInputChange($event)"
+/>

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.html
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.html
@@ -6,35 +6,36 @@
           <div
             class="composer-attachments__chip"
             [class.composer-attachments__chip--error]="attachment.status === 'error'"
+            [class.composer-attachments__chip--uploaded]="attachment.status === 'uploaded'"
           >
             <span
               class="composer-attachments__icon material-icons"
               [class.composer-attachments__icon--spinning]="attachment.status === 'uploading'"
               aria-hidden="true"
-              >{{ attachment.status === 'uploading' ? 'progress_activity' : getFileIcon(attachment.file.name) }}</span
+              >{{ chipIcon(attachment) }}</span
             >
             <span class="composer-attachments__name" [title]="attachment.file.name">{{
               middleTruncate(attachment.file.name)
             }}</span>
             <span class="composer-attachments__kind">{{ kindLabel(attachment.file.name) }}</span>
-            @if (namespaceBadge()) {
+            @if (showNamespaceBadge(attachment)) {
               <span class="composer-attachments__badge">namespace</span>
             }
             <ds-icon-button
               icon="close"
-              title="Remove attachment"
+              [title]="removeTitle(attachment)"
               [disabled]="disabled()"
               (action)="removed.emit(attachment.id)"
             />
             @if (attachment.status === 'error' && attachment.error) {
-              <span class="composer-attachments__error">{{ attachment.error }}</span>
+              <span class="composer-attachments__error" role="alert">{{ attachment.error }}</span>
             }
           </div>
         }
       </div>
     }
     @if (limitError(); as limit) {
-      <p class="composer-attachments__limit">{{ limit }}</p>
+      <p class="composer-attachments__limit" role="alert">{{ limit }}</p>
     }
   </div>
 }

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.scss
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.scss
@@ -1,0 +1,81 @@
+.composer-attachments {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  width: 100%;
+
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  &__chip {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.375rem 0.375rem 0.375rem 0.625rem;
+    border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+    border-radius: 12px;
+    background: var(--color-surface-secondary, rgba(0, 0, 0, 0.04));
+    font-size: 0.8125rem;
+
+    &--error {
+      border-color: var(--color-error, #d13438);
+    }
+  }
+
+  &__icon {
+    font-size: 1.25rem;
+    color: var(--color-text-secondary, rgba(0, 0, 0, 0.6));
+
+    &--spinning {
+      animation: composer-attachments-spin 1s linear infinite;
+    }
+  }
+
+  &__name {
+    font-weight: 500;
+  }
+
+  &__kind {
+    font-size: 0.6875rem;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary, rgba(0, 0, 0, 0.6));
+  }
+
+  &__badge {
+    padding: 0.0625rem 0.375rem;
+    border-radius: 999px;
+    background: var(--color-primary, #0071e3);
+    color: var(--color-text-inverse, #fff);
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+
+  &__error {
+    flex-basis: 100%;
+    font-size: 0.75rem;
+    color: var(--color-error, #d13438);
+  }
+
+  &__limit {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-error, #d13438);
+  }
+
+  &__file-input {
+    display: none;
+  }
+}
+
+@keyframes composer-attachments-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.scss
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.scss
@@ -24,6 +24,10 @@
     &--error {
       border-color: var(--color-error, #d13438);
     }
+
+    &--uploaded {
+      border-color: var(--color-success, #2e7d32);
+    }
   }
 
   &__icon {

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.spec.ts
@@ -1,0 +1,136 @@
+import { ApplicationRef, ComponentRef, createComponent, EnvironmentInjector } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
+import { ComposerAttachmentsComponent } from './composer-attachments.component'
+import { PendingAttachment } from './composer-attachments.utils'
+
+/**
+ * Instantiate the component inside an injection context and wire the signal inputs via
+ * ComponentRef.setInput() (same recipe as case-drawer.component.spec.ts).
+ */
+function makeComponent(attachments: PendingAttachment[]): ComponentRef<ComposerAttachmentsComponent> {
+  const environmentInjector = TestBed.inject(EnvironmentInjector)
+  const appRef = TestBed.inject(ApplicationRef)
+
+  const ref = createComponent(ComposerAttachmentsComponent, { environmentInjector })
+  appRef.attachView(ref.hostView)
+  ref.setInput('attachments', attachments)
+  ref.changeDetectorRef.detectChanges()
+  return ref
+}
+
+function attachment(name: string, status: PendingAttachment['status'] = 'pending', error?: string): PendingAttachment {
+  return { id: `id-${name}`, file: new File(['x'], name), status, error }
+}
+
+describe('ComposerAttachmentsComponent', () => {
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('renders one chip per attachment with name and kind label', () => {
+    const ref = makeComponent([attachment('report.pdf'), attachment('data.xlsx')])
+    const host = ref.location.nativeElement as HTMLElement
+
+    const chips = host.querySelectorAll('.composer-attachments__chip')
+    expect(chips).toHaveLength(2)
+    expect(chips[0]!.textContent).toContain('report.pdf')
+    expect(chips[0]!.textContent).toContain('PDF')
+    expect(chips[1]!.textContent).toContain('XLSX')
+  })
+
+  it('shows the mapped error on a failed chip', () => {
+    const ref = makeComponent([attachment('dup.pdf', 'error', 'A file with this name already exists.')])
+    const host = ref.location.nativeElement as HTMLElement
+
+    expect(host.querySelector('.composer-attachments__chip--error')).not.toBeNull()
+    expect(host.querySelector('.composer-attachments__error')?.textContent).toContain(
+      'A file with this name already exists.'
+    )
+  })
+
+  it('shows the namespace badge only when the input is set', () => {
+    const ref = makeComponent([attachment('a.txt')])
+    const host = ref.location.nativeElement as HTMLElement
+    expect(host.querySelector('.composer-attachments__badge')).toBeNull()
+
+    ref.setInput('namespaceBadge', true)
+    ref.changeDetectorRef.detectChanges()
+
+    expect(host.querySelector('.composer-attachments__badge')?.textContent).toContain('namespace')
+  })
+
+  it('shows the limit message', () => {
+    const ref = makeComponent([])
+    ref.setInput('limitError', 'You can attach up to 10 files per message.')
+    ref.changeDetectorRef.detectChanges()
+
+    const host = ref.location.nativeElement as HTMLElement
+    expect(host.querySelector('.composer-attachments__limit')?.textContent).toContain('up to 10 files')
+  })
+
+  it('emits removed with the attachment id when the remove button is clicked', () => {
+    const ref = makeComponent([attachment('a.txt')])
+    const emitted: string[] = []
+    ref.instance.removed.subscribe((id) => emitted.push(id))
+
+    const removeButton = (ref.location.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+      '.composer-attachments__chip button'
+    )
+    removeButton?.click()
+
+    expect(emitted).toEqual(['id-a.txt'])
+  })
+
+  it('emits filesSelected and resets the input value on file selection', () => {
+    const ref = makeComponent([])
+    const emitted: File[][] = []
+    ref.instance.filesSelected.subscribe((selected) => emitted.push(selected))
+    const input = (ref.location.nativeElement as HTMLElement).querySelector<HTMLInputElement>(
+      '.composer-attachments__file-input'
+    )!
+
+    const file = new File(['x'], 'picked.txt')
+    Object.defineProperty(input, 'files', { value: [file], configurable: true })
+    input.dispatchEvent(new Event('change'))
+
+    expect(emitted).toEqual([[file]])
+    expect(input.value).toBe('')
+  })
+
+  it('openPicker clicks the hidden file input', () => {
+    const ref = makeComponent([])
+    const input = (ref.location.nativeElement as HTMLElement).querySelector<HTMLInputElement>(
+      '.composer-attachments__file-input'
+    )!
+    const clickSpy = jest.spyOn(input, 'click')
+
+    ref.instance.openPicker()
+
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('disables the remove buttons while uploading', () => {
+    const ref = makeComponent([attachment('a.txt')])
+    ref.setInput('disabled', true)
+    ref.changeDetectorRef.detectChanges()
+
+    const removeButton = (ref.location.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+      '.composer-attachments__chip button'
+    )
+    expect(removeButton?.disabled).toBe(true)
+  })
+})
+
+describe('ComposerAttachmentsComponent — status rendering', () => {
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('shows a spinner icon while uploading and the kind icon otherwise', () => {
+    const ref = makeComponent([
+      { id: 'u', file: new File(['x'], 'up.pdf'), status: 'uploading' },
+      { id: 'p', file: new File(['x'], 'wait.pdf'), status: 'pending' },
+    ])
+    const icons = (ref.location.nativeElement as HTMLElement).querySelectorAll('.composer-attachments__icon')
+
+    expect(icons[0]!.textContent).toContain('progress_activity')
+    expect(icons[1]!.textContent).toContain('picture_as_pdf')
+  })
+})

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.ts
@@ -1,0 +1,48 @@
+import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core'
+import { IconButtonComponent } from '@whoz-oss/design-system'
+import { getFileIcon } from '../../services/exchange-content.utils'
+import { kindLabel, middleTruncate, PendingAttachment } from './composer-attachments.utils'
+
+/**
+ * ComposerAttachmentsComponent — presentational chip row for the files staged on a chat
+ * message (ChatGPT-style): one chip per attachment (kind icon, middle-truncated name,
+ * extension label, remove button), a per-chip error line, the attachment-limit message,
+ * and the always-rendered hidden file input the host's "+" button opens via [openPicker].
+ */
+@Component({
+  selector: 'agentos-composer-attachments',
+  imports: [IconButtonComponent],
+  templateUrl: './composer-attachments.component.html',
+  styleUrl: './composer-attachments.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ComposerAttachmentsComponent {
+  readonly attachments = input.required<PendingAttachment[]>()
+  /** True when the resolved upload target is the namespace exchange (previewed on each chip). */
+  readonly namespaceBadge = input(false)
+  readonly limitError = input<string | null>(null)
+  /** Disables the remove buttons while an upload batch is in flight. */
+  readonly disabled = input(false)
+
+  readonly removed = output<string>()
+  readonly filesSelected = output<File[]>()
+
+  private readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput')
+
+  protected readonly getFileIcon = getFileIcon
+  protected readonly kindLabel = kindLabel
+  protected readonly middleTruncate = middleTruncate
+
+  /** Opens the native picker; called by the host's "+" button through a template ref. */
+  openPicker(): void {
+    this.fileInput()?.nativeElement.click()
+  }
+
+  protected onFileInputChange(event: Event): void {
+    const inputEl = event.target as HTMLInputElement
+    const files = inputEl.files ? Array.from(inputEl.files) : []
+    if (files.length > 0) this.filesSelected.emit(files)
+    // Reset so re-selecting the same file fires (change) again.
+    inputEl.value = ''
+  }
+}

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core'
+import { ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
 import { IconButtonComponent } from '@whoz-oss/design-system'
 import { getFileIcon } from '../../services/exchange-content.utils'
 import { kindLabel, middleTruncate, PendingAttachment } from './composer-attachments.utils'
@@ -29,9 +30,30 @@ export class ComposerAttachmentsComponent {
 
   private readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput')
 
-  protected readonly getFileIcon = getFileIcon
   protected readonly kindLabel = kindLabel
   protected readonly middleTruncate = middleTruncate
+
+  protected chipIcon(attachment: PendingAttachment): string {
+    if (attachment.status === 'uploading') return 'progress_activity'
+    if (attachment.status === 'uploaded') return 'check_circle'
+    return getFileIcon(attachment.file.name)
+  }
+
+  /**
+   * The badge reflects the scope the file actually went to once uploaded; before that it
+   * previews the batch-level target resolved from the message text.
+   */
+  protected showNamespaceBadge(attachment: PendingAttachment): boolean {
+    return attachment.uploadedScope
+      ? attachment.uploadedScope === ExchangeFileEntryScopeEnum.NAMESPACE
+      : this.namespaceBadge()
+  }
+
+  protected removeTitle(attachment: PendingAttachment): string {
+    return attachment.status === 'uploaded'
+      ? `Remove ${attachment.file.name} from the list (the uploaded file stays in the exchange)`
+      : `Remove ${attachment.file.name}`
+  }
 
   /** Opens the native picker; called by the host's "+" button through a template ref. */
   openPicker(): void {

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.spec.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.spec.ts
@@ -1,0 +1,175 @@
+import { TestBed } from '@angular/core/testing'
+import { ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
+import { ExchangeStateService } from '../../services/exchange-state.service'
+import { ComposerAttachmentsService } from './composer-attachments.service'
+import { MAX_ATTACHMENTS } from './composer-attachments.utils'
+
+describe('ComposerAttachmentsService', () => {
+  let exchangeState: { uploadFile: jest.Mock }
+  let service: ComposerAttachmentsService
+
+  function files(count: number, prefix = 'file'): File[] {
+    return Array.from({ length: count }, (_, i) => new File(['x'], `${prefix}-${i}.txt`))
+  }
+
+  function dragEvent(types: string[] = ['Files'], dropped: File[] = []): DragEvent {
+    return {
+      preventDefault: jest.fn(),
+      dataTransfer: { types, files: dropped, dropEffect: 'none' },
+      relatedTarget: null,
+    } as unknown as DragEvent
+  }
+
+  beforeEach(() => {
+    exchangeState = { uploadFile: jest.fn().mockResolvedValue({ success: true }) }
+    TestBed.configureTestingModule({
+      providers: [ComposerAttachmentsService, { provide: ExchangeStateService, useValue: exchangeState }],
+    })
+    service = TestBed.inject(ComposerAttachmentsService)
+  })
+
+  describe('staging', () => {
+    it('adds files as pending attachments', () => {
+      service.addFiles(files(2))
+      expect(service.attachments().map((a) => a.status)).toEqual(['pending', 'pending'])
+      expect(service.hasAttachments()).toBe(true)
+      expect(service.limitError()).toBeNull()
+    })
+
+    it('caps at the maximum and surfaces the limit message', () => {
+      service.addFiles(files(12))
+      expect(service.attachments()).toHaveLength(MAX_ATTACHMENTS)
+      expect(service.limitError()).toBe(`You can attach up to ${MAX_ATTACHMENTS} files per message.`)
+    })
+
+    it('enforces the cap across successive adds', () => {
+      service.addFiles(files(8, 'first'))
+      service.addFiles(files(5, 'second'))
+      expect(service.attachments()).toHaveLength(MAX_ATTACHMENTS)
+      expect(service.limitError()).not.toBeNull()
+    })
+
+    it('remove() drops the chip and clears the limit message', () => {
+      service.addFiles(files(10))
+      const id = service.attachments()[0]!.id
+      service.remove(id)
+      expect(service.attachments()).toHaveLength(9)
+      expect(service.attachments().some((a) => a.id === id)).toBe(false)
+    })
+
+    it('reset() clears everything', () => {
+      service.addFiles(files(3))
+      service.reset()
+      expect(service.attachments()).toEqual([])
+      expect(service.hasAttachments()).toBe(false)
+      expect(service.limitError()).toBeNull()
+    })
+  })
+
+  describe('drag & drop', () => {
+    it('dragenter with files sets the highlight', () => {
+      const event = dragEvent()
+      service.onDragEnter(event)
+      expect(service.isDragOver()).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('dragenter without files is ignored (text selection drag)', () => {
+      const event = dragEvent(['text/plain'])
+      service.onDragEnter(event)
+      expect(service.isDragOver()).toBe(false)
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('dragleave to a child of the container keeps the highlight', () => {
+      const container = document.createElement('div')
+      const child = document.createElement('span')
+      container.appendChild(child)
+      service.onDragEnter(dragEvent())
+
+      service.onDragLeave({ relatedTarget: child } as unknown as DragEvent, container)
+
+      expect(service.isDragOver()).toBe(true)
+    })
+
+    it('dragleave outside the container clears the highlight', () => {
+      const container = document.createElement('div')
+      const outside = document.createElement('div')
+      service.onDragEnter(dragEvent())
+
+      service.onDragLeave({ relatedTarget: outside } as unknown as DragEvent, container)
+
+      expect(service.isDragOver()).toBe(false)
+    })
+
+    it('drop adds the files and clears the highlight', () => {
+      service.onDragEnter(dragEvent())
+      const event = dragEvent(['Files'], files(2))
+
+      service.onDrop(event)
+
+      expect(service.isDragOver()).toBe(false)
+      expect(service.attachments()).toHaveLength(2)
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+  })
+
+  describe('uploadAllAndBuildMention', () => {
+    it('uploads sequentially, marks everything uploaded and returns the mention', async () => {
+      service.addFiles([new File(['x'], 'a.pdf'), new File(['x'], 'b.xlsx')])
+
+      const mention = await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.CASE)
+
+      expect(mention).toBe('[Files attached to the case exchange: a.pdf, b.xlsx]')
+      expect(service.attachments().map((a) => a.status)).toEqual(['uploaded', 'uploaded'])
+      expect(exchangeState.uploadFile).toHaveBeenCalledTimes(2)
+      expect(exchangeState.uploadFile).toHaveBeenCalledWith(ExchangeFileEntryScopeEnum.CASE, expect.any(File))
+      expect(service.isUploading()).toBe(false)
+    })
+
+    it('continues past a failure, returns null and maps the error on the failed chip', async () => {
+      service.addFiles([new File(['x'], 'dup.pdf'), new File(['x'], 'ok.txt')])
+      exchangeState.uploadFile
+        .mockResolvedValueOnce({ success: false, error: 'A file with this name already exists.' })
+        .mockResolvedValueOnce({ success: true })
+
+      const mention = await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.CASE)
+
+      expect(mention).toBeNull()
+      const [failed, succeeded] = service.attachments()
+      expect(failed!.status).toBe('error')
+      expect(failed!.error).toBe('A file with this name already exists.')
+      expect(succeeded!.status).toBe('uploaded')
+      expect(exchangeState.uploadFile).toHaveBeenCalledTimes(2)
+    })
+
+    it('a retry skips the files already uploaded (no self-inflicted conflict)', async () => {
+      service.addFiles([new File(['x'], 'dup.pdf'), new File(['x'], 'ok.txt')])
+      exchangeState.uploadFile
+        .mockResolvedValueOnce({ success: false, error: 'A file with this name already exists.' })
+        .mockResolvedValue({ success: true })
+      await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.CASE)
+      exchangeState.uploadFile.mockClear()
+      exchangeState.uploadFile.mockResolvedValue({ success: true })
+
+      const mention = await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.CASE)
+
+      expect(exchangeState.uploadFile).toHaveBeenCalledTimes(1)
+      expect(mention).toBe('[Files attached to the case exchange: dup.pdf, ok.txt]')
+    })
+
+    it('toggles isUploading around the batch', async () => {
+      service.addFiles([new File(['x'], 'a.pdf')])
+      let uploadingDuringCall = false
+      exchangeState.uploadFile.mockImplementation(async () => {
+        uploadingDuringCall = service.isUploading()
+        return { success: true }
+      })
+
+      await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.CASE)
+
+      expect(uploadingDuringCall).toBe(true)
+      expect(service.isUploading()).toBe(false)
+    })
+  })
+})

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.spec.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.spec.ts
@@ -50,11 +50,23 @@ describe('ComposerAttachmentsService', () => {
     })
 
     it('remove() drops the chip and clears the limit message', () => {
-      service.addFiles(files(10))
+      service.addFiles(files(12))
+      expect(service.limitError()).not.toBeNull()
       const id = service.attachments()[0]!.id
       service.remove(id)
       expect(service.attachments()).toHaveLength(9)
       expect(service.attachments().some((a) => a.id === id)).toBe(false)
+      expect(service.limitError()).toBeNull()
+    })
+
+    it('staging and removal are frozen while an upload batch is in flight', () => {
+      service.addFiles(files(1))
+      service.isUploading.set(true)
+
+      service.addFiles(files(2, 'late'))
+      service.remove(service.attachments()[0]!.id)
+
+      expect(service.attachments()).toHaveLength(1)
     })
 
     it('reset() clears everything', () => {
@@ -81,24 +93,16 @@ describe('ComposerAttachmentsService', () => {
       expect(event.preventDefault).not.toHaveBeenCalled()
     })
 
-    it('dragleave to a child of the container keeps the highlight', () => {
-      const container = document.createElement('div')
-      const child = document.createElement('span')
-      container.appendChild(child)
+    it('crossing a child (enter then leave pair) keeps the highlight; leaving for real clears it', () => {
+      // Container enter, then a child boundary: child enter bubbles before the previous
+      // element's leave, so the depth counter never touches zero until the real exit.
+      // (Depth-based on purpose: WebKit reports relatedTarget as null on dragleave.)
       service.onDragEnter(dragEvent())
-
-      service.onDragLeave({ relatedTarget: child } as unknown as DragEvent, container)
-
+      service.onDragEnter(dragEvent())
+      service.onDragLeave()
       expect(service.isDragOver()).toBe(true)
-    })
 
-    it('dragleave outside the container clears the highlight', () => {
-      const container = document.createElement('div')
-      const outside = document.createElement('div')
-      service.onDragEnter(dragEvent())
-
-      service.onDragLeave({ relatedTarget: outside } as unknown as DragEvent, container)
-
+      service.onDragLeave()
       expect(service.isDragOver()).toBe(false)
     })
 
@@ -156,6 +160,35 @@ describe('ComposerAttachmentsService', () => {
 
       expect(exchangeState.uploadFile).toHaveBeenCalledTimes(1)
       expect(mention).toBe('[Files attached to the case exchange: dup.pdf, ok.txt]')
+    })
+
+    it('a reset during the batch (case switch) aborts: null returned, remaining files not uploaded', async () => {
+      service.addFiles([new File(['x'], 'a.pdf'), new File(['x'], 'b.pdf')])
+      exchangeState.uploadFile.mockImplementationOnce(async () => {
+        // Simulates reinitialise() on a mid-upload case switch.
+        service.reset()
+        return { success: true }
+      })
+
+      const mention = await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.CASE)
+
+      expect(mention).toBeNull()
+      expect(exchangeState.uploadFile).toHaveBeenCalledTimes(1)
+    })
+
+    it('a retry under a different scope yields a mixed-scope mention', async () => {
+      service.addFiles([new File(['x'], 'a.pdf'), new File(['x'], 'dup.pdf')])
+      exchangeState.uploadFile
+        .mockResolvedValueOnce({ success: true })
+        .mockResolvedValueOnce({ success: false, error: 'A file with this name already exists.' })
+      await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.CASE)
+      exchangeState.uploadFile.mockResolvedValue({ success: true })
+
+      const mention = await service.uploadAllAndBuildMention(ExchangeFileEntryScopeEnum.NAMESPACE)
+
+      expect(mention).toBe(
+        '[Files attached to the case exchange: a.pdf]\n[Files attached to the namespace exchange: dup.pdf]'
+      )
     })
 
     it('toggles isUploading around the batch', async () => {

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.ts
@@ -1,0 +1,120 @@
+import { computed, inject, Injectable, signal } from '@angular/core'
+import { ExchangeScope, ExchangeStateService } from '../../services/exchange-state.service'
+import { buildAttachmentMention, MAX_ATTACHMENTS, PendingAttachment } from './composer-attachments.utils'
+
+/**
+ * ComposerAttachmentsService — staging and upload orchestration for the files attached to a
+ * chat message. Provided by each composer component (NOT root): every composer gets an
+ * isolated instance whose lifecycle follows its host.
+ *
+ * Pending files live here (never in [ExchangeStateService]); uploads delegate to
+ * [ExchangeStateService.uploadFile], reusing its server-error mapping and manifest refresh.
+ */
+@Injectable()
+export class ComposerAttachmentsService {
+  private readonly exchangeState = inject(ExchangeStateService)
+
+  private nextId = 0
+
+  readonly attachments = signal<PendingAttachment[]>([])
+  readonly limitError = signal<string | null>(null)
+  readonly isDragOver = signal(false)
+  readonly isUploading = signal(false)
+  readonly hasAttachments = computed(() => this.attachments().length > 0)
+
+  addFiles(files: File[] | FileList): void {
+    const incoming = Array.from(files)
+    if (incoming.length === 0) return
+    const current = this.attachments()
+    const room = MAX_ATTACHMENTS - current.length
+    this.limitError.set(incoming.length > room ? `You can attach up to ${MAX_ATTACHMENTS} files per message.` : null)
+    const accepted = incoming.slice(0, Math.max(0, room)).map(
+      (file): PendingAttachment => ({
+        id: `attachment-${this.nextId++}`,
+        file,
+        status: 'pending',
+      })
+    )
+    if (accepted.length > 0) this.attachments.set([...current, ...accepted])
+  }
+
+  /** Removes the chip only: an already-uploaded file stays on the server (deletable via the drawer). */
+  remove(id: string): void {
+    this.attachments.update((current) => current.filter((attachment) => attachment.id !== id))
+    if (this.attachments().length < MAX_ATTACHMENTS) this.limitError.set(null)
+  }
+
+  reset(): void {
+    this.attachments.set([])
+    this.limitError.set(null)
+    this.isDragOver.set(false)
+    this.isUploading.set(false)
+  }
+
+  // ── Drag & drop (bound directly from the host templates) ──────────────────────
+
+  onDragEnter(event: DragEvent): void {
+    if (!this.holdsFiles(event)) return
+    event.preventDefault()
+    this.isDragOver.set(true)
+  }
+
+  onDragOver(event: DragEvent): void {
+    if (!this.holdsFiles(event)) return
+    event.preventDefault()
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+  }
+
+  /** Clears the highlight only when the pointer actually leaves [container], not a child of it. */
+  onDragLeave(event: DragEvent, container: HTMLElement): void {
+    const related = event.relatedTarget as Node | null
+    if (related && container.contains(related)) return
+    this.isDragOver.set(false)
+  }
+
+  onDrop(event: DragEvent): void {
+    if (!this.holdsFiles(event)) return
+    event.preventDefault()
+    this.isDragOver.set(false)
+    const files = event.dataTransfer?.files
+    if (files && files.length > 0) this.addFiles(files)
+  }
+
+  /**
+   * Uploads every non-uploaded attachment to [scope], continuing on failure so one duplicate
+   * does not silently skip the rest of the batch (mirrors ExchangeShellComponent.onUpload).
+   * Entries already `uploaded` by a previous attempt are skipped (no self-inflicted 409) but
+   * still appear in the mention. Returns the mention block on full success, or null when at
+   * least one file failed — its chip then carries the server-mapped error.
+   */
+  async uploadAllAndBuildMention(scope: ExchangeScope): Promise<string | null> {
+    this.isUploading.set(true)
+    try {
+      let anyFailure = false
+      for (const attachment of this.attachments()) {
+        if (attachment.status === 'uploaded') continue
+        this.patch(attachment.id, { status: 'uploading', error: undefined })
+        const result = await this.exchangeState.uploadFile(scope, attachment.file)
+        if (result.success) {
+          this.patch(attachment.id, { status: 'uploaded', uploadedScope: scope })
+        } else {
+          anyFailure = true
+          this.patch(attachment.id, { status: 'error', error: result.error ?? 'Upload failed' })
+        }
+      }
+      return anyFailure ? null : buildAttachmentMention(this.attachments())
+    } finally {
+      this.isUploading.set(false)
+    }
+  }
+
+  private holdsFiles(event: DragEvent): boolean {
+    return event.dataTransfer?.types.includes('Files') ?? false
+  }
+
+  private patch(id: string, changes: Partial<PendingAttachment>): void {
+    this.attachments.update((current) =>
+      current.map((attachment) => (attachment.id === id ? { ...attachment, ...changes } : attachment))
+    )
+  }
+}

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.service.ts
@@ -16,6 +16,16 @@ export class ComposerAttachmentsService {
 
   private nextId = 0
 
+  /**
+   * Bumped by [reset]. An upload batch captures the value on entry and aborts (returns null)
+   * when it changed mid-flight — e.g. the user switched case during the await, which resets
+   * this composer-scoped state while the exchange singleton is re-pointed to the new case.
+   */
+  private generation = 0
+
+  /** Depth of nested dragenter/dragleave pairs — see [onDragLeave]. */
+  private dragDepth = 0
+
   readonly attachments = signal<PendingAttachment[]>([])
   readonly limitError = signal<string | null>(null)
   readonly isDragOver = signal(false)
@@ -23,6 +33,9 @@ export class ComposerAttachmentsService {
   readonly hasAttachments = computed(() => this.attachments().length > 0)
 
   addFiles(files: File[] | FileList): void {
+    // The upload loop iterates a snapshot: a file staged mid-batch would silently never
+    // upload. The hosts disable the pickers during a batch; this is the backstop.
+    if (this.isUploading()) return
     const incoming = Array.from(files)
     if (incoming.length === 0) return
     const current = this.attachments()
@@ -40,15 +53,18 @@ export class ComposerAttachmentsService {
 
   /** Removes the chip only: an already-uploaded file stays on the server (deletable via the drawer). */
   remove(id: string): void {
+    if (this.isUploading()) return
     this.attachments.update((current) => current.filter((attachment) => attachment.id !== id))
     if (this.attachments().length < MAX_ATTACHMENTS) this.limitError.set(null)
   }
 
   reset(): void {
+    this.generation++
     this.attachments.set([])
     this.limitError.set(null)
     this.isDragOver.set(false)
     this.isUploading.set(false)
+    this.dragDepth = 0
   }
 
   // ── Drag & drop (bound directly from the host templates) ──────────────────────
@@ -56,6 +72,7 @@ export class ComposerAttachmentsService {
   onDragEnter(event: DragEvent): void {
     if (!this.holdsFiles(event)) return
     event.preventDefault()
+    this.dragDepth++
     this.isDragOver.set(true)
   }
 
@@ -65,16 +82,21 @@ export class ComposerAttachmentsService {
     if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
   }
 
-  /** Clears the highlight only when the pointer actually leaves [container], not a child of it. */
-  onDragLeave(event: DragEvent, container: HTMLElement): void {
-    const related = event.relatedTarget as Node | null
-    if (related && container.contains(related)) return
-    this.isDragOver.set(false)
+  /**
+   * Enter/leave pairs are counted instead of checking `relatedTarget` containment: WebKit
+   * reports `relatedTarget` as null on dragleave (bug 66547), which would collapse the
+   * overlay on the first child crossing in Safari. Every child boundary fires one enter
+   * then one leave on the container (bubbling), so the depth reaches 0 only on real exit.
+   */
+  onDragLeave(): void {
+    if (this.dragDepth > 0) this.dragDepth--
+    if (this.dragDepth === 0) this.isDragOver.set(false)
   }
 
   onDrop(event: DragEvent): void {
     if (!this.holdsFiles(event)) return
     event.preventDefault()
+    this.dragDepth = 0
     this.isDragOver.set(false)
     const files = event.dataTransfer?.files
     if (files && files.length > 0) this.addFiles(files)
@@ -85,16 +107,22 @@ export class ComposerAttachmentsService {
    * does not silently skip the rest of the batch (mirrors ExchangeShellComponent.onUpload).
    * Entries already `uploaded` by a previous attempt are skipped (no self-inflicted 409) but
    * still appear in the mention. Returns the mention block on full success, or null when at
-   * least one file failed — its chip then carries the server-mapped error.
+   * least one file failed (its chip then carries the server-mapped error) or when [reset]
+   * was called mid-flight (case/namespace switch) — the caller must not send in either case.
    */
   async uploadAllAndBuildMention(scope: ExchangeScope): Promise<string | null> {
+    const generation = this.generation
     this.isUploading.set(true)
     try {
       let anyFailure = false
       for (const attachment of this.attachments()) {
+        // Aborted by reset(): the exchange singleton may already point at another case, so
+        // uploading the remaining files would land them in the wrong exchange.
+        if (this.generation !== generation) return null
         if (attachment.status === 'uploaded') continue
         this.patch(attachment.id, { status: 'uploading', error: undefined })
         const result = await this.exchangeState.uploadFile(scope, attachment.file)
+        if (this.generation !== generation) return null
         if (result.success) {
           this.patch(attachment.id, { status: 'uploaded', uploadedScope: scope })
         } else {
@@ -102,9 +130,9 @@ export class ComposerAttachmentsService {
           this.patch(attachment.id, { status: 'error', error: result.error ?? 'Upload failed' })
         }
       }
-      return anyFailure ? null : buildAttachmentMention(this.attachments())
+      return anyFailure || this.generation !== generation ? null : buildAttachmentMention(this.attachments())
     } finally {
-      this.isUploading.set(false)
+      if (this.generation === generation) this.isUploading.set(false)
     }
   }
 

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.utils.spec.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.utils.spec.ts
@@ -1,0 +1,91 @@
+import { ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
+import {
+  buildAttachmentMention,
+  kindLabel,
+  middleTruncate,
+  PendingAttachment,
+  resolveUploadScope,
+} from './composer-attachments.utils'
+
+function uploaded(name: string, scope: ExchangeFileEntryScopeEnum): PendingAttachment {
+  return { id: name, file: new File(['x'], name), status: 'uploaded', uploadedScope: scope }
+}
+
+describe('resolveUploadScope', () => {
+  it('targets the case exchange when the message has no namespace intent', () => {
+    expect(resolveUploadScope('please summarize this file', true)).toBe(ExchangeFileEntryScopeEnum.CASE)
+  })
+
+  it('targets the namespace when explicitly asked for and the user can write it', () => {
+    expect(resolveUploadScope('put it in the namespace please', true)).toBe(ExchangeFileEntryScopeEnum.NAMESPACE)
+  })
+
+  it('falls back to the case when the user cannot write the namespace', () => {
+    expect(resolveUploadScope('put it in the namespace please', false)).toBe(ExchangeFileEntryScopeEnum.CASE)
+  })
+
+  it('matches the standalone word only ("namespaces" does not trigger)', () => {
+    expect(resolveUploadScope('list the namespaces', true)).toBe(ExchangeFileEntryScopeEnum.CASE)
+  })
+
+  it('is case-insensitive', () => {
+    expect(resolveUploadScope('add to the NAMESPACE documents', true)).toBe(ExchangeFileEntryScopeEnum.NAMESPACE)
+  })
+})
+
+describe('buildAttachmentMention', () => {
+  it('lists case-exchange files on a single line', () => {
+    const mention = buildAttachmentMention([
+      uploaded('a.pdf', ExchangeFileEntryScopeEnum.CASE),
+      uploaded('b.xlsx', ExchangeFileEntryScopeEnum.CASE),
+    ])
+    expect(mention).toBe('[Files attached to the case exchange: a.pdf, b.xlsx]')
+  })
+
+  it('lists namespace-exchange files on their own line', () => {
+    const mention = buildAttachmentMention([uploaded('c.md', ExchangeFileEntryScopeEnum.NAMESPACE)])
+    expect(mention).toBe('[Files attached to the namespace exchange: c.md]')
+  })
+
+  it('produces one line per scope for a mixed batch', () => {
+    const mention = buildAttachmentMention([
+      uploaded('a.pdf', ExchangeFileEntryScopeEnum.CASE),
+      uploaded('c.md', ExchangeFileEntryScopeEnum.NAMESPACE),
+    ])
+    expect(mention).toBe(
+      '[Files attached to the case exchange: a.pdf]\n[Files attached to the namespace exchange: c.md]'
+    )
+  })
+
+  it('ignores attachments without an uploaded scope', () => {
+    const pending: PendingAttachment = { id: 'p', file: new File(['x'], 'p.txt'), status: 'pending' }
+    expect(buildAttachmentMention([pending])).toBe('')
+  })
+})
+
+describe('middleTruncate', () => {
+  it('keeps short names untouched', () => {
+    expect(middleTruncate('report.pdf')).toBe('report.pdf')
+  })
+
+  it('cuts long names in the middle, preserving the extension end', () => {
+    const name = 'a-very-long-file-name-that-never-ends-2026.pdf'
+    const truncated = middleTruncate(name)
+    expect(truncated.length).toBeLessThanOrEqual(32)
+    expect(truncated).toContain('…')
+    expect(truncated.endsWith('2026.pdf')).toBe(true)
+  })
+})
+
+describe('kindLabel', () => {
+  it('returns the uppercased extension', () => {
+    expect(kindLabel('report.pdf')).toBe('PDF')
+    expect(kindLabel('data.xlsx')).toBe('XLSX')
+  })
+
+  it('falls back to FILE without an extension', () => {
+    expect(kindLabel('README')).toBe('FILE')
+    expect(kindLabel('.gitignore')).toBe('FILE')
+    expect(kindLabel('archive.')).toBe('FILE')
+  })
+})

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.utils.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.utils.ts
@@ -1,0 +1,71 @@
+import { ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
+import { ExchangeScope } from '../../services/exchange-state.service'
+
+/**
+ * Pure helpers for the composer file-attachment feature (no Angular, no HTTP),
+ * mirroring the style of `services/exchange-content.utils.ts`.
+ */
+
+/** Maximum number of files attachable to a single message. */
+export const MAX_ATTACHMENTS = 10
+
+export type AttachmentStatus = 'pending' | 'uploading' | 'uploaded' | 'error'
+
+/** A file staged in the composer, not yet (or partially) uploaded to the exchange. */
+export interface PendingAttachment {
+  id: string
+  file: File
+  status: AttachmentStatus
+  error?: string
+  /** Scope the file was actually uploaded to; recorded at upload time, drives the mention. */
+  uploadedScope?: ExchangeScope
+}
+
+/**
+ * NAIVE namespace-intent heuristic: the standalone word "namespace" anywhere in the message
+ * targets the namespace exchange (when the user can write it). False positives are accepted
+ * in V1 — e.g. "do NOT put this in the namespace" still matches — the chip badge previews
+ * the resolved target so the user sees it before submitting.
+ */
+export const NAMESPACE_INTENT = /\bnamespace\b/i
+
+/** Upload target for the message: namespace when explicitly asked for AND writable, else case. */
+export function resolveUploadScope(text: string, canWriteNamespace: boolean): ExchangeScope {
+  return NAMESPACE_INTENT.test(text) && canWriteNamespace
+    ? ExchangeFileEntryScopeEnum.NAMESPACE
+    : ExchangeFileEntryScopeEnum.CASE
+}
+
+/**
+ * Mention block appended to the outgoing message so the agent knows which files were just
+ * attached and where — messages carry no attachment metadata, the exchange does.
+ */
+export function buildAttachmentMention(attachments: PendingAttachment[]): string {
+  const namesFor = (scope: ExchangeScope): string[] =>
+    attachments.filter((attachment) => attachment.uploadedScope === scope).map((attachment) => attachment.file.name)
+
+  const lines: string[] = []
+  const caseNames = namesFor(ExchangeFileEntryScopeEnum.CASE)
+  const namespaceNames = namesFor(ExchangeFileEntryScopeEnum.NAMESPACE)
+  if (caseNames.length > 0) lines.push(`[Files attached to the case exchange: ${caseNames.join(', ')}]`)
+  if (namespaceNames.length > 0) {
+    lines.push(`[Files attached to the namespace exchange: ${namespaceNames.join(', ')}]`)
+  }
+  return lines.join('\n')
+}
+
+/** "a-very-long-file-name.pdf" cut in the middle with an ellipsis when above [max] characters. */
+export function middleTruncate(name: string, max = 32): string {
+  if (name.length <= max) return name
+  const keep = max - 1
+  const head = Math.ceil(keep / 2)
+  const tail = Math.floor(keep / 2)
+  return `${name.slice(0, head)}…${name.slice(name.length - tail)}`
+}
+
+/** Short kind label for the chip, e.g. "PDF"; "FILE" when there is no extension. */
+export function kindLabel(filename: string): string {
+  const dot = filename.lastIndexOf('.')
+  if (dot <= 0 || dot === filename.length - 1) return 'FILE'
+  return filename.slice(dot + 1).toUpperCase()
+}

--- a/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.utils.ts
+++ b/libs/agentos-ui/src/lib/components/composer-attachments/composer-attachments.utils.ts
@@ -36,6 +36,11 @@ export function resolveUploadScope(text: string, canWriteNamespace: boolean): Ex
     : ExchangeFileEntryScopeEnum.CASE
 }
 
+/** True when [resolveUploadScope] resolves to the namespace exchange (chip badge preview). */
+export function isNamespaceTargeted(text: string, canWriteNamespace: boolean): boolean {
+  return resolveUploadScope(text, canWriteNamespace) === ExchangeFileEntryScopeEnum.NAMESPACE
+}
+
 /**
  * Mention block appended to the outgoing message so the agent knows which files were just
  * attached and where — messages carry no attachment metadata, the exchange does.

--- a/libs/agentos-ui/src/lib/services/exchange-state.service.spec.ts
+++ b/libs/agentos-ui/src/lib/services/exchange-state.service.spec.ts
@@ -253,6 +253,19 @@ describe('ExchangeStateService', () => {
       expect(result.success).toBe(true)
       expect(controller.uploadNamespaceFileExchange).toHaveBeenCalledWith('ns-1', expect.any(File))
     })
+
+    it('clear() then initializeForNamespace re-inits cleanly (chat to home transition)', () => {
+      init()
+      service.clear()
+      controller.getNamespaceFilesManifestExchange.mockReturnValue(
+        of(manifest(ExchangeManifestCapabilityEnum.READ_WRITE, [nsFile]))
+      )
+
+      service.initializeForNamespace('ns-1')
+
+      expect(service.namespaceStatus()).toBe('ready')
+      expect(service.canWriteNamespace()).toBe(true)
+    })
   })
 
   describe('refreshCase (agent file activity)', () => {

--- a/libs/agentos-ui/src/lib/services/exchange-state.service.spec.ts
+++ b/libs/agentos-ui/src/lib/services/exchange-state.service.spec.ts
@@ -230,6 +230,31 @@ describe('ExchangeStateService', () => {
     })
   })
 
+  describe('initializeForNamespace (composer outside any case)', () => {
+    it('fetches only the namespace manifest and enables canWriteNamespace on READ_WRITE', () => {
+      controller.getCaseFilesManifestExchange.mockClear()
+      controller.getNamespaceFilesManifestExchange.mockReturnValue(
+        of(manifest(ExchangeManifestCapabilityEnum.READ_WRITE, [nsFile]))
+      )
+
+      service.initializeForNamespace('ns-1')
+
+      expect(controller.getNamespaceFilesManifestExchange).toHaveBeenCalledWith('ns-1')
+      expect(controller.getCaseFilesManifestExchange).not.toHaveBeenCalled()
+      expect(service.canWriteNamespace()).toBe(true)
+    })
+
+    it('uploads to the namespace without any case initialised', async () => {
+      controller.uploadNamespaceFileExchange.mockReturnValue(of(nsFile))
+
+      service.initializeForNamespace('ns-1')
+      const result = await service.uploadFile(ExchangeFileEntryScopeEnum.NAMESPACE, new File(['x'], 'shared.md'))
+
+      expect(result.success).toBe(true)
+      expect(controller.uploadNamespaceFileExchange).toHaveBeenCalledWith('ns-1', expect.any(File))
+    })
+  })
+
   describe('refreshCase (agent file activity)', () => {
     it('refetches only the case manifest, leaving the read-only namespace scope untouched', () => {
       init()

--- a/libs/agentos-ui/src/lib/services/exchange-state.service.ts
+++ b/libs/agentos-ui/src/lib/services/exchange-state.service.ts
@@ -136,6 +136,15 @@ export class ExchangeStateService {
     this.refreshManifest()
   }
 
+  /**
+   * Namespace-only initialisation for composers rendered outside any case (home screen):
+   * loads the namespace manifest so `canWriteNamespace()` gating works before a case exists.
+   */
+  initializeForNamespace(namespaceId: string): void {
+    this.namespaceId = namespaceId
+    this.namespaceRefresh$.next()
+  }
+
   clear(): void {
     this.namespaceId = null
     this.caseId = null


### PR DESCRIPTION
Brings ChatGPT-style file attachments to the AgentOS chat input, in both composers: the case chat and the new-case home screen.

## What it does

- **Drag & drop** files anywhere on the chat (overlay "Drop files to attach"; non-file drags are ignored), or click the new **"+" button** at the left of the input to open the native picker.
- Staged files show as **removable chips** above the textarea: kind icon (reuses `getFileIcon`), middle-truncated name, extension label, X button, per-file error line. Up to 10 files per message; the cap is enforced across successive adds with a visible message.
- On submit, files are **uploaded to the case exchange first**, then the message is sent with a trailing mention so the agent knows what to read (messages have no attachment field; the exchange is the transport):
  `[Files attached to the case exchange: report.pdf, data.xlsx]`
- **Namespace targeting on explicit request**: when the message contains the word "namespace" and the user can write the namespace exchange (server-computed manifest capability, fail-closed, same gate as the drawer), the upload goes to the namespace exchange instead. A `namespace` badge on the chips previews the resolved target while typing. The heuristic is deliberately naive (documented in code); the badge is the safety net.
- **Failure handling**: uploads run sequentially and continue on failure (one duplicate does not skip the batch); any failure blocks the message send, keeps the typed text, and shows the mapped server error on the chip (type not allowed / name already exists / too large). A retry skips the files already uploaded, so nothing is double-uploaded.
- **Home screen flow**: create case, upload to the fresh case id, send the first message, navigate. The created case id is remembered so a retry after a failed upload reuses it instead of creating a duplicate case.

## Design notes

- New `composer-attachments` trio under `libs/agentos-ui`, shared by both composers: pure utils, a component-provided `ComposerAttachmentsService` (isolated instance per composer; delegates uploads to `ExchangeStateService.uploadFile`, reusing its error mapping and manifest refresh), and a signals-first presentational chip component (OnPush, `input()`/`output()`/`viewChild()`).
- Only service change: `ExchangeStateService.initializeForNamespace(namespaceId)` so the home screen can gate the namespace option before any case exists.
- No backend change: existing upload endpoints, allow-list, size caps and capability model are reused as-is.

## Testing

- New Jest specs: utils (heuristic, mention formats, truncation), service (staging, cap, drag & drop semantics, upload orchestration incl. retry-skips-uploaded), chip component (rendering, outputs, hidden input mechanics), and the first specs for `case-chat` and `case-home` (upload-then-send ordering, mention content, failure blocks send, namespace routing, case-reuse on retry). 187 tests green on `nx test agentos-ui`; `nx lint` and a full client AOT build pass.
- Manual run through the dev stack: attached a file on the home screen, chip rendered, case created, file landed in the case exchange, message ended with the mention, and the agent read the file via `case-exchange__readFile` and summarized it.
