### PR TITLE
fix: flaky ConcurrentModificationException in InMemoryEntityRepository.findByParent

### DIFF
--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/entity/InMemoryEntityRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/entity/InMemoryEntityRepository.kt
@@ -62,10 +62,15 @@ class InMemoryEntityRepository<T : Entity, P>(
         withRemoved: Boolean,
     ): List<T> = ids.mapNotNull { entitiesById[it] }.filter { withRemoved || !it.metadata.removed }
 
-    override fun findByParent(parentId: P): List<T> =
-        (entityIdsByParentId[parentKey(parentId)] ?: emptyList())
-            .mapNotNull { entitiesById[it] }
-            .filter { !it.metadata.removed }
+    override fun findByParent(parentId: P): List<T> {
+        // Take a snapshot of the id list under the same lock used by save() to prevent
+        // ConcurrentModificationException: save() adds/removes from the MutableList while
+        // coroutines may call findByParent() concurrently from a background thread.
+        val idSnapshot: List<UUID> = synchronized(this) {
+            entityIdsByParentId[parentKey(parentId)]?.toList() ?: emptyList()
+        }
+        return idSnapshot.mapNotNull { entitiesById[it] }.filter { !it.metadata.removed }
+    }
 
     /** Returns all non-removed entities across all parents. Useful in tests. */
     fun findAll(): List<T> = entitiesById.values.filter { !it.metadata.removed }.sortedWith(comparator)


### PR DESCRIPTION
## Root cause

`InMemoryEntityRepository` uses a `ConcurrentHashMap<Any, MutableList<UUID>>` for its parent index. `save()` is `@Synchronized` and mutates the `MutableList` (via `add`, `remove`). `findByParent()` was **not** synchronized and iterated the same `MutableList` directly — a classic `ConcurrentModificationException` race.

In `CaseServiceImplSpec`, `CaseServiceImpl` launches background coroutines (run loop, eviction watcher, naming trigger) on `Dispatchers.IO`. These coroutines call `handleStatusChange` → `caseRepository.save(...)` concurrently with other coroutines calling `caseEventService.findByParent(caseId)` (inside `triggerNamingIfNeeded`) or `caseRepository.findByParent(...)`. When both hit the same `MutableList` simultaneously, the iterator throws `ConcurrentModificationException`.

## Fix

`findByParent()` now takes a snapshot of the id list under the same `synchronized(this)` lock used by `save()` before iterating:

```kotlin
val idSnapshot: List<UUID> = synchronized(this) {
    entityIdsByParentId[parentKey(parentId)]?.toList() ?: emptyList()
}
return idSnapshot.mapNotNull { entitiesById[it] }.filter { !it.metadata.removed }
```

The snapshot is an immutable copy — safe to iterate outside the lock. `entitiesById` is a `ConcurrentHashMap`, so individual lookups on it remain thread-safe without the lock.

## What about the shutdown noise?

The `ResourceNotFoundException` logs during shutdown (`Error killing case X during shutdown`) are a separate concern: they appear when Spring destroys the `CaseServiceImpl` bean and `shutdown()` tries to kill cases that exist in `activeRuntimes` but whose ids are no longer in the in-memory repository (cleaned up between tests). This is already caught and logged as a warning — no test failure, just noise. It is unrelated to the flaky CME.