### PR TITLE
feat: make exchange agent tools configurable by env

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/integrationConfig/IntegrationTypeDescriptor.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/integrationConfig/IntegrationTypeDescriptor.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.sdk.api.integrationConfig
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.JsonNode
+import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * HTTP response item returned by `GET /api/integration-types` and
@@ -19,6 +20,11 @@ import com.fasterxml.jackson.databind.JsonNode
  * @property builtIn True for built-in integrations enabled by adding their [type] directly to an
  *   agent's `integrations` map (no [IntegrationConfig] instance). False for regular,
  *   instance-backed integration types.
+ * @property enabledByDefault What this instance grants an agent that has made no choice about this
+ *   type — i.e. whose `integrations` map does not mention it at all. An agent's own choice always
+ *   wins, in both directions; this only fills the gap. Clients render it so the "platform default"
+ *   state of a toggle can say which way it resolves. Always false for non-[builtIn] types, which
+ *   are never granted implicitly.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class IntegrationTypeDescriptor(
@@ -27,4 +33,11 @@ data class IntegrationTypeDescriptor(
     val description: String,
     val configSchema: JsonNode?,
     val builtIn: Boolean = false,
+    @field:Schema(
+        description =
+            "What this instance grants an agent whose integrations map does not mention this type at all. " +
+                "An agent's own choice always wins, in both directions; this only fills the gap, so a client can " +
+                "label the \"platform default\" state of a toggle. Always false for non-built-in types.",
+    )
+    val enabledByDefault: Boolean = false,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
@@ -4,6 +4,7 @@ import io.whozoss.agentos.agent.AgentConfigProperties
 import io.whozoss.agentos.caseFlow.CaseConfigProperties
 import io.whozoss.agentos.config.PersistenceConfigProperties
 import io.whozoss.agentos.exchange.ExchangeStorageConfigProperties
+import io.whozoss.agentos.exchange.ExchangeToolsConfigProperties
 import io.whozoss.agentos.service.config.AgentOsPluginsConfigProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -23,6 +24,7 @@ import org.springframework.boot.runApplication
     AgentOsPluginsConfigProperties::class,
     PersistenceConfigProperties::class,
     ExchangeStorageConfigProperties::class,
+    ExchangeToolsConfigProperties::class,
 )
 class AgentOSApplication
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -14,6 +14,7 @@ import io.whozoss.agentos.delegation.SubCaseManager
 import io.whozoss.agentos.exchange.ExchangeCapabilityService
 import io.whozoss.agentos.exchange.ExchangeIntegrationTypes
 import io.whozoss.agentos.exchange.ExchangeStorageService
+import io.whozoss.agentos.exchange.ExchangeToolGrantService
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.metrics.ToolMetricsService
@@ -35,8 +36,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import mu.KLogging
 import org.springframework.stereotype.Service
-import java.nio.file.Files
-import java.nio.file.Path
 import java.util.UUID
 
 /**
@@ -63,6 +62,7 @@ class AgentServiceImpl(
     private val idCompressorService: IdCompressorService,
     private val exchangeStorageService: ExchangeStorageService,
     private val exchangeCapabilityService: ExchangeCapabilityService,
+    private val exchangeToolGrantService: ExchangeToolGrantService,
     private val agentDocumentResolver: AgentDocumentResolver,
     private val agentConfigProperties: AgentConfigProperties,
 ) : AgentService {
@@ -602,70 +602,56 @@ class AgentServiceImpl(
      * [io.whozoss.agentos.exchange.ExchangeController] path, which applies no deny-list (users manage
      * their own files); the two views of the same directory can therefore differ for such files.
      *
-     * Gating is fail-closed (enablement lives in [AgentConfig.integrations], not a dedicated flag):
+     * Gating: the agent's own [AgentConfig.integrations] map decides, with a platform-level fallback
+     * for agents that say nothing at all
+     * ([io.whozoss.agentos.exchange.ExchangeToolsConfigProperties.caseEnabledByDefault] /
+     * [io.whozoss.agentos.exchange.ExchangeToolsConfigProperties.namespaceEnabledByDefault], both off
+     * by default, so an upgrade changes no agent's tool set):
      * - if the file-plugin is not loaded ([ExchangeIntegrationTypes.FILE_ACCESS] absent) → no tools;
-     * - case exchange (read/write) requires the [ExchangeIntegrationTypes.CASE] key AND a live
-     *   [context.caseId];
-     * - namespace exchange requires the [ExchangeIntegrationTypes.NAMESPACE] key; the agent inherits
-     *   the invoking user's namespace right — read/write when the user holds Namespace WRITE
+     * - key absent → the platform default decides, and no per-tool filter applies;
+     * - key present, null → granted, all tools;
+     * - key present, non-empty → granted, filtered to the listed tools;
+     * - key present, empty → explicit opt-out: nothing is granted and no scope directory is created
+     *   (the empty list would otherwise filter every tool out *after* the grant had materialised the
+     *   root);
+     * - the case scope additionally requires a live [context.caseId];
+     * - the namespace scope grants read/write only when the invoking user holds Namespace WRITE
      *   (admin/super-admin), read-only otherwise.
+     *
+     * The default is a decision local to [ExchangeToolGrantService] and never a mutation of
+     * [AgentConfig.integrations]: materialising it in the map would leak into the persisted config,
+     * the YAML export, and the peer descriptions the redirect tool puts in every agent's prompt.
      */
     private fun buildExchangeTools(
         config: AgentConfig,
         context: AgentExecutionContext,
         toolContext: ToolContext,
     ): List<StandardTool<*>> {
-        val filePlugin = toolRegistryService.findPlugin(ExchangeIntegrationTypes.FILE_ACCESS) ?: return emptyList()
-
-        // Point the file-plugin's own tools at the exchange directory for the scope, honouring
-        // the per-tool allowlist carried as the integrations-map value (null = all tools).
-        fun grant(
-            root: Path,
-            readOnly: Boolean,
-            configName: String,
-            allowedTools: List<String>?,
-        ): List<StandardTool<*>> {
-            // Materialise the root before building the plugin tools even for a read-only grant: the
-            // file-plugin's BoundaryPathResolver canonicalises rootPath (toRealPath) at construction,
-            // which throws if the directory does not exist. This is why a read-only resolution (e.g.
-            // the debug getDefinition endpoint) still creates an empty scope dir.
-            Files.createDirectories(root)
-            val cfg =
-                objectMapper
-                    .createObjectNode()
-                    .put("rootPath", root.toAbsolutePath().toString())
-                    .put("readOnly", readOnly)
-                    // Align the agent read tool's size cap with the exchange's own read limit, so an
-                    // agent can read back a file the controller read/download path serves (the plugin
-                    // otherwise falls back to its smaller built-in default). The plugin key is megabytes.
-                    .put("readMaxSizeMb", (exchangeStorageService.readMaxSizeBytes / (1024 * 1024)).coerceAtLeast(1))
-            logger.info { "Granting $configName (FILE_ACCESS, readOnly=$readOnly) to agent '${config.name}' at $root" }
-            // Honour the per-tool allowlist via the same matcher every other integration uses
-            // (accepts both bare and `configName__tool` forms); null = all tools.
-            return filePlugin
-                .provideTools(cfg, configName, toolContext)
-                .filter { toolResolverService.isToolAllowed(it.name, configName, allowedTools) }
-        }
-
-        val integrations = config.integrations ?: emptyMap()
+        val integrations = config.integrations
         val tools = mutableListOf<StandardTool<*>>()
         val caseId = context.caseId
         val caseCreatedAt = context.caseCreatedAt
-        if (integrations.containsKey(ExchangeIntegrationTypes.CASE) && caseId != null && caseCreatedAt != null) {
+
+        val caseGrant = exchangeToolGrantService.resolveCaseGrant(integrations)
+        if (caseGrant != null && caseId != null && caseCreatedAt != null) {
             // The agent gets read/write on the case exchange by design (it produces files during a run).
             // User-facing write is separately gated: the exchange upload/delete endpoints require Case
             // WRITE via @PreAuthorize, and the manifest exposes the computed ExchangeCapability.
             tools +=
-                grant(
-                    exchangeStorageService.caseRoot(context.namespaceId, caseId, caseCreatedAt),
+                exchangeToolGrantService.grantTools(
+                    root = exchangeStorageService.caseRoot(context.namespaceId, caseId, caseCreatedAt),
                     readOnly = false,
                     configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
-                    allowedTools = integrations[ExchangeIntegrationTypes.CASE],
+                    allowedTools = caseGrant.allowedTools,
+                    toolContext = toolContext,
                 )
         }
-        if (integrations.containsKey(ExchangeIntegrationTypes.NAMESPACE)) {
+
+        val namespaceGrant = exchangeToolGrantService.resolveNamespaceGrant(integrations)
+        if (namespaceGrant != null) {
             // The agent inherits the invoking user's namespace right: read/write for a namespace
-            // admin (Namespace WRITE, super-admin included), read-only for a plain member.
+            // admin (Namespace WRITE, super-admin included), read-only for a plain member. Resolved
+            // only once the grant stands, so a scope nobody was granted costs no permission query.
             val userCanWriteNamespace =
                 context.userId?.let {
                     exchangeCapabilityService.canWrite(
@@ -675,11 +661,12 @@ class AgentServiceImpl(
                     )
                 } ?: false
             tools +=
-                grant(
-                    exchangeStorageService.namespaceRoot(context.namespaceId),
+                exchangeToolGrantService.grantTools(
+                    root = exchangeStorageService.namespaceRoot(context.namespaceId),
                     readOnly = !userCanWriteNamespace,
                     configName = ExchangeIntegrationTypes.NAMESPACE_CONFIG_NAME,
-                    allowedTools = integrations[ExchangeIntegrationTypes.NAMESPACE],
+                    allowedTools = namespaceGrant.allowedTools,
+                    toolContext = toolContext,
                 )
         }
         return tools

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -614,9 +614,14 @@ class AgentServiceImpl(
      * - key present, empty → explicit opt-out: nothing is granted and no scope directory is created
      *   (the empty list would otherwise filter every tool out *after* the grant had materialised the
      *   root);
-     * - the case scope additionally requires a live [context.caseId];
-     * - the namespace scope grants read/write only when the invoking user holds Namespace WRITE
-     *   (admin/super-admin), read-only otherwise.
+     * - the case scope additionally requires a live [context.caseId]; it needs no permission gate of
+     *   its own because its root is the run's own case, which the invoking user already holds Case
+     *   WRITE on to have reached this point;
+     * - the namespace scope requires the invoking user to hold Namespace READ, the same floor every
+     *   REST namespace-file endpoint enforces via `@PreAuthorize`. A run without an identified user
+     *   is denied fail-closed, so a definition preview resolved without a user reports no namespace
+     *   exchange tools. Read/write when the user also holds Namespace WRITE (admin/super-admin),
+     *   read-only otherwise.
      *
      * The default is a decision local to [ExchangeToolGrantService] and never a mutation of
      * [AgentConfig.integrations]: materialising it in the map would leak into the persisted config,
@@ -648,26 +653,38 @@ class AgentServiceImpl(
         }
 
         val namespaceGrant = exchangeToolGrantService.resolveNamespaceGrant(integrations)
-        if (namespaceGrant != null) {
-            // The agent inherits the invoking user's namespace right: read/write for a namespace
-            // admin (Namespace WRITE, super-admin included), read-only for a plain member. Resolved
-            // only once the grant stands, so a scope nobody was granted costs no permission query.
-            val userCanWriteNamespace =
-                context.userId?.let {
-                    exchangeCapabilityService.canWrite(
-                        it.toString(),
-                        EntityType.NAMESPACE,
-                        context.namespaceId.toString(),
-                    )
-                } ?: false
-            tools +=
-                exchangeToolGrantService.grantTools(
-                    root = exchangeStorageService.namespaceRoot(context.namespaceId),
-                    readOnly = !userCanWriteNamespace,
-                    configName = ExchangeIntegrationTypes.NAMESPACE_CONFIG_NAME,
-                    allowedTools = namespaceGrant.allowedTools,
-                    toolContext = toolContext,
+        // The agent inherits the invoking user's namespace rights. Namespace READ is the floor the
+        // REST namespace-file endpoints already enforce via @PreAuthorize, so the agent path must
+        // hold it too: a user with only a direct Case edge must not read the whole namespace
+        // exchange through an agent. A run without an identified user is denied fail-closed. The
+        // permission queries run only once the grant stands, so a scope nobody was granted costs
+        // no permission query.
+        val namespaceUserId = context.userId?.toString()
+        if (namespaceGrant != null && namespaceUserId != null) {
+            val userCanReadNamespace =
+                exchangeCapabilityService.canRead(
+                    userId = namespaceUserId,
+                    entityType = EntityType.NAMESPACE,
+                    entityId = context.namespaceId.toString(),
                 )
+            if (userCanReadNamespace) {
+                // Read/write for a namespace admin (Namespace WRITE, super-admin included),
+                // read-only for a plain member.
+                val userCanWriteNamespace =
+                    exchangeCapabilityService.canWrite(
+                        userId = namespaceUserId,
+                        entityType = EntityType.NAMESPACE,
+                        entityId = context.namespaceId.toString(),
+                    )
+                tools +=
+                    exchangeToolGrantService.grantTools(
+                        root = exchangeStorageService.namespaceRoot(context.namespaceId),
+                        readOnly = !userCanWriteNamespace,
+                        configName = ExchangeIntegrationTypes.NAMESPACE_CONFIG_NAME,
+                        allowedTools = namespaceGrant.allowedTools,
+                        toolContext = toolContext,
+                    )
+            }
         }
         return tools
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
@@ -15,13 +15,14 @@ import java.util.UUID
  * by an AiProvider — resolution is deferred to the runtime layer.
  *
  * [integrations] is an optional map from integration name to an optional list of
- * allowed tool names. A null map binds no integration at all: the tool resolver
- * grants no tools, and only the platform-level exchange defaults (see the property
- * KDoc below) can still add the built-in file tools. When set, only tools whose
- * integration key matches an entry in this map are given to the agent. A null list
- * for a given key means all tools from that integration are allowed; a non-null
- * list restricts to exactly those tool names (or suffixes for multi-instance tools
- * named `CONFIG__tool`).
+ * allowed tool names. The map is what the agent declares, key by key: a plugin
+ * integration contributes tools only when its name appears as an entry, so a null
+ * map binds none of them at all. The two built-in exchange keys are the exception,
+ * and they are decided per key rather than per map: an absent key defers to the
+ * platform default (see the property KDoc below), whether the rest of the map is
+ * set or not. A null list for a given key means all tools from that integration are
+ * allowed; a non-null list restricts to exactly those tool names (or suffixes for
+ * multi-instance tools named `CONFIG__tool`).
  *
  * Examples (from a Coday-style agent YAML):
  * ```yaml

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
@@ -55,7 +55,11 @@ data class AgentConfig(
      * Reserved keys `CASE_FILE_EXCHANGE` / `NAMESPACE_FILE_EXCHANGE`
      * (see [io.whozoss.agentos.exchange.ExchangeIntegrationTypes]) enable the built-in
      * file-exchange integrations: they have no [IntegrationConfig] instance and are resolved by
-     * `AgentServiceImpl.buildExchangeTools` rather than the normal plugin path.
+     * `AgentServiceImpl.buildExchangeTools` rather than the normal plugin path. For those two keys
+     * only, an **empty list is an explicit opt-out** rather than an empty allow-list, and an
+     * **absent key does not mean "never granted"**: the platform defaults
+     * `agentos.exchange.tools.case-enabled-by-default` /
+     * `...namespace-enabled-by-default` (off by default) decide for an agent that stays silent.
      */
     val integrations: Map<String, List<String>?>? = null,
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfig.kt
@@ -15,11 +15,13 @@ import java.util.UUID
  * by an AiProvider — resolution is deferred to the runtime layer.
  *
  * [integrations] is an optional map from integration name to an optional list of
- * allowed tool names. When null, the agent receives all tools available in the
- * namespace (no filtering). When set, only tools whose integration key matches an
- * entry in this map are given to the agent. A null list for a given key means all
- * tools from that integration are allowed; a non-null list restricts to exactly
- * those tool names (or suffixes for multi-instance tools named `CONFIG__tool`).
+ * allowed tool names. A null map binds no integration at all: the tool resolver
+ * grants no tools, and only the platform-level exchange defaults (see the property
+ * KDoc below) can still add the built-in file tools. When set, only tools whose
+ * integration key matches an entry in this map are given to the agent. A null list
+ * for a given key means all tools from that integration are allowed; a non-null
+ * list restricts to exactly those tool names (or suffixes for multi-instance tools
+ * named `CONFIG__tool`).
  *
  * Examples (from a Coday-style agent YAML):
  * ```yaml
@@ -47,7 +49,10 @@ data class AgentConfig(
     val instructions: String? = null,
     val modelName: String? = null,
     /**
-     * Optional tool-access filter. null = no restriction (all namespace tools).
+     * Integration bindings with an optional per-tool allowlist. null = no bindings:
+     * [io.whozoss.agentos.tool.ToolResolverService] then resolves no tools for this agent
+     * (only the platform exchange defaults described below can still grant the built-in
+     * file tools).
      * Map key = integration name (matches [IntegrationConfig.name] or
      * [ToolPlugin.integrationType] for config-less plugins).
      * Map value = allowed tool names, or null for all tools of that integration.
@@ -60,6 +65,8 @@ data class AgentConfig(
      * **absent key does not mean "never granted"**: the platform defaults
      * `agentos.exchange.tools.case-enabled-by-default` /
      * `...namespace-enabled-by-default` (off by default) decide for an agent that stays silent.
+     * The namespace key is further gated at run time: whatever this map says, the scope is only
+     * granted when the invoking user holds Namespace READ.
      */
     val integrations: Map<String, List<String>?>? = null,
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
@@ -1,6 +1,5 @@
 package io.whozoss.agentos.agentConfig
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -262,7 +261,13 @@ class AgentConfigController(
          * YAML mapper configured for clean, human-readable output:
          * - No `---` document start marker
          * - No Jackson type tags
-         * - Null and empty values omitted (via [toExportModel] filtering + NON_EMPTY inclusion)
+         * - Null and empty top-level values omitted by [toExportModel] itself
+         *
+         * Deliberately no mapper-level inclusion policy: `setSerializationInclusion` also sets the
+         * CONTENT inclusion, which prunes entries inside the `integrations` map. There a null value
+         * ("all tools of the integration") and an empty list (explicit opt-out) are distinct,
+         * meaningful states that must survive the export so the file re-imports identically through
+         * [FilesystemAgentConfigRepository].
          */
         private val YAML_MAPPER: ObjectMapper =
             ObjectMapper(
@@ -272,7 +277,6 @@ class AgentConfigController(
                     .build(),
             ).registerModule(KotlinModule.Builder().build())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
     }
 }
 
@@ -320,9 +324,10 @@ internal fun toDto(entity: AgentConfig) =
  * Only the fields that [FilesystemAgentConfigRepository] reads are included, so the exported
  * file can be dropped directly into the namespace `agents/` directory.
  *
- * The map is built explicitly rather than via a data class so that null/empty values can be
- * omitted without a per-field `@JsonInclude` annotation. The YAML_MAPPER's
- * `NON_EMPTY` inclusion policy then handles the rest.
+ * The map is built explicitly rather than via a data class so that null/empty top-level values
+ * can be omitted without a per-field `@JsonInclude` annotation. Entries inside a non-empty
+ * `integrations` map are kept verbatim: a null value (all tools of the integration) and an
+ * empty list (explicit opt-out) are distinct states the re-import must see unchanged.
  */
 private fun toExportModel(entity: AgentConfig): Map<String, Any?> =
     buildMap {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/AgentConfigController.kt
@@ -261,7 +261,7 @@ class AgentConfigController(
          * YAML mapper configured for clean, human-readable output:
          * - No `---` document start marker
          * - No Jackson type tags
-         * - Null and empty top-level values omitted by [toExportModel] itself
+         * - Null, blank and empty top-level values omitted by [toExportModel] itself
          *
          * Deliberately no mapper-level inclusion policy: `setSerializationInclusion` also sets the
          * CONTENT inclusion, which prunes entries inside the `integrations` map. There a null value
@@ -324,17 +324,18 @@ internal fun toDto(entity: AgentConfig) =
  * Only the fields that [FilesystemAgentConfigRepository] reads are included, so the exported
  * file can be dropped directly into the namespace `agents/` directory.
  *
- * The map is built explicitly rather than via a data class so that null/empty top-level values
- * can be omitted without a per-field `@JsonInclude` annotation. Entries inside a non-empty
- * `integrations` map are kept verbatim: a null value (all tools of the integration) and an
- * empty list (explicit opt-out) are distinct states the re-import must see unchanged.
+ * The map is built explicitly rather than via a data class so that null, blank and empty top-level
+ * values can be omitted without a per-field `@JsonInclude` annotation. Doing it here rather than
+ * with a mapper-level inclusion policy is what keeps the filtering out of the `integrations` map,
+ * whose entries are kept verbatim: a null value (all tools of the integration) and an empty list
+ * (explicit opt-out) are distinct states the re-import must see unchanged.
  */
 private fun toExportModel(entity: AgentConfig): Map<String, Any?> =
     buildMap {
         put("name", entity.name)
-        entity.description?.let { put("description", it) }
-        entity.instructions?.let { put("instructions", it) }
-        entity.modelName?.let { put("modelName", it) }
+        entity.description?.takeIf { it.isNotBlank() }?.let { put("description", it) }
+        entity.instructions?.takeIf { it.isNotBlank() }?.let { put("instructions", it) }
+        entity.modelName?.takeIf { it.isNotBlank() }?.let { put("modelName", it) }
         entity.integrations?.takeIf { it.isNotEmpty() }?.let { put("integrations", it) }
         entity.subAgents?.takeIf { it.isNotEmpty() }?.let { put("subAgents", it) }
         entity.docs?.takeIf { it.isNotEmpty() }?.let { put("docs", it) }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeCapabilityService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeCapabilityService.kt
@@ -7,19 +7,26 @@ import io.whozoss.agentos.sdk.api.exchange.ExchangeCapability
 import org.springframework.stereotype.Service
 
 /**
- * Single source of truth for "can this user write this exchange scope" and the resulting
- * [ExchangeCapability].
+ * Single source of truth for the exchange scope permission checks ([canRead], [canWrite]) and the
+ * resulting [ExchangeCapability].
  *
  * Consumed both by the REST layer ([ExchangeController] — the manifest's server-computed capability)
  * and by the agent tool-grant path ([io.whozoss.agentos.agent.AgentServiceImpl.buildExchangeTools] —
- * the namespace grant's `readOnly` flag), so the two never diverge: the write rule is defined here
- * once. Write == the entity's WRITE permission (Case/Namespace ADMIN, super-admin included), per the
- * permission model.
+ * the namespace grant's READ gate and its `readOnly` flag), so the two never diverge: the rules are
+ * defined here once. Read == the entity's READ permission, write == the entity's WRITE permission
+ * (Case/Namespace ADMIN, super-admin included), per the permission model.
  */
 @Service
 class ExchangeCapabilityService(
     private val permissionService: PermissionService,
 ) {
+    /** True when [userId] may read the given exchange scope entity. */
+    fun canRead(
+        userId: String,
+        entityType: EntityType,
+        entityId: String,
+    ): Boolean = permissionService.hasPermission(userId, entityType, entityId, Action.READ)
+
     /** True when [userId] may write the given exchange scope entity. */
     fun canWrite(
         userId: String,
@@ -28,8 +35,8 @@ class ExchangeCapabilityService(
     ): Boolean = permissionService.hasPermission(userId, entityType, entityId, Action.WRITE)
 
     /**
-     * The caller's capability over the scope. READ is the floor (callers already hold READ via
-     * `@PreAuthorize`); upgrades to READ_WRITE when [canWrite] holds.
+     * The caller's capability over the scope. READ is the floor (the REST callers already hold READ
+     * via `@PreAuthorize`); upgrades to READ_WRITE when [canWrite] holds.
      */
     fun capability(
         userId: String,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeIntegrationTypes.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeIntegrationTypes.kt
@@ -26,8 +26,17 @@ object ExchangeIntegrationTypes {
     const val CASE_CONFIG_NAME = "case-exchange"
     const val NAMESPACE_CONFIG_NAME = "namespace-exchange"
 
-    /** Catalogue descriptors for the built-in exchange integrations (toggle-only, no config). */
-    fun builtInDescriptors(): List<IntegrationTypeDescriptor> =
+    /**
+     * Catalogue descriptors for the built-in exchange integrations (toggle-only, no config).
+     *
+     * The two flags come from [ExchangeToolsConfigProperties] and are published so a client can tell
+     * what an agent that made no choice actually gets. They describe the fallback only: an agent that
+     * declares the key wins in both directions.
+     */
+    fun builtInDescriptors(
+        caseEnabledByDefault: Boolean,
+        namespaceEnabledByDefault: Boolean,
+    ): List<IntegrationTypeDescriptor> =
         listOf(
             IntegrationTypeDescriptor(
                 type = CASE,
@@ -35,6 +44,7 @@ object ExchangeIntegrationTypes {
                 description = "Read/write access to the files shared within the current case.",
                 configSchema = null,
                 builtIn = true,
+                enabledByDefault = caseEnabledByDefault,
             ),
             IntegrationTypeDescriptor(
                 type = NAMESPACE,
@@ -42,6 +52,7 @@ object ExchangeIntegrationTypes {
                 description = "Read access to the namespace's shared files; read/write for namespace admins.",
                 configSchema = null,
                 builtIn = true,
+                enabledByDefault = namespaceEnabledByDefault,
             ),
         )
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeStorageService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeStorageService.kt
@@ -49,13 +49,6 @@ class ExchangeStorageService(
     private val mountRoot: Path = Path.of(config.mountRoot)
 
     /**
-     * Read size cap (bytes) applied to the user-facing read/download path. Also surfaced to the agent
-     * file-plugin grant so the agent's read tool honours the same limit on the same directories rather
-     * than the plugin's smaller built-in default.
-     */
-    val readMaxSizeBytes: Long get() = config.readMaxSizeBytes
-
-    /**
      * Whether an upload with this relative path passes the configured extension allow-list.
      * An empty [ExchangeStorageConfigProperties.allowedUploadExtensions] allows any extension.
      *

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantService.kt
@@ -33,12 +33,14 @@ data class ExchangeGrant(
  * Split out of [io.whozoss.agentos.agent.AgentServiceImpl] so that the Spring-bound tuning
  * ([ExchangeToolsConfigProperties]) and the JSON node it produces live next to the rest of the
  * exchange and can be exercised without standing up an agent. `AgentServiceImpl` keeps what only it
- * knows — the run's case id and the invoking user's Namespace WRITE right — and calls
+ * knows — the run's case id and the invoking user's Namespace READ/WRITE rights — and calls
  * [resolveCaseGrant] / [resolveNamespaceGrant], then [grantTools].
  *
- * Deciding and granting are two calls on purpose: resolving is free, whereas [grantTools] creates
- * the scope directory and its namespace caller needs a permission query to compute `readOnly`. A
- * scope nobody was granted must cost neither.
+ * Deciding and granting are two calls on purpose: resolving costs only an in-memory plugin-registry
+ * lookup, whereas [grantTools] creates the scope directory and the namespace caller needs
+ * permission queries before it can call [grantTools]. A scope nobody was granted must cost neither.
+ * That is also why resolution already denies when the file-plugin is absent: on a plugin-less
+ * instance no grant could ever produce a tool, so no caller should pay a permission query for one.
  */
 @Service
 class ExchangeToolGrantService(
@@ -70,6 +72,8 @@ class ExchangeToolGrantService(
      * [resolveGrant], upstream of this call, rather than by the tool-name filter.
      *
      * Fail-closed and side-effect free when the file-plugin is not loaded: no tools, no directory.
+     * [resolveGrant] already denies in that case, so this check is defence in depth for a caller
+     * that reaches [grantTools] without a resolution.
      */
     fun grantTools(
         root: Path,
@@ -98,6 +102,9 @@ class ExchangeToolGrantService(
 
     /**
      * Resolves the enablement cases for one built-in exchange integration key:
+     * - file-plugin absent   → no grant, whatever the declaration: no grant could produce a tool,
+     *                          and resolving one anyway would make the namespace caller pay its
+     *                          permission queries for nothing;
      * - key absent           → [enabledByDefault] decides; a default grant exposes every tool;
      * - key present, null    → the agent enables the scope with every tool;
      * - key present, `[]`    → the agent opts out: no grant, hence no scope directory;
@@ -119,6 +126,7 @@ class ExchangeToolGrantService(
         val declared = integrations?.containsKey(integrationKey) == true
         val declaration = integrations?.get(integrationKey)
         return when {
+            toolRegistryService.findPlugin(ExchangeIntegrationTypes.FILE_ACCESS) == null -> null
             !declared && enabledByDefault -> ExchangeGrant(allowedTools = null)
             !declared -> null
             declaration == null -> ExchangeGrant(allowedTools = null)
@@ -135,6 +143,11 @@ class ExchangeToolGrantService(
      * derives from the exchange read cap so the agent's read tools honour the same limit as the REST
      * read/download path rather than the plugin's smaller built-in default — the plugin key is
      * megabytes, floored at 1.
+     *
+     * Nothing validates the bound properties themselves, so the values whose out-of-range settings
+     * would break the plugin's tools deep inside a tool call, far from the misconfiguration that
+     * caused them, are clamped here. Only those: a value the tools degrade gracefully on (e.g. a
+     * zero `documentMaxAttachedImages` or `imageMaxSourcePixels`) is passed through as configured.
      */
     private fun buildFileToolConfig(
         root: Path,
@@ -147,16 +160,20 @@ class ExchangeToolGrantService(
                 .put("readOnly", readOnly)
                 .put("readMaxSizeMb", (storageProperties.readMaxSizeBytes / (1024 * 1024)).coerceAtLeast(1))
                 .put("imageMaxDimension", properties.imageMaxDimension)
-                // Clamped: the JPEG writer rejects a quality outside [0, 1] with an
-                // IllegalArgumentException raised deep inside a tool call, long after the bad value
-                // was set. Nothing validates the bound properties themselves.
+                // Clamped: the JPEG writer rejects a quality outside [0, 1].
                 .put("imageJpegQuality", properties.imageJpegQuality.coerceIn(0f, 1f))
                 .put("imageMaxSourcePixels", properties.imageMaxSourcePixels)
                 .put("imagePassThroughMaxBytes", properties.imagePassThroughMaxBytes)
-                .put("documentMaxOutputChars", properties.documentMaxOutputChars)
+                // Floored at 1: with a non-positive budget readDocument's paging never advances;
+                // the [truncated] notice keeps pointing the model at the same startElement.
+                .put("documentMaxOutputChars", properties.documentMaxOutputChars.coerceAtLeast(1))
                 .put("documentMaxAttachedImages", properties.documentMaxAttachedImages)
-                .put("documentMaxTableColumns", properties.documentMaxTableColumns)
-                .put("documentMaxCellChars", properties.documentMaxCellChars)
+                // Floored at 1: readDocument's column cap is a coerceIn(1, max) whose range is
+                // empty below 1, throwing on every table-bearing document.
+                .put("documentMaxTableColumns", properties.documentMaxTableColumns.coerceAtLeast(1))
+                // Floored at 0: a negative cell cap makes readDocument call String.take with a
+                // negative count, which throws; zero is a legal (if drastic) truncation.
+                .put("documentMaxCellChars", properties.documentMaxCellChars.coerceAtLeast(0))
         // The plugin reads this key with `takeIf { it.isArray }`, so it must be a real ArrayNode —
         // an empty one when nothing is configured, never a missing key or a scalar. putArray returns
         // the ArrayNode, hence the separate statement.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantService.kt
@@ -1,0 +1,169 @@
+package io.whozoss.agentos.exchange
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.tool.ToolRegistryService
+import io.whozoss.agentos.tool.ToolResolverService
+import mu.KLogging
+import org.springframework.stereotype.Service
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * A resolved decision to expose one exchange scope to an agent.
+ *
+ * Only ever produced by [ExchangeToolGrantService]; the absence of an instance (a null
+ * [ExchangeGrant]) *is* the "not granted" case, so the tools of a scope an agent opted out of cannot
+ * be built by accident.
+ *
+ * [allowedTools] mirrors the value carried by the agent's `integrations` map: null exposes every
+ * tool the file-plugin provides, a non-empty list restricts to those names (bare or
+ * `<configName>__<tool>`). An empty list never reaches here — it is the opt-out and yields no grant.
+ */
+data class ExchangeGrant(
+    val allowedTools: List<String>?,
+)
+
+/**
+ * Owns the exchange → file-plugin grant: whether a scope is exposed to an agent, and with which
+ * plugin configuration.
+ *
+ * Split out of [io.whozoss.agentos.agent.AgentServiceImpl] so that the Spring-bound tuning
+ * ([ExchangeToolsConfigProperties]) and the JSON node it produces live next to the rest of the
+ * exchange and can be exercised without standing up an agent. `AgentServiceImpl` keeps what only it
+ * knows — the run's case id and the invoking user's Namespace WRITE right — and calls
+ * [resolveCaseGrant] / [resolveNamespaceGrant], then [grantTools].
+ *
+ * Deciding and granting are two calls on purpose: resolving is free, whereas [grantTools] creates
+ * the scope directory and its namespace caller needs a permission query to compute `readOnly`. A
+ * scope nobody was granted must cost neither.
+ */
+@Service
+class ExchangeToolGrantService(
+    private val properties: ExchangeToolsConfigProperties,
+    private val storageProperties: ExchangeStorageConfigProperties,
+    private val toolRegistryService: ToolRegistryService,
+    private val toolResolverService: ToolResolverService,
+    private val objectMapper: ObjectMapper,
+) {
+    /**
+     * The case exchange grant implied by an agent's [integrations] map, or null when the scope must
+     * not be exposed. See [resolveGrant] for the cases.
+     */
+    fun resolveCaseGrant(integrations: Map<String, List<String>?>?): ExchangeGrant? =
+        resolveGrant(ExchangeIntegrationTypes.CASE, properties.caseEnabledByDefault, integrations)
+
+    /** The namespace exchange grant implied by an agent's [integrations] map, or null. */
+    fun resolveNamespaceGrant(integrations: Map<String, List<String>?>?): ExchangeGrant? =
+        resolveGrant(ExchangeIntegrationTypes.NAMESPACE, properties.namespaceEnabledByDefault, integrations)
+
+    /**
+     * Builds the file-plugin tools for one exchange scope rooted at [root], filtered through
+     * [allowedTools].
+     *
+     * Materialises [root] before building the tools even for a read-only grant: the file-plugin's
+     * BoundaryPathResolver canonicalises `rootPath` (toRealPath) at construction, which throws if the
+     * directory does not exist. This is why a read-only resolution (e.g. the debug getDefinition
+     * endpoint) still creates an empty scope dir — and why an opt-out has to be caught by
+     * [resolveGrant], upstream of this call, rather than by the tool-name filter.
+     *
+     * Fail-closed and side-effect free when the file-plugin is not loaded: no tools, no directory.
+     */
+    fun grantTools(
+        root: Path,
+        readOnly: Boolean,
+        configName: String,
+        allowedTools: List<String>?,
+        toolContext: ToolContext,
+    ): List<StandardTool<*>> {
+        val filePlugin = toolRegistryService.findPlugin(ExchangeIntegrationTypes.FILE_ACCESS)
+        return when (filePlugin) {
+            null -> emptyList()
+            else -> {
+                Files.createDirectories(root)
+                logger.info {
+                    "Granting $configName (FILE_ACCESS, readOnly=$readOnly) " +
+                        "to agent '${toolContext.agentName}' at $root"
+                }
+                // Honour the per-tool allowlist via the same matcher every other integration uses
+                // (accepts both bare and `configName__tool` forms); null = all tools.
+                filePlugin
+                    .provideTools(buildFileToolConfig(root, readOnly), configName, toolContext)
+                    .filter { toolResolverService.isToolAllowed(it.name, configName, allowedTools) }
+            }
+        }
+    }
+
+    /**
+     * Resolves the enablement cases for one built-in exchange integration key:
+     * - key absent           → [enabledByDefault] decides; a default grant exposes every tool;
+     * - key present, null    → the agent enables the scope with every tool;
+     * - key present, `[]`    → the agent opts out: no grant, hence no scope directory;
+     * - key present, filled  → the agent enables the scope, restricted to those tool names.
+     *
+     * The empty list is a genuine opt-out rather than an empty allow-list.
+     * [ToolResolverService.isToolAllowed] would already reject every tool, but [grantTools] creates
+     * the scope directory before that filter runs, so the decision has to short-circuit here to keep
+     * the exchange free of phantom directories.
+     *
+     * `containsKey` and `get` are both needed: a key absent and a key mapped to null are
+     * indistinguishable through `get` alone, yet they mean opposite things here.
+     */
+    private fun resolveGrant(
+        integrationKey: String,
+        enabledByDefault: Boolean,
+        integrations: Map<String, List<String>?>?,
+    ): ExchangeGrant? {
+        val declared = integrations?.containsKey(integrationKey) == true
+        val declaration = integrations?.get(integrationKey)
+        return when {
+            !declared && enabledByDefault -> ExchangeGrant(allowedTools = null)
+            !declared -> null
+            declaration == null -> ExchangeGrant(allowedTools = null)
+            declaration.isEmpty() -> null
+            else -> ExchangeGrant(allowedTools = declaration)
+        }
+    }
+
+    /**
+     * The configuration node handed to the file-plugin's `provideTools`.
+     *
+     * Every key the plugin knows is emitted, so its compiled fallbacks only ever apply to a jar older
+     * than a key. [root] and [readOnly] come from the caller (computed per run); `readMaxSizeMb`
+     * derives from the exchange read cap so the agent's read tools honour the same limit as the REST
+     * read/download path rather than the plugin's smaller built-in default — the plugin key is
+     * megabytes, floored at 1.
+     */
+    private fun buildFileToolConfig(
+        root: Path,
+        readOnly: Boolean,
+    ): ObjectNode {
+        val node =
+            objectMapper
+                .createObjectNode()
+                .put("rootPath", root.toAbsolutePath().toString())
+                .put("readOnly", readOnly)
+                .put("readMaxSizeMb", (storageProperties.readMaxSizeBytes / (1024 * 1024)).coerceAtLeast(1))
+                .put("imageMaxDimension", properties.imageMaxDimension)
+                // Clamped: the JPEG writer rejects a quality outside [0, 1] with an
+                // IllegalArgumentException raised deep inside a tool call, long after the bad value
+                // was set. Nothing validates the bound properties themselves.
+                .put("imageJpegQuality", properties.imageJpegQuality.coerceIn(0f, 1f))
+                .put("imageMaxSourcePixels", properties.imageMaxSourcePixels)
+                .put("imagePassThroughMaxBytes", properties.imagePassThroughMaxBytes)
+                .put("documentMaxOutputChars", properties.documentMaxOutputChars)
+                .put("documentMaxAttachedImages", properties.documentMaxAttachedImages)
+                .put("documentMaxTableColumns", properties.documentMaxTableColumns)
+                .put("documentMaxCellChars", properties.documentMaxCellChars)
+        // The plugin reads this key with `takeIf { it.isArray }`, so it must be a real ArrayNode —
+        // an empty one when nothing is configured, never a missing key or a scalar. putArray returns
+        // the ArrayNode, hence the separate statement.
+        val denyPatterns = node.putArray("extraDenyPatterns")
+        properties.extraDenyPatterns.forEach { denyPatterns.add(it) }
+        return node
+    }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolsConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolsConfigProperties.kt
@@ -45,7 +45,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *     tools:
  *       case-enabled-by-default: true
  *       image-max-dimension: 1568
- *       extra-deny-patterns: "*.bak,internal-*"
+ *       extra-deny-patterns: "*.bak,*confidential*"
  * ```
  */
 @ConfigurationProperties(prefix = "agentos.exchange.tools")
@@ -61,15 +61,24 @@ data class ExchangeToolsConfigProperties(
      */
     val caseEnabledByDefault: Boolean = false,
     /**
-     * Same platform default for [ExchangeIntegrationTypes.NAMESPACE]. Write access still follows the
-     * invoking user's Namespace WRITE right, so turning this on widens what an agent can read, never
-     * what it can write.
+     * Same platform default for [ExchangeIntegrationTypes.NAMESPACE]. Every namespace grant, this
+     * default included, additionally requires the invoking user to hold Namespace READ; a run
+     * without an identified user is denied (fail-closed). Write access follows the user's
+     * Namespace WRITE right.
      */
     val namespaceEnabledByDefault: Boolean = false,
     /**
-     * Glob patterns blocked on top of the plugin's built-in sensitive-file list (`.env`, `*.key`,
+     * Patterns blocked on top of the plugin's built-in sensitive-file list (`.env`, `*.key`,
      * `*.pem`, ...). Additive only: an instance can harden the deny-list for its own naming
      * conventions, it can never weaken the built-in one.
+     *
+     * A pattern matches the final path segment only (the file or directory name), never the full
+     * relative path, with the plugin's simple matcher (`matchesPattern`): `*suffix`, `prefix*`,
+     * `*contains*` or an exact name. A pattern containing a slash therefore matches nothing, and a
+     * directory-scoped intent does not carry: `internal-*` denies the directory entry
+     * `internal-reports` while a read of the file `summary.md` inside it still passes, because only
+     * that leaf name is tested. To fence off content, use name patterns that hold at every depth,
+     * like `*.bak` or `*confidential*`.
      */
     val extraDenyPatterns: List<String> = emptyList(),
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolsConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/exchange/ExchangeToolsConfigProperties.kt
@@ -1,0 +1,119 @@
+package io.whozoss.agentos.exchange
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Platform-level policy for the file-plugin tools granted on the exchange scopes: which agents get
+ * them at all, and how those tools behave.
+ *
+ * Bound from the `agentos.exchange.tools` prefix in application.yml.
+ *
+ * The SDK and the plugins carry no Spring dependency — a [io.whozoss.agentos.sdk.tool.ToolPlugin]
+ * receives its whole configuration as the `JsonNode` handed to `provideTools`. This class is
+ * therefore the service-side home of every knob the file-plugin reads, and [ExchangeToolGrantService]
+ * is what turns it into that node. A plugin jar predating one of these keys simply ignores it and
+ * falls back to its own compiled default.
+ *
+ * One single set of values is shared by the case and the namespace scope: an agent sees the same
+ * limits wherever a file lives, and an operator gets one knob per concern rather than two. The
+ * plugin's three remaining keys are deliberately absent here — `rootPath` and `readOnly` are
+ * computed per run (scope root, invoking user's Namespace WRITE right), and `readMaxSizeMb` derives
+ * from `agentos.exchange.read-max-size-bytes` so the agent read cap can never drift from the one the
+ * REST read/download path enforces.
+ *
+ * The tuning defaults below duplicate the file-plugin's own constants (`ImageProcessor`,
+ * `ReadDocumentTool`): the plugin is a separate, Spring-free module whose classes are not on the
+ * service classpath, so they cannot be imported. Keep the two in sync when the plugin moves.
+ *
+ * Override with environment variables (Spring Boot relaxed binding):
+ * - AGENTOS_EXCHANGE_TOOLS_CASE_ENABLED_BY_DEFAULT
+ * - AGENTOS_EXCHANGE_TOOLS_NAMESPACE_ENABLED_BY_DEFAULT
+ * - AGENTOS_EXCHANGE_TOOLS_EXTRA_DENY_PATTERNS (comma-separated)
+ * - AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_DIMENSION
+ * - AGENTOS_EXCHANGE_TOOLS_IMAGE_JPEG_QUALITY
+ * - AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_SOURCE_PIXELS
+ * - AGENTOS_EXCHANGE_TOOLS_IMAGE_PASS_THROUGH_MAX_BYTES
+ * - AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_OUTPUT_CHARS
+ * - AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_ATTACHED_IMAGES
+ * - AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_TABLE_COLUMNS
+ * - AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_CELL_CHARS
+ *
+ * Example (application.yml):
+ * ```yaml
+ * agentos:
+ *   exchange:
+ *     tools:
+ *       case-enabled-by-default: true
+ *       image-max-dimension: 1568
+ *       extra-deny-patterns: "*.bak,internal-*"
+ * ```
+ */
+@ConfigurationProperties(prefix = "agentos.exchange.tools")
+data class ExchangeToolsConfigProperties(
+    /**
+     * Grants the case exchange to every agent that does not mention
+     * [ExchangeIntegrationTypes.CASE] in its `integrations` map.
+     *
+     * Off by default so switching it on stays an explicit operator decision: a default grant
+     * materialises a case exchange directory for every case a granted agent runs in, and widens the
+     * tool set every agent advertises to its LLM. An agent that declares the key always wins,
+     * including with an empty list — the explicit opt-out.
+     */
+    val caseEnabledByDefault: Boolean = false,
+    /**
+     * Same platform default for [ExchangeIntegrationTypes.NAMESPACE]. Write access still follows the
+     * invoking user's Namespace WRITE right, so turning this on widens what an agent can read, never
+     * what it can write.
+     */
+    val namespaceEnabledByDefault: Boolean = false,
+    /**
+     * Glob patterns blocked on top of the plugin's built-in sensitive-file list (`.env`, `*.key`,
+     * `*.pem`, ...). Additive only: an instance can harden the deny-list for its own naming
+     * conventions, it can never weaken the built-in one.
+     */
+    val extraDenyPatterns: List<String> = emptyList(),
+    /**
+     * Longest-edge size, in pixels, of the images `readAsImage` and `readDocument` hand to the LLM;
+     * larger ones are downscaled. The right value tracks the vision model in use, which is why it
+     * belongs to the instance rather than to a constant.
+     */
+    val imageMaxDimension: Int = 1024,
+    /**
+     * JPEG re-encoding quality, in `[0, 1]`, for those same two tools: prompt bytes traded against
+     * the legibility of screenshots and scans. [ExchangeToolGrantService] clamps an out-of-range
+     * value — the JPEG writer would otherwise throw in the middle of a tool call, far from the
+     * misconfiguration that caused it.
+     */
+    val imageJpegQuality: Float = 0.80f,
+    /**
+     * Decode-bomb guard: any source or embedded image above this pixel count is refused before being
+     * decoded. Raise it only on an instance whose heap can absorb the larger raster.
+     */
+    val imageMaxSourcePixels: Long = 50_000_000L,
+    /**
+     * Originals at or below this byte size that already fit [imageMaxDimension] are forwarded
+     * untouched instead of re-encoded, which preserves text sharpness in screenshots and diagrams.
+     */
+    val imagePassThroughMaxBytes: Long = 1L * 1024 * 1024,
+    /**
+     * Markdown character budget of a single `readDocument` call; a longer document is paged via
+     * `startElement`. The main lever on how much of a large `.docx` fits in one agent context, so it
+     * scales with the context window of the models the instance runs.
+     */
+    val documentMaxOutputChars: Int = 100_000,
+    /**
+     * Maximum embedded pictures `readDocument` attaches per call — the image half of that same
+     * budget, bounding the token blow-up of an image-heavy document.
+     */
+    val documentMaxAttachedImages: Int = 10,
+    /**
+     * Columns beyond this are dropped when `readDocument` renders a `.docx` table to Markdown, so one
+     * wide table cannot eat the whole output budget.
+     */
+    val documentMaxTableColumns: Int = 64,
+    /**
+     * A single table cell longer than this is truncated by `readDocument`, so one verbose cell cannot
+     * dominate the rendered table.
+     */
+    val documentMaxCellChars: Int = 5000,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolRegistryService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolRegistryService.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.tool
 
 import io.whozoss.agentos.exchange.ExchangeIntegrationTypes
+import io.whozoss.agentos.exchange.ExchangeToolsConfigProperties
 import io.whozoss.agentos.integrationConfig.IntegrationTypeRegistry
 import io.whozoss.agentos.sdk.tool.ToolPlugin
 import jakarta.annotation.PostConstruct
@@ -24,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap
 class ToolRegistryService(
     private val pluginManager: PluginManager,
     private val integrationTypeRegistry: IntegrationTypeRegistry,
+    private val exchangeToolsConfigProperties: ExchangeToolsConfigProperties,
     /**
      * Spring-managed [ToolPlugin] beans (internal integrations such as REDIRECT).
      * Registered alongside PF4J-loaded plugins; Spring injects all implementations
@@ -51,7 +53,11 @@ class ToolRegistryService(
      */
     private fun registerBuiltInExchangeTypes() {
         if (findPlugin(ExchangeIntegrationTypes.FILE_ACCESS) != null) {
-            ExchangeIntegrationTypes.builtInDescriptors().forEach(integrationTypeRegistry::registerBuiltIn)
+            ExchangeIntegrationTypes
+                .builtInDescriptors(
+                    caseEnabledByDefault = exchangeToolsConfigProperties.caseEnabledByDefault,
+                    namespaceEnabledByDefault = exchangeToolsConfigProperties.namespaceEnabledByDefault,
+                ).forEach(integrationTypeRegistry::registerBuiltIn)
         } else {
             logger.info { "File-plugin (FILE_ACCESS) not loaded — built-in exchange integration types not registered" }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -21,8 +21,10 @@ class ToolResolverService(
      * identity (namespace, user, external id, agent name, case events).
      *
      * @param agentIntegrations Optional integration filter from AgentConfig.integrations.
-     *   When null, the agent has no integration bindings and no tools are resolved.
-     *   This is intentional: an agent with no declared integrations runs tool-free.
+     *   When null, the agent has no integration bindings and this resolver returns no tools.
+     *   That is a property of this resolver only, not of the whole run: the built-in exchange
+     *   scopes are granted outside it by [io.whozoss.agentos.exchange.ExchangeToolGrantService],
+     *   whose platform defaults can hand the file-plugin tools to an agent that declares nothing.
      * @param context Runtime context forwarded to each [ToolPlugin.provideTools] call.
      *   [ToolContext.userId] must be non-null.
      */

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -123,14 +123,18 @@ agentos:
       # integrations map. An agent that lists the key decides for itself; an empty list opts out.
       # Override with env var: AGENTOS_EXCHANGE_TOOLS_CASE_ENABLED_BY_DEFAULT
       # case-enabled-by-default: false
-      # Same platform default for NAMESPACE_FILE_EXCHANGE. Write access still follows the invoking
-      # user's Namespace WRITE right, so this hands write access to nobody new.
+      # Same platform default for NAMESPACE_FILE_EXCHANGE. Every namespace grant, default or
+      # declared, also requires the invoking user to hold Namespace READ; a run without an
+      # identified user is denied. Write access follows the user's Namespace WRITE right.
       # Override with env var: AGENTOS_EXCHANGE_TOOLS_NAMESPACE_ENABLED_BY_DEFAULT
       # namespace-enabled-by-default: false
-      # Comma-separated extra glob patterns blocked for the agent file tools, on top of the plugin's
-      # built-in sensitive-file list (.env, *.key, *.pem). Additive only — built-ins always apply.
+      # Comma-separated extra patterns blocked for the agent file tools, on top of the plugin's
+      # built-in sensitive-file list (.env, *.key, *.pem). Additive only, built-ins always apply.
+      # A pattern matches the file or directory NAME only, never the path: *suffix, prefix*,
+      # *contains* or an exact name. A path-shaped pattern like "secrets/*" matches nothing, and a
+      # prefix pattern denies a matching directory entry without denying the files inside it.
       # Override with env var: AGENTOS_EXCHANGE_TOOLS_EXTRA_DENY_PATTERNS
-      # extra-deny-patterns: "*.bak,internal-*"
+      # extra-deny-patterns: "*.bak,*confidential*"
       # Longest edge (px) of the images readAsImage/readDocument hand to the LLM; larger ones are
       # downscaled. Track the vision model in use.
       # Override with env var: AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_DIMENSION

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -111,6 +111,55 @@ agentos:
     # covers text/doc/data/image/code; empty allows any. Expected to differ per AgentOS instance.
     # Override with env var: AGENTOS_EXCHANGE_ALLOWED_UPLOAD_EXTENSIONS
     # allowed-upload-extensions: txt,md,pdf,png,csv,json
+    # Max size (bytes) the read/download endpoints load into memory. Also caps the agent read tools
+    # on the same directories, converted to whole megabytes with a floor of 1 MB.
+    # Override with env var: AGENTOS_EXCHANGE_READ_MAX_SIZE_BYTES
+    # read-max-size-bytes: 104857600
+    # File tools granted to agents on the case / namespace exchange. One set of values is shared by
+    # both scopes; rootPath and readOnly are computed per run, and readMaxSizeMb derives from
+    # read-max-size-bytes above.
+    tools:
+      # Grant the case exchange to every agent that does not mention CASE_FILE_EXCHANGE in its
+      # integrations map. An agent that lists the key decides for itself; an empty list opts out.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_CASE_ENABLED_BY_DEFAULT
+      # case-enabled-by-default: false
+      # Same platform default for NAMESPACE_FILE_EXCHANGE. Write access still follows the invoking
+      # user's Namespace WRITE right, so this hands write access to nobody new.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_NAMESPACE_ENABLED_BY_DEFAULT
+      # namespace-enabled-by-default: false
+      # Comma-separated extra glob patterns blocked for the agent file tools, on top of the plugin's
+      # built-in sensitive-file list (.env, *.key, *.pem). Additive only — built-ins always apply.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_EXTRA_DENY_PATTERNS
+      # extra-deny-patterns: "*.bak,internal-*"
+      # Longest edge (px) of the images readAsImage/readDocument hand to the LLM; larger ones are
+      # downscaled. Track the vision model in use.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_DIMENSION
+      # image-max-dimension: 1024
+      # JPEG re-encoding quality between 0 and 1: prompt bytes against the legibility of screenshots
+      # and scans. Out-of-range values are clamped.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_IMAGE_JPEG_QUALITY
+      # image-jpeg-quality: 0.80
+      # Decode-bomb guard: a source or embedded image above this pixel count is refused before being
+      # decoded. Raise it only if the heap can absorb the larger raster.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_SOURCE_PIXELS
+      # image-max-source-pixels: 50000000
+      # Originals at or below this byte size that already fit the max dimension are forwarded
+      # untouched instead of re-encoded, preserving text sharpness.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_IMAGE_PASS_THROUGH_MAX_BYTES
+      # image-pass-through-max-bytes: 1048576
+      # Markdown character budget of one readDocument call; a longer document is paged via
+      # startElement. Scales with the context window of the models this instance runs.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_OUTPUT_CHARS
+      # document-max-output-chars: 100000
+      # Maximum embedded pictures readDocument attaches per call — the image half of that budget.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_ATTACHED_IMAGES
+      # document-max-attached-images: 10
+      # Table columns beyond this are dropped when readDocument renders a .docx table to Markdown.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_TABLE_COLUMNS
+      # document-max-table-columns: 64
+      # A single table cell longer than this is truncated by readDocument.
+      # Override with env var: AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_CELL_CHARS
+      # document-max-cell-chars: 5000
   defaults:
   # Environment-level fallback agent name. Consulted when a namespace has no
   # defaultAgentName configured. The named agent must exist in the case's namespace.

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -3,6 +3,7 @@ package io.whozoss.agentos.agent
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -21,8 +22,10 @@ import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.chat.ChatClientProvider
 import io.whozoss.agentos.exchange.ExchangeCapabilityService
 import io.whozoss.agentos.exchange.ExchangeGrant
+import io.whozoss.agentos.exchange.ExchangeStorageConfigProperties
 import io.whozoss.agentos.exchange.ExchangeStorageService
 import io.whozoss.agentos.exchange.ExchangeToolGrantService
+import io.whozoss.agentos.exchange.ExchangeToolsConfigProperties
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.metrics.ToolMetricsService
@@ -33,6 +36,7 @@ import io.whozoss.agentos.sdk.aiProvider.AiApiType
 import io.whozoss.agentos.sdk.aiProvider.AiModel
 import io.whozoss.agentos.sdk.aiProvider.AiProvider
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolPlugin
 import io.whozoss.agentos.tool.ToolRegistryService
 import io.whozoss.agentos.tool.ToolResolverService
@@ -40,6 +44,7 @@ import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
 import io.whozoss.agentos.util.IdCompressorService
 import org.springframework.ai.chat.client.ChatClient
+import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
 import java.util.UUID
@@ -181,8 +186,8 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
         // -------------------------------------------------------------------------
         // File-exchange tool gating — what only AgentServiceImpl knows: the run's case id and the
-        // invoking user's Namespace WRITE right. The enablement rules and the plugin config node
-        // belong to ExchangeToolGrantService and are covered by its own spec.
+        // invoking user's Namespace READ/WRITE rights. The enablement rules and the plugin config
+        // node belong to ExchangeToolGrantService and are covered by its own spec.
         // -------------------------------------------------------------------------
 
         "case exchange is granted at the case root with read/write when a live case is present" {
@@ -198,6 +203,10 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.findAgentByName("case-agent", context)
 
+            // The agent's own integrations map must reach the grant service verbatim: a regression
+            // passing e.g. null instead would let a default-on instance re-grant tools to an agent
+            // that opted out.
+            verify(exactly = 1) { exchangeToolGrantService.resolveCaseGrant(mapOf("CASE_FILE_EXCHANGE" to null)) }
             verify(exactly = 1) {
                 exchangeToolGrantService.grantTools(
                     root = caseRootPath,
@@ -225,6 +234,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
             agentService.findAgentByName("case-agent-filtered", context)
 
             verify(exactly = 1) {
+                exchangeToolGrantService.resolveCaseGrant(mapOf("CASE_FILE_EXCHANGE" to listOf("readFile")))
+            }
+            verify(exactly = 1) {
                 exchangeToolGrantService.grantTools(
                     root = caseRootPath,
                     readOnly = false,
@@ -235,11 +247,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
             }
         }
 
-        "namespace exchange is granted read-only, and case is fail-closed without a live case id" {
-            val nsRootPath = Path.of("/tmp/ns-exchange-test")
+        "namespace exchange is denied without an identified user, and case is fail-closed without a live case id" {
             every { exchangeToolGrantService.resolveCaseGrant(any()) } returns ExchangeGrant(allowedTools = null)
             every { exchangeToolGrantService.resolveNamespaceGrant(any()) } returns ExchangeGrant(allowedTools = null)
-            every { exchangeStorageService.namespaceRoot(namespaceId) } returns nsRootPath
 
             val config =
                 agentConfig(name = "ns-agent", modelName = "sonnet").copy(
@@ -255,6 +265,41 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.resolveDefinition(config.metadata.id, namespaceId, userId = null)
 
+            // The grant service still receives the agent's exact integrations map...
+            verify(exactly = 1) {
+                exchangeToolGrantService.resolveNamespaceGrant(
+                    mapOf("CASE_FILE_EXCHANGE" to null, "NAMESPACE_FILE_EXCHANGE" to null),
+                )
+            }
+            // ...but Namespace READ cannot be established without an identified user, so the
+            // namespace grant is denied fail-closed before any permission query; and with no live
+            // case id the case scope is not granted either. Nothing may be built.
+            verify(exactly = 0) { exchangeCapabilityService.canRead(any(), any(), any()) }
+            verify(exactly = 0) { exchangeToolGrantService.grantTools(any(), any(), any(), any(), any()) }
+        }
+
+        "namespace exchange is granted read-only when the user holds Namespace READ but not WRITE" {
+            val nsRootPath = Path.of("/tmp/ns-exchange-ro-test")
+            val readerId = UUID.randomUUID()
+            every { exchangeToolGrantService.resolveNamespaceGrant(any()) } returns ExchangeGrant(allowedTools = null)
+            every { exchangeStorageService.namespaceRoot(namespaceId) } returns nsRootPath
+            every {
+                exchangeCapabilityService.canRead(readerId.toString(), EntityType.NAMESPACE, namespaceId.toString())
+            } returns true
+            every {
+                exchangeCapabilityService.canWrite(readerId.toString(), EntityType.NAMESPACE, namespaceId.toString())
+            } returns false
+
+            val config =
+                agentConfig(name = "ns-reader", modelName = "sonnet")
+                    .copy(integrations = mapOf("NAMESPACE_FILE_EXCHANGE" to null))
+            every { agentConfigService.findById(config.metadata.id) } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns modelConfig(alias = "sonnet")
+            every { aiProviderService.getById(aiProviderId) } returns providerConfig()
+            every { aiProviderService.resolveProvider(any(), any(), any()) } returns providerConfig()
+
+            agentService.resolveDefinition(config.metadata.id, namespaceId, userId = readerId)
+
             verify(exactly = 1) {
                 exchangeToolGrantService.grantTools(
                     root = nsRootPath,
@@ -264,16 +309,29 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     toolContext = any(),
                 )
             }
-            // resolveDefinition carries no live case id → case exchange must NOT be granted
-            verify(exactly = 0) {
-                exchangeToolGrantService.grantTools(
-                    root = any(),
-                    readOnly = any(),
-                    configName = "case-exchange",
-                    allowedTools = any(),
-                    toolContext = any(),
-                )
-            }
+        }
+
+        "namespace exchange is denied when the user lacks Namespace READ, before any write check" {
+            // The hole this closes: a user holding a direct Case edge without namespace membership
+            // must not read the whole namespace exchange through an agent.
+            val strangerId = UUID.randomUUID()
+            every { exchangeToolGrantService.resolveNamespaceGrant(any()) } returns ExchangeGrant(allowedTools = null)
+            every {
+                exchangeCapabilityService.canRead(strangerId.toString(), EntityType.NAMESPACE, namespaceId.toString())
+            } returns false
+
+            val config =
+                agentConfig(name = "ns-stranger", modelName = "sonnet")
+                    .copy(integrations = mapOf("NAMESPACE_FILE_EXCHANGE" to null))
+            every { agentConfigService.findById(config.metadata.id) } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns modelConfig(alias = "sonnet")
+            every { aiProviderService.getById(aiProviderId) } returns providerConfig()
+            every { aiProviderService.resolveProvider(any(), any(), any()) } returns providerConfig()
+
+            agentService.resolveDefinition(config.metadata.id, namespaceId, userId = strangerId)
+
+            verify(exactly = 0) { exchangeCapabilityService.canWrite(any(), any(), any()) }
+            verify(exactly = 0) { exchangeToolGrantService.grantTools(any(), any(), any(), any(), any()) }
         }
 
         "namespace exchange is read/write when the invoking user holds Namespace WRITE" {
@@ -281,6 +339,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
             val writerId = UUID.randomUUID()
             every { exchangeToolGrantService.resolveNamespaceGrant(any()) } returns ExchangeGrant(allowedTools = null)
             every { exchangeStorageService.namespaceRoot(namespaceId) } returns nsRootPath
+            every {
+                exchangeCapabilityService.canRead(writerId.toString(), EntityType.NAMESPACE, namespaceId.toString())
+            } returns true
             every {
                 exchangeCapabilityService.canWrite(writerId.toString(), EntityType.NAMESPACE, namespaceId.toString())
             } returns true
@@ -297,6 +358,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
             agentService.resolveDefinition(config.metadata.id, namespaceId, userId = writerId)
 
             verify(exactly = 1) {
+                exchangeToolGrantService.resolveNamespaceGrant(mapOf("NAMESPACE_FILE_EXCHANGE" to null))
+            }
+            verify(exactly = 1) {
                 exchangeToolGrantService.grantTools(
                     root = nsRootPath,
                     readOnly = false,
@@ -307,10 +371,10 @@ class AgentServiceImplUnitSpec : StringSpec() {
             }
         }
 
-        "namespace write capability is not queried when the namespace grant is denied" {
-            // Locks the decision-before-permission order: canWrite is a Neo4j lookup, and a scope
-            // nobody was granted must not pay for it. Regressing to computing readOnly up front
-            // would make this fail.
+        "namespace permissions are not queried when the namespace grant is denied" {
+            // Locks the decision-before-permission order: canRead/canWrite are Neo4j lookups, and a
+            // scope nobody was granted must not pay for them. Regressing to computing the rights up
+            // front would make this fail.
             val config = agentConfig(name = "no-exchange-agent", modelName = "sonnet")
             every { agentConfigService.findById(config.metadata.id) } returns config
             every { aiModelService.findAiModel(namespaceId, "sonnet") } returns modelConfig(alias = "sonnet")
@@ -319,7 +383,82 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.resolveDefinition(config.metadata.id, namespaceId, userId = UUID.randomUUID())
 
+            verify(exactly = 0) { exchangeCapabilityService.canRead(any(), any(), any()) }
             verify(exactly = 0) { exchangeCapabilityService.canWrite(any(), any(), any()) }
+        }
+
+        "with the real grant service, no integrations key gets case tools on a default-on instance and [] gets none" {
+            // Composes the REAL ExchangeToolGrantService so the AgentServiceImpl -> grant-service
+            // seam is exercised end to end: a regression passing anything but the agent's own
+            // integrations map would surface here as the opted-out agent regaining tools.
+            val realGrantService =
+                ExchangeToolGrantService(
+                    properties = ExchangeToolsConfigProperties(caseEnabledByDefault = true),
+                    storageProperties = ExchangeStorageConfigProperties(),
+                    toolRegistryService = toolRegistryService,
+                    toolResolverService = toolResolverService,
+                    objectMapper = testObjectMapper,
+                )
+            val composedService =
+                AgentServiceImpl(
+                    chatClientProvider = chatClientProvider,
+                    toolResolverService = toolResolverService,
+                    aiModelService = aiModelService,
+                    aiProviderService = aiProviderService,
+                    namespaceService = namespaceService,
+                    integrationConfigService = integrationConfigService,
+                    userService = userService,
+                    agentConfigService = agentConfigService,
+                    intentionGenerator = intentionGenerator,
+                    confirmationManager = confirmationManager,
+                    objectMapper = testObjectMapper,
+                    toolRegistryService = toolRegistryService,
+                    toolMetricsService = toolMetricsService,
+                    caseEventService = caseEventService,
+                    exchangeStorageService = exchangeStorageService,
+                    exchangeCapabilityService = exchangeCapabilityService,
+                    exchangeToolGrantService = realGrantService,
+                    agentDocumentResolver = agentDocumentResolver,
+                    idCompressorService = IdCompressorService(),
+                    agentConfigProperties = AgentConfigProperties(),
+                )
+            val caseTool = mockk<StandardTool<*>>()
+            every { caseTool.name } returns "case-exchange__readFile"
+            every { caseTool.description } returns "read a file from the case exchange"
+            val filePlugin = mockk<ToolPlugin>()
+            every { filePlugin.provideTools(any(), "case-exchange", any()) } returns listOf(caseTool)
+            every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
+            every { toolResolverService.isToolAllowed(any(), any(), any()) } returns true
+            // Capture what reaches the shared de-dup: the definitive combined tool set.
+            val combinedTools = mutableListOf<List<StandardTool<*>>>()
+            every { toolResolverService.dedupToolsByName(capture(combinedTools)) } answers { firstArg() }
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns modelConfig(alias = "sonnet")
+            every { aiProviderService.getById(aiProviderId) } returns providerConfig()
+            every { chatClientProvider.getChatClient(any(), any(), any()) } returns mockk<ChatClient>(relaxed = true)
+
+            // No integrations key at all: the platform default grants the case exchange.
+            val silentRoot = Files.createTempDirectory("agent-exchange-compose").resolve("case-root")
+            every { exchangeStorageService.caseRoot(namespaceId, caseId, any()) } returns silentRoot
+            val silentConfig = agentConfig(name = "silent-agent", modelName = "sonnet")
+            every { agentConfigService.findByName(namespaceId, "silent-agent") } returns silentConfig
+
+            composedService.findAgentByName("silent-agent", context)
+
+            combinedTools.last().map { it.name } shouldBe listOf("case-exchange__readFile")
+            Files.exists(silentRoot) shouldBe true
+
+            // An explicit [] opts out even on the default-on instance: no tools, no scope directory.
+            val optedOutRoot = Files.createTempDirectory("agent-exchange-optout").resolve("case-root")
+            every { exchangeStorageService.caseRoot(namespaceId, caseId, any()) } returns optedOutRoot
+            val optedOutConfig =
+                agentConfig(name = "opted-out-agent", modelName = "sonnet")
+                    .copy(integrations = mapOf("CASE_FILE_EXCHANGE" to emptyList()))
+            every { agentConfigService.findByName(namespaceId, "opted-out-agent") } returns optedOutConfig
+
+            composedService.findAgentByName("opted-out-agent", context)
+
+            combinedTools.last().shouldBeEmpty()
+            Files.exists(optedOutRoot) shouldBe false
         }
 
         // WZ-31596: when advancedExecution=true, AgentAdvancedContext must receive the

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -1,6 +1,5 @@
 package io.whozoss.agentos.agent
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
@@ -12,7 +11,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
@@ -22,7 +20,9 @@ import io.whozoss.agentos.aiProvider.AiProviderService
 import io.whozoss.agentos.caseEvent.CaseEventService
 import io.whozoss.agentos.chat.ChatClientProvider
 import io.whozoss.agentos.exchange.ExchangeCapabilityService
+import io.whozoss.agentos.exchange.ExchangeGrant
 import io.whozoss.agentos.exchange.ExchangeStorageService
+import io.whozoss.agentos.exchange.ExchangeToolGrantService
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.metrics.ToolMetricsService
@@ -40,7 +40,7 @@ import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
 import io.whozoss.agentos.util.IdCompressorService
 import org.springframework.ai.chat.client.ChatClient
-import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Instant
 import java.util.UUID
 
@@ -62,6 +62,10 @@ class AgentServiceImplUnitSpec : StringSpec() {
     private val agentDocumentResolver: AgentDocumentResolver = mockk(relaxed = true)
     private val exchangeStorageService: ExchangeStorageService = mockk(relaxed = true)
     private val exchangeCapabilityService: ExchangeCapabilityService = mockk(relaxed = true)
+
+    // Strict on purpose: a relaxed mock would return a non-null ExchangeGrant and silently grant the
+    // exchange in every unrelated test. The defaults stubbed in init deny both scopes.
+    private val exchangeToolGrantService: ExchangeToolGrantService = mockk()
     private val agentService =
         AgentServiceImpl(
             chatClientProvider = chatClientProvider,
@@ -80,6 +84,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             caseEventService = caseEventService,
             exchangeStorageService = exchangeStorageService,
             exchangeCapabilityService = exchangeCapabilityService,
+            exchangeToolGrantService = exchangeToolGrantService,
             agentDocumentResolver = agentDocumentResolver,
             idCompressorService = IdCompressorService(),
             agentConfigProperties = AgentConfigProperties(),
@@ -141,8 +146,10 @@ class AgentServiceImplUnitSpec : StringSpec() {
             emptyList()
         // dedupToolsByName is the shared collision-reconciler; identity is fine (no collisions in these tests).
         every { toolResolverService.dedupToolsByName(any()) } answers { firstArg() }
-        // isToolAllowed gates the exchange grant's per-tool allowlist; allow all (tests use null allowlists).
-        every { toolResolverService.isToolAllowed(any(), any(), any()) } returns true
+        // Both exchange scopes are denied unless a test says otherwise, mirroring the shipped defaults.
+        every { exchangeToolGrantService.resolveCaseGrant(any()) } returns null
+        every { exchangeToolGrantService.resolveNamespaceGrant(any()) } returns null
+        every { exchangeToolGrantService.grantTools(any(), any(), any(), any(), any()) } returns emptyList()
 
         every { namespaceService.findById(namespaceId) } returns namespace
         every { integrationConfigService.findByParent(any()) } returns emptyList()
@@ -173,14 +180,15 @@ class AgentServiceImplUnitSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
-        // File-exchange tool gating (B4) — fail-closed
+        // File-exchange tool gating — what only AgentServiceImpl knows: the run's case id and the
+        // invoking user's Namespace WRITE right. The enablement rules and the plugin config node
+        // belong to ExchangeToolGrantService and are covered by its own spec.
         // -------------------------------------------------------------------------
 
-        "case exchange routes through the FILE_ACCESS plugin rooted at the case dir when enabled with a live case" {
-            val tmp = Files.createTempDirectory("case-exchange-test")
-            val filePlugin = mockk<ToolPlugin>(relaxed = true)
-            every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
-            every { exchangeStorageService.caseRoot(namespaceId, caseId, any()) } returns tmp
+        "case exchange is granted at the case root with read/write when a live case is present" {
+            val caseRootPath = Path.of("/tmp/case-exchange-test")
+            every { exchangeToolGrantService.resolveCaseGrant(any()) } returns ExchangeGrant(allowedTools = null)
+            every { exchangeStorageService.caseRoot(namespaceId, caseId, any()) } returns caseRootPath
 
             val config = agentConfig(name = "case-agent", modelName = "sonnet").copy(integrations = mapOf("CASE_FILE_EXCHANGE" to null))
             every { agentConfigService.findByName(namespaceId, "case-agent") } returns config
@@ -190,19 +198,48 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.findAgentByName("case-agent", context)
 
-            val cfg = slot<JsonNode>()
-            verify { filePlugin.provideTools(capture(cfg), "case-exchange", any()) }
-            cfg.captured.get("rootPath").asText() shouldBe tmp.toAbsolutePath().toString()
-            cfg.captured.get("readOnly").asBoolean() shouldBe false
-
-            every { toolRegistryService.findPlugin(any()) } returns null
+            verify(exactly = 1) {
+                exchangeToolGrantService.grantTools(
+                    root = caseRootPath,
+                    readOnly = false,
+                    configName = "case-exchange",
+                    allowedTools = null,
+                    toolContext = any(),
+                )
+            }
         }
 
-        "namespace exchange routes through FILE_ACCESS read-only, and case is fail-closed without a live case id" {
-            val tmp = Files.createTempDirectory("ns-exchange-test")
-            val filePlugin = mockk<ToolPlugin>(relaxed = true)
-            every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
-            every { exchangeStorageService.namespaceRoot(namespaceId) } returns tmp
+        "the per-tool allowlist carried by the grant is forwarded to the file-plugin grant" {
+            val caseRootPath = Path.of("/tmp/case-exchange-allowlist-test")
+            every { exchangeToolGrantService.resolveCaseGrant(any()) } returns ExchangeGrant(allowedTools = listOf("readFile"))
+            every { exchangeStorageService.caseRoot(namespaceId, caseId, any()) } returns caseRootPath
+
+            val config =
+                agentConfig(name = "case-agent-filtered", modelName = "sonnet")
+                    .copy(integrations = mapOf("CASE_FILE_EXCHANGE" to listOf("readFile")))
+            every { agentConfigService.findByName(namespaceId, "case-agent-filtered") } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns modelConfig(alias = "sonnet")
+            every { aiProviderService.getById(aiProviderId) } returns providerConfig()
+            every { chatClientProvider.getChatClient(any(), any(), any()) } returns mockk<ChatClient>(relaxed = true)
+
+            agentService.findAgentByName("case-agent-filtered", context)
+
+            verify(exactly = 1) {
+                exchangeToolGrantService.grantTools(
+                    root = caseRootPath,
+                    readOnly = false,
+                    configName = "case-exchange",
+                    allowedTools = listOf("readFile"),
+                    toolContext = any(),
+                )
+            }
+        }
+
+        "namespace exchange is granted read-only, and case is fail-closed without a live case id" {
+            val nsRootPath = Path.of("/tmp/ns-exchange-test")
+            every { exchangeToolGrantService.resolveCaseGrant(any()) } returns ExchangeGrant(allowedTools = null)
+            every { exchangeToolGrantService.resolveNamespaceGrant(any()) } returns ExchangeGrant(allowedTools = null)
+            every { exchangeStorageService.namespaceRoot(namespaceId) } returns nsRootPath
 
             val config =
                 agentConfig(name = "ns-agent", modelName = "sonnet").copy(
@@ -218,21 +255,32 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.resolveDefinition(config.metadata.id, namespaceId, userId = null)
 
-            val cfg = slot<JsonNode>()
-            verify { filePlugin.provideTools(capture(cfg), "namespace-exchange", any()) }
-            cfg.captured.get("readOnly").asBoolean() shouldBe true
+            verify(exactly = 1) {
+                exchangeToolGrantService.grantTools(
+                    root = nsRootPath,
+                    readOnly = true,
+                    configName = "namespace-exchange",
+                    allowedTools = null,
+                    toolContext = any(),
+                )
+            }
             // resolveDefinition carries no live case id → case exchange must NOT be granted
-            verify(exactly = 0) { filePlugin.provideTools(any(), "case-exchange", any()) }
-
-            every { toolRegistryService.findPlugin(any()) } returns null
+            verify(exactly = 0) {
+                exchangeToolGrantService.grantTools(
+                    root = any(),
+                    readOnly = any(),
+                    configName = "case-exchange",
+                    allowedTools = any(),
+                    toolContext = any(),
+                )
+            }
         }
 
         "namespace exchange is read/write when the invoking user holds Namespace WRITE" {
-            val tmp = Files.createTempDirectory("ns-exchange-rw-test")
-            val filePlugin = mockk<ToolPlugin>(relaxed = true)
+            val nsRootPath = Path.of("/tmp/ns-exchange-rw-test")
             val writerId = UUID.randomUUID()
-            every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
-            every { exchangeStorageService.namespaceRoot(namespaceId) } returns tmp
+            every { exchangeToolGrantService.resolveNamespaceGrant(any()) } returns ExchangeGrant(allowedTools = null)
+            every { exchangeStorageService.namespaceRoot(namespaceId) } returns nsRootPath
             every {
                 exchangeCapabilityService.canWrite(writerId.toString(), EntityType.NAMESPACE, namespaceId.toString())
             } returns true
@@ -248,11 +296,30 @@ class AgentServiceImplUnitSpec : StringSpec() {
 
             agentService.resolveDefinition(config.metadata.id, namespaceId, userId = writerId)
 
-            val cfg = slot<JsonNode>()
-            verify { filePlugin.provideTools(capture(cfg), "namespace-exchange", any()) }
-            cfg.captured.get("readOnly").asBoolean() shouldBe false
+            verify(exactly = 1) {
+                exchangeToolGrantService.grantTools(
+                    root = nsRootPath,
+                    readOnly = false,
+                    configName = "namespace-exchange",
+                    allowedTools = null,
+                    toolContext = any(),
+                )
+            }
+        }
 
-            every { toolRegistryService.findPlugin(any()) } returns null
+        "namespace write capability is not queried when the namespace grant is denied" {
+            // Locks the decision-before-permission order: canWrite is a Neo4j lookup, and a scope
+            // nobody was granted must not pay for it. Regressing to computing readOnly up front
+            // would make this fail.
+            val config = agentConfig(name = "no-exchange-agent", modelName = "sonnet")
+            every { agentConfigService.findById(config.metadata.id) } returns config
+            every { aiModelService.findAiModel(namespaceId, "sonnet") } returns modelConfig(alias = "sonnet")
+            every { aiProviderService.getById(aiProviderId) } returns providerConfig()
+            every { aiProviderService.resolveProvider(any(), any(), any()) } returns providerConfig()
+
+            agentService.resolveDefinition(config.metadata.id, namespaceId, userId = UUID.randomUUID())
+
+            verify(exactly = 0) { exchangeCapabilityService.canWrite(any(), any(), any()) }
         }
 
         // WZ-31596: when advancedExecution=true, AgentAdvancedContext must receive the
@@ -538,6 +605,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     caseEventService = caseEventService,
                     exchangeStorageService = exchangeStorageService,
                     exchangeCapabilityService = exchangeCapabilityService,
+                    exchangeToolGrantService = exchangeToolGrantService,
                     agentDocumentResolver = agentDocumentResolver,
                     idCompressorService = IdCompressorService(),
                     agentConfigProperties = AgentConfigProperties(),

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerExportSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agentConfig/AgentConfigControllerExportSpec.kt
@@ -173,6 +173,48 @@ class AgentConfigControllerExportSpec : StringSpec({
     }
 
     // -------------------------------------------------------------------------
+    // YAML body — built-in exchange states inside integrations are preserved
+    // -------------------------------------------------------------------------
+
+    "export YAML preserves a null integration value (all tools enabled)" {
+        val c = config(integrations = mapOf("NAMESPACE_FILE_EXCHANGE" to null))
+        every { service.findById(c.metadata.id) } returns c
+
+        val body = controller.export(c.metadata.id).body!!
+
+        body shouldContain "integrations:"
+        body shouldContain "NAMESPACE_FILE_EXCHANGE: null"
+    }
+
+    "export YAML preserves an empty-list integration value (explicit opt-out)" {
+        val c = config(integrations = mapOf("CASE_FILE_EXCHANGE" to emptyList()))
+        every { service.findById(c.metadata.id) } returns c
+
+        val body = controller.export(c.metadata.id).body!!
+
+        body shouldContain "integrations:"
+        body shouldContain "CASE_FILE_EXCHANGE: []"
+    }
+
+    "export YAML preserves null and empty-list integration values alongside a regular integration" {
+        val c = config(
+            integrations = mapOf(
+                "JIRA" to listOf("GetIssue"),
+                "NAMESPACE_FILE_EXCHANGE" to null,
+                "CASE_FILE_EXCHANGE" to emptyList(),
+            ),
+        )
+        every { service.findById(c.metadata.id) } returns c
+
+        val body = controller.export(c.metadata.id).body!!
+
+        body shouldContain "JIRA:"
+        body shouldContain "GetIssue"
+        body shouldContain "NAMESPACE_FILE_EXCHANGE: null"
+        body shouldContain "CASE_FILE_EXCHANGE: []"
+    }
+
+    // -------------------------------------------------------------------------
     // YAML body — excluded fields (scope metadata)
     // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeCapabilityServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeCapabilityServiceUnitSpec.kt
@@ -1,0 +1,63 @@
+package io.whozoss.agentos.exchange
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.permissions.Action
+import io.whozoss.agentos.permissions.EntityType
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.sdk.api.exchange.ExchangeCapability
+import java.util.UUID
+
+/**
+ * Unit tests for [ExchangeCapabilityService], the single place where the exchange read and write
+ * rules are defined.
+ *
+ * Each method is a one-line delegation, so what is worth pinning is the [Action] it asks for: the
+ * three members differ by that argument alone, and swapping one for another compiles, passes every
+ * caller's spec (they all mock this service), and silently changes who can reach the exchange.
+ */
+class ExchangeCapabilityServiceUnitSpec : StringSpec() {
+    private val permissionService: PermissionService = mockk()
+    private val service = ExchangeCapabilityService(permissionService)
+
+    private val userId = UUID.randomUUID().toString()
+    private val namespaceId = UUID.randomUUID().toString()
+
+    init {
+        "canRead asks the permission service for READ, not WRITE" {
+            // A copy-paste of the canWrite body would still compile and still pass every caller
+            // spec, while denying the namespace exchange to every plain member.
+            every { permissionService.hasPermission(userId, EntityType.NAMESPACE, namespaceId, Action.READ) } returns true
+            every { permissionService.hasPermission(userId, EntityType.NAMESPACE, namespaceId, Action.WRITE) } returns false
+
+            service.canRead(userId, EntityType.NAMESPACE, namespaceId) shouldBe true
+        }
+
+        "canRead is false when the user lacks READ on the scope" {
+            every { permissionService.hasPermission(userId, EntityType.NAMESPACE, namespaceId, Action.READ) } returns false
+
+            service.canRead(userId, EntityType.NAMESPACE, namespaceId) shouldBe false
+        }
+
+        "canWrite asks the permission service for WRITE, not READ" {
+            every { permissionService.hasPermission(userId, EntityType.NAMESPACE, namespaceId, Action.READ) } returns true
+            every { permissionService.hasPermission(userId, EntityType.NAMESPACE, namespaceId, Action.WRITE) } returns false
+
+            service.canWrite(userId, EntityType.NAMESPACE, namespaceId) shouldBe false
+        }
+
+        "capability upgrades to READ_WRITE only when the user holds WRITE" {
+            every { permissionService.hasPermission(userId, EntityType.CASE, namespaceId, Action.WRITE) } returns true
+
+            service.capability(userId, EntityType.CASE, namespaceId) shouldBe ExchangeCapability.READ_WRITE
+        }
+
+        "capability stays READ for a caller without WRITE" {
+            every { permissionService.hasPermission(userId, EntityType.CASE, namespaceId, Action.WRITE) } returns false
+
+            service.capability(userId, EntityType.CASE, namespaceId) shouldBe ExchangeCapability.READ
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantServiceUnitSpec.kt
@@ -80,6 +80,13 @@ class ExchangeToolGrantServiceUnitSpec : StringSpec() {
     }
 
     init {
+        // Resolution requires the file-plugin: on a plugin-less instance no grant can ever produce
+        // a tool, so resolveGrant denies before any caller pays a permission query. Loaded by
+        // default here; the plugin-absent tests override this.
+        every {
+            toolRegistryService.findPlugin(ExchangeIntegrationTypes.FILE_ACCESS)
+        } returns mockk<ToolPlugin>(relaxed = true)
+
         // -------------------------------------------------------------------------
         // Enablement — the agent's declaration wins, the platform default is the fallback
         // -------------------------------------------------------------------------
@@ -144,6 +151,22 @@ class ExchangeToolGrantServiceUnitSpec : StringSpec() {
             grantService.resolveNamespaceGrant(null).shouldNotBeNull()
         }
 
+        "no grant on any path when the FILE_ACCESS plugin is not loaded" {
+            // The plugin check sits in the resolution on purpose: a resolved grant is what makes
+            // AgentServiceImpl pay the namespace permission queries, and on a plugin-less instance
+            // that cost would buy nothing. grantTools keeps its own check as defence in depth.
+            every { toolRegistryService.findPlugin(ExchangeIntegrationTypes.FILE_ACCESS) } returns null
+            val grantService =
+                service(
+                    ExchangeToolsConfigProperties(caseEnabledByDefault = true, namespaceEnabledByDefault = true),
+                )
+
+            grantService.resolveCaseGrant(mapOf(ExchangeIntegrationTypes.CASE to null)) shouldBe null
+            grantService.resolveNamespaceGrant(mapOf(ExchangeIntegrationTypes.NAMESPACE to null)) shouldBe null
+            grantService.resolveCaseGrant(null) shouldBe null
+            grantService.resolveNamespaceGrant(null) shouldBe null
+        }
+
         // -------------------------------------------------------------------------
         // Plugin configuration node
         // -------------------------------------------------------------------------
@@ -202,6 +225,32 @@ class ExchangeToolGrantServiceUnitSpec : StringSpec() {
                 .get("imageJpegQuality")
                 .asDouble()
                 .toFloat() shouldBe 0.0f
+        }
+
+        "a non-positive table-column cap is floored at 1 rather than crashing every table read" {
+            // ReadDocumentTool derives its column count via coerceIn(1, documentMaxTableColumns),
+            // which throws on the empty range a zero or negative cap would produce.
+            captureConfig(service(ExchangeToolsConfigProperties(documentMaxTableColumns = 0)))
+                .get("documentMaxTableColumns")
+                .asInt() shouldBe 1
+
+            captureConfig(service(ExchangeToolsConfigProperties(documentMaxTableColumns = -3)))
+                .get("documentMaxTableColumns")
+                .asInt() shouldBe 1
+        }
+
+        "a non-positive output budget is floored at 1 so readDocument paging can advance" {
+            // With a non-positive budget the render loop breaks immediately and the [truncated]
+            // notice points the model at the same startElement forever.
+            captureConfig(service(ExchangeToolsConfigProperties(documentMaxOutputChars = 0)))
+                .get("documentMaxOutputChars")
+                .asInt() shouldBe 1
+        }
+
+        "a negative cell cap is floored at 0 rather than handed to String.take" {
+            captureConfig(service(ExchangeToolsConfigProperties(documentMaxCellChars = -1)))
+                .get("documentMaxCellChars")
+                .asInt() shouldBe 0
         }
 
         "readMaxSizeMb derives from the exchange read cap" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantServiceUnitSpec.kt
@@ -1,0 +1,290 @@
+package io.whozoss.agentos.exchange
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolPlugin
+import io.whozoss.agentos.tool.ToolRegistryService
+import io.whozoss.agentos.tool.ToolResolverService
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+
+/**
+ * Unit tests for [ExchangeToolGrantService]: the enablement rules of the two built-in exchange
+ * integrations, and the configuration node handed to the file plugin.
+ *
+ * The node assertions mirror how `FileToolProvider.provideTools` actually reads each key — notably
+ * `asDouble().toFloat()` for the JPEG quality and `isArray` for the deny patterns — so a change in
+ * the JSON representation shows up here rather than at runtime inside a tool call.
+ */
+class ExchangeToolGrantServiceUnitSpec : StringSpec() {
+    private val toolRegistryService: ToolRegistryService = mockk()
+    private val toolResolverService: ToolResolverService = mockk()
+
+    private fun service(
+        properties: ExchangeToolsConfigProperties = ExchangeToolsConfigProperties(),
+        storageProperties: ExchangeStorageConfigProperties = ExchangeStorageConfigProperties(),
+    ) = ExchangeToolGrantService(
+        properties = properties,
+        storageProperties = storageProperties,
+        toolRegistryService = toolRegistryService,
+        toolResolverService = toolResolverService,
+        objectMapper = ObjectMapper(),
+    )
+
+    private val toolContext =
+        ToolContext(
+            namespaceId = UUID.randomUUID(),
+            userId = null,
+            userExternalId = null,
+            caseEvents = emptyList(),
+            agentName = "my-agent",
+        )
+
+    private fun tool(name: String): StandardTool<*> {
+        val standardTool = mockk<StandardTool<*>>()
+        every { standardTool.name } returns name
+        return standardTool
+    }
+
+    /** A path that does not exist yet, so a test can assert whether the grant materialised it. */
+    private fun unmaterialisedRoot(prefix: String): Path = Files.createTempDirectory(prefix).resolve("scope")
+
+    private fun captureConfig(
+        grantService: ExchangeToolGrantService,
+        root: Path = unmaterialisedRoot("grant-config"),
+        readOnly: Boolean = false,
+    ): JsonNode {
+        val filePlugin = mockk<ToolPlugin>(relaxed = true)
+        every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
+        grantService.grantTools(
+            root = root,
+            readOnly = readOnly,
+            configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
+            allowedTools = null,
+            toolContext = toolContext,
+        )
+        val cfg = slot<JsonNode>()
+        verify { filePlugin.provideTools(capture(cfg), ExchangeIntegrationTypes.CASE_CONFIG_NAME, any()) }
+        return cfg.captured
+    }
+
+    init {
+        // -------------------------------------------------------------------------
+        // Enablement — the agent's declaration wins, the platform default is the fallback
+        // -------------------------------------------------------------------------
+
+        "no case grant when the key is absent and the platform default is off" {
+            service().resolveCaseGrant(emptyMap()) shouldBe null
+        }
+
+        "no case grant when the agent declares no integrations at all" {
+            service().resolveCaseGrant(null) shouldBe null
+        }
+
+        "the platform default grants every tool when the key is absent" {
+            val grant = service(ExchangeToolsConfigProperties(caseEnabledByDefault = true)).resolveCaseGrant(emptyMap())
+
+            grant.shouldNotBeNull()
+            grant.allowedTools shouldBe null
+        }
+
+        "the platform default also applies to an agent that declares no integrations at all" {
+            val grant = service(ExchangeToolsConfigProperties(caseEnabledByDefault = true)).resolveCaseGrant(null)
+
+            grant.shouldNotBeNull()
+            grant.allowedTools shouldBe null
+        }
+
+        "a key declared with no list grants every tool" {
+            val grant = service().resolveCaseGrant(mapOf(ExchangeIntegrationTypes.CASE to null))
+
+            grant.shouldNotBeNull()
+            grant.allowedTools shouldBe null
+        }
+
+        "a key declared with a list restricts to those tool names" {
+            val grant = service().resolveCaseGrant(mapOf(ExchangeIntegrationTypes.CASE to listOf("readFile", "ls")))
+
+            grant.shouldNotBeNull()
+            grant.allowedTools shouldBe listOf("readFile", "ls")
+        }
+
+        "an empty list opts the agent out even when the platform default is on" {
+            // The central opt-out case: isToolAllowed would already reject every tool, but grantTools
+            // creates the scope directory before that filter runs — so the decision short-circuits here.
+            val grantService = service(ExchangeToolsConfigProperties(caseEnabledByDefault = true))
+
+            grantService.resolveCaseGrant(mapOf(ExchangeIntegrationTypes.CASE to emptyList())) shouldBe null
+        }
+
+        "an empty list opts the agent out of the namespace exchange too" {
+            val grantService = service(ExchangeToolsConfigProperties(namespaceEnabledByDefault = true))
+
+            grantService.resolveNamespaceGrant(mapOf(ExchangeIntegrationTypes.NAMESPACE to emptyList())) shouldBe null
+        }
+
+        "each scope reads its own platform default" {
+            val grantService =
+                service(
+                    ExchangeToolsConfigProperties(caseEnabledByDefault = false, namespaceEnabledByDefault = true),
+                )
+
+            grantService.resolveCaseGrant(null) shouldBe null
+            grantService.resolveNamespaceGrant(null).shouldNotBeNull()
+        }
+
+        // -------------------------------------------------------------------------
+        // Plugin configuration node
+        // -------------------------------------------------------------------------
+
+        "every configured file-tool setting is carried into the plugin config" {
+            val properties =
+                ExchangeToolsConfigProperties(
+                    imageMaxDimension = 1568,
+                    imageJpegQuality = 0.55f,
+                    imageMaxSourcePixels = 12_000_000L,
+                    imagePassThroughMaxBytes = 2048L,
+                    documentMaxOutputChars = 1234,
+                    documentMaxAttachedImages = 3,
+                    documentMaxTableColumns = 8,
+                    documentMaxCellChars = 99,
+                )
+
+            val cfg = captureConfig(service(properties))
+
+            cfg.get("imageMaxDimension").asInt() shouldBe 1568
+            // The plugin reads this as asDouble()?.toFloat(); asserting the raw double would fail.
+            cfg.get("imageJpegQuality").asDouble().toFloat() shouldBe 0.55f
+            cfg.get("imageMaxSourcePixels").asLong() shouldBe 12_000_000L
+            cfg.get("imagePassThroughMaxBytes").asLong() shouldBe 2048L
+            cfg.get("documentMaxOutputChars").asInt() shouldBe 1234
+            cfg.get("documentMaxAttachedImages").asInt() shouldBe 3
+            cfg.get("documentMaxTableColumns").asInt() shouldBe 8
+            cfg.get("documentMaxCellChars").asInt() shouldBe 99
+        }
+
+        "extraDenyPatterns is emitted as a JSON array" {
+            val properties = ExchangeToolsConfigProperties(extraDenyPatterns = listOf("*.bak", "internal-*"))
+
+            val patterns = captureConfig(service(properties)).get("extraDenyPatterns")
+
+            patterns.isArray shouldBe true
+            patterns.map { it.asText() } shouldBe listOf("*.bak", "internal-*")
+        }
+
+        "extraDenyPatterns is an empty array when nothing is configured" {
+            // The plugin reads the key with `takeIf { it.isArray }`: a missing key or a scalar would
+            // silently mean "no extra pattern", so the array itself is the contract.
+            val patterns = captureConfig(service()).get("extraDenyPatterns")
+
+            patterns.isArray shouldBe true
+            patterns.size() shouldBe 0
+        }
+
+        "an out-of-range jpeg quality is clamped rather than handed to the JPEG writer" {
+            captureConfig(service(ExchangeToolsConfigProperties(imageJpegQuality = 1.5f)))
+                .get("imageJpegQuality")
+                .asDouble()
+                .toFloat() shouldBe 1.0f
+
+            captureConfig(service(ExchangeToolsConfigProperties(imageJpegQuality = -0.2f)))
+                .get("imageJpegQuality")
+                .asDouble()
+                .toFloat() shouldBe 0.0f
+        }
+
+        "readMaxSizeMb derives from the exchange read cap" {
+            val storage = ExchangeStorageConfigProperties(readMaxSizeBytes = 50L * 1024 * 1024)
+
+            captureConfig(service(storageProperties = storage)).get("readMaxSizeMb").asLong() shouldBe 50L
+        }
+
+        "readMaxSizeMb is floored at 1 MB" {
+            val storage = ExchangeStorageConfigProperties(readMaxSizeBytes = 512L * 1024)
+
+            captureConfig(service(storageProperties = storage)).get("readMaxSizeMb").asLong() shouldBe 1L
+        }
+
+        "the runtime rootPath and readOnly reach the plugin unchanged" {
+            val root = unmaterialisedRoot("grant-runtime")
+
+            val cfg = captureConfig(service(), root = root, readOnly = true)
+
+            cfg.get("rootPath").asText() shouldBe root.toAbsolutePath().toString()
+            cfg.get("readOnly").asBoolean() shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // Materialisation
+        // -------------------------------------------------------------------------
+
+        "the scope root is created before the plugin tools are built" {
+            // The file-plugin's BoundaryPathResolver canonicalises rootPath at construction and throws
+            // when the directory is missing, so the grant has to materialise it first.
+            val root = unmaterialisedRoot("grant-materialise")
+            every { toolRegistryService.findPlugin("FILE_ACCESS") } returns mockk<ToolPlugin>(relaxed = true)
+
+            service().grantTools(
+                root = root,
+                readOnly = false,
+                configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
+                allowedTools = null,
+                toolContext = toolContext,
+            )
+
+            Files.exists(root) shouldBe true
+        }
+
+        "no tools and no directory when the FILE_ACCESS plugin is not loaded" {
+            val root = unmaterialisedRoot("grant-no-plugin")
+            every { toolRegistryService.findPlugin("FILE_ACCESS") } returns null
+
+            val tools =
+                service().grantTools(
+                    root = root,
+                    readOnly = false,
+                    configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
+                    allowedTools = null,
+                    toolContext = toolContext,
+                )
+
+            tools.shouldBeEmpty()
+            Files.exists(root) shouldBe false
+        }
+
+        "the plugin tools are filtered through the shared allowlist matcher" {
+            val root = unmaterialisedRoot("grant-filter")
+            val filePlugin = mockk<ToolPlugin>()
+            every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
+            every { filePlugin.provideTools(any(), any(), any()) } returns listOf(tool("readFile"), tool("editFiles"))
+            every {
+                toolResolverService.isToolAllowed("readFile", ExchangeIntegrationTypes.CASE_CONFIG_NAME, any())
+            } returns true
+            every {
+                toolResolverService.isToolAllowed("editFiles", ExchangeIntegrationTypes.CASE_CONFIG_NAME, any())
+            } returns false
+
+            val tools =
+                service().grantTools(
+                    root = root,
+                    readOnly = false,
+                    configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
+                    allowedTools = listOf("readFile"),
+                    toolContext = toolContext,
+                )
+
+            tools.map { it.name } shouldBe listOf("readFile")
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/exchange/ExchangeToolGrantServiceUnitSpec.kt
@@ -313,15 +313,19 @@ class ExchangeToolGrantServiceUnitSpec : StringSpec() {
         }
 
         "the plugin tools are filtered through the shared allowlist matcher" {
+            // The allowlist is stubbed by value, not with any(): any() is a ConstantMatcher that also
+            // matches null, so it would keep this test green even if grantTools stopped forwarding
+            // the agent's list, which silently hands every write tool back to a restricted agent.
+            val allowlist = listOf("readFile")
             val root = unmaterialisedRoot("grant-filter")
             val filePlugin = mockk<ToolPlugin>()
             every { toolRegistryService.findPlugin("FILE_ACCESS") } returns filePlugin
             every { filePlugin.provideTools(any(), any(), any()) } returns listOf(tool("readFile"), tool("editFiles"))
             every {
-                toolResolverService.isToolAllowed("readFile", ExchangeIntegrationTypes.CASE_CONFIG_NAME, any())
+                toolResolverService.isToolAllowed("readFile", ExchangeIntegrationTypes.CASE_CONFIG_NAME, allowlist)
             } returns true
             every {
-                toolResolverService.isToolAllowed("editFiles", ExchangeIntegrationTypes.CASE_CONFIG_NAME, any())
+                toolResolverService.isToolAllowed("editFiles", ExchangeIntegrationTypes.CASE_CONFIG_NAME, allowlist)
             } returns false
 
             val tools =
@@ -329,11 +333,16 @@ class ExchangeToolGrantServiceUnitSpec : StringSpec() {
                     root = root,
                     readOnly = false,
                     configName = ExchangeIntegrationTypes.CASE_CONFIG_NAME,
-                    allowedTools = listOf("readFile"),
+                    allowedTools = allowlist,
                     toolContext = toolContext,
                 )
 
             tools.map { it.name } shouldBe listOf("readFile")
+            // Pins the forwarding itself: a strict mock would already throw on a null allowlist, and
+            // this makes the intent explicit for the next reader.
+            verify {
+                toolResolverService.isToolAllowed("readFile", ExchangeIntegrationTypes.CASE_CONFIG_NAME, allowlist)
+            }
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/CompositeIntegrationTypeRegistrySpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/CompositeIntegrationTypeRegistrySpec.kt
@@ -30,11 +30,29 @@ class CompositeIntegrationTypeRegistrySpec :
         }
 
         "the built-in exchange descriptors are the two file-exchange types, flagged builtIn with no config" {
-            val descriptors = ExchangeIntegrationTypes.builtInDescriptors()
+            val descriptors =
+                ExchangeIntegrationTypes.builtInDescriptors(
+                    caseEnabledByDefault = false,
+                    namespaceEnabledByDefault = false,
+                )
 
             descriptors.map { it.type } shouldContainExactlyInAnyOrder
                 listOf(ExchangeIntegrationTypes.CASE, ExchangeIntegrationTypes.NAMESPACE)
             descriptors.all { it.builtIn } shouldBe true
             descriptors.all { it.configSchema == null } shouldBe true
+            descriptors.all { !it.enabledByDefault } shouldBe true
+        }
+
+        "each built-in exchange descriptor publishes its own platform default" {
+            // The client renders this to say which way the "platform default" state of a toggle
+            // resolves, so the two scopes must not be conflated.
+            val descriptors =
+                ExchangeIntegrationTypes.builtInDescriptors(
+                    caseEnabledByDefault = true,
+                    namespaceEnabledByDefault = false,
+                )
+
+            descriptors.single { it.type == ExchangeIntegrationTypes.CASE }.enabledByDefault shouldBe true
+            descriptors.single { it.type == ExchangeIntegrationTypes.NAMESPACE }.enabledByDefault shouldBe false
         }
     })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractAgentConfigPersistenceSpec.kt
@@ -743,5 +743,19 @@ abstract class AbstractAgentConfigPersistenceSpec : StringSpec() {
             reloaded.integrations?.containsKey("CASE_FILE_EXCHANGE") shouldBe true
             reloaded.integrations?.containsKey("NAMESPACE_FILE_EXCHANGE") shouldBe false
         }
+
+        "save round-trips an empty tool list on an exchange key as an empty list, not null" {
+            // [] is the explicit opt-out and null the full grant, so collapsing one into the other
+            // across the integrationsJson round-trip would flip the agent to platform-default.
+            val ns = namespaceRepo.save(namespace())
+            val saved = agentConfigRepo.save(
+                agentConfig(ns.id, "opted-out-agent").copy(integrations = mapOf("CASE_FILE_EXCHANGE" to emptyList())),
+            )
+
+            val reloaded = agentConfigRepo.findByParent(ns.id, withDisabled = true).single { it.id == saved.id }
+
+            reloaded.integrations?.containsKey("CASE_FILE_EXCHANGE") shouldBe true
+            reloaded.integrations?.get("CASE_FILE_EXCHANGE") shouldBe emptyList<String>()
+        }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolRegistryServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolRegistryServiceUnitSpec.kt
@@ -1,0 +1,92 @@
+package io.whozoss.agentos.tool
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.exchange.ExchangeIntegrationTypes
+import io.whozoss.agentos.exchange.ExchangeToolsConfigProperties
+import io.whozoss.agentos.integrationConfig.CompositeIntegrationTypeRegistry
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolPlugin
+import org.pf4j.PluginManager
+
+/**
+ * Unit spec for the built-in exchange type registration in [ToolRegistryService].
+ *
+ * The two [ExchangeToolsConfigProperties] flags are passed as adjacent Booleans into
+ * [ExchangeIntegrationTypes.builtInDescriptors], and the client labels the "platform default"
+ * state of each toggle from the resulting descriptor — so a silent argument swap or a wrong
+ * property reference would mislabel the UI without failing anywhere else.
+ */
+class ToolRegistryServiceUnitSpec :
+    StringSpec({
+
+        fun makePlugin(integrationType: String): ToolPlugin =
+            object : ToolPlugin {
+                override val integrationType = integrationType
+                override val configSchema: JsonNode? = null
+
+                override fun provideTools(
+                    config: JsonNode?,
+                    configName: String?,
+                    context: ToolContext?,
+                ): List<StandardTool<*>> = emptyList()
+            }
+
+        fun initializedRegistry(
+            plugins: List<ToolPlugin>,
+            properties: ExchangeToolsConfigProperties,
+        ): CompositeIntegrationTypeRegistry {
+            val pluginManager = mockk<PluginManager>(relaxed = true)
+            every { pluginManager.getExtensions(ToolPlugin::class.java) } returns plugins
+            every { pluginManager.whichPlugin(any()) } returns null
+            val registry = CompositeIntegrationTypeRegistry()
+            ToolRegistryService(
+                pluginManager = pluginManager,
+                integrationTypeRegistry = registry,
+                exchangeToolsConfigProperties = properties,
+            ).initialize()
+            return registry
+        }
+
+        "each exchange descriptor carries its own platform default from the config properties" {
+            // Asymmetric flags: a swap of the two Boolean arguments would make both assertions fail.
+            val registry =
+                initializedRegistry(
+                    plugins = listOf(makePlugin(ExchangeIntegrationTypes.FILE_ACCESS)),
+                    properties =
+                        ExchangeToolsConfigProperties(
+                            caseEnabledByDefault = true,
+                            namespaceEnabledByDefault = false,
+                        ),
+                )
+
+            val case = registry.findByType(ExchangeIntegrationTypes.CASE)
+            val namespace = registry.findByType(ExchangeIntegrationTypes.NAMESPACE)
+            case shouldNotBe null
+            namespace shouldNotBe null
+            case!!.enabledByDefault shouldBe true
+            namespace!!.enabledByDefault shouldBe false
+        }
+
+        "no built-in exchange descriptor is registered when the FILE_ACCESS plugin is absent" {
+            // Some other plugin being loaded must not be enough: the gate is FILE_ACCESS
+            // specifically, and the platform defaults cannot resurrect the descriptors.
+            val registry =
+                initializedRegistry(
+                    plugins = listOf(makePlugin("DATETIME")),
+                    properties =
+                        ExchangeToolsConfigProperties(
+                            caseEnabledByDefault = true,
+                            namespaceEnabledByDefault = true,
+                        ),
+                )
+
+            registry.listTypes().shouldBeEmpty()
+        }
+    })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
+import io.whozoss.agentos.exchange.ExchangeToolsConfigProperties
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationTypeRegistry
 import io.whozoss.agentos.sdk.entity.EntityMetadata
@@ -87,7 +88,12 @@ class ToolResolverServiceSpec :
             val pluginManager = mockk<PluginManager>(relaxed = true)
             every { pluginManager.getExtensions(ToolPlugin::class.java) } returns plugins
             every { pluginManager.whichPlugin(any()) } returns null
-            val registry = ToolRegistryService(pluginManager, mockk<IntegrationTypeRegistry>(relaxed = true))
+            val registry =
+                ToolRegistryService(
+                    pluginManager,
+                    mockk<IntegrationTypeRegistry>(relaxed = true),
+                    ExchangeToolsConfigProperties(),
+                )
             registry.initialize()
             return registry
         }

--- a/agentos/docs/file-exchange.md
+++ b/agentos/docs/file-exchange.md
@@ -47,8 +47,8 @@ agent read cap can never drift from the one the REST path enforces.
 | Property | Env var | Default | Purpose |
 |---|---|---|---|
 | `agentos.exchange.tools.case-enabled-by-default` | `AGENTOS_EXCHANGE_TOOLS_CASE_ENABLED_BY_DEFAULT` | `false` | Grants `CASE_FILE_EXCHANGE` to every agent that does not mention it. |
-| `agentos.exchange.tools.namespace-enabled-by-default` | `AGENTOS_EXCHANGE_TOOLS_NAMESPACE_ENABLED_BY_DEFAULT` | `false` | Same for `NAMESPACE_FILE_EXCHANGE`; write access still follows Namespace `WRITE`. |
-| `agentos.exchange.tools.extra-deny-patterns` | `AGENTOS_EXCHANGE_TOOLS_EXTRA_DENY_PATTERNS` | empty | Extra globs blocked on top of the built-in sensitive-file list (additive only). |
+| `agentos.exchange.tools.namespace-enabled-by-default` | `AGENTOS_EXCHANGE_TOOLS_NAMESPACE_ENABLED_BY_DEFAULT` | `false` | Same for `NAMESPACE_FILE_EXCHANGE`; the invoking user must also hold Namespace `READ`, and write follows Namespace `WRITE`. |
+| `agentos.exchange.tools.extra-deny-patterns` | `AGENTOS_EXCHANGE_TOOLS_EXTRA_DENY_PATTERNS` | empty | Extra patterns blocked on top of the built-in sensitive-file list (additive only). Matched against file names only, see below. |
 | `agentos.exchange.tools.image-max-dimension` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_DIMENSION` | `1024` | Longest edge (px) of images `readAsImage` / `readDocument` send to the LLM. |
 | `agentos.exchange.tools.image-jpeg-quality` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_JPEG_QUALITY` | `0.80` | JPEG re-encoding quality, clamped to `[0, 1]`. |
 | `agentos.exchange.tools.image-max-source-pixels` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_SOURCE_PIXELS` | `50000000` | Decode-bomb guard. |
@@ -57,6 +57,14 @@ agent read cap can never drift from the one the REST path enforces.
 | `agentos.exchange.tools.document-max-attached-images` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_ATTACHED_IMAGES` | `10` | Max embedded pictures attached per call. |
 | `agentos.exchange.tools.document-max-table-columns` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_TABLE_COLUMNS` | `64` | Columns dropped beyond this when rendering a `.docx` table. |
 | `agentos.exchange.tools.document-max-cell-chars` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_CELL_CHARS` | `5000` | A longer table cell is truncated. |
+
+`extra-deny-patterns` matches the **final path segment only** (the file or directory name), never
+the full relative path, and supports only `*suffix`, `prefix*`, `*contains*` and exact names (the
+file-plugin's `matchesPattern`, applied by `BoundaryPathResolver` to the resolved name). A
+path-shaped pattern such as `secrets/*` therefore matches nothing, and a prefix pattern such as
+`internal-*` denies the directory entry `internal-reports` while leaving
+`internal-reports/summary.md` readable through its direct path. To fence off content, use name
+patterns that hold at every depth, like `*.bak` or `*confidential*`.
 
 These reach the file plugin as the `provideTools` configuration node: the SDK and the plugins carry
 no Spring dependency, so `ExchangeToolGrantService` is what turns the bound properties into that
@@ -94,7 +102,7 @@ Case and namespace exchange are exposed as **built-in integration types** (`Exch
 | Type | Scope | Access |
 |---|---|---|
 | `CASE_FILE_EXCHANGE` | current case | read / write |
-| `NAMESPACE_FILE_EXCHANGE` | namespace shared | read; read / write when the invoking user is a namespace admin |
+| `NAMESPACE_FILE_EXCHANGE` | namespace shared | requires the invoking user to hold Namespace `READ`; read / write when they hold Namespace `WRITE` (admin) |
 
 They appear in `GET /api/integration-types` with `builtIn = true`, but only when the `FILE_ACCESS`
 plugin is loaded. Enablement is per agent, through the agent's `integrations` map (no persisted
@@ -110,7 +118,16 @@ boolean flags), with a platform-level fallback for an agent that says nothing:
 The empty list is a genuine opt-out rather than an empty allow-list. `ToolResolverService.isToolAllowed`
 would already reject every tool, but the grant creates the scope directory *before* that filter runs,
 so the decision short-circuits earlier in `ExchangeToolGrantService.resolveCaseGrant` /
-`resolveNamespaceGrant`.
+`resolveNamespaceGrant`. Resolution also short-circuits when the `FILE_ACCESS` plugin is not loaded:
+no grant, hence no permission query and no directory (`grantTools` re-checks the plugin as defence in
+depth).
+
+The namespace scope carries one more gate. However the grant arises (platform default or the agent's
+own declaration), it stands only when the invoking user holds Namespace `READ`, and a run without an
+identified user is denied outright (fail-closed): the agent reads the shared files on behalf of a
+user, so no user means no access. One visible consequence: the definition-preview endpoint
+(`getDefinition` with `withUserOverlay=false`) resolves no user and therefore does not report the
+namespace exchange tools.
 
 The three states are what the agent form in `agentos-ui` renders, per built-in type: *Platform
 default*, *Enabled*, *Disabled*. "Platform default" is a state the user can see and keep, not a
@@ -118,13 +135,21 @@ synonym for off — that is what stops an agent nobody ever configured from bein
 the first time someone saves an unrelated change on a default-on instance. To label which way it
 resolves, `GET /api/integration-types` publishes `enabledByDefault` on each descriptor.
 
+A persisted per-tool allowlist survives the form too: when the stored value is a non-empty tool list
+and the user leaves the row on *Enabled*, the original list is written back unchanged rather than
+silently widened to "all tools", and the restriction is surfaced as read-only text under the row (the
+form edits enablement, not the list).
+
 Per-run tools are built by `AgentServiceImpl.buildExchangeTools`, which keeps what only it knows (the
-run's `caseId`, the invoking user's Namespace `WRITE` right) and delegates the decision, the plugin
-configuration and the `ToolResolverService.isToolAllowed` filtering to `ExchangeToolGrantService`. The
-platform default is a decision local to that service and never a mutation of `AgentConfig.integrations`,
-which would otherwise leak into the persisted config, the YAML export and the peer descriptions the
-redirect tool puts in every agent's prompt. Granted tool names follow `<configName>__<tool>` (for
-example `case-exchange__editFiles`).
+run's `caseId`, the invoking user's Namespace `READ` and `WRITE` rights) and delegates the decision,
+the plugin configuration and the `ToolResolverService.isToolAllowed` filtering to
+`ExchangeToolGrantService`. The platform default is a decision local to that service and never a
+mutation of `AgentConfig.integrations`, which would otherwise leak into the persisted config, the
+YAML export and the peer descriptions the redirect tool puts in every agent's prompt. The YAML export
+in turn round-trips the agent's own choice in both directions: a built-in key mapped to null
+(enabled, all tools) and one mapped to `[]` (opt-out) are both preserved, so exporting and
+re-importing an agent keeps its exchange stance. Granted tool names follow `<configName>__<tool>`
+(for example `case-exchange__editFiles`).
 
 ## Safety
 

--- a/agentos/docs/file-exchange.md
+++ b/agentos/docs/file-exchange.md
@@ -18,12 +18,13 @@ so the REST path and the agent tool path always resolve to the same directory.
 
 ## Configuration
 
-Mount root, bound from the `agentos.exchange` prefix (Spring relaxed binding):
+Storage and user-facing limits, bound from the `agentos.exchange` prefix (Spring relaxed binding):
 
 | Property | Env var | Default | Purpose |
 |---|---|---|---|
 | `agentos.exchange.mount-root` | `AGENTOS_EXCHANGE_MOUNT_ROOT` | `data/exchange/` | Root directory for all exchange files. Relative paths resolve against the JVM working directory. |
 | `agentos.exchange.allowed-upload-extensions` | `AGENTOS_EXCHANGE_ALLOWED_UPLOAD_EXTENSIONS` | text / doc / data / image / code set | Extensions allowed for user uploads (lowercase, no dot; empty = allow any). A disallowed type is rejected with 400. |
+| `agentos.exchange.read-max-size-bytes` | `AGENTOS_EXCHANGE_READ_MAX_SIZE_BYTES` | `104857600` (100 MB) | Max size the read/download endpoints load into memory (larger is rejected with 422). Also caps the agent read tools on the same directories, in whole megabytes with a floor of 1. |
 
 Upload size limits are global Spring multipart settings (they also bound plugin-jar uploads),
 raised from Spring's 1 MB default:
@@ -33,8 +34,35 @@ raised from Spring's 1 MB default:
 | `spring.servlet.multipart.max-file-size` | `AGENTOS_MULTIPART_MAX_FILE_SIZE` | `25MB` | Max size of a single uploaded file. |
 | `spring.servlet.multipart.max-request-size` | `AGENTOS_MULTIPART_MAX_REQUEST_SIZE` | `30MB` | Max size of the whole multipart request. |
 
-All three follow the repo convention: `${ENV_VAR:default}` placeholders, the `AGENTOS_*` prefix,
-and Spring relaxed binding.
+The multipart pair uses explicit `${ENV_VAR:default}` placeholders because it lives under the
+`spring.*` namespace; the `agentos.*` keys rely on Spring relaxed binding alone. Both follow the
+`AGENTOS_*` prefix convention.
+
+Agent-facing tool policy, bound from the `agentos.exchange.tools` prefix. **One set of values is
+shared by both scopes**: an agent sees the same limits whether a file sits in the case or the
+namespace exchange. The plugin's three other keys are absent by design — `rootPath` and `readOnly`
+are computed per run, and `readMaxSizeMb` derives from `agentos.exchange.read-max-size-bytes` so the
+agent read cap can never drift from the one the REST path enforces.
+
+| Property | Env var | Default | Purpose |
+|---|---|---|---|
+| `agentos.exchange.tools.case-enabled-by-default` | `AGENTOS_EXCHANGE_TOOLS_CASE_ENABLED_BY_DEFAULT` | `false` | Grants `CASE_FILE_EXCHANGE` to every agent that does not mention it. |
+| `agentos.exchange.tools.namespace-enabled-by-default` | `AGENTOS_EXCHANGE_TOOLS_NAMESPACE_ENABLED_BY_DEFAULT` | `false` | Same for `NAMESPACE_FILE_EXCHANGE`; write access still follows Namespace `WRITE`. |
+| `agentos.exchange.tools.extra-deny-patterns` | `AGENTOS_EXCHANGE_TOOLS_EXTRA_DENY_PATTERNS` | empty | Extra globs blocked on top of the built-in sensitive-file list (additive only). |
+| `agentos.exchange.tools.image-max-dimension` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_DIMENSION` | `1024` | Longest edge (px) of images `readAsImage` / `readDocument` send to the LLM. |
+| `agentos.exchange.tools.image-jpeg-quality` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_JPEG_QUALITY` | `0.80` | JPEG re-encoding quality, clamped to `[0, 1]`. |
+| `agentos.exchange.tools.image-max-source-pixels` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_SOURCE_PIXELS` | `50000000` | Decode-bomb guard. |
+| `agentos.exchange.tools.image-pass-through-max-bytes` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_PASS_THROUGH_MAX_BYTES` | `1048576` | Small originals already fitting the max dimension are sent untouched. |
+| `agentos.exchange.tools.document-max-output-chars` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_OUTPUT_CHARS` | `100000` | Markdown budget per `readDocument` call. |
+| `agentos.exchange.tools.document-max-attached-images` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_ATTACHED_IMAGES` | `10` | Max embedded pictures attached per call. |
+| `agentos.exchange.tools.document-max-table-columns` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_TABLE_COLUMNS` | `64` | Columns dropped beyond this when rendering a `.docx` table. |
+| `agentos.exchange.tools.document-max-cell-chars` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_CELL_CHARS` | `5000` | A longer table cell is truncated. |
+
+These reach the file plugin as the `provideTools` configuration node: the SDK and the plugins carry
+no Spring dependency, so `ExchangeToolGrantService` is what turns the bound properties into that
+node. The defaults duplicate the plugin's own constants — a plugin jar predating one of these keys
+simply ignores it and falls back to its compiled default, so tuning a value without redeploying the
+plugin has no visible effect.
 
 ## REST API
 
@@ -69,11 +97,34 @@ Case and namespace exchange are exposed as **built-in integration types** (`Exch
 | `NAMESPACE_FILE_EXCHANGE` | namespace shared | read; read / write when the invoking user is a namespace admin |
 
 They appear in `GET /api/integration-types` with `builtIn = true`, but only when the `FILE_ACCESS`
-plugin is loaded. Enable them per agent through the agent's `integrations` map (no persisted boolean
-flags). Per-run tools are built in `AgentServiceImpl.buildExchangeTools`, which points the file plugin
-at the computed scope root and filters the tool set through the shared
-`ToolResolverService.isToolAllowed` allowlist. Granted tool names follow `<configName>__<tool>`
-(for example `case-exchange__editFiles`).
+plugin is loaded. Enablement is per agent, through the agent's `integrations` map (no persisted
+boolean flags), with a platform-level fallback for an agent that says nothing:
+
+| `integrations` entry | Result |
+|---|---|
+| key absent | the platform default (`agentos.exchange.tools.*-enabled-by-default`, off by default) decides; when on, every tool is granted |
+| `CASE_FILE_EXCHANGE:` (null) | granted, every tool |
+| `CASE_FILE_EXCHANGE: [readFile, ls]` | granted, restricted to those names (bare or `case-exchange__readFile`) |
+| `CASE_FILE_EXCHANGE: []` | **opt-out** — nothing granted, and no scope directory is created |
+
+The empty list is a genuine opt-out rather than an empty allow-list. `ToolResolverService.isToolAllowed`
+would already reject every tool, but the grant creates the scope directory *before* that filter runs,
+so the decision short-circuits earlier in `ExchangeToolGrantService.resolveCaseGrant` /
+`resolveNamespaceGrant`.
+
+The three states are what the agent form in `agentos-ui` renders, per built-in type: *Platform
+default*, *Enabled*, *Disabled*. "Platform default" is a state the user can see and keep, not a
+synonym for off — that is what stops an agent nobody ever configured from being silently switched off
+the first time someone saves an unrelated change on a default-on instance. To label which way it
+resolves, `GET /api/integration-types` publishes `enabledByDefault` on each descriptor.
+
+Per-run tools are built by `AgentServiceImpl.buildExchangeTools`, which keeps what only it knows (the
+run's `caseId`, the invoking user's Namespace `WRITE` right) and delegates the decision, the plugin
+configuration and the `ToolResolverService.isToolAllowed` filtering to `ExchangeToolGrantService`. The
+platform default is a decision local to that service and never a mutation of `AgentConfig.integrations`,
+which would otherwise leak into the persisted config, the YAML export and the peer descriptions the
+redirect tool puts in every agent's prompt. Granted tool names follow `<configName>__<tool>` (for
+example `case-exchange__editFiles`).
 
 ## Safety
 
@@ -82,7 +133,10 @@ at the computed scope root and filters the tool set through the shared
 - **Path containment**: the resolved path must stay within the scope root. Traversal (`../`) and
   symlink escapes are rejected.
 - **No phantom directories**: reads and deletes on a never-written scope return 404 without
-  materializing empty shard directories.
+  materializing empty shard directories. The agent grant is the one exception — the file plugin
+  canonicalizes `rootPath` at construction, so granting a scope creates its directory. Turning
+  `case-enabled-by-default` on therefore materializes a case exchange directory for every case a
+  granted agent runs in; an agent that opts out with `[]` creates nothing.
 - **Upload allow-list**: user uploads are restricted to a configurable set of file extensions
   (`agentos.exchange.allowed-upload-extensions`); a disallowed type is rejected with 400.
 

--- a/agentos/docs/file-exchange.md
+++ b/agentos/docs/file-exchange.md
@@ -112,7 +112,7 @@ boolean flags), with a platform-level fallback for an agent that says nothing:
 |---|---|
 | key absent | the platform default (`agentos.exchange.tools.*-enabled-by-default`, off by default) decides; when on, every tool is granted |
 | `CASE_FILE_EXCHANGE:` (null) | granted, every tool |
-| `CASE_FILE_EXCHANGE: [readFile, ls]` | granted, restricted to those names (bare or `case-exchange__readFile`) |
+| `CASE_FILE_EXCHANGE: [readFile, listFiles]` | granted, restricted to those names (bare or `case-exchange__readFile`) |
 | `CASE_FILE_EXCHANGE: []` | **opt-out** — nothing granted, and no scope directory is created |
 
 The empty list is a genuine opt-out rather than an empty allow-list. `ToolResolverService.isToolAllowed`

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -3195,12 +3195,20 @@ components:
           type: string
         displayName:
           type: string
+        enabledByDefault:
+          type: boolean
+          description: "What this instance grants an agent whose integrations map\
+            \ does not mention this type at all. An agent's own choice always wins,\
+            \ in both directions; this only fills the gap, so a client can label the\
+            \ \"platform default\" state of a toggle. Always false for non-built-in\
+            \ types."
         type:
           type: string
       required:
       - builtIn
       - description
       - displayName
+      - enabledByDefault
       - type
     IntentionGeneratedEvent:
       allOf:

--- a/libs/agentos-api-client/src/lib/model/integration-type-descriptor.ts
+++ b/libs/agentos-api-client/src/lib/model/integration-type-descriptor.ts
@@ -13,5 +13,9 @@ export interface IntegrationTypeDescriptor {
   configSchema?: any | null
   description: string
   displayName: string
+  /**
+   * What this instance grants an agent whose integrations map does not mention this type at all. An agent\'s own choice always wins, in both directions; this only fills the gap, so a client can label the \"platform default\" state of a toggle. Always false for non-built-in types.
+   */
+  enabledByDefault: boolean
   type: string
 }

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.html
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.html
@@ -101,16 +101,20 @@
             <p class="agent-config-form__integrations-separator">Built-in integrations</p>
             @for (row of builtInRows(); track row.type) {
               <div class="agent-config-form__integration-row">
-                <label class="agent-config-form__integration-toggle">
-                  <input
-                    class="agent-config-form__integration-checkbox"
-                    type="checkbox"
-                    [checked]="row.enabled()"
-                    (change)="toggleBuiltIn(row)"
-                  />
+                <label class="agent-config-form__integration-toggle" [attr.for]="'built-in-' + row.type">
                   <span class="agent-config-form__integration-name">{{ row.displayName }}</span>
                   <span class="agent-config-form__integration-type">built-in</span>
                 </label>
+                <select
+                  class="agent-config-form__integration-state"
+                  [id]="'built-in-' + row.type"
+                  [value]="row.state()"
+                  (change)="setBuiltInState(row, $any($event.target).value)"
+                >
+                  <option value="default">{{ builtInDefaultLabel(row) }}</option>
+                  <option value="on">Enabled</option>
+                  <option value="off">Disabled</option>
+                </select>
                 <p class="agent-config-form__integration-builtin-desc">{{ row.description }}</p>
               </div>
             }

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.html
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.html
@@ -115,6 +115,11 @@
                   <option value="on">Enabled</option>
                   <option value="off">Disabled</option>
                 </select>
+                @if (row.state() === 'on' && row.restrictedTools) {
+                  <p class="agent-config-form__integration-restriction">
+                    Restricted to: {{ row.restrictedTools.join(', ') }} (set outside this form, preserved on save)
+                  </p>
+                }
                 <p class="agent-config-form__integration-builtin-desc">{{ row.description }}</p>
               </div>
             }

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.scss
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.scss
@@ -202,6 +202,14 @@
     }
   }
 
+  &__integration-restriction {
+    margin: 0 0 0 1.5rem;
+    font-size: 0.8rem;
+    font-style: italic;
+    color: var(--color-text-secondary, #6e6e73);
+    line-height: 1.4;
+  }
+
   &__integration-builtin-desc {
     margin: 0 0 0 1.5rem;
     font-size: 0.8rem;

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.scss
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.scss
@@ -185,6 +185,23 @@
     color: var(--color-text-secondary, #6e6e73);
   }
 
+  &__integration-state {
+    margin-left: 1.5rem;
+    padding: 0.375rem 0.625rem;
+    border-radius: 8px;
+    border: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
+    background: transparent;
+    color: var(--color-text, #1d1d1f);
+    font-size: 0.875rem;
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.15s ease;
+
+    &:focus {
+      border-color: var(--color-primary, #007aff);
+    }
+  }
+
   &__integration-builtin-desc {
     margin: 0 0 0 1.5rem;
     font-size: 0.8rem;

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.spec.ts
@@ -17,7 +17,7 @@ import { AgentConfigFormComponent } from './agent-config-form.component'
  * there are no dedicated boolean fields any more.
  *
  * The component class is driven directly (ngOnInit / submit) without rendering the template,
- * except the listing tests which render via detectChanges.
+ * except the listing and tri-state select tests which render via detectChanges.
  */
 describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
   let controller: {
@@ -65,6 +65,7 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
         type: string
         enabledByDefault: boolean
         state: { (): BuiltInState; set: (v: BuiltInState) => void }
+        restrictedTools: string[] | null
       }>
       submit: () => void
     }
@@ -155,6 +156,19 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
       ).toBe('off')
     })
 
+    it('hydrates a non-empty allowlist as an enabled row carrying the restriction', () => {
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: ['readFile'] } })))
+
+      component.ngOnInit()
+
+      const row = internals()
+        .builtInRows()
+        .find((r) => r.type === CASE)
+      expect(row?.state()).toBe('on')
+      expect(row?.restrictedTools).toEqual(['readFile'])
+    })
+
     it('carries the platform default of each type onto its row', () => {
       integrationType.listTypesIntegrationType.mockReturnValue(
         of([
@@ -238,8 +252,35 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
       expect(controller.updateAgentConfig.mock.calls[0][1].integrations).toEqual({ [NAMESPACE]: [] })
     })
 
+    it('writes a hydrated per-tool allowlist back verbatim instead of widening it to all tools', () => {
+      // The form has no editor for a non-empty allowlist (set via API or YAML): a row left on `on`
+      // must not turn ['readFile'] into null and silently grant editFiles / remove / moveFile.
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: ['readFile'] } })))
+      component.ngOnInit()
+
+      internals().submit()
+
+      expect(controller.updateAgentConfig.mock.calls[0][1].integrations).toEqual({ [CASE]: ['readFile'] })
+    })
+
+    it('lets an explicit opt-out override a hydrated allowlist', () => {
+      // Switching the row to `off` is the one edit the form does offer on a restricted grant.
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: ['readFile'] } })))
+      component.ngOnInit()
+      internals()
+        .builtInRows()
+        .find((r) => r.type === CASE)!
+        .state.set('off')
+
+      internals().submit()
+
+      expect(controller.updateAgentConfig.mock.calls[0][1].integrations).toEqual({ [CASE]: [] })
+    })
+
     it('preserves an already-enabled built-in when the integration-types endpoint is unavailable', () => {
-      // The types call fails → builtInRows is empty (fail-safe, no toggle rendered), but the agent
+      // The types call fails → builtInRows is empty (fail-safe, no row rendered), but the agent
       // already had CASE enabled: saving unrelated changes must NOT silently strip it from the map.
       routeAgentConfigId = 'a-1'
       controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: null } })))
@@ -277,6 +318,55 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
       integrationType.listTypesIntegrationType.mockReturnValue(throwError(() => new Error('boom')))
       fixture.detectChanges()
       expect(internals().builtInRows()).toEqual([])
+    })
+  })
+
+  describe('tri-state select (template)', () => {
+    const selectFor = (type: string): HTMLSelectElement => {
+      const select = (fixture.nativeElement as HTMLElement).querySelector<HTMLSelectElement>(`#built-in-${type}`)
+      expect(select).not.toBeNull()
+      return select!
+    }
+
+    it('offers exactly the three tri-state values as options', () => {
+      fixture.detectChanges()
+      expect(Array.from(selectFor(CASE).options).map((o) => o.value)).toEqual(['default', 'on', 'off'])
+    })
+
+    it('routes a change event on the select to the row state', () => {
+      fixture.detectChanges()
+      const select = selectFor(CASE)
+      select.value = 'off'
+      select.dispatchEvent(new Event('change'))
+
+      expect(
+        internals()
+          .builtInRows()
+          .find((r) => r.type === CASE)
+          ?.state()
+      ).toBe('off')
+    })
+
+    it('labels the default option as disabled when the platform default is off', () => {
+      fixture.detectChanges()
+      expect(selectFor(CASE).options[0].textContent?.trim()).toBe('Platform default (disabled)')
+    })
+
+    it('labels the default option as enabled when the platform default is on', () => {
+      integrationType.listTypesIntegrationType.mockReturnValue(of([{ ...builtInTypes[0], enabledByDefault: true }]))
+      fixture.detectChanges()
+      expect(selectFor(CASE).options[0].textContent?.trim()).toBe('Platform default (enabled)')
+    })
+
+    it('surfaces a persisted allowlist as read-only text under the row', () => {
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: ['readFile', 'ls'] } })))
+      fixture.detectChanges()
+
+      const restriction = (fixture.nativeElement as HTMLElement).querySelector(
+        '.agent-config-form__integration-restriction'
+      )
+      expect(restriction?.textContent).toContain('readFile, ls')
     })
   })
 })

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.spec.ts
@@ -36,22 +36,36 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
   const NAMESPACE = 'NAMESPACE_FILE_EXCHANGE'
 
   const builtInTypes = [
-    { type: CASE, displayName: 'Case file exchange', description: 'Case files.', configSchema: null, builtIn: true },
+    {
+      type: CASE,
+      displayName: 'Case file exchange',
+      description: 'Case files.',
+      configSchema: null,
+      builtIn: true,
+      enabledByDefault: false,
+    },
     {
       type: NAMESPACE,
       displayName: 'Namespace file exchange',
       description: 'NS files.',
       configSchema: null,
       builtIn: true,
+      enabledByDefault: false,
     },
     // a regular (non-built-in) type must be excluded from the built-in section
-    { type: 'JIRA', displayName: 'Jira', description: '', configSchema: {}, builtIn: false },
+    { type: 'JIRA', displayName: 'Jira', description: '', configSchema: {}, builtIn: false, enabledByDefault: false },
   ]
