### PR TITLE
fix: tolerate a null ChatResponse.getResult() in CompressingChatClient

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/CompressingChatClient.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/CompressingChatClient.kt
@@ -115,7 +115,9 @@ class CompressingChatClient(
                 logger.debug { "[CompressingChatClient] call.chatResponse() — null response from delegate" }
                 return null
             }
-            val raw = response.result.output.text?.trim() ?: return response
+            // A metadata-only response (e.g. an Anthropic MESSAGE_START chunk with an empty
+            // content list) has a null result; it carries no text, so pass it through untouched.
+            val raw = response.result?.output?.text?.trim() ?: return response
             val decompressed = compressorService.uncompress(raw, buffer)
             logger.debug {
                 "[CompressingChatClient] call.chatResponse() — ${raw.length} chars raw → ${decompressed.length} chars decompressed, buffer=${buffer.hashCode()}"
@@ -163,7 +165,9 @@ class CompressingChatClient(
                 .doOnNext { lastResponseRef.set(it) }
                 .flatMapIterable { response ->
                     val results = mutableListOf<ChatResponse>()
-                    val chunk = response.result.output.text?.takeIf { it.isNotEmpty() }
+                    // Streaming metadata chunks (e.g. Anthropic MESSAGE_START, content=[]) have a
+                    // null result and no text to compress, so skip them.
+                    val chunk = response.result?.output?.text?.takeIf { it.isNotEmpty() }
                     if (chunk != null) {
                         totalRawChars += chunk.length
                         val decompressed = compressorService.feed(chunk, buffer)
@@ -195,7 +199,7 @@ class CompressingChatClient(
 
         override fun content(): Flux<String> {
             logger.debug { "[CompressingChatClient] stream.content() started — buffer=${buffer.hashCode()}" }
-            return chatResponse().mapNotNull { it.result.output.text?.takeIf { t -> t.isNotEmpty() } }
+            return chatResponse().mapNotNull { it.result?.output?.text?.takeIf { t -> t.isNotEmpty() } }
         }
     }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/chat/CompressingChatClientSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/chat/CompressingChatClientSpec.kt
@@ -311,6 +311,83 @@ class CompressingChatClientSpec :
         }
 
         // -----------------------------------------------------------------------
+        // Null-result chunks (regression, #1115 / wz-33039)
+        //
+        // A streaming provider emits metadata-only chunks whose ChatResponse has no
+        // generations, so getResult() is null — e.g. the Anthropic MESSAGE_START event
+        // with an empty content list. These must be tolerated, not throw an NPE.
+        // -----------------------------------------------------------------------
+
+        "prompt(Prompt) stream: a chunk whose result is null is skipped, not fatal" {
+            val service = IdCompressorService()
+            val delegate = mockk<ChatClient>(relaxed = true)
+            val reqSpec = mockk<ChatClient.ChatClientRequestSpec>(relaxed = true)
+            val streamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { delegate.prompt(any<Prompt>()) } returns reqSpec
+            every { reqSpec.stream() } returns streamSpec
+            // First chunk carries no generations (getResult() == null), then a real text chunk.
+            every { streamSpec.chatResponse() } returns Flux.just(
+                ChatResponse(emptyList<Generation>()),
+                ChatResponse(
+                    listOf(
+                        Generation(
+                            AssistantMessage("hello"),
+                            ChatGenerationMetadata.builder().finishReason("stop").build(),
+                        ),
+                    ),
+                ),
+            )
+
+            val responses = CompressingChatClient(delegate, service)
+                .prompt(Prompt(listOf(UserMessage("hi"))))
+                .stream().chatResponse().collectList().block()!!
+
+            responses.joinToString("") { it.result?.output?.text ?: "" } shouldContain "hello"
+        }
+
+        "prompt(Prompt) stream content(): a chunk whose result is null is skipped, not fatal" {
+            val service = IdCompressorService()
+            val delegate = mockk<ChatClient>(relaxed = true)
+            val reqSpec = mockk<ChatClient.ChatClientRequestSpec>(relaxed = true)
+            val streamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+            every { delegate.prompt(any<Prompt>()) } returns reqSpec
+            every { reqSpec.stream() } returns streamSpec
+            every { streamSpec.chatResponse() } returns Flux.just(
+                ChatResponse(emptyList<Generation>()),
+                ChatResponse(
+                    listOf(
+                        Generation(
+                            AssistantMessage("world"),
+                            ChatGenerationMetadata.builder().finishReason("stop").build(),
+                        ),
+                    ),
+                ),
+            )
+
+            val strings = CompressingChatClient(delegate, service)
+                .prompt(Prompt(listOf(UserMessage("hi"))))
+                .stream().content().collectList().block()!!
+
+            strings.joinToString("") shouldContain "world"
+        }
+
+        "prompt(Prompt) call: a chatResponse whose result is null is returned untouched (no NPE)" {
+            val service = IdCompressorService()
+            val delegate = mockk<ChatClient>(relaxed = true)
+            val reqSpec = mockk<ChatClient.ChatClientRequestSpec>(relaxed = true)
+            val callSpec = mockk<ChatClient.CallResponseSpec>(relaxed = true)
+            every { delegate.prompt(any<Prompt>()) } returns reqSpec
+            every { reqSpec.call() } returns callSpec
+            every { callSpec.chatResponse() } returns ChatResponse(emptyList<Generation>())
+
+            val response = CompressingChatClient(delegate, service)
+                .prompt(Prompt(listOf(UserMessage("hi")))).call().chatResponse()
+
+            response shouldNotBe null
+            response!!.result shouldBe null
+        }
+
+        // -----------------------------------------------------------------------
         // prompt(String) — string shorthand
         // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

When an agent streams a response through `CompressingChatClient`, the first chunk from the provider is metadata-only. For Anthropic, the `MESSAGE_START` event carries an empty content list, so Spring AI maps it to a `ChatResponse` with no generations and `getResult()` returns `null`.

`CompressingChatClient` dereferenced `response.result.output.text` without a null check in three places:

- `CompressingCallSpec.chatResponse()` (blocking)
- `CompressingStreamSpec.chatResponse()` (streaming)
- `CompressingStreamSpec.content()`

The first null-result chunk therefore threw:

```
java.lang.NullPointerException: Cannot invoke "org.springframework.ai.chat.model.Generation.getOutput()"
because the return value of "org.springframework.ai.chat.model.ChatResponse.getResult()" is null
```

and the agent turn failed to emit any text (the run retried and produced no response).

This has been present since `CompressingChatClient.kt` was introduced in #1115 (wz-33039). It surfaces whenever an agent actually reaches a streaming LLM call with a provider that emits a metadata-only first chunk (reproduced with an AgentAdvanced agent on `claude-sonnet-4-5`).

## Fix

Guard the three dereferences with safe calls. A chunk with no result carries no text, so it is:

- passed through untouched in the blocking and streaming `chatResponse()` paths;
- filtered out in `content()`.

## Tests

Added three regression tests to `CompressingChatClientSpec` that feed a `ChatResponse` with no generations (`getResult() == null`), covering the streaming `chatResponse()`, streaming `content()`, and blocking `chatResponse()` paths. They fail on the current code with the NPE and pass with the fix; the full spec is green (23 tests).
