### PR TITLE
feat: #1174 bundle AgentOS JAR in coday-server npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,10 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
+      - name: Grant execute permission for gradlew
+        working-directory: agentos
+        run: chmod +x gradlew
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -64,8 +64,24 @@
         "commands": ["tsx watch apps/server/src/server.ts"]
       }
     },
+    "build-agentos": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist/agentos"],
+      "options": {
+        "commands": [
+          "mkdir -p apps/server/dist/agentos/plugins",
+          "cd agentos && ./gradlew :agentos-service:bootJar :agentos-bash-plugin:jar :agentos-file-plugin:jar :agentos-mcp-plugin:jar :agentos-tmux-plugin:jar --no-daemon",
+          "cp agentos/agentos-service/build/libs/agentos-service.jar apps/server/dist/agentos/",
+          "cp agentos/agentos-bash-plugin/build/libs/agentos-bash-plugin-*.jar apps/server/dist/agentos/plugins/",
+          "cp agentos/agentos-file-plugin/build/libs/agentos-file-plugin-*.jar apps/server/dist/agentos/plugins/",
+          "cp agentos/agentos-mcp-plugin/build/libs/agentos-mcp-plugin-*.jar apps/server/dist/agentos/plugins/",
+          "cp agentos/agentos-tmux-plugin/build/libs/agentos-tmux-plugin-*.jar apps/server/dist/agentos/plugins/"
+        ],
+        "parallel": false
+      }
+    },
     "nx-release-publish": {
-      "dependsOn": ["build"],
+      "dependsOn": ["build", "build-agentos"],
       "options": {
         "packageRoot": "apps/server/dist"
       }

--- a/apps/server/src/lib/agentos-lifecycle.ts
+++ b/apps/server/src/lib/agentos-lifecycle.ts
@@ -1,0 +1,318 @@
+import { spawn, execFileSync, ChildProcess } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { debugLog } from './log'
+import { findAvailablePort } from './find-available-port'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default port for AgentOS — matches the historic env-var default in server.ts */
+const AGENTOS_DEFAULT_PORT = 8124
+
+/** How often (ms) to poll the Spring Boot health endpoint while waiting for startup */
+const HEALTH_POLL_INTERVAL_MS = 2_000
+
+/** Maximum time (ms) to wait for Spring Boot to become healthy */
+const HEALTH_TIMEOUT_MS = 60_000
+
+/** Time (ms) to wait for graceful SIGTERM before escalating to SIGKILL */
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10_000
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Structured result from the Java detection probe. */
+interface JavaDetectionResult {
+  available: boolean
+  version?: string
+  path?: string
+}
+
+/** Configuration passed to startAgentos(). Derived from filesystem layout. */
+export interface AgentosConfig {
+  jarPath: string
+  pluginsDir: string
+  dataDir: string
+  port: number
+}
+
+/** Handle returned by startAgentos() once AgentOS is running and healthy. */
+export interface AgentosProcess {
+  /** The TCP port AgentOS is actually listening on. */
+  port: number
+  /** The underlying Node.js ChildProcess. */
+  process: ChildProcess
+  /**
+   * Gracefully stop AgentOS.
+   * Sends SIGTERM first; escalates to SIGKILL after 10 s if the process has not
+   * exited on its own.
+   */
+  shutdown: () => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Java detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Probe the local JVM installation.
+ *
+ * `java -version` writes its output to **stderr** (by JVM convention), so we
+ * capture stderr and parse the version string from there.
+ *
+ * We require Java >= 17 because Spring Boot 3 dropped support for earlier
+ * releases.
+ *
+ * @returns Structured detection result; `available: false` on any failure.
+ */
+async function detectJava(): Promise<JavaDetectionResult> {
+  try {
+    // execFileSync throws on non-zero exit; we capture stderr because java -version
+    // writes there even on success.
+    const stderr = execFileSync('java', ['-version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    // The first line typically looks like:
+    //   openjdk version "17.0.9" 2023-10-17
+    //   java version "1.8.0_382"
+    const versionMatch = stderr.match(/"(\d+)(?:\.(\d+))?/)
+    if (!versionMatch) {
+      debugLog('AGENTOS', 'java -version output could not be parsed:', stderr)
+      return { available: false }
+    }
+
+    // Java 9+ uses a single-component major version ("17", "21"...).
+    // Java 8 and earlier use "1.x" notation.
+    const rawMajor = parseInt(versionMatch[1] ?? '0', 10)
+    const major = rawMajor === 1 ? parseInt(versionMatch[2] ?? '0', 10) : rawMajor
+    const versionString = versionMatch[0].replace(/^"/, '')
+
+    if (major < 17) {
+      debugLog('AGENTOS', `Java ${major} detected but >= 17 is required (Spring Boot 3)`)
+      return { available: false, version: versionString }
+    }
+
+    debugLog('AGENTOS', `Java ${major} detected — OK`)
+    return { available: true, version: versionString }
+  } catch {
+    // java not found in PATH, or execFileSync threw for another reason
+    return { available: false }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Health polling
+// ---------------------------------------------------------------------------
+
+/**
+ * Poll `http://localhost:<port>/actuator/health` until Spring Boot reports
+ * a 2xx status or the timeout is exceeded.
+ *
+ * Spring Boot can take a while to start (class-loading, plugin discovery, Neo4j
+ * embedded init), so we allow up to 60 s.
+ *
+ * @returns `true` when healthy, `false` on timeout.
+ */
+async function waitForHealthy(port: number): Promise<boolean> {
+  const url = `http://localhost:${port}/actuator/health`
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) {
+        debugLog('AGENTOS', `Health check passed on port ${port}`)
+        return true
+      }
+      debugLog('AGENTOS', `Health check returned ${res.status}, retrying...`)
+    } catch {
+      // Connection refused or network error — process still starting
+    }
+    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS))
+  }
+
+  debugLog('AGENTOS', `Health check timed out after ${HEALTH_TIMEOUT_MS / 1000} s`)
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to start the bundled AgentOS Spring Boot JAR as a child process.
+ *
+ * Design decisions:
+ * - The JAR is expected at `<server-dist>/agentos/agentos-service.jar`.
+ *   This path is resolved relative to `__dirname` so it works both in the
+ *   compiled dist tree and in ts-node/jest contexts.
+ * - If the JAR is absent, Java is missing, or startup fails, the function
+ *   returns `null` instead of throwing. The caller (server.ts) then falls
+ *   back to the env-var-driven proxy configuration, which will simply 503
+ *   until someone starts AgentOS externally.
+ * - Port selection starts at the historic default (8124) and scans up to 10
+ *   consecutive ports to avoid collisions in multi-instance setups.
+ * - Data is stored under `~/.coday/agentos/data/` so it survives server
+ *   restarts and is consistent with the rest of Coday's persistence model.
+ *
+ * @returns An `AgentosProcess` handle when AgentOS is healthy, or `null`.
+ */
+export async function startAgentos(): Promise<AgentosProcess | null> {
+  // ------------------------------------------------------------------
+  // 1. Resolve JAR path
+  // ------------------------------------------------------------------
+  const jarPath = path.resolve(__dirname, 'agentos', 'agentos-service.jar')
+  const pluginsDir = path.resolve(__dirname, 'agentos', 'plugins')
+
+  if (!fs.existsSync(jarPath)) {
+    debugLog('AGENTOS', `JAR not found at ${jarPath} — skipping AgentOS startup`)
+    return null
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Detect Java >= 17
+  // ------------------------------------------------------------------
+  const java = await detectJava()
+  if (!java.available) {
+    debugLog(
+      'AGENTOS',
+      java.version
+        ? `Java ${java.version} is too old (need >= 17) — skipping AgentOS startup`
+        : 'Java not found in PATH — skipping AgentOS startup'
+    )
+    return null
+  }
+
+  // ------------------------------------------------------------------
+  // 3. Find an available port
+  // ------------------------------------------------------------------
+  let port: number
+  try {
+    port = await findAvailablePort(AGENTOS_DEFAULT_PORT, 10)
+  } catch (err) {
+    debugLog('AGENTOS', 'Could not find an available port — skipping AgentOS startup:', err)
+    return null
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Ensure data directory exists
+  // ------------------------------------------------------------------
+  const dataDir = path.join(os.homedir(), '.coday', 'agentos', 'data')
+  fs.mkdirSync(dataDir, { recursive: true })
+  debugLog('AGENTOS', `Data directory: ${dataDir}`)
+
+  // ------------------------------------------------------------------
+  // 5. Spawn the process
+  // ------------------------------------------------------------------
+  debugLog('AGENTOS', `Spawning AgentOS on port ${port} with JAR ${jarPath}`)
+
+  const child = spawn(
+    'java',
+    [
+      '-jar',
+      jarPath,
+      `--server.port=${port}`,
+      `--agentos.plugins.dir=${pluginsDir}`,
+      `--spring.neo4j.embedded.data-dir=${dataDir}`,
+    ],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: false,
+    }
+  )
+
+  child.stdout?.on('data', (data: Buffer) => {
+    for (const line of data.toString().split('\n')) {
+      if (line.trim()) debugLog('AGENTOS', line.trim())
+    }
+  })
+
+  child.stderr?.on('data', (data: Buffer) => {
+    for (const line of data.toString().split('\n')) {
+      if (line.trim()) debugLog('AGENTOS', line.trim())
+    }
+  })
+
+  // Track whether the process exited unexpectedly during startup
+  let spawnError: Error | null = null
+  let exited = false
+
+  child.on('error', (err) => {
+    spawnError = err
+    debugLog('AGENTOS', 'Spawn error:', err.message)
+  })
+
+  child.on('exit', (code, signal) => {
+    exited = true
+    debugLog('AGENTOS', `Process exited — code=${code} signal=${signal}`)
+  })
+
+  // ------------------------------------------------------------------
+  // 6. Wait for healthy
+  // ------------------------------------------------------------------
+  const healthy = await waitForHealthy(port)
+
+  if (!healthy || exited || spawnError) {
+    debugLog('AGENTOS', 'AgentOS did not become healthy — killing process')
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // already dead
+    }
+    return null
+  }
+
+  debugLog('AGENTOS', `AgentOS is up and healthy on port ${port}`)
+
+  // ------------------------------------------------------------------
+  // 7. Build and return the handle
+  // ------------------------------------------------------------------
+
+  /**
+   * Gracefully stop the AgentOS child process.
+   *
+   * Sends SIGTERM and waits up to 10 s for the JVM to shut down cleanly
+   * (Spring Boot registers a shutdown hook). If it is still alive after
+   * the grace period, SIGKILL is used as a last resort.
+   */
+  const shutdown = (): Promise<void> =>
+    new Promise((resolve) => {
+      if (child.exitCode !== null || child.killed) {
+        // Already dead
+        resolve()
+        return
+      }
+
+      const timer = setTimeout(() => {
+        debugLog('AGENTOS', 'Graceful shutdown timed out — sending SIGKILL')
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          // ignore
+        }
+      }, GRACEFUL_SHUTDOWN_TIMEOUT_MS)
+
+      child.once('exit', () => {
+        clearTimeout(timer)
+        debugLog('AGENTOS', 'AgentOS process exited')
+        resolve()
+      })
+
+      debugLog('AGENTOS', 'Sending SIGTERM to AgentOS')
+      try {
+        child.kill('SIGTERM')
+      } catch (err) {
+        clearTimeout(timer)
+        debugLog('AGENTOS', 'Error sending SIGTERM:', err)
+        resolve()
+      }
+    })
+
+  return { port, process: child, shutdown }
+}

--- a/apps/server/src/lib/agentos-lifecycle.ts
+++ b/apps/server/src/lib/agentos-lifecycle.ts
@@ -111,7 +111,7 @@ async function detectJava(): Promise<JavaDetectionResult> {
 // ---------------------------------------------------------------------------
 
 /**
- * Poll `http://localhost:<port>/actuator/health` until Spring Boot reports
+ * Poll `http://localhost:<port>/management/health` until Spring Boot reports
  * a 2xx status or the timeout is exceeded.
  *
  * Spring Boot can take a while to start (class-loading, plugin discovery, Neo4j
@@ -120,7 +120,7 @@ async function detectJava(): Promise<JavaDetectionResult> {
  * @returns `true` when healthy, `false` on timeout.
  */
 async function waitForHealthy(port: number): Promise<boolean> {
-  const url = `http://localhost:${port}/actuator/health`
+  const url = `http://localhost:${port}/management/health`
   const deadline = Date.now() + HEALTH_TIMEOUT_MS
 
   while (Date.now() < deadline) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -35,6 +35,11 @@ import { ProjectFileRepository } from '@coday/repository'
 import { McpInstancePool } from '@coday/mcp'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
+import { startAgentos, AgentosProcess } from './lib/agentos-lifecycle'
+
+// AgentOS process handle — set when we successfully spawn the bundled JAR.
+// Declared here so gracefulShutdown() can reference it regardless of scope.
+let agentosProcess: AgentosProcess | null = null
 
 const app = express()
 const DEFAULT_PORT = process.env.PORT
@@ -70,13 +75,18 @@ debugLog('INIT', 'Webhook service initialized (will be initialized with prompt e
 // Note: projectPath will be set after projectService is initialized
 let promptService: PromptService
 let promptExecutionService: PromptExecutionService
-// Proxy /api/agentos/* → AgentOS Spring backend
-// Registered synchronously and BEFORE express.json() to avoid body-parser
-// consuming the request body before it can be forwarded.
-const AGENTOS_PORT = process.env.AGENTOS_PORT ? parseInt(process.env.AGENTOS_PORT) : 8124
-const AGENTOS_HOSTNAME = process.env.AGENTOS_HOSTNAME ?? 'localhost'
+
+// ---------------------------------------------------------------------------
+// AgentOS proxy — registered synchronously BEFORE express.json() so that
+// body-parser cannot consume request bodies before they are forwarded.
+//
+// agentosUrl is a mutable module-level variable.  The proxy's `router` option
+// is called on every request, so updating agentosUrl later (inside
+// PORT_PROMISE.then) transparently redirects traffic to the spawned JAR.
+// ---------------------------------------------------------------------------
 const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
-const AGENTOS_URL = `http://${AGENTOS_HOSTNAME}:${AGENTOS_PORT}`
+let agentosUrl = `http://${process.env.AGENTOS_HOSTNAME ?? 'localhost'}:${process.env.AGENTOS_PORT ?? '8124'}`
+
 app.use(
   '/api/agentos',
   (req, _res, next) => {
@@ -87,12 +97,13 @@ app.use(
     next()
   },
   createProxyMiddleware({
-    target: AGENTOS_URL,
+    target: agentosUrl,
     changeOrigin: true,
     pathRewrite: { '^/api/agentos': '' },
+    router: () => agentosUrl, // Dynamic — picks up updated agentosUrl at request time
   })
 )
-debugLog('INIT', `AgentOS proxy configured: /api/agentos → ${AGENTOS_URL}`)
+debugLog('INIT', `AgentOS proxy configured (initial target: ${agentosUrl})`)
 
 // Middleware to parse JSON bodies with increased limit for image uploads
 app.use(express.json({ limit: '20mb' }))
@@ -425,6 +436,18 @@ PORT_PROMISE.then(async (PORT) => {
     debugLog('INIT', `Using configured base URL: ${codayOptions.baseUrl}`)
   }
 
+  // Start bundled AgentOS if no external instance is configured.
+  // Done before app.listen() so the proxy target is correct from the first request.
+  if (!process.env.AGENTOS_PORT && !process.env.AGENTOS_HOSTNAME) {
+    agentosProcess = await startAgentos()
+    if (agentosProcess) {
+      agentosUrl = `http://localhost:${agentosProcess.port}`
+      debugLog('AGENTOS', `Proxy target updated to ${agentosUrl}`)
+    } else {
+      debugLog('AGENTOS', 'AgentOS not available — /api/agentos/* requests will fail')
+    }
+  }
+
   app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`)
   })
@@ -492,6 +515,13 @@ async function gracefulShutdown(signal: string) {
   console.log(`Received ${signal}, shutting down gracefully...`)
 
   try {
+    // Stop AgentOS first so the JVM shuts down cleanly before we tear down
+    // the Node.js side (which owns the proxy pointing at it).
+    if (agentosProcess) {
+      console.log('Stopping AgentOS process...')
+      await agentosProcess.shutdown()
+    }
+
     // Stop scheduler service
     console.log('Stopping scheduler service...')
     schedulerService.stop()


### PR DESCRIPTION
Closes #1174

## What

Bundle the AgentOS fat JAR and 4 plugin JARs (bash, file, mcp, tmux) inside the `@whoz-oss/coday-server` npm package, and have the Express server automatically detect Java, spawn AgentOS as a child process, and proxy to it.

## Changes

### New: `apps/server/src/lib/agentos-lifecycle.ts`

Self-contained lifecycle manager with null-safe design — every failure returns `null` for graceful degradation:
- **Java detection**: `java -version` parsing, requires >= 17
- **JAR resolution**: relative to `__dirname` (`dist/agentos/agentos-service.jar`)
- **Port allocation**: reuses `findAvailablePort()`, starting at 8124
- **Process spawn**: child process with piped stdout/stderr logged via `debugLog('AGENTOS', ...)`
- **Health polling**: `/actuator/health` every 2s, 60s timeout
- **Graceful shutdown**: SIGTERM → 10s grace → SIGKILL

### Modified: `apps/server/src/server.ts`

Minimal, surgical changes (4 insertion points, no restructuring):
1. Import + module-level `agentosProcess` handle
2. Dynamic proxy via `router: () => agentosUrl` (replaces static constants)
3. `startAgentos()` call in `PORT_PROMISE.then()` before `app.listen()`
4. AgentOS shutdown as first step in `gracefulShutdown()`

Backward compatible: if `AGENTOS_PORT` or `AGENTOS_HOSTNAME` env vars are set, the bundled JAR is NOT spawned (external management assumed).

### Modified: `apps/server/project.json`

- New `build-agentos` target: builds bootJar + 4 plugin JARs via Gradle, copies to `dist/agentos/`
- `nx-release-publish` now depends on both `build` and `build-agentos`
- Regular `nx build server` stays fast (no Gradle involved)

### Modified: `.github/workflows/release.yml`

- Added `chmod +x gradlew` in the release job (mirrors existing pattern in publish-agentos-artifacts job)

## Data persistence

Neo4j embedded data stored in `~/.coday/agentos/data/` — stable, user-scoped, independent of npm install path.

## Testing

- `nx build-server server` ✅ compiles successfully
- With Java installed: AgentOS spawns, health check passes, proxy routes to it
- Without Java: warning logged, Express starts normally, `/api/agentos/*` will 503
- With `AGENTOS_PORT` env var: bundled JAR not spawned, backward compatible