+
+  type BuiltInState = 'default' | 'on' | 'off'
 
   const internals = () =>
     component as unknown as {
       nameControl: { setValue: (v: string) => void }
-      builtInRows: () => Array<{ type: string; enabled: { (): boolean; set: (v: boolean) => void } }>
+      builtInRows: () => Array<{
+        type: string
+        enabledByDefault: boolean
+        state: { (): BuiltInState; set: (v: BuiltInState) => void }
+      }>
       submit: () => void
     }
 
@@ -115,15 +129,45 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
       ).toEqual([CASE, NAMESPACE])
     })
 
-    it('hydrates the enabled state from the config integrations map (edit mode)', () => {
+    it('hydrates the tri-state from the config integrations map (edit mode)', () => {
       routeAgentConfigId = 'a-1'
       controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: null } })))
 
       component.ngOnInit()
 
       const rows = internals().builtInRows()
-      expect(rows.find((r) => r.type === CASE)?.enabled()).toBe(true)
-      expect(rows.find((r) => r.type === NAMESPACE)?.enabled()).toBe(false)
+      expect(rows.find((r) => r.type === CASE)?.state()).toBe('on')
+      // No key at all → the agent expressed no choice; the platform default decides, not the form.
+      expect(rows.find((r) => r.type === NAMESPACE)?.state()).toBe('default')
+    })
+
+    it('reads an empty array as an explicit opt-out, not as an enabled row', () => {
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: [] } })))
+
+      component.ngOnInit()
+
+      expect(
+        internals()
+          .builtInRows()
+          .find((r) => r.type === CASE)
+          ?.state()
+      ).toBe('off')
+    })
+
+    it('carries the platform default of each type onto its row', () => {
+      integrationType.listTypesIntegrationType.mockReturnValue(
+        of([
+          { ...builtInTypes[0], enabledByDefault: true },
+          { ...builtInTypes[1], enabledByDefault: false },
+        ])
+      )
+
+      component.ngOnInit()
+
+      const rows = internals().builtInRows()
+      expect(rows.find((r) => r.type === CASE)?.enabledByDefault).toBe(true)
+      expect(rows.find((r) => r.type === NAMESPACE)?.enabledByDefault).toBe(false)
     })
   })
 
