### PR TITLE
fix: #1160 Prevent corrupted thread YAML round-trips

### DIFF
--- a/apps/server/src/lib/thread-coday-manager.ts
+++ b/apps/server/src/lib/thread-coday-manager.ts
@@ -42,6 +42,7 @@ class ThreadCodayInstance {
   private inactivityTimeout?: NodeJS.Timeout
   private isOneshot: boolean = false
   private isReplaying: boolean = false
+  private isCleaningUp: boolean = false
   coday?: Coday
 
   // Timeouts configuration
@@ -402,8 +403,11 @@ class ThreadCodayInstance {
       }
     }
 
-    // If this is a ThreadUpdateEvent with a name, update the thread service cache
-    if (event instanceof ThreadUpdateEvent && (event.name || event.summary)) {
+    // If this is a ThreadUpdateEvent with a name, update the thread service cache.
+    // Skip during cleanup — autoSave is writing the file concurrently, and this
+    // fire-and-forget IIFE would race with it (read-modify-write vs full write).
+    // The ThreadPostProcessor handles name/summary updates after autoSave completes.
+    if (event instanceof ThreadUpdateEvent && (event.name || event.summary) && !this.isCleaningUp) {
       debugLog('THREAD_CODAY', `Updating thread cache for ${this.threadId} name/summary`)
       // Update only the metadata (name/summary) in the thread service cache.
       // IMPORTANT: do NOT reload from disk and re-save — that would overwrite the in-memory
@@ -498,6 +502,10 @@ class ThreadCodayInstance {
    * Cleanup and destroy the Coday instance
    */
   async cleanup(): Promise<void> {
+    // Set cleanup flag FIRST — prevents broadcastEvent's fire-and-forget IIFE from
+    // launching concurrent read-modify-write operations on the YAML file while
+    // autoSave (triggered by coday.kill()) is writing it.
+    this.isCleaningUp = true
     debugLog('THREAD_CODAY', `Cleaning up thread ${this.threadId}`)
 
     // Clear all timeouts

--- a/libs/model/src/lib/ai-thread.ts
+++ b/libs/model/src/lib/ai-thread.ts
@@ -120,8 +120,15 @@ export class AiThread {
     this.projectId = thread.projectId ?? ''
     this.name = thread.name ?? ''
     this.summary = thread.summary ?? ''
-    this.starring = thread.starring ?? []
-    this.users = thread.users ?? (thread.username ? [{ userId: thread.username }] : [])
+    // Defensive: starring must be an array (YAML round-trip can produce false instead of [])
+    this.starring = Array.isArray(thread.starring) ? thread.starring : []
+    // Defensive: users must be a non-empty array (empty [] from YAML won't trigger ?? fallback)
+    this.users =
+      Array.isArray(thread.users) && thread.users.length > 0
+        ? thread.users
+        : thread.username
+          ? [{ userId: thread.username }]
+          : []
     this.createdDate = thread.createdDate ?? new Date().toISOString()
     this.modifiedDate = thread.modifiedDate ?? this.createdDate
     this.price = thread.price ?? 0

--- a/libs/model/src/lib/coday-events.ts
+++ b/libs/model/src/lib/coday-events.ts
@@ -334,7 +334,19 @@ export class MessageEvent extends CodayEvent {
     super(event, MessageEvent.type)
     this.role = event.role!
     this.name = event.name!
-    this.content = event.content!
+    // Defensive: YAML round-trip can produce a string or single object instead of array
+    const rawContent = event.content
+    if (Array.isArray(rawContent)) {
+      this.content = rawContent.map((item) =>
+        typeof item === 'string' ? { type: 'text' as const, content: item } : item
+      )
+    } else if (typeof rawContent === 'string') {
+      this.content = [{ type: 'text', content: rawContent }]
+    } else if (rawContent && typeof rawContent === 'object' && 'type' in rawContent) {
+      this.content = [rawContent as MessageContent]
+    } else {
+      this.content = []
+    }
 
     this.length = this.content
       .map((content) => {

--- a/libs/repository/src/lib/thread-file.repository.ts
+++ b/libs/repository/src/lib/thread-file.repository.ts
@@ -169,7 +169,10 @@ export class ThreadFileRepository implements ThreadRepository {
       }
 
       const serialized = { ...thread.serialize(), version: aiThreadMigrations.length + 1 }
-      const contentToSave = yaml.stringify(serialized)
+      // lineWidth: 0 prevents line wrapping that breaks round-trip
+      // blockQuote: false prevents | and > block scalars that cause parse failures
+      // when content contains code/minified JS with YAML-significant characters (: # etc.)
+      const contentToSave = yaml.stringify(serialized, { lineWidth: 0, blockQuote: false })
 
       // Write the new file
       await fs.writeFile(newThreadPath, contentToSave, 'utf-8')

--- a/libs/utils/src/lib/write-yaml-file.ts
+++ b/libs/utils/src/lib/write-yaml-file.ts
@@ -3,7 +3,10 @@ import { writeFileSync } from 'node:fs'
 
 export function writeYamlFile(filePath: string, content: any): void {
   try {
-    const stringified = yaml.stringify(content, { lineWidth: 0 })
+    // lineWidth: 0 prevents line wrapping that breaks round-trip
+    // blockQuote: false prevents | and > block scalars that cause parse failures
+    // when content contains code/minified JS with YAML-significant characters (: # etc.)
+    const stringified = yaml.stringify(content, { lineWidth: 0, blockQuote: false })
     writeFileSync(filePath, stringified)
   } catch (error) {
     console.error(`Failed to write file ${filePath}:`, error)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,52 @@
+# Thread Repair Scripts
+
+Utility scripts to scan and repair corrupted Coday thread YAML files.
+
+## Prerequisites
+
+Run from the project root (the scripts use the `yaml` package from `node_modules`).
+
+## Scripts
+
+### fix-all-threads.mjs
+
+Scan and repair all threads in a project directory.
+
+```bash
+node scripts/fix-all-threads.mjs <threads-directory>
+```
+
+Example:
+```bash
+node scripts/fix-all-threads.mjs ~/.coday/projects/CODAY/threads
+```
+
+### fix-thread.mjs
+
+Repair a single thread file.
+
+```bash
+node scripts/fix-thread.mjs <path-to-thread.yml>
+```
+
+Example:
+```bash
+node scripts/fix-thread.mjs ~/.coday/projects/CODAY/threads/67f8123c-6c81-4055-ae77-f88f92715b2b.yml
+```
+
+## What gets fixed
+
+- **`starring`**: boolean or invalid type → `[]`
+- **`users`**: empty array → populated from `username` field
+- **`projectId`**: empty string → inferred from directory name
+- **`content`**: string or single object → wrapped in proper `[{ type: 'text', content }]` array
+- **Trailing orphaned invites**: invite/choice events at end of thread without a matching answer → removed
+- **Empty files** (0 bytes): deleted automatically (batch script only)
+
+## Backups
+
+A `.bak` backup is created for every modified file before writing. Empty files are deleted without backup.
+
+## After running
+
+If any repaired thread was already open in the server, **restart Coday** to clear the in-memory instance. Threads not yet opened will be read correctly on next access without a restart.

--- a/scripts/fix-all-threads.mjs
+++ b/scripts/fix-all-threads.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Scan and fix ALL thread YAML files in a project's threads directory.
+ * Applies the same fixes as fix-thread.mjs to every .yml file found.
+ *
+ * Prerequisites: run from the project root (needs 'yaml' package from node_modules)
+ *
+ * Usage:
+ *   node scripts/fix-all-threads.mjs <threads-directory> [projectId]
+ *
+ * Examples:
+ *   node scripts/fix-all-threads.mjs ~/.coday/projects/MYPROJECT/threads
+ *   node scripts/fix-all-threads.mjs ~/.coday/projects/MYPROJECT/threads MYPROJECT
+ */
+
+import { readFileSync, writeFileSync, copyFileSync, readdirSync, statSync, unlinkSync } from 'node:fs'
+import { parse, stringify } from 'yaml'
+import { join, basename, dirname } from 'node:path'
+
+/** YAML stringify options that prevent round-trip failures */
+const YAML_OPTIONS = { lineWidth: 0, blockQuote: false }
+
+const threadsDir = process.argv[2]
+const projectIdOverride = process.argv[3]
+
+if (!threadsDir) {
+  console.error('Usage: node scripts/fix-all-threads.mjs <threads-directory> [projectId]')
+  console.error('Example: node scripts/fix-all-threads.mjs ~/.coday/projects/MYPROJECT/threads')
+  process.exit(1)
+}
+
+const inferredProjectId = projectIdOverride || basename(dirname(threadsDir))
+console.log(`Scanning: ${threadsDir}`)
+console.log(`Project ID: ${inferredProjectId}`)
+console.log()
+
+const files = readdirSync(threadsDir).filter(f => f.endsWith('.yml') && !f.endsWith('.bak'))
+console.log(`Found ${files.length} thread file(s)\n`)
+
+let totalFixed = 0
+let totalErrors = 0
+let totalSkipped = 0
+let totalEmpty = 0
+
+for (const file of files) {
+  const filePath = join(threadsDir, file)
+
+  // Delete empty files (0 bytes) — created by race conditions, never had content
+  const stat = statSync(filePath)
+  if (stat.size === 0) {
+    unlinkSync(filePath)
+    console.log(`  🗑️  ${file}: empty file deleted`)
+    totalEmpty++
+    continue
+  }
+
+  let raw
+  try {
+    raw = readFileSync(filePath, 'utf-8')
+  } catch (err) {
+    console.error(`  ❌ ${file}: Cannot read: ${err.message}`)
+    totalErrors++
+    continue
+  }
+
+  let data
+  try {
+    data = parse(raw)
+  } catch (err) {
+    console.error(`  ❌ ${file}: YAML parse error: ${err.message}`)
+    totalErrors++
+    continue
+  }
+
+  if (!data || !data.id) {
+    console.error(`  ❌ ${file}: Invalid thread file (missing id)`)
+    totalErrors++
+    continue
+  }
+
+  let changed = false
+  const fixes = []
+
+  // Fix starring
+  if (!Array.isArray(data.starring)) {
+    fixes.push(`starring: ${JSON.stringify(data.starring)} → []`)
+    data.starring = []
+    changed = true
+  }
+
+  // Fix users
+  if (!Array.isArray(data.users) || data.users.length === 0) {
+    if (data.username) {
+      fixes.push(`users: [] → [{ userId: '${data.username}' }]`)
+      data.users = [{ userId: data.username }]
+      changed = true
+    }
+  }
+
+  // Fix projectId
+  if (!data.projectId) {
+    fixes.push(`projectId: '' → '${inferredProjectId}'`)
+    data.projectId = inferredProjectId
+    changed = true
+  }
+
+  // Fix message content
+  let contentFixCount = 0
+  if (Array.isArray(data.messages)) {
+    for (const msg of data.messages) {
+      if (msg.type !== 'message') continue
+
+      if (msg.content && !Array.isArray(msg.content)) {
+        if (typeof msg.content === 'string') {
+          msg.content = [{ type: 'text', content: msg.content }]
+          contentFixCount++
+        } else if (typeof msg.content === 'object' && msg.content.type) {
+          msg.content = [msg.content]
+          contentFixCount++
+        }
+      }
+
+      if (Array.isArray(msg.content)) {
+        for (let j = 0; j < msg.content.length; j++) {
+          if (typeof msg.content[j] === 'string') {
+            msg.content[j] = { type: 'text', content: msg.content[j] }
+            contentFixCount++
+          }
+        }
+      }
+    }
+  }
+  if (contentFixCount > 0) {
+    fixes.push(`content: ${contentFixCount} message(s) repaired`)
+    changed = true
+  }
+
+  // Fix trailing orphaned invites
+  let trimCount = 0
+  if (Array.isArray(data.messages)) {
+    while (data.messages.length > 0) {
+      const last = data.messages[data.messages.length - 1]
+      if (last.type === 'invite' || last.type === 'choice') {
+        data.messages.pop()
+        trimCount++
+      } else {
+        break
+      }
+    }
+  }
+  if (trimCount > 0) {
+    fixes.push(`trailing invites: ${trimCount} removed`)
+    changed = true
+  }
+
+  if (!changed) {
+    totalSkipped++
+    continue
+  }
+
+  // Backup and write
+  copyFileSync(filePath, filePath + '.bak')
+  writeFileSync(filePath, stringify(data, YAML_OPTIONS), 'utf-8')
+
+  console.log(`  ✅ ${file} (${data.messages?.length ?? 0} msgs) — ${fixes.join(', ')}`)
+  totalFixed++
+}
+
+console.log()
+console.log(`Done! Fixed: ${totalFixed}, Skipped (ok): ${totalSkipped}, Empty deleted: ${totalEmpty}, Errors: ${totalErrors}`)

--- a/scripts/fix-thread.mjs
+++ b/scripts/fix-thread.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Fix a corrupted Coday thread YAML file.
+ *
+ * Repairs:
+ *   - starring: false → []
+ *   - users: [] → [{ userId: username }]
+ *   - projectId: '' → inferred from directory structure
+ *   - message content: string/object → [{ type: 'text', content }]
+ *   - trailing orphaned invite/choice events removed
+ *   - Re-serializes with blockQuote:false to prevent YAML round-trip failures
+ *
+ * Prerequisites: run from the project root (needs 'yaml' package from node_modules)
+ *
+ * Usage:
+ *   node scripts/fix-thread.mjs <path-to-thread.yml> [projectId]
+ *
+ * Examples:
+ *   node scripts/fix-thread.mjs ~/.coday/projects/MYPROJECT/threads/abc123.yml
+ *   node scripts/fix-thread.mjs ~/.coday/projects/MYPROJECT/threads/abc123.yml MYPROJECT
+ */
+
+import { readFileSync, writeFileSync, copyFileSync } from 'node:fs'
+import { parse, stringify } from 'yaml'
+import { basename, dirname } from 'node:path'
+
+/** YAML stringify options that prevent round-trip failures */
+const YAML_OPTIONS = { lineWidth: 0, blockQuote: false }
+
+const filePath = process.argv[2]
+const projectIdOverride = process.argv[3]
+
+if (!filePath) {
+  console.error('Usage: node scripts/fix-thread.mjs <path-to-thread.yml> [projectId]')
+  process.exit(1)
+}
+
+// 1. Read and parse
+console.log(`Reading: ${filePath}`)
+const raw = readFileSync(filePath, 'utf-8')
+
+let data
+try {
+  data = parse(raw)
+} catch (err) {
+  console.error(`YAML parse error: ${err.message}`)
+  process.exit(1)
+}
+
+if (!data || !data.id) {
+  console.error('Invalid thread file: missing id')
+  process.exit(1)
+}
+
+console.log(`Thread: ${data.id}`)
+console.log(`  name: ${data.name}`)
+console.log(`  username: ${data.username}`)
+console.log(`  projectId: ${JSON.stringify(data.projectId)}`)
+console.log(`  starring: ${JSON.stringify(data.starring)}`)
+console.log(`  users: ${JSON.stringify(data.users)}`)
+console.log(`  messages: ${data.messages?.length ?? 0}`)
+console.log()
+
+let changed = false
+
+// 2. Fix starring
+if (!Array.isArray(data.starring)) {
+  console.log(`FIX starring: ${JSON.stringify(data.starring)} → []`)
+  data.starring = []
+  changed = true
+}
+
+// 3. Fix users
+if (!Array.isArray(data.users) || data.users.length === 0) {
+  if (data.username) {
+    const newUsers = [{ userId: data.username }]
+    console.log(`FIX users: ${JSON.stringify(data.users)} → ${JSON.stringify(newUsers)}`)
+    data.users = newUsers
+    changed = true
+  }
+}
+
+// 4. Fix projectId
+if (!data.projectId) {
+  const threadsDir = dirname(filePath)
+  const projectDir = dirname(threadsDir)
+  const inferred = projectIdOverride || basename(projectDir)
+  console.log(`FIX projectId: ${JSON.stringify(data.projectId)} → ${JSON.stringify(inferred)}`)
+  data.projectId = inferred
+  changed = true
+}
+
+// 5. Fix message content fields
+let contentFixCount = 0
+if (Array.isArray(data.messages)) {
+  for (const msg of data.messages) {
+    if (msg.type !== 'message') continue
+
+    if (msg.content && !Array.isArray(msg.content)) {
+      if (typeof msg.content === 'string') {
+        msg.content = [{ type: 'text', content: msg.content }]
+        contentFixCount++
+      } else if (typeof msg.content === 'object' && msg.content.type) {
+        msg.content = [msg.content]
+        contentFixCount++
+      }
+    }
+
+    if (Array.isArray(msg.content)) {
+      for (let j = 0; j < msg.content.length; j++) {
+        if (typeof msg.content[j] === 'string') {
+          msg.content[j] = { type: 'text', content: msg.content[j] }
+          contentFixCount++
+        }
+      }
+    }
+  }
+}
+
+if (contentFixCount > 0) {
+  console.log(`FIX content: repaired ${contentFixCount} message(s) with non-array content`)
+  changed = true
+}
+
+// 6. Fix trailing orphaned invite/choice events
+if (Array.isArray(data.messages) && data.messages.length > 0) {
+  let trimCount = 0
+  while (data.messages.length > 0) {
+    const last = data.messages[data.messages.length - 1]
+    if (last.type === 'invite' || last.type === 'choice') {
+      data.messages.pop()
+      trimCount++
+    } else {
+      break
+    }
+  }
+  if (trimCount > 0) {
+    console.log(`FIX trailing invites: removed ${trimCount} orphaned invite/choice event(s)`)
+    changed = true
+  }
+}
+
+if (!changed) {
+  console.log('No fixes needed. Re-serializing for clean round-trip...')
+}
+
+// 7. Backup and re-serialize
+const backupPath = filePath + '.bak'
+copyFileSync(filePath, backupPath)
+console.log(`\nBackup: ${backupPath}`)
+
+const output = stringify(data, YAML_OPTIONS)
+writeFileSync(filePath, output, 'utf-8')
+
+console.log(`Written: ${filePath} (${(output.length / 1024).toFixed(1)} KB)`)
+console.log('Done!')


### PR DESCRIPTION
### fix: thread corruption from YAML round-trip failures and cleanup race condition

Problem
Multiple threads become inaccessible after server cleanup, with errors like Failed to read thread or this.content.map is not a function. A scan of 255 threads revealed 9 corrupted and 5 irrecoverable.

Root Causes :

**1. YAML block scalar round-trip failure**

yaml.stringify() used | (literal block scalar) for multiline strings. When the content contained minified JavaScript, the re-parse failed because YAML-significant characters (:, #) in the JS were interpreted as YAML structure. This corrupted MessageEvent.content from an array to a string, causing this.content.map is not a function.

Additionally, ThreadFileRepository.save() called yaml.stringify() without options while writeYamlFile() used { lineWidth: 0 } — two write paths with inconsistent formatting.

### **2. Non-defensive constructors**

AiThread constructor used ?? (nullish coalescing) which only catches null/undefined:

starring: false in YAML → false ?? [] = false → crash on .includes()
users: [] in YAML → [] ?? fallback = [] → hasAccess() always returns false, thread invisible

### **3. Race condition during cleanup**

During ThreadCodayInstance.cleanup(), a fire-and-forget IIFE in broadcastEvent() launched concurrent read-modify-write operations on the YAML file while autoSave (triggered by coday.kill()) was writing it. This produced empty files (0 bytes) or corrupted metadata.

Fixes
blockQuote: false in both ThreadFileRepository.save() and writeYamlFile() — prevents | and > block scalars that break round-trip
Defensive AiThread constructor — Array.isArray() checks instead of ?? for starring and users
Defensive MessageEvent constructor — handles content as string, single object, or array gracefully
isCleaningUp flag in ThreadCodayInstance — blocks the fire-and-forget IIFE in broadcastEvent() during cleanup, eliminating the race condition
Repair scripts (scripts/fix-thread.mjs, scripts/fix-all-threads.mjs) — batch scan and fix existing corrupted threads (content, metadata, trailing orphaned invites, empty files)