### PR TITLE
feat: rename a case from the drawer row actions

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
@@ -170,7 +170,11 @@
 <!-- ===== ROW TEMPLATE (recursive) ===== -->
 <ng-template #caseRowTpl let-node="node" let-depth="depth">
   <div class="case-tree-node" [style.--depth]="depth">
-    <div class="case-tree-node__row" [class.case-tree-node__row--active]="node.id === activeCaseId()">
+    <div
+      class="case-tree-node__row"
+      [class.case-tree-node__row--active]="node.id === activeCaseId()"
+      [class.case-tree-node__row--editing]="editingCaseId() === node.id"
+    >
       <!-- Expand toggle (only when children exist) -->
       @if (node.children?.length) {
         <button
@@ -202,10 +206,37 @@
         <agentos-case-status-glyph [status]="node.status" [size]="15" />
       }
 
-      <!-- Case title (clickable) -->
-      <button type="button" class="case-tree-node__select" (click)="onItemSelected(node.id)">
-        <span class="case-tree-node__name">{{ node.name }}</span>
-      </button>
+      <!--
+        Case title: clickable button, swapped whole for the inline editor while renaming.
+        Nesting the input inside the button would be invalid HTML, and clicking into it would
+        trigger onItemSelected and navigate away from the row being edited.
+      -->
+      @if (editingCaseId() === node.id) {
+        <div class="case-tree-node__edit">
+          <input
+            #renameInput
+            type="text"
+            class="case-tree-node__name-input"
+            [value]="editingTitle()"
+            aria-label="Case title"
+            [attr.aria-invalid]="renameError() ? 'true' : null"
+            [attr.aria-describedby]="renameError() ? 'rename-error-' + node.id : null"
+            autocomplete="off"
+            spellcheck="false"
+            (click)="$event.stopPropagation()"
+            (input)="onRenameInput($any($event.target).value)"
+            (keydown)="onRenameKeydown($event)"
+            (blur)="onRenameBlur()"
+          />
+          @if (renameError(); as error) {
+            <p class="case-tree-node__rename-error" role="alert" [id]="'rename-error-' + node.id">{{ error }}</p>
+          }
+        </div>
+      } @else {
+        <button type="button" class="case-tree-node__select" (click)="onItemSelected(node.id)">
+          <span class="case-tree-node__name">{{ node.name }}</span>
+        </button>
+      }
 
       <!-- Status label — hidden on hover to reveal action buttons -->
       <span
@@ -245,6 +276,29 @@
               />
             </svg>
           </button>