@@ -134,7 +178,7 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
       internals()
         .builtInRows()
         .find((r) => r.type === CASE)!
-        .enabled.set(true)
+        .state.set('on')
 
       internals().submit()
 
@@ -143,6 +187,34 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
       expect(payload.caseExchange).toBeUndefined()
       expect(payload.namespaceExchange).toBeUndefined()
       expect(router.navigate).toHaveBeenCalled()
+    })
+
+    it('writes an empty array for a built-in the user explicitly disabled', () => {
+      // The opt-out has to be persisted, otherwise a platform default of on would grant it back.
+      component.ngOnInit()
+      internals().nameControl.setValue('My Agent')
+      internals()
+        .builtInRows()
+        .find((r) => r.type === CASE)!
+        .state.set('off')
+
+      internals().submit()
+
+      expect(controller.createAgentConfig.mock.calls[0][0].integrations).toEqual({ [CASE]: [] })
+    })
+
+    it('writes no key for a built-in left on the platform default', () => {
+      // The regression this guards: saving an unrelated change must not turn "never chosen" into
+      // "chosen off" and silently strip the exchange from an agent on a default-on instance.
+      integrationType.listTypesIntegrationType.mockReturnValue(
+        of([{ ...builtInTypes[0], enabledByDefault: true }, builtInTypes[1]])
+      )
+      component.ngOnInit()
+      internals().nameControl.setValue('My Agent')
+
+      internals().submit()
+
+      expect(controller.createAgentConfig.mock.calls[0][0].integrations).toBeUndefined()
     })
 
     it('carries a hydrated built-in through an update payload', () => {
@@ -154,6 +226,16 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
 
       const payload = controller.updateAgentConfig.mock.calls[0][1]
       expect(payload.integrations).toEqual({ [NAMESPACE]: null })
+    })
+
+    it('carries a hydrated opt-out through an update payload', () => {
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [NAMESPACE]: [] } })))
+      component.ngOnInit()
+
+      internals().submit()
+
+      expect(controller.updateAgentConfig.mock.calls[0][1].integrations).toEqual({ [NAMESPACE]: [] })
     })
 
     it('preserves an already-enabled built-in when the integration-types endpoint is unavailable', () => {

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.spec.ts
@@ -231,6 +231,24 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
       expect(controller.createAgentConfig.mock.calls[0][0].integrations).toBeUndefined()
     })
 
+    it('deletes the key when a hydrated built-in is switched back to the platform default', () => {
+      // The only path that exercises the key-deletion branch of the preservation loop: the create-mode
+      // test above has an empty existingConfig, so it would stay green even if the branch were keyed on
+      // the payload rather than on what the form can render, and a user handing an agent back to the
+      // platform default would silently keep its previous choice.
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: null } })))
+      component.ngOnInit()
+      internals()
+        .builtInRows()
+        .find((r) => r.type === CASE)!
+        .state.set('default')
+
+      internals().submit()
+
+      expect(controller.updateAgentConfig.mock.calls[0][1].integrations).toBeUndefined()
+    })
+
     it('carries a hydrated built-in through an update payload', () => {
       routeAgentConfigId = 'a-1'
       controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [NAMESPACE]: null } })))
@@ -331,6 +349,17 @@ describe('AgentConfigFormComponent (built-in exchange integrations)', () => {
     it('offers exactly the three tri-state values as options', () => {
       fixture.detectChanges()
       expect(Array.from(selectFor(CASE).options).map((o) => o.value)).toEqual(['default', 'on', 'off'])
+    })
+
+    it('renders the hydrated state on the control', () => {
+      // Covers the state to DOM direction, carried solely by [value]="row.state()". Without it an
+      // opt-out would display as "Platform default", which on a default-on instance reads as the
+      // exact opposite of what the agent is configured to do.
+      routeAgentConfigId = 'a-1'
+      controller.getByIdAgentConfig.mockReturnValue(of(editConfig({ integrations: { [CASE]: [] } })))
+      fixture.detectChanges()
+
+      expect(selectFor(CASE).value).toBe('off')
     })
 
     it('routes a change event on the select to the row state', () => {

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.ts
@@ -366,7 +366,8 @@ export class AgentConfigFormComponent implements OnInit {
    * Disabled rows → excluded from the map.
    * Built-in rows are tri-state: `on` → null (or the persisted allowlist, preserved verbatim),
    * `off` → [] (explicit opt-out), `default` → key omitted so the platform default keeps deciding.
-   * If nothing at all is selected → undefined (no filter, agent sees all namespace tools).
+   * If nothing at all is selected → undefined, which binds no integration: the backend resolver
+   * grants no plugin tools, and only the platform exchange defaults can still add the file tools.
    */
   protected buildIntegrationsPayload(): AgentConfig['integrations'] {
     // null per integration means "all tools allowed" (backend contract). The generated TS type

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.ts
@@ -30,15 +30,27 @@ interface IntegrationRow {
 }
 
 /**
+ * What an agent says about a built-in integration.
+ *
+ * `default` is a real, persisted state — the absence of the key in AgentConfig.integrations — and
+ * not a synonym for "off": the platform decides for an agent that stays silent. Keeping it as its
+ * own state is what stops an agent that was never configured from being silently switched off the
+ * first time someone saves an unrelated change on the form.
+ */
+type BuiltInState = 'default' | 'on' | 'off'
+
+/**
  * A built-in integration (e.g. file exchange) surfaced by the backend in /api/integration-types
- * with `builtIn = true`. Enabled by adding its `type` to AgentConfig.integrations — no instance,
- * no per-tool allowlist (toggle only).
+ * with `builtIn = true`. Carried in AgentConfig.integrations under its `type` key — no instance,
+ * no per-tool allowlist, so the key's value only ever encodes on (null) or off (empty array).
  */
 interface BuiltInIntegrationRow {
   type: string
   displayName: string
   description: string
-  enabled: WritableSignal<boolean>
+  /** What this instance grants when the agent says nothing; labels the `default` state. */
+  enabledByDefault: boolean
+  state: WritableSignal<BuiltInState>
 }
 
 /**
@@ -272,19 +284,27 @@ export class AgentConfigFormComponent implements OnInit {
   }
 
   /**
-   * Build a toggle row per built-in integration type, pre-checked when the agent's integrations
-   * map already contains its `type` key.
+   * Build a tri-state row per built-in integration type, hydrated from the agent's integrations map:
+   * - key absent      → `default`, the agent expressed no choice and the platform decides;
+   * - key with `[]`   → `off`, an explicit opt-out that beats a platform default of on;
+   * - key otherwise   → `on` (the backend stores null for "all tools").
    */
   private buildBuiltInRows(
     types: IntegrationTypeDescriptor[],
     existingIntegrations: AgentConfig['integrations']
   ): BuiltInIntegrationRow[] {
-    return types.map((t) => ({
-      type: t.type,
-      displayName: t.displayName,
-      description: t.description,
-      enabled: signal(existingIntegrations != null && t.type in existingIntegrations),
-    }))
+    return types.map((t) => {
+      const declared = existingIntegrations != null && t.type in existingIntegrations
+      const entry = existingIntegrations?.[t.type]
+      const state: BuiltInState = !declared ? 'default' : Array.isArray(entry) && entry.length === 0 ? 'off' : 'on'
+      return {
+        type: t.type,
+        displayName: t.displayName,
+        description: t.description,
+        enabledByDefault: t.enabledByDefault === true,
+        state: signal(state),
+      }
+    })
   }
 
   /** Toggle the enabled signal for a given row. */
@@ -292,9 +312,14 @@ export class AgentConfigFormComponent implements OnInit {
     row.enabled.update((v) => !v)
   }
 
-  /** Toggle a built-in integration row. */
-  protected toggleBuiltIn(row: BuiltInIntegrationRow): void {
-    row.enabled.update((v) => !v)
+  /** Set the tri-state of a built-in integration row from the select. */
+  protected setBuiltInState(row: BuiltInIntegrationRow, value: string): void {
+    row.state.set(value as BuiltInState)
+  }
+
+  /** Label for the `default` option, so the user can see which way it currently resolves. */
+  protected builtInDefaultLabel(row: BuiltInIntegrationRow): string {
+    return row.enabledByDefault ? 'Platform default (enabled)' : 'Platform default (disabled)'
   }
 
   /** Add the current newSubAgentControl value as a new row, then reset the input. */
@@ -327,7 +352,9 @@ export class AgentConfigFormComponent implements OnInit {
    * Enabled rows with no tool names → null (all tools allowed).
    * Enabled rows with tool names → trimmed, non-empty string array.
    * Disabled rows → excluded from the map.
-   * If no rows are enabled → undefined (no filter, agent sees all namespace tools).
+   * Built-in rows are tri-state: `on` → null, `off` → [] (explicit opt-out), `default` → key omitted
+   * so the platform default keeps deciding.
+   * If nothing at all is selected → undefined (no filter, agent sees all namespace tools).
    */
 
   protected buildIntegrationsPayload(): AgentConfig['integrations'] {
@@ -348,9 +375,14 @@ export class AgentConfigFormComponent implements OnInit {
               .filter((t) => t.length > 0)
     }
 
-    // Built-in integrations are toggle-only: their type key with a null value (= all tools).
-    for (const row of this.builtInRows().filter((r) => r.enabled())) {
-      result[row.type] = null as any
+    // Built-in integrations carry no per-tool list, so the key's value encodes the choice itself:
+    // null = enabled (all tools), [] = explicitly disabled. A row left on `default` writes no key at
+    // all — that absence is what lets the platform default decide, and overwriting it with [] would
+    // turn "never chosen" into "chosen off" behind the user's back.
+    for (const row of this.builtInRows()) {
+      const state = row.state()
+      if (state === 'on') result[row.type] = null as any
+      else if (state === 'off') result[row.type] = []
     }
 
     // Preserve any existing integration key the form could not represent this session — e.g. a

--- a/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/agent-config-form/agent-config-form.component.ts
@@ -41,8 +41,10 @@ type BuiltInState = 'default' | 'on' | 'off'
 
 /**
  * A built-in integration (e.g. file exchange) surfaced by the backend in /api/integration-types
- * with `builtIn = true`. Carried in AgentConfig.integrations under its `type` key — no instance,
- * no per-tool allowlist, so the key's value only ever encodes on (null) or off (empty array).
+ * with `builtIn = true`. Carried in AgentConfig.integrations under its `type` key, whose value
+ * follows the backend contract: null enables every tool, an empty array is an explicit opt-out,
+ * and a non-empty array restricts the grant to those tool names. The form only edits the first
+ * two; a persisted allowlist is surfaced read-only and written back verbatim on save.
  */
 interface BuiltInIntegrationRow {
   type: string
@@ -51,6 +53,12 @@ interface BuiltInIntegrationRow {
   /** What this instance grants when the agent says nothing; labels the `default` state. */
   enabledByDefault: boolean
   state: WritableSignal<BuiltInState>
+  /**
+   * Non-empty per-tool allowlist persisted outside this form (API or YAML). The form offers no
+   * editor for it, so it is shown read-only and re-emitted verbatim while the row stays on `on`;
+   * mapping it to null would silently widen the grant to every tool.
+   */
+  restrictedTools: string[] | null
 }
 
 /**
@@ -149,7 +157,8 @@ export class AgentConfigFormComponent implements OnInit {
 
   /**
    * Built-in integration rows (e.g. file exchange) surfaced by the backend only when their
-   * prerequisite plugin is loaded. Toggled on/off; enablement rides AgentConfig.integrations.
+   * prerequisite plugin is loaded. Each row is a tri-state (platform default / on / off)
+   * persisted through AgentConfig.integrations.
    */
   protected readonly builtInRows = signal<BuiltInIntegrationRow[]>([])
 
@@ -245,14 +254,14 @@ export class AgentConfigFormComponent implements OnInit {
 
   /**
    * Resolve whether the file-exchange plugin is loaded by looking for a `FILE_ACCESS`
-   * integration type. Resilient: any error (e.g. endpoint unavailable) resolves to false
-   * so it never blocks the integrations load — and the checkboxes stay hidden (fail-safe).
+   * integration type. Resilient: any error (e.g. endpoint unavailable) resolves to an empty
+   * list so it never blocks the integrations load, and the built-in rows stay hidden (fail-safe).
    */
   private loadBuiltInTypes(): Observable<IntegrationTypeDescriptor[]> {
     return this.integrationTypeController.listTypesIntegrationType().pipe(
       map((types) => types.filter((t) => t.builtIn === true)),
       catchError((err) => {
-        // Fail-safe: hide the built-in toggles rather than block the form, but leave a diagnostic.
+        // Fail-safe: hide the built-in rows rather than block the form, but leave a diagnostic.
         console.error('[agent-config-form] failed to load integration types', err)
         return of([])
       })
@@ -285,9 +294,11 @@ export class AgentConfigFormComponent implements OnInit {
 
   /**
    * Build a tri-state row per built-in integration type, hydrated from the agent's integrations map:
-   * - key absent      → `default`, the agent expressed no choice and the platform decides;
-   * - key with `[]`   → `off`, an explicit opt-out that beats a platform default of on;
-   * - key otherwise   → `on` (the backend stores null for "all tools").
+   * - key absent          → `default`, the agent expressed no choice and the platform decides;
+   * - key with `[]`       → `off`, an explicit opt-out that beats a platform default of on;
+   * - key with null       → `on`, every tool allowed;
+   * - key with tool names → `on`, restricted to those names; the list is kept on the row so the
+   *   save path can write it back verbatim instead of widening it to "all tools".
    */
   private buildBuiltInRows(
     types: IntegrationTypeDescriptor[],
@@ -303,6 +314,7 @@ export class AgentConfigFormComponent implements OnInit {
         description: t.description,
         enabledByDefault: t.enabledByDefault === true,
         state: signal(state),
+        restrictedTools: Array.isArray(entry) && entry.length > 0 ? entry : null,
       }
     })
   }
@@ -352,11 +364,10 @@ export class AgentConfigFormComponent implements OnInit {
    * Enabled rows with no tool names → null (all tools allowed).
    * Enabled rows with tool names → trimmed, non-empty string array.
    * Disabled rows → excluded from the map.
-   * Built-in rows are tri-state: `on` → null, `off` → [] (explicit opt-out), `default` → key omitted
-   * so the platform default keeps deciding.
+   * Built-in rows are tri-state: `on` → null (or the persisted allowlist, preserved verbatim),
+   * `off` → [] (explicit opt-out), `default` → key omitted so the platform default keeps deciding.
    * If nothing at all is selected → undefined (no filter, agent sees all namespace tools).
    */
-
   protected buildIntegrationsPayload(): AgentConfig['integrations'] {
     // null per integration means "all tools allowed" (backend contract). The generated TS type
     // declares Array<string> but the backend accepts null; springdoc does not emit nullable:true
@@ -375,13 +386,15 @@ export class AgentConfigFormComponent implements OnInit {
               .filter((t) => t.length > 0)
     }
 
-    // Built-in integrations carry no per-tool list, so the key's value encodes the choice itself:
-    // null = enabled (all tools), [] = explicitly disabled. A row left on `default` writes no key at
-    // all — that absence is what lets the platform default decide, and overwriting it with [] would
-    // turn "never chosen" into "chosen off" behind the user's back.
+    // Built-in keys follow the backend contract: null = enabled with every tool, [] = explicit
+    // opt-out, non-empty = restricted to those tool names. The form only chooses between the first
+    // two, so a persisted allowlist is written back verbatim while the row stays on `on`; mapping
+    // it to null would silently grant the agent every tool. A row left on `default` writes no key
+    // at all: that absence is what lets the platform default decide, and overwriting it with []
+    // would turn "never chosen" into "chosen off" behind the user's back.
     for (const row of this.builtInRows()) {
       const state = row.state()
-      if (state === 'on') result[row.type] = null as any
+      if (state === 'on') result[row.type] = row.restrictedTools ?? (null as any)
       else if (state === 'off') result[row.type] = []
     }
 


### PR DESCRIPTION
## Why

The two built-in exchange integrations (`CASE_FILE_EXCHANGE`, `NAMESPACE_FILE_EXCHANGE`) are declared `configSchema = null`: no `IntegrationConfig` is ever persisted for them, and their tools are built imperatively in `AgentServiceImpl.buildExchangeTools`. Two gaps followed from that.

**Nine of twelve plugin settings were unreachable.** `FileToolProvider.provideTools` reads 12 keys; `buildExchangeTools` built a node with 3 (`rootPath`, `readOnly`, `readMaxSizeMb`). `extraDenyPatterns` and the eight image/document knobs stayed pinned to the plugin's compiled constants, with no operational lever of any kind.

**There was no instance-level enablement.** The exchange could only be turned on agent by agent, through the `integrations` map. An operator could not decide that every agent on a deployment should get it.

## What

New `ExchangeToolsConfigProperties` (prefix `agentos.exchange.tools`) and `ExchangeToolGrantService`, which owns the grant decision and turns the bound properties into the `provideTools` node. The SDK and the plugins keep no Spring dependency: the values still reach the plugin through the existing `JsonNode` contract, so nothing under `agentos-sdk/` or `agentos-file-plugin/` is touched.

Eleven new environment variables, all off or at the plugin's own value by default:

| Property | Env var | Default |
|---|---|---|
| `…tools.case-enabled-by-default` | `AGENTOS_EXCHANGE_TOOLS_CASE_ENABLED_BY_DEFAULT` | `false` |
| `…tools.namespace-enabled-by-default` | `AGENTOS_EXCHANGE_TOOLS_NAMESPACE_ENABLED_BY_DEFAULT` | `false` |
| `…tools.extra-deny-patterns` | `AGENTOS_EXCHANGE_TOOLS_EXTRA_DENY_PATTERNS` | empty |
| `…tools.image-max-dimension` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_DIMENSION` | `1024` |
| `…tools.image-jpeg-quality` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_JPEG_QUALITY` | `0.80` |
| `…tools.image-max-source-pixels` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_MAX_SOURCE_PIXELS` | `50000000` |
| `…tools.image-pass-through-max-bytes` | `AGENTOS_EXCHANGE_TOOLS_IMAGE_PASS_THROUGH_MAX_BYTES` | `1048576` |
| `…tools.document-max-output-chars` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_OUTPUT_CHARS` | `100000` |
| `…tools.document-max-attached-images` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_ATTACHED_IMAGES` | `10` |
| `…tools.document-max-table-columns` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_TABLE_COLUMNS` | `64` |
| `…tools.document-max-cell-chars` | `AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_CELL_CHARS` | `5000` |

One set of values is shared by both scopes. `rootPath` and `readOnly` stay computed per run, and `readMaxSizeMb` keeps deriving from `agentos.exchange.read-max-size-bytes` so the agent read cap cannot drift from the one the REST path enforces.

## Enablement is now a tri-state

Carried by `AgentConfig.integrations`, no new field:

| `integrations` entry | Result |
|---|---|
| key absent | the platform default decides |
| `CASE_FILE_EXCHANGE:` (null) | granted, every tool |
| `CASE_FILE_EXCHANGE: [readFile, ls]` | granted, restricted to those names |
| `CASE_FILE_EXCHANGE: []` | explicit opt-out |

The agent's own choice always wins, in both directions; the default only fills the gap. The empty list is a genuine opt-out rather than an empty allow-list: `isToolAllowed` would already reject every tool, but the grant creates the scope directory *before* that filter runs, so the decision short-circuits in `resolveGrant` and no phantom directory is materialised.

The default is a decision local to `ExchangeToolGrantService` and never a mutation of `AgentConfig.integrations` — writing the key into the map would leak it into the persisted config, the YAML export, and the peer descriptions `RedirectTool` puts in every agent's prompt.

## Why the frontend had to move

`IntegrationTypeDescriptor` gains `enabledByDefault`, and the agent form renders three states (*Platform default* / *Enabled* / *Disabled*) instead of a checkbox.

This is not cosmetic. The old form hydrated `enabled` from `type in integrations`, so an explicit opt-out (`[]`) displayed as **checked**; and an unchecked row was simply omitted from the map, which is indistinguishable from "never configured". On a default-on instance, an agent nobody had ever configured would therefore have been silently switched off the first time someone saved an unrelated change. A test now guards that path.

## Also in this PR

- `buildExchangeTools` drops from 74 to 49 lines, keeps only what it alone knows (the run's `caseId`, the invoking user's Namespace `WRITE`), and loses its early return.
- `ExchangeStorageService.readMaxSizeBytes` is removed — `buildExchangeTools` was its only caller.
- `agentos.exchange.read-max-size-bytes` is documented for the first time. It has existed since the exchange shipped but appeared in neither `application.yml` nor `docs/file-exchange.md`.
- `docs/file-exchange.md`: the claim that all three `agentos.exchange` keys use `${ENV_VAR:default}` placeholders was false — they rely on relaxed binding alone.

## Verification

- `agentos-service` 1957 tests, `agentos-sdk` 8, `agentos-ui` 214 — all green
- `nx lint agentos-ui` clean
- OpenAPI spec and TS client regenerated; the only delta is `enabledByDefault`

Behaviour with no environment variable set is unchanged: the nine tuning defaults replicate the plugin constants exactly, and both enablement defaults ship off.

## Known limitations, deliberately out of scope

- **A default-on instance materialises a case exchange directory per case a granted agent runs in.** The file plugin canonicalises `rootPath` at construction, so a grant must create its directory. Deferring that would mean touching `BoundaryPathResolver`. Documented under §Safety.
- **`grantTools` has no try/catch.** On a read-only filesystem or a full quota, the `IOException` escapes `findAgentByName`; with a default of on, that would break every agent instead of only those that opted in. Adding a catch is a behaviour change that deserves its own ticket.
- The generated TS client is out of sync with the committed spec on master for unrelated models (`Case.lastMessageAt`, `ToolResponseEvent.images`, `ExchangeControllerService` doc comments). I reverted those hunks to keep this diff scoped; they need a dedicated regeneration commit.


---

## Follow-up: review findings addressed (commit 2)

An adversarial review pass over this diff surfaced four defects, three of them in behaviour this PR introduced. All are fixed in the second commit.

**Namespace READ is now required on the agent grant path.** The grant derived only `readOnly` from Namespace `WRITE` and never checked `READ`, while every REST namespace-file endpoint enforces it via `@PreAuthorize`. A user holding a direct Case `ADMIN` edge without namespace membership could read the whole shared exchange through any agent, files their own REST calls deny. The gap predates this PR, but the new platform default scales it from individually configured agents to every agent behind one flag. `ExchangeCapabilityService` gains `canRead`, and the namespace grant requires it.

> **Behaviour change worth flagging:** a run without an identified user is now denied fail-closed, so `GET /api/agent-configs/{id}/definition` called with `withUserOverlay=false` no longer reports namespace exchange tools.

**The `[]` opt-out did not survive the YAML export.** The export mapper's `NON_EMPTY` inclusion also applies to map *content*, so it pruned both the `[]` opt-out and the `null` "all tools" value out of the `integrations` map. Re-importing such a file re-granted the exchange to an agent an admin had explicitly opted out, which defeats the tri-state this PR is built around. `toExportModel` already filters top-level values itself, so the mapper-level policy is dropped.

**The agent form widened a per-tool allowlist to all tools.** A non-empty array hydrated to the `on` state and was written back as `null`, so an agent restricted to `readFile` silently gained `editFiles`, `remove` and `moveFile`. The allowlist is now carried on the row, surfaced read-only, and re-emitted verbatim.

**The AgentServiceImpl to grant-service seam was unverified.** Both resolve calls were stubbed with `any()` and never verified, so a regression passing `null` instead of `config.integrations` would have kept every test green while an opted-out agent regained its tools. Pinned by exact-argument verifications plus a test composing the two services for real.

Smaller fixes: the FILE_ACCESS presence check moves up into `resolveGrant` so a plugin-less instance pays no permission query; `documentMaxTableColumns`, `documentMaxOutputChars` and `documentMaxCellChars` are clamped like `imageJpegQuality` already was, each crashing or livelocking a tool call when set out of range; `extraDenyPatterns` is documented as matching the final path segment only, so operators do not write path-shaped patterns that silently match nothing; and two stale KDoc claims are corrected (`ToolResolverService` on tool-free agents, `AgentConfig.integrations` on null semantics).

Suites after the fixes: `agentos-service` 1970, `agentos-sdk` 8, `agentos-ui` 222, all green.