+          @if (node.canRename) {
+            <button
+              type="button"
+              class="case-tree-node__action-btn"
+              title="Rename case"
+              (click)="startRename(node); $event.stopPropagation()"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
+              </svg>
+            </button>
+          }
           @if (node.canDelete) {
             <button
               type="button"

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.html
@@ -371,7 +371,13 @@
     </div>
 
     <!-- Children -->
-    @if (isExpanded(node.id) && node.children?.length) {
+    <!--
+      No recursion while a search is active: collectMatching already flattens every matching
+      descendant into the displayed list, so recursing here renders the same case twice. That
+      duplicate breaks the inline editor, which assumes one row per case: the singular
+      renameInput query focuses the wrong copy, and both copies emit the same error element id.
+    -->
+    @if (!isSearchActive() && isExpanded(node.id) && node.children?.length) {
       @for (child of node.children; track child.id) {
         <ng-container [ngTemplateOutlet]="caseRowTpl" [ngTemplateOutletContext]="{ node: child, depth: depth + 1 }" />
       }

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
@@ -318,8 +318,68 @@
     pointer-events: auto;
   }
 
-  // Action buttons (star, delete)
+  // Action buttons (star, rename, delete)
   &__action-btn {
     @include ds.action-btn(28px);
+  }
+
+  // ── Inline rename editor ──────────────────────────────────────────────
+  //
+  // The actions and the status label are absolutely positioned over the right end of the row,
+  // so they must be hidden while the editor is open or they would sit on top of the input.
+  // The reveal rules above carry a :hover / :focus-within pseudo-class, so these selectors need
+  // one of their own to win on specificity: source order alone would not be enough, and the
+  // focused input trips :focus-within for the whole duration of the edit.
+  &__row--editing:hover &__actions,
+  &__row--editing:focus-within &__actions,
+  &__row--editing:hover &__status-label,
+  &__row--editing:focus-within &__status-label {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  // Takes the place, and the flex share, of __select so the row keeps its layout.
+  // Relative so the validation message can anchor to it.
+  &__edit {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  &__name-input {
+    // Same metrics as __name so the row height does not change when the editor opens.
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    padding: 1px 6px;
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: 400;
+    color: var(--color-text);
+    background: var(--color-bg-secondary, #fff);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+
+    &:focus-visible {
+      @include ds.focus-ring;
+    }
+  }
+
+  // Out of flow: rows are laid out in a scrolling list, so an in-flow message would grow the
+  // row and shift every row below it while the user is still clicking.
+  &__rename-error {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 2;
+    margin: 2px 0 0;
+    padding: 2px 6px;
+    font-size: 11px;
+    color: var(--color-error, #ff3b30);
+    background: var(--color-bg-secondary, #fff);
+    border-radius: 4px;
+    white-space: nowrap;
   }
 }

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.scss
@@ -349,10 +349,14 @@
   }
 
   &__name-input {
-    // Same metrics as __name so the row height does not change when the editor opens.
+    // __name is bare text; the input adds 1px of padding and 1px of border on each side, which
+    // box-sizing does not absorb with height:auto. The negative block margin lets that 4px grow
+    // outward into the row's own vertical padding, so the row keeps its height when the editor
+    // opens and the list below does not shift.
     width: 100%;
     min-width: 0;
     box-sizing: border-box;
+    margin-block: -2px;
     padding: 1px 6px;
     font-family: inherit;
     font-size: 15px;

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.spec.ts
@@ -1,5 +1,5 @@
 import { ApplicationRef, ComponentRef, createComponent, EnvironmentInjector } from '@angular/core'
-import { TestBed } from '@angular/core/testing'
+import { fakeAsync, flush, TestBed } from '@angular/core/testing'
 import { Case, CaseRoleEnum } from '@whoz-oss/agentos-api-client'
 import { CaseDrawerComponent, CaseTreeItem } from './case-drawer.component'
 
@@ -24,6 +24,11 @@ const memberNode = (overrides: Partial<CaseTreeItem> = {}): CaseTreeItem =>
  * We use createComponent() + ApplicationRef.attachView() so that signal
  * inputs are properly initialised (input() requires an injection context).
  *
+ * The host is appended to the document because focus is only observable on a connected
+ * element: HTMLElement.focus() is a no-op on a detached node, so a focus assertion against a
+ * floating host silently reads document.body and passes for the wrong reason. [cleanupHosts]
+ * removes them again.
+ *
  * Returns the ComponentRef so a test can push new inputs afterwards; use [makeComponent]
  * when only the instance is needed.
  */
@@ -33,12 +38,17 @@ function makeComponentRef(cases: Case[] = [], activeCaseId: string | null = null
 
   const ref = createComponent(CaseDrawerComponent, { environmentInjector })
   appRef.attachView(ref.hostView)
+  document.body.appendChild(ref.location.nativeElement)
 
   if (cases.length) ref.setInput('cases', cases)
   if (activeCaseId) ref.setInput('activeCaseId', activeCaseId)
   ref.changeDetectorRef.detectChanges()
 
   return ref
+}
+
+function cleanupHosts(): void {
+  document.querySelectorAll('agentos-case-drawer').forEach((node) => node.remove())
 }
 
 function makeComponent(cases: Case[] = [], activeCaseId: string | null = null): CaseDrawerComponent {
@@ -50,7 +60,7 @@ function makeComponent(cases: Case[] = [], activeCaseId: string | null = null): 
  * abandon-when-the-row-is-gone guard both live in an afterRenderEffect, which detectChanges()
  * alone does not run.
  */
-function tick(ref: ComponentRef<CaseDrawerComponent>): void {
+function render(ref: ComponentRef<CaseDrawerComponent>): void {
   ref.changeDetectorRef.detectChanges()
   TestBed.inject(ApplicationRef).tick()
 }
@@ -60,7 +70,10 @@ function host(ref: ComponentRef<CaseDrawerComponent>): HTMLElement {
 }
 
 describe('CaseDrawerComponent', () => {
-  afterEach(() => TestBed.resetTestingModule())
+  afterEach(() => {
+    cleanupHosts()
+    TestBed.resetTestingModule()
+  })
 
   it('emits deleteRequested with the case id when a delete is requested', () => {
     const component = makeComponent()
@@ -380,7 +393,7 @@ describe('CaseDrawerComponent', () => {
       ref.instance['startRename'](editedNode())
 
       ref.setInput('cases', [{ ...CASE_A, title: 'Patched' } as unknown as Case])
-      tick(ref)
+      render(ref)
 
       expect(ref.instance['editingCaseId']()).toBe('a')
     })
@@ -396,11 +409,11 @@ describe('CaseDrawerComponent', () => {
     ])('abandons the edit when %s', (_label, mutate) => {
       const ref = makeComponentRef([CASE_A])
       ref.instance['startRename'](editedNode())
-      tick(ref)
+      render(ref)
       expect(ref.instance['editingCaseId']()).toBe('a')
 
       mutate(ref)
-      tick(ref)
+      render(ref)
 
       expect(ref.instance['editingCaseId']()).toBeNull()
     })
@@ -419,11 +432,11 @@ describe('CaseDrawerComponent', () => {
       const ref = makeComponentRef([parent, child, other], 'c')
 
       ref.instance['startRename'](adminNode({ id: 'c', name: 'Child' }))
-      tick(ref)
+      render(ref)
       expect(host(ref).querySelector('.case-tree-node__name-input')).not.toBeNull()
 
       ref.setInput('activeCaseId', 'o')
-      tick(ref)
+      render(ref)
 
       expect(ref.instance['isExpanded']('p')).toBe(false)
       expect(ref.instance['editingCaseId']()).toBeNull()
@@ -447,7 +460,7 @@ describe('CaseDrawerComponent', () => {
       const ref = makeComponentRef([CASE_A])
 
       host(ref).querySelector<HTMLButtonElement>('[title="Rename case"]')!.click()
-      tick(ref)
+      render(ref)
 
       const input = host(ref).querySelector<HTMLInputElement>('.case-tree-node__name-input')
       expect(input).not.toBeNull()
@@ -461,7 +474,7 @@ describe('CaseDrawerComponent', () => {
       ref.instance.renameRequested.subscribe((e) => emitted.push(e))
 
       host(ref).querySelector<HTMLButtonElement>('[title="Rename case"]')!.click()
-      tick(ref)
+      render(ref)
       const input = host(ref).querySelector<HTMLInputElement>('.case-tree-node__name-input')!
       input.value = 'New name'
       input.dispatchEvent(new Event('input'))
@@ -474,12 +487,12 @@ describe('CaseDrawerComponent', () => {
       const ref = makeComponentRef([CASE_A])
 
       host(ref).querySelector<HTMLButtonElement>('[title="Rename case"]')!.click()
-      tick(ref)
+      render(ref)
       const input = host(ref).querySelector<HTMLInputElement>('.case-tree-node__name-input')!
       input.value = '  '
       input.dispatchEvent(new Event('input'))
       input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
-      tick(ref)
+      render(ref)
 
       const error = host(ref).querySelector('.case-tree-node__rename-error')
       expect(error?.getAttribute('role')).toBe('alert')
@@ -487,5 +500,84 @@ describe('CaseDrawerComponent', () => {
       expect(input.getAttribute('aria-invalid')).toBe('true')
       expect(input.getAttribute('aria-describedby')).toBe(error?.id)
     })
+
+    it('renders one row per case while a search is active, so one editor opens', () => {
+      // The filtered list already contains every matching descendant, so the row template must
+      // not also recurse into children: a second copy of the same case would give the singular
+      // renameInput query the wrong element and duplicate the error node's DOM id.
+      const parent = { id: 'p', namespaceId: 'ns', title: 'Alpha parent', role: CaseRoleEnum.ADMIN } as unknown as Case
+      const child = {
+        id: 'c',
+        namespaceId: 'ns',
+        title: 'Alpha child',
+        parentCaseId: 'p',
+        role: CaseRoleEnum.ADMIN,
+      } as unknown as Case
+      const ref = makeComponentRef([parent, child], 'c')
+      ref.setInput('filterQuery', 'alpha')
+      render(ref)
+
+      expect(host(ref).querySelectorAll('.case-tree-node__row')).toHaveLength(2)
+
+      host(ref).querySelectorAll<HTMLButtonElement>('[title="Rename case"]')[1].click()
+      render(ref)
+
+      expect(host(ref).querySelectorAll('.case-tree-node__name-input')).toHaveLength(1)
+    })
+  })
+
+  // Focus only behaves on a connected element, hence the host being appended to the document,
+  // and the editor focuses through a setTimeout, hence fakeAsync + flush.
+  describe('inline rename, focus', () => {
+    const CASE_A = { id: 'a', namespaceId: 'ns', title: 'Old name', role: CaseRoleEnum.ADMIN } as unknown as Case
+
+    function openEditor(ref: ComponentRef<CaseDrawerComponent>): HTMLInputElement {
+      host(ref).querySelector<HTMLButtonElement>('[title="Rename case"]')!.click()
+      render(ref)
+      flush()
+      return host(ref).querySelector<HTMLInputElement>('.case-tree-node__name-input')!
+    }
+
+    it('focuses the editor and pre-selects the current name', fakeAsync(() => {
+      const ref = makeComponentRef([CASE_A])
+
+      const input = openEditor(ref)
+
+      expect(document.activeElement).toBe(input)
+      expect(input.selectionStart).toBe(0)
+      expect(input.selectionEnd).toBe('Old name'.length)
+    }))
+
+    it('pre-selects again on a later open, so the reset is not sticky', fakeAsync(() => {
+      const ref = makeComponentRef([CASE_A])
+      const first = openEditor(ref)
+      first.value = 'Half typed'
+      first.dispatchEvent(new Event('input'))
+      first.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      render(ref)
+      flush()
+
+      const second = openEditor(ref)
+
+      expect(second.value).toBe('Old name')
+      expect(second.selectionEnd).toBe('Old name'.length)
+    }))
+
+    it('does not commit on a blur that leaves the input focused (window deactivation)', fakeAsync(() => {
+      const ref = makeComponentRef([CASE_A])
+      const emitted: Array<{ id: string; title: string }> = []
+      ref.instance.renameRequested.subscribe((e) => emitted.push(e))
+      const input = openEditor(ref)
+      input.value = 'Half typed'
+      input.dispatchEvent(new Event('input'))
+
+      // Alt-tab: the browser fires blur but leaves the input as document.activeElement.
+      expect(document.activeElement).toBe(input)
+      input.dispatchEvent(new Event('blur'))
+      render(ref)
+
+      expect(emitted).toEqual([])
+      expect(ref.instance['editingCaseId']()).toBe('a')
+    }))
   })
 })

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.spec.ts
@@ -1,7 +1,21 @@
-import { ApplicationRef, createComponent, EnvironmentInjector } from '@angular/core'
+import { ApplicationRef, ComponentRef, createComponent, EnvironmentInjector } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import { Case, CaseRoleEnum } from '@whoz-oss/agentos-api-client'
-import { CaseDrawerComponent } from './case-drawer.component'
+import { CaseDrawerComponent, CaseTreeItem } from './case-drawer.component'
+
+const adminNode = (overrides: Partial<CaseTreeItem> = {}): CaseTreeItem => ({
+  id: 'x',
+  name: 'x',
+  favorite: false,
+  canDelete: true,
+  canRename: true,
+  status: 'IDLE',
+  children: [],
+  ...overrides,
+})
+
+const memberNode = (overrides: Partial<CaseTreeItem> = {}): CaseTreeItem =>
+  adminNode({ id: 'y', name: 'y', canDelete: false, canRename: false, ...overrides })
 
 /**
  * Instantiate CaseDrawerComponent inside an injection context and wire up
@@ -9,8 +23,11 @@ import { CaseDrawerComponent } from './case-drawer.component'
  *
  * We use createComponent() + ApplicationRef.attachView() so that signal
  * inputs are properly initialised (input() requires an injection context).
+ *
+ * Returns the ComponentRef so a test can push new inputs afterwards; use [makeComponent]
+ * when only the instance is needed.
  */
-function makeComponent(cases: Case[] = [], activeCaseId: string | null = null): CaseDrawerComponent {
+function makeComponentRef(cases: Case[] = [], activeCaseId: string | null = null): ComponentRef<CaseDrawerComponent> {
   const environmentInjector = TestBed.inject(EnvironmentInjector)
   const appRef = TestBed.inject(ApplicationRef)
 
@@ -21,7 +38,25 @@ function makeComponent(cases: Case[] = [], activeCaseId: string | null = null): 
   if (activeCaseId) ref.setInput('activeCaseId', activeCaseId)
   ref.changeDetectorRef.detectChanges()
 
-  return ref.instance
+  return ref
+}
+
+function makeComponent(cases: Case[] = [], activeCaseId: string | null = null): CaseDrawerComponent {
+  return makeComponentRef(cases, activeCaseId).instance
+}
+
+/**
+ * Change detection PLUS the after-render hooks. The rename editor's focus and its
+ * abandon-when-the-row-is-gone guard both live in an afterRenderEffect, which detectChanges()
+ * alone does not run.
+ */
+function tick(ref: ComponentRef<CaseDrawerComponent>): void {
+  ref.changeDetectorRef.detectChanges()
+  TestBed.inject(ApplicationRef).tick()
+}
+
+function host(ref: ComponentRef<CaseDrawerComponent>): HTMLElement {
+  return ref.location.nativeElement as HTMLElement
 }
 
 describe('CaseDrawerComponent', () => {
@@ -42,7 +77,7 @@ describe('CaseDrawerComponent', () => {
     const emitted: Array<{ id: string; starred: boolean }> = []
     component.starToggled.subscribe((e) => emitted.push(e))
 
-    component['onStarToggled']({ id: 'case-9', name: 'case-9', favorite: false, canDelete: false })
+    component['onStarToggled']({ id: 'case-9', name: 'case-9', favorite: false, canDelete: false, canRename: false })
 
     expect(emitted).toEqual([{ id: 'case-9', starred: true }])
   })
@@ -52,14 +87,14 @@ describe('CaseDrawerComponent', () => {
     const emitted: Array<{ id: string; starred: boolean }> = []
     component.starToggled.subscribe((e) => emitted.push(e))
 
-    component['onStarToggled']({ id: 'case-9', name: 'case-9', favorite: true, canDelete: false })
+    component['onStarToggled']({ id: 'case-9', name: 'case-9', favorite: true, canDelete: false, canRename: false })
 
     expect(emitted).toEqual([{ id: 'case-9', starred: false }])
   })
 
   it('does not mutate the node on toggle (optimism lives in CaseStateService)', () => {
     const component = makeComponent()
-    const item = { id: 'case-9', name: 'case-9', favorite: false, canDelete: false }
+    const item = { id: 'case-9', name: 'case-9', favorite: false, canDelete: false, canRename: false }
 
     component['onStarToggled'](item)
 
@@ -78,7 +113,7 @@ describe('CaseDrawerComponent', () => {
     expect(roots[0].children.map((i) => i.id)).toEqual(['child'])
   })
 
-  it('carries favorite and canDelete onto each tree node', () => {
+  it('carries favorite, canDelete and canRename onto each tree node', () => {
     const cases: Case[] = [
       { id: 'admin-fav', namespaceId: 'ns', favorite: true, role: CaseRoleEnum.ADMIN } as unknown as Case,
       { id: 'member', namespaceId: 'ns', favorite: false, role: CaseRoleEnum.MEMBER } as unknown as Case,
@@ -87,8 +122,10 @@ describe('CaseDrawerComponent', () => {
 
     const byId = (id: string) => component['rootItems']().find((i) => i.id === id)!
     expect(byId('admin-fav').canDelete).toBe(true)
+    expect(byId('admin-fav').canRename).toBe(true)
     expect(byId('admin-fav').favorite).toBe(true)
     expect(byId('member').canDelete).toBe(false)
+    expect(byId('member').canRename).toBe(false)
   })
 
   it('groups favorited roots under a Favorites section (favorites first)', () => {
@@ -147,12 +184,12 @@ describe('CaseDrawerComponent', () => {
   it('builds overflow-menu items: star toggle, and delete only when the caller may delete', () => {
     const component = makeComponent()
 
-    const admin = component['menuItemsFor']({ id: 'x', name: 'x', favorite: false, canDelete: true, children: [] })
+    const admin = component['menuItemsFor'](adminNode())
     expect(admin.map((i) => i.key)).toEqual(['star', 'delete'])
     expect(admin[0].label).toBe('Add to favorites')
     expect(admin.find((i) => i.key === 'delete')?.variant).toBe('danger')
 
-    const favMember = component['menuItemsFor']({ id: 'y', name: 'y', favorite: true, canDelete: false, children: [] })
+    const favMember = component['menuItemsFor'](memberNode({ favorite: true }))
     expect(favMember.map((i) => i.key)).toEqual(['star'])
     expect(favMember[0].label).toBe('Remove from favorites')
   })
@@ -163,7 +200,7 @@ describe('CaseDrawerComponent', () => {
     const deletes: string[] = []
     component.starToggled.subscribe((e) => stars.push(e))
     component.deleteRequested.subscribe((id) => deletes.push(id))
-    const node = { id: 'case-1', name: 'case-1', favorite: false, canDelete: true, children: [] }
+    const node = adminNode({ id: 'case-1', name: 'case-1' })
 
     component['onMenuAction'](node, 'star')
     component['onMenuAction'](node, 'delete')
@@ -188,5 +225,267 @@ describe('CaseDrawerComponent', () => {
 
     component['toggleExpand'](new Event('click'), 'p')
     expect(component['isExpanded']('p')).toBe(true)
+  })
+
+  describe('inline rename', () => {
+    const CASE_A = { id: 'a', namespaceId: 'ns', title: 'Old name', role: CaseRoleEnum.ADMIN } as unknown as Case
+    const editedNode = (name = 'Old name') => adminNode({ id: 'a', name })
+
+    /** Collect renameRequested emissions for the assertions below. */
+    function captureRenames(component: CaseDrawerComponent): Array<{ id: string; title: string }> {
+      const emitted: Array<{ id: string; title: string }> = []
+      component.renameRequested.subscribe((e) => emitted.push(e))
+      return emitted
+    }
+
+    it('opens the editor seeded with the row label when rename is picked', () => {
+      const component = makeComponent([CASE_A])
+
+      component['startRename'](editedNode())
+
+      expect(component['editingCaseId']()).toBe('a')
+      expect(component['editingTitle']()).toBe('Old name')
+      expect(component['renameError']()).toBeNull()
+    })
+
+    it('emits the trimmed title and leaves edit mode on commit', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('  New name  ')
+      component['commitRename']()
+
+      expect(emitted).toEqual([{ id: 'a', title: 'New name' }])
+      expect(component['editingCaseId']()).toBeNull()
+    })
+
+    it('does not emit when the title is unchanged (nothing to persist)', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['commitRename']()
+
+      expect(emitted).toEqual([])
+      expect(component['editingCaseId']()).toBeNull()
+    })
+
+    it('rejects an empty title, keeps the editor open and emits nothing', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('   ')
+      component['commitRename']()
+
+      expect(emitted).toEqual([])
+      expect(component['renameError']()).toBe('Name cannot be empty')
+      expect(component['editingCaseId']()).toBe('a')
+    })
+
+    it('rejects a title over the maximum length', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('x'.repeat(201))
+      component['commitRename']()
+
+      expect(emitted).toEqual([])
+      expect(component['renameError']()).toContain('too long')
+    })
+
+    it('clears the error as soon as the user edits the draft again', () => {
+      const component = makeComponent([CASE_A])
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('')
+      component['commitRename']()
+      expect(component['renameError']()).not.toBeNull()
+
+      component['onRenameInput']('New name')
+
+      expect(component['renameError']()).toBeNull()
+    })
+
+    it('emits once when commit is called twice', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('New name')
+      component['commitRename']()
+      component['commitRename']()
+
+      expect(emitted).toHaveLength(1)
+    })
+
+    it('emits once when the teardown blur follows a commit', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('New name')
+      component['commitRename']()
+      component['onRenameBlur']()
+
+      expect(emitted).toHaveLength(1)
+    })
+
+    it('emits nothing when a blur follows a cancel', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('New name')
+      component['cancelRename']()
+      component['onRenameBlur']()
+
+      expect(emitted).toEqual([])
+    })
+
+    it('discards an invalid draft on blur rather than leaving the row stuck in edit mode', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('')
+      component['onRenameBlur']()
+
+      expect(emitted).toEqual([])
+      expect(component['editingCaseId']()).toBeNull()
+    })
+
+    it('commits on Enter and cancels on Escape', () => {
+      const component = makeComponent([CASE_A])
+      const emitted = captureRenames(component)
+
+      component['startRename'](editedNode())
+      component['onRenameInput']('Renamed')
+      component['onRenameKeydown'](new KeyboardEvent('keydown', { key: 'Enter' }))
+      expect(emitted).toEqual([{ id: 'a', title: 'Renamed' }])
+
+      component['startRename'](editedNode('Renamed'))
+      component['onRenameInput']('Another')
+      component['onRenameKeydown'](new KeyboardEvent('keydown', { key: 'Escape' }))
+
+      expect(emitted).toHaveLength(1)
+      expect(component['editingCaseId']()).toBeNull()
+    })
+
+    it('keeps the editor open when the tree is rebuilt around it', () => {
+      // The optimistic title patch replaces every tree node object, hence the id keying.
+      const ref = makeComponentRef([CASE_A])
+      ref.instance['startRename'](editedNode())
+
+      ref.setInput('cases', [{ ...CASE_A, title: 'Patched' } as unknown as Case])
+      tick(ref)
+
+      expect(ref.instance['editingCaseId']()).toBe('a')
+    })
+
+    // The editor is abandoned whenever its row stops being rendered. The guard checks the
+    // input's presence rather than enumerating the reasons a row can disappear, so every one
+    // of these is covered by the same code path. (blur) never fires when Angular destroys the
+    // view, so without the guard the draft would survive and re-open on stale state.
+    it.each([
+      ['the case leaves the list', (ref: ComponentRef<CaseDrawerComponent>) => ref.setInput('cases', [])],
+      ['a search hides the row', (ref: ComponentRef<CaseDrawerComponent>) => ref.setInput('filterQuery', 'zzz')],
+      ['compact mode replaces the tree', (ref: ComponentRef<CaseDrawerComponent>) => ref.setInput('compact', true)],
+    ])('abandons the edit when %s', (_label, mutate) => {
+      const ref = makeComponentRef([CASE_A])
+      ref.instance['startRename'](editedNode())
+      tick(ref)
+      expect(ref.instance['editingCaseId']()).toBe('a')
+
+      mutate(ref)
+      tick(ref)
+
+      expect(ref.instance['editingCaseId']()).toBeNull()
+    })
+
+    it('abandons the edit when an ancestor collapses because the active case changed', () => {
+      // Renaming a sub-case then navigating away collapses its parent, destroying the row.
+      const parent = { id: 'p', namespaceId: 'ns', title: 'Parent', role: CaseRoleEnum.ADMIN } as unknown as Case
+      const child = {
+        id: 'c',
+        namespaceId: 'ns',
+        title: 'Child',
+        parentCaseId: 'p',
+        role: CaseRoleEnum.ADMIN,
+      } as unknown as Case
+      const other = { id: 'o', namespaceId: 'ns', title: 'Other', role: CaseRoleEnum.ADMIN } as unknown as Case
+      const ref = makeComponentRef([parent, child, other], 'c')
+
+      ref.instance['startRename'](adminNode({ id: 'c', name: 'Child' }))
+      tick(ref)
+      expect(host(ref).querySelector('.case-tree-node__name-input')).not.toBeNull()
+
+      ref.setInput('activeCaseId', 'o')
+      tick(ref)
+
+      expect(ref.instance['isExpanded']('p')).toBe(false)
+      expect(ref.instance['editingCaseId']()).toBeNull()
+    })
+  })
+
+  // The harness renders a real host element, so the template wiring can be asserted directly
+  // rather than only through the protected handlers.
+  describe('inline rename, rendered', () => {
+    const CASE_A = { id: 'a', namespaceId: 'ns', title: 'Old name', role: CaseRoleEnum.ADMIN } as unknown as Case
+
+    it('shows a rename action only when the caller may rename', () => {
+      const admin = makeComponentRef([CASE_A])
+      expect(host(admin).querySelector('[title="Rename case"]')).not.toBeNull()
+
+      const member = makeComponentRef([{ ...CASE_A, role: CaseRoleEnum.MEMBER } as unknown as Case])
+      expect(host(member).querySelector('[title="Rename case"]')).toBeNull()
+    })
+
+    it('swaps the title button for an input seeded with the current name when the action is clicked', () => {
+      const ref = makeComponentRef([CASE_A])
+
+      host(ref).querySelector<HTMLButtonElement>('[title="Rename case"]')!.click()
+      tick(ref)
+
+      const input = host(ref).querySelector<HTMLInputElement>('.case-tree-node__name-input')
+      expect(input).not.toBeNull()
+      expect(input!.value).toBe('Old name')
+      expect(host(ref).querySelector('.case-tree-node__select')).toBeNull()
+    })
+
+    it('commits through the template wiring on blur', () => {
+      const ref = makeComponentRef([CASE_A])
+      const emitted: Array<{ id: string; title: string }> = []
+      ref.instance.renameRequested.subscribe((e) => emitted.push(e))
+
+      host(ref).querySelector<HTMLButtonElement>('[title="Rename case"]')!.click()
+      tick(ref)
+      const input = host(ref).querySelector<HTMLInputElement>('.case-tree-node__name-input')!
+      input.value = 'New name'
+      input.dispatchEvent(new Event('input'))
+      input.dispatchEvent(new Event('blur'))
+
+      expect(emitted).toEqual([{ id: 'a', title: 'New name' }])
+    })
+
+    it('renders the validation message as an alert tied to the input', () => {
+      const ref = makeComponentRef([CASE_A])
+
+      host(ref).querySelector<HTMLButtonElement>('[title="Rename case"]')!.click()
+      tick(ref)
+      const input = host(ref).querySelector<HTMLInputElement>('.case-tree-node__name-input')!
+      input.value = '  '
+      input.dispatchEvent(new Event('input'))
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+      tick(ref)
+
+      const error = host(ref).querySelector('.case-tree-node__rename-error')
+      expect(error?.getAttribute('role')).toBe('alert')
+      expect(error?.textContent).toContain('cannot be empty')
+      expect(input.getAttribute('aria-invalid')).toBe('true')
+      expect(input.getAttribute('aria-describedby')).toBe(error?.id)
+    })
   })
 })

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
@@ -209,7 +209,11 @@ export class CaseDrawerComponent {
   /** Title the editor was seeded with, used to skip a no-op rename. */
   private renameOriginal = ''
 
-  /** Only one row can be in edit mode, so a singular query is enough. */
+  /**
+   * A case appears on exactly one row, so one edited case means one input and a singular query
+   * is enough. That holds only because the row template does not recurse into children while a
+   * search is active, where the flattened list already contains every matching descendant.
+   */
   private readonly renameInput = viewChild<ElementRef<HTMLInputElement>>('renameInput')
 
   /** Case whose draft has already been pre-selected, so a re-render does not re-select it. */

--- a/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-drawer/case-drawer.component.ts
@@ -1,11 +1,14 @@
 import {
+  afterRenderEffect,
   ChangeDetectionStrategy,
   Component,
   computed,
+  ElementRef,
   input,
   output,
   signal,
   TemplateRef,
+  viewChild,
   ViewChild,
 } from '@angular/core'
 import { NgTemplateOutlet } from '@angular/common'
@@ -16,8 +19,8 @@ import { CaseItemComponent, CaseListItem } from '../case-item/case-item.componen
 /**
  * A case list item extended with a recursive children list (parent/child cases).
  * Only root nodes are passed to ds-entity-list; children are rendered inline by the
- * itemTemplate. Inherits `favorite` + `canDelete` from [CaseListItem] so each row can
- * render the star toggle and the (ADMIN-gated) delete action.
+ * itemTemplate. Inherits `favorite`, `canDelete` and `canRename` from [CaseListItem] so each
+ * row can render the star toggle and the (ADMIN-gated) rename and delete actions.
  */
 export interface CaseTreeItem extends CaseListItem {
   children: CaseTreeItem[]
@@ -58,6 +61,7 @@ export class CaseDrawerComponent {
   readonly createRequested = output<void>()
   readonly deleteRequested = output<string>()
   readonly starToggled = output<{ id: string; starred: boolean }>()
+  readonly renameRequested = output<{ id: string; title: string }>()
 
   @ViewChild('caseRowTpl', { static: true }) caseRowTpl!: TemplateRef<{ node: CaseTreeItem; depth: number }>
 
@@ -185,6 +189,64 @@ export class CaseDrawerComponent {
 
   protected readonly expandOverrides = signal(new Map<string, boolean>())
 
+  // ---------------------------------------------------------------------------
+  // Inline rename
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Case currently renamed inline, keyed by ID rather than by node: [rootItems] rebuilds every
+   * tree node whenever cases() changes (which the optimistic title patch does), so a node
+   * reference would go stale mid-edit.
+   */
+  protected readonly editingCaseId = signal<string | null>(null)
+
+  /** Draft title being typed. */
+  protected readonly editingTitle = signal('')
+
+  /** Validation message shown under the input, null while the draft is valid. */
+  protected readonly renameError = signal<string | null>(null)
+
+  /** Title the editor was seeded with, used to skip a no-op rename. */
+  private renameOriginal = ''
+
+  /** Only one row can be in edit mode, so a singular query is enough. */
+  private readonly renameInput = viewChild<ElementRef<HTMLInputElement>>('renameInput')
+
+  /** Case whose draft has already been pre-selected, so a re-render does not re-select it. */
+  private selectedForId: string | null = null
+
+  constructor() {
+    afterRenderEffect((onCleanup) => {
+      const id = this.editingCaseId()
+      if (!id) return
+
+      const input = this.renameInput()?.nativeElement
+      if (!input) {
+        // The edited row is no longer rendered: the search filter hid it, compact mode replaced
+        // the tree by the badge rail, the case was deleted, or an ancestor collapsed because the
+        // active case changed. Angular destroys the view without firing (blur), so the draft
+        // would otherwise survive and the editor would re-open on stale state later.
+        this.cancelRename()
+        return
+      }
+
+      // setTimeout rather than a microtask: the rename button lives in the row's hover actions,
+      // and with zone.js the tick runs synchronously between the listeners of a single click
+      // dispatch. Only a macrotask is guaranteed to land after the whole dispatch has settled.
+      const timer = setTimeout(() => {
+        input.focus()
+        // Pre-select on a genuine open only. The row's view is recreated whenever the tree
+        // regroups (starring another case moves rows between groups), and re-selecting there
+        // would make the next keystroke wipe a half-typed draft.
+        if (this.selectedForId !== id) {
+          input.select()
+          this.selectedForId = id
+        }
+      })
+      onCleanup(() => clearTimeout(timer))
+    })
+  }
+
   protected isExpanded(id: string): boolean {
     return this.expandOverrides().get(id) ?? this.autoExpandedIds().has(id)
   }
@@ -226,6 +288,75 @@ export class CaseDrawerComponent {
     this.deleteRequested.emit(id)
   }
 
+  /** Open the inline editor on a row, seeded with its current label. */
+  protected startRename(node: CaseTreeItem): void {
+    this.renameOriginal = node.name
+    this.editingTitle.set(node.name)
+    this.renameError.set(null)
+    this.selectedForId = null
+    this.editingCaseId.set(node.id)
+  }
+
+  protected onRenameInput(value: string): void {
+    this.editingTitle.set(value)
+    if (this.renameError()) this.renameError.set(null)
+  }
+
+  protected onRenameKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      this.commitRename()
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      this.cancelRename()
+    }
+  }
+
+  /**
+   * Blur commits a valid draft and discards an invalid one: leaving the row stuck in edit mode,
+   * showing an error under an unfocused input, would be worse. Enter is the path that surfaces
+   * the error and keeps the focus so the user can fix the draft.
+   *
+   * Bails out when the blur came from the whole window being deactivated (alt-tab, browser
+   * chrome), which would otherwise persist a half-typed name. That case is told apart by the
+   * input still being document.activeElement: a real focus move updates it, a window
+   * deactivation does not. The browser refocuses the input on return, so the edit carries on.
+   */
+  protected onRenameBlur(): void {
+    if (!this.editingCaseId()) return
+    if (this.renameInput()?.nativeElement === document.activeElement) return
+    if (caseTitleError(this.editingTitle().trim())) this.cancelRename()
+    else this.commitRename()
+  }
+
+  /**
+   * Validate the draft and emit the rename. Idempotent by construction: the first call clears
+   * [editingCaseId], so the blur that follows an Enter (or a second Enter) is a no-op.
+   */
+  protected commitRename(): void {
+    const id = this.editingCaseId()
+    if (!id) return
+    const title = this.editingTitle().trim()
+    const error = caseTitleError(title)
+    if (error) {
+      this.renameError.set(error)
+      return
+    }
+    this.editingCaseId.set(null)
+    this.renameError.set(null)
+    // Unchanged title: nothing to persist, so no request.
+    if (title === this.renameOriginal) return
+    this.renameRequested.emit({ id, title })
+  }
+
+  protected cancelRename(): void {
+    this.editingCaseId.set(null)
+    this.editingTitle.set('')
+    this.renameError.set(null)
+  }
+
   /**
    * @internal Used by tests via component['menuItemsFor']
    * Kept for backward-compat with existing specs.
@@ -257,6 +388,22 @@ export class CaseDrawerComponent {
 
   // Exposed to the template for use in @switch / [class] bindings
   protected readonly Status = CaseStatusEventStatusEnum
+}
+
+/** Longest title a user may set, matching the legacy thread rename input. */
+const MAX_CASE_TITLE_LENGTH = 200
+
+/**
+ * Validation message for an already-trimmed case title, or null when it is valid.
+ *
+ * Empty is rejected outright: the server accepts it (PUT /api/cases/{id} does
+ * `resource.title ?: existing.title`, a null-guard only) and a blank title makes it re-trigger
+ * LLM auto-naming on every subsequent message.
+ */
+function caseTitleError(title: string): string | null {
+  if (!title) return 'Name cannot be empty'
+  if (title.length > MAX_CASE_TITLE_LENGTH) return `Name is too long (max ${MAX_CASE_TITLE_LENGTH} characters)`
+  return null
 }
 
 /**

--- a/libs/agentos-ui/src/lib/components/case-item/case-item.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-item/case-item.component.ts
@@ -4,14 +4,16 @@ import { EntityListItem } from '@whoz-oss/design-system'
 
 /**
  * A drawer list item for a case. Extends the shared [EntityListItem] with the
- * case-specific `favorite` and `canDelete` flags (kept off the design-system interface,
- * which only needs `groupKey`/`groupLabel`).
+ * case-specific `favorite`, `canDelete` and `canRename` flags (kept off the design-system
+ * interface, which only needs `groupKey`/`groupLabel`).
  */
 export interface CaseListItem extends EntityListItem {
   /** Per-user favorite flag — drives the Favorites grouping and the star menu action. */
   favorite: boolean
   /** Whether the caller may delete this case (direct ADMIN relation). Gates the delete button. */
   canDelete: boolean
+  /** Whether the caller may rename this case. Gates the rename menu action. */
+  canRename: boolean
 }
 
 /**
@@ -37,6 +39,9 @@ export class CaseItemComponent {
       favorite: c.favorite,
       // Only a direct ADMIN can delete; MEMBER (or no direct relation) cannot.
       canDelete: c.role === CaseRoleEnum.ADMIN,
+      // Renaming goes through PUT /api/cases/{id}, gated server-side on Case:WRITE. That is a
+      // permission of its own, which today resolves to the same direct ADMIN relation as delete.
+      canRename: c.role === CaseRoleEnum.ADMIN,
     }
   }
 }

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.html
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.html
@@ -57,6 +57,7 @@
     (createRequested)="onCreateRequested()"
     (deleteRequested)="onDeleteRequested($event)"
     (starToggled)="onStarToggled($event)"
+    (renameRequested)="onRenameRequested($event)"
     (menuToggled)="toggleMenu($event)"
     (menuClosed)="closeMenu($event)"
     (navigateTo)="onMenuNavigate($event)"

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.spec.ts
@@ -21,6 +21,7 @@ describe('CaseShellComponent', () => {
     loadCases: jest.Mock
     deleteCase: jest.Mock
     setStarred: jest.Mock
+    renameCase: jest.Mock
   }
   let userStateMock: { currentUser: jest.Mock; loadMe: jest.Mock }
   let namespaceControllerMock: { listAllNamespace: jest.Mock }
@@ -35,6 +36,7 @@ describe('CaseShellComponent', () => {
       loadCases: jest.fn(),
       deleteCase: jest.fn().mockReturnValue(of(undefined)),
       setStarred: jest.fn().mockReturnValue(of(undefined)),
+      renameCase: jest.fn().mockReturnValue(of(undefined)),
     }
     userStateMock = {
       currentUser: jest.fn().mockReturnValue(null),
@@ -139,6 +141,39 @@ describe('CaseShellComponent', () => {
       caseStateMock.setStarred.mockReturnValue(throwError(() => new Error('boom')))
 
       component['onStarToggled']({ id: 'case-1', starred: true })
+
+      expect(errorSpy).toHaveBeenCalled()
+      expect(alertSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('rename', () => {
+    it('delegates the rename to the state service', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm')
+      const component = makeComponent({ ns: NS_ID })
+
+      component['onRenameRequested']({ id: 'case-1', title: 'New name' })
+
+      expect(caseStateMock.renameCase).toHaveBeenCalledWith('case-1', 'New name')
+      // The drawer already validated the title, so nothing is confirmed here.
+      expect(confirmSpy).not.toHaveBeenCalled()
+    })
+
+    it('stays on the active case', () => {
+      const component = makeComponent({ ns: NS_ID, case: 'case-1' })
+
+      component['onRenameRequested']({ id: 'case-1', title: 'New name' })
+
+      expect(routerMock.navigate).not.toHaveBeenCalled()
+    })
+
+    it('alerts the user when the rename request fails', () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined)
+      const component = makeComponent({ ns: NS_ID })
+      caseStateMock.renameCase.mockReturnValue(throwError(() => new Error('boom')))
+
+      component['onRenameRequested']({ id: 'case-1', title: 'New name' })
 
       expect(errorSpy).toHaveBeenCalled()
       expect(alertSpy).toHaveBeenCalled()

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
@@ -255,6 +255,23 @@ export class CaseShellComponent {
       })
   }
 
+  /**
+   * Persist a rename requested from the drawer. The drawer has already validated the title and
+   * closed its editor; the new title is applied optimistically by the service and reverted here
+   * on failure, so there is nothing to confirm and nowhere to navigate.
+   */
+  protected onRenameRequested(event: { id: string; title: string }): void {
+    this.caseState
+      .renameCase(event.id, event.title)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        error: (err) => {
+          console.error(`[CaseShell] Failed to rename case ${event.id}:`, err)
+          alert('Could not rename the case. Please try again.')
+        },
+      })
+  }
+
   // ---------------------------------------------------------------------------
   // Navigation
   // ---------------------------------------------------------------------------

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.html
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.html
@@ -107,6 +107,7 @@
         (createRequested)="createRequested.emit()"
         (deleteRequested)="deleteRequested.emit($event)"
         (starToggled)="starToggled.emit($event)"
+        (renameRequested)="renameRequested.emit($event)"
       />
     </div>
 

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.ts
@@ -161,6 +161,7 @@ export class ShellSidebarComponent {
   readonly createRequested = output<void>()
   readonly deleteRequested = output<string>()
   readonly starToggled = output<{ id: string; starred: boolean }>()
+  readonly renameRequested = output<{ id: string; title: string }>()
   readonly menuToggled = output<MouseEvent>()
   readonly menuClosed = output<Event>()
   readonly navigateTo = output<string>()

--- a/libs/agentos-ui/src/lib/services/case-state.service.spec.ts
+++ b/libs/agentos-ui/src/lib/services/case-state.service.spec.ts
@@ -10,6 +10,7 @@ describe('CaseStateService', () => {
     deleteCase: jest.Mock
     starCase: jest.Mock
     unstarCase: jest.Mock
+    updateCase: jest.Mock
   }
 
   function makeService(listMineMock?: jest.Mock): CaseStateService {
@@ -18,6 +19,7 @@ describe('CaseStateService', () => {
       deleteCase: jest.fn().mockReturnValue(of(undefined)),
       starCase: jest.fn().mockReturnValue(of(undefined)),
       unstarCase: jest.fn().mockReturnValue(of(undefined)),
+      updateCase: jest.fn().mockReturnValue(of(caseWith('a'))),
     }
     TestBed.configureTestingModule({
       providers: [CaseStateService, { provide: CaseControllerService, useValue: controllerMock }],
@@ -108,5 +110,87 @@ describe('CaseStateService', () => {
 
     expect(controllerMock.unstarCase).toHaveBeenCalledWith('a')
     expect(svc.cases()[0].favorite).toBe(false)
+  })
+
+  describe('renameCase', () => {
+    const titledCase = (id: string, title?: string, extra: Partial<Case> = {}): Case =>
+      ({ id, namespaceId: 'ns', favorite: false, title, ...extra }) as unknown as Case
+
+    it('patches the title optimistically and sends the whole resource', () => {
+      const svc = makeService(jest.fn().mockReturnValue(of([titledCase('a', 'Old')])))
+      svc.loadCases('ns-1')
+
+      svc.renameCase('a', 'New').subscribe()
+
+      // namespaceId is @NotNull on the DTO, so a title-only body would be rejected with a 400.
+      expect(controllerMock.updateCase).toHaveBeenCalledWith('a', expect.objectContaining({ namespaceId: 'ns' }))
+      expect(controllerMock.updateCase).toHaveBeenCalledWith('a', expect.objectContaining({ title: 'New' }))
+      expect(svc.cases()[0].title).toBe('New')
+    })
+
+    it('reverts the optimistic title when the request fails', () => {
+      const svc = makeService(jest.fn().mockReturnValue(of([titledCase('a', 'Old')])))
+      svc.loadCases('ns-1')
+      controllerMock.updateCase.mockReturnValue(throwError(() => new Error('boom')))
+
+      svc.renameCase('a', 'New').subscribe({ error: () => undefined })
+
+      expect(svc.cases()[0].title).toBe('Old')
+    })
+
+    it('reverts to undefined when the case had no title (the drawer falls back to the id)', () => {
+      const svc = makeService(jest.fn().mockReturnValue(of([titledCase('a')])))
+      svc.loadCases('ns-1')
+      controllerMock.updateCase.mockReturnValue(throwError(() => new Error('boom')))
+
+      svc.renameCase('a', 'New').subscribe({ error: () => undefined })
+
+      expect(svc.cases()[0].title).toBeUndefined()
+    })
+
+    it('does not reload the namespace on success (unlike deleteCase)', () => {
+      const listMine = jest.fn().mockReturnValue(of([titledCase('a', 'Old')]))
+      const svc = makeService(listMine)
+      svc.loadCases('ns-1')
+
+      svc.renameCase('a', 'New').subscribe()
+
+      expect(listMine).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores the response so favorite and role survive the rename', () => {
+      // Single-case endpoints map a DTO that carries neither favorite nor role: merging the
+      // response back would silently un-star the case and drop its ADMIN-gated actions.
+      const stored = titledCase('a', 'Old', { favorite: true, role: 'ADMIN' } as Partial<Case>)
+      const svc = makeService(jest.fn().mockReturnValue(of([stored])))
+      svc.loadCases('ns-1')
+      controllerMock.updateCase.mockReturnValue(of(titledCase('a', 'New')))
+
+      svc.renameCase('a', 'New').subscribe()
+
+      expect(svc.cases()[0].favorite).toBe(true)
+      expect(svc.cases()[0].role).toBe('ADMIN')
+    })
+
+    it('does nothing until subscribed', () => {
+      const svc = makeService(jest.fn().mockReturnValue(of([titledCase('a', 'Old')])))
+      svc.loadCases('ns-1')
+
+      svc.renameCase('a', 'New')
+
+      expect(controllerMock.updateCase).not.toHaveBeenCalled()
+      expect(svc.cases()[0].title).toBe('Old')
+    })
+
+    it('errors without calling the controller when the case is not in the list', () => {
+      const svc = makeService(jest.fn().mockReturnValue(of([titledCase('a', 'Old')])))
+      svc.loadCases('ns-1')
+      let failed = false
+
+      svc.renameCase('gone', 'New').subscribe({ error: () => (failed = true) })
+
+      expect(failed).toBe(true)
+      expect(controllerMock.updateCase).not.toHaveBeenCalled()
+    })
   })
 })

--- a/libs/agentos-ui/src/lib/services/case-state.service.ts
+++ b/libs/agentos-ui/src/lib/services/case-state.service.ts
@@ -11,6 +11,7 @@ import { catchError, defer, Observable, Subscription, tap, throwError } from 'rx
  * Responsibilities:
  * - Load and hold the case list for the current namespace
  * - Apply in-place title patches from CaseUpdatedEvent without a full reload
+ * - Run the per-case mutations the drawer offers (star, rename, delete)
  */
 @Injectable({ providedIn: 'root' })
 export class CaseStateService {
@@ -79,9 +80,52 @@ export class CaseStateService {
     })
   }
 
+  /**
+   * Rename a case. The title is applied optimistically to the list (so the drawer reflects it at
+   * once) and reverted locally if the request fails, exactly like [setStarred].
+   *
+   * Sends the whole resource: PUT /api/cases/{id} only honours `title` (namespaceId and status
+   * are mass-assignment guarded server-side), but the endpoint is @Valid and CaseDto.namespaceId
+   * is @NotNull, so a title-only body would be rejected with a 400.
+   *
+   * The response is deliberately ignored. Single-case endpoints build their DTO with a mapper
+   * that sets neither `favorite` nor `role`, so merging it back would silently un-star the case
+   * and drop the ADMIN-gated actions until the next full reload. No reload either: a title-only
+   * update does not bump `modified`, so the drawer's ordering is unaffected.
+   *
+   * Note the rename is not broadcast: the server emits no CaseUpdatedEvent on this path, so
+   * other clients only see the new title on their next list load.
+   */
+  renameCase(caseId: string, title: string): Observable<Case> {
+    // defer for the same reason as setStarred: the optimistic patch is tied to subscription.
+    return defer(() => {
+      const existing = this.cases().find((c) => c.id === caseId)
+      if (!existing) {
+        return throwError(() => new Error(`[CaseState] Case ${caseId} is not in the current list`))
+      }
+      const previousTitle = existing.title
+      this.patchTitle(caseId, title)
+      return this.caseController.updateCase(caseId, { ...existing, title }).pipe(
+        catchError((err) => {
+          this.patchTitle(caseId, previousTitle)
+          return throwError(() => err)
+        })
+      )
+    })
+  }
+
   /** Set the favorite flag of a single case in-place (immutably, to re-emit the signal). */
   private patchFavorite(caseId: string, favorite: boolean): void {
     this.cases.update((list) => list.map((c) => (c.id === caseId ? { ...c, favorite } : c)))
+  }
+
+  /**
+   * Set the title of a single case in-place (immutably, to re-emit the signal).
+   * Accepts undefined so a revert can restore a case that had no title: '' is not nullish, and
+   * the drawer falls back to the case ID only on a nullish title.
+   */
+  private patchTitle(caseId: string, title: string | undefined): void {
+    this.cases.update((list) => list.map((c) => (c.id === caseId ? { ...c, title } : c)))
   }
 
   /** Reload the currently held namespace (no-op before the first load). */
@@ -105,7 +149,7 @@ export class CaseStateService {
    * No-op if the case is not in the current list.
    */
   updateCaseTitle(caseId: string, title: string): void {
-    this.cases.update((list) => list.map((c) => (c.id === caseId ? { ...c, title } : c)))
+    this.patchTitle(caseId, title)
   }
 
   /**


### PR DESCRIPTION
> Rebased onto master after #1166 landed. That PR replaced the drawer's three-dots menu with inline hover actions, so the rename entry point was redesigned accordingly: it is now a third action button on the row, not a menu item.

## What

A case row in the left drawer offers star and delete on hover. This adds **rename**, so a user can fix a title that is still the server default (`Case <uuid>`) or an LLM-generated one.

Clicking the pencil swaps the row label for an inline input, seeded with the current title and pre-selected:

- **Enter** commits, **Escape** cancels
- **blur** commits a valid draft and discards an invalid one, rather than leaving the row stuck in edit mode with an error under an unfocused input
- an empty or over-long (>200 chars) title shows an inline error and keeps the focus so the draft can be fixed
- committing an unchanged title emits nothing, so no request is sent

Gated on `role === ADMIN`, like delete. Available on the expanded drawer rows, which is where the row actions live.

## How

Frontend only. `PUT /api/cases/{id}` already exists, is gated on `hasPermission(#id, 'Case', 'WRITE')` and only honours `title` (`namespaceId` and `status` are mass-assignment guarded). The generated client already exposes `updateCase()` and had no caller. So: **no Kotlin change, no `pnpm regen`, no OpenAPI or generated-client diff.**

```
rename button
  -> CaseDrawerComponent  edit state (signals, keyed by case id)
  -> renameRequested {id, title}
  -> ShellSidebarComponent (relay)
  -> CaseShellComponent.onRenameRequested
  -> CaseStateService.renameCase   optimistic patch + revert on failure
  -> CaseControllerService.updateCase
```

`renameCase` mirrors `setStarred` (`defer` + optimistic patch + revert in `catchError`) and reuses the existing `updateCaseTitle` patch, now extracted into a shared `patchTitle`.

## Design notes

Four points that are easy to get wrong, all commented in the code:

1. **The whole `__select` button is swapped out**, not just the inner `<span>`. Nesting the input inside the button would be invalid HTML, and a click into the field would fire `onItemSelected` and navigate away from the row being edited.
2. **The editor is abandoned by checking that its input is still rendered**, in the `afterRenderEffect`, rather than by enumerating the reasons a row can vanish. A search filter, compact mode, a deleted case and an ancestor collapsing because the active case changed all destroy the row's view without firing `blur`, so an abandoned draft would otherwise survive and be committed by a later click. There is a test per cause, including the ancestor-collapse one.
3. **The PUT response is deliberately ignored.** `toDto` sets neither `favorite` nor `role`, so merging it back into the signal would silently un-star the case and drop its ADMIN-gated actions until the next full list load. There is a regression test for this. No reload either: a title-only update does not bump `modified`, so the drawer ordering is unaffected.
4. **A blur caused by the window losing focus does not commit.** It is told apart by the input still being `document.activeElement`, which a real focus move updates and a window deactivation does not. Without it, alt-tabbing away mid-edit persists a half-typed name.

The edit state is keyed by case id because `rootItems` rebuilds every tree node whenever `cases()` changes, which the optimistic patch does. The pre-selection only happens on a genuine open, so a tree regroup (starring another case moves rows between groups) recreates the input without wiping a half-typed draft.

## Known limitations

- **No SSE broadcast.** `CaseServiceImpl.update` only routes status changes through the case runtime, so a rename emits no `CaseUpdatedEvent`. Other clients see the new title on their next list load. Same as the existing star behaviour.
- **No server-side validation.** `CaseController.update` does `resource.title ?: existing.title`, a null-guard only, so an empty string would be persisted, and a blank title makes `triggerNamingIfNeeded` re-fire LLM auto-naming on every subsequent message. Hence the strict non-empty check on the client. A dedicated endpoint with `@NotBlank`/`@Size` would be the proper fix, out of scope here.
- **Race with auto-naming.** `CaseNamingService.nameCase` reloads the case then writes `fresh.copy(title = ...)`, so renaming while an LLM naming call is in flight gets overwritten. Narrow window (first user message, first agent turn), backend-side fix only.
- **The revert in `catchError` is unconditional**, so two renames in flight can leave the row showing the older title while the server holds the newer one, behind an explicit failure alert. Same shape as the existing `setStarred`. A compare-and-set revert would fix both.
- `case-drawer.component.ts` grows further past the ~200-line component budget. `caseTitleError` and `MAX_CASE_TITLE_LENGTH` are pure and would sit better in a `case-drawer.utils.ts` with their own spec, which would also let the exact 200-character boundary be asserted directly.

## Testing

- `nx test agentos-ui`: 240 tests, 19 suites, all green. The rename tests cover validation, no-op rename, the double-commit guard, Enter/Escape, blur interleavings, the editor surviving a tree rebuild, and abandonment for each of the four ways a row can disappear. Four of them assert the rendered DOM (the action button's visibility per permission, the input swap and its seeded value, the commit path through the template's own `(blur)`, and the `role="alert"` error with its `aria-describedby` pairing). Service tests cover the optimistic patch, the revert including preserving `undefined`, the absence of a reload, the ignored response, `defer`, and the case-not-in-list path.
- `nx lint agentos-ui`: clean.
- `nx build client`: passes, so templates type-check under AOT.
- Not yet exercised in a browser: the focus behaviour on a real click and the window-blur guard, both of which depend on browser focus semantics that jsdom does not implement.
