### PR TITLE
feat: portable paths in filesystem IntegrationConfig via {{NAMESPACE_CONFIG_PATH}} token

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -151,7 +151,20 @@ class FilesystemAgentConfigRepository(
             .sortedBy { it.name }
     }
 
-    private fun parseYamlFile(file: Path): AgentConfig? {
+    /**
+     * [directory] (the cache's root, i.e. `<configPath>/agents`) is unused here —
+     * agent `docs` entries resolve relative to the YAML file itself ([file].parent),
+     * a deliberately distinct mechanism from the `{{NAMESPACE_CONFIG_PATH}}` token used
+     * for [io.whozoss.agentos.integrationConfig.IntegrationConfig] parameters. `docs` has a
+     * known, fixed semantics (file / directory listing) inherited from Coday, so it keeps
+     * its own path-resolution rule rather than being unified with the free-form
+     * `parameters` substitution.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    private fun parseYamlFile(
+        directory: Path,
+        file: Path,
+    ): AgentConfig? {
         val model = yamlMapper.readValue(file.toFile(), AgentConfigYamlModel::class.java)
         if (model.name.isBlank()) {
             logger.warn { "[FilesystemAgentConfigRepository] Skipping $file: 'name' is blank" }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/FilesystemIntegrationConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/FilesystemIntegrationConfigRepository.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import io.whozoss.agentos.namespace.NamespaceRepository
 import io.whozoss.agentos.plugin.filesystem.FilesystemYamlCacheRegistry
+import io.whozoss.agentos.plugin.filesystem.substituteConfigPath
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import mu.KLogging
 import java.nio.file.Path
@@ -34,7 +35,6 @@ class FilesystemIntegrationConfigRepository(
     private val namespaceRepository: NamespaceRepository,
     ttl: Duration = Duration.ofMinutes(5),
 ) : IntegrationConfigRepository by delegate {
-
     private val yamlMapper =
         ObjectMapper(YAMLFactory()).registerModule(KotlinModule.Builder().build())
 
@@ -84,9 +84,10 @@ class FilesystemIntegrationConfigRepository(
             // No namespace context means no configPath to read from.
             return fromDelegate
         }
-        val persistedNsSharedNames = fromDelegate
-            .filter { it.namespaceId == namespaceId && it.userId == null }
-            .mapTo(HashSet()) { it.name.lowercase() }
+        val persistedNsSharedNames =
+            fromDelegate
+                .filter { it.namespaceId == namespaceId && it.userId == null }
+                .mapTo(HashSet()) { it.name.lowercase() }
         val filesystem = filesystemConfigs(namespaceId, excludeNames = persistedNsSharedNames)
         return fromDelegate + filesystem
     }
@@ -130,26 +131,43 @@ class FilesystemIntegrationConfigRepository(
             .sortedBy { it.name }
     }
 
-    private fun parseYamlFile(file: Path): IntegrationConfig? {
-        val model = yamlMapper.readValue(file.toFile(), IntegrationConfigYamlModel::class.java)
-        if (model.name.isBlank()) {
+    /**
+     * [directory] is the cache's root directory (`<configPath>/integrations`, possibly with
+     * files nested arbitrarily deep under it via [io.whozoss.agentos.plugin.filesystem.FilesystemYamlCache]'s
+     * recursive walk). `directory.parent` is therefore the namespace's `configPath` regardless
+     * of where [file] itself sits — deriving it from `file.parent` would be wrong for any file
+     * not directly at the top level.
+     *
+     * The `{{NAMESPACE_CONFIG_PATH}}` token is substituted only in [IntegrationConfig.parameters]
+     * — never in `name`, `integrationType`, or `description`, which have no path semantics.
+     */
+    private fun parseYamlFile(
+        directory: Path,
+        file: Path,
+    ): IntegrationConfig? {
+        val integrationConfigYaml = yamlMapper.readValue(file.toFile(), IntegrationConfigYamlModel::class.java)
+        if (integrationConfigYaml.name.isBlank()) {
             logger.warn { "[FilesystemIntegrationConfigRepository] Skipping $file: 'name' is blank" }
             return null
         }
-        if (model.integrationType.isBlank()) {
+        if (integrationConfigYaml.integrationType.isBlank()) {
             logger.warn { "[FilesystemIntegrationConfigRepository] Skipping $file: 'integrationType' is blank" }
             return null
         }
+        val configPath = directory.parent?.toString()
         return IntegrationConfig(
             // Stable UUID derived from the name so identity survives restarts.
             // namespaceId is null here; it is overwritten by the caller.
-            metadata = EntityMetadata(id = UUID.nameUUIDFromBytes("filesystem-integration:${model.name}".toByteArray(Charsets.UTF_8))),
+            metadata =
+                EntityMetadata(
+                    id = UUID.nameUUIDFromBytes("filesystem-integration:${integrationConfigYaml.name}".toByteArray(Charsets.UTF_8)),
+                ),
             namespaceId = null,
             userId = null,
-            name = model.name,
-            integrationType = model.integrationType,
-            description = model.description,
-            parameters = model.parameters,
+            name = integrationConfigYaml.name,
+            integrationType = integrationConfigYaml.integrationType,
+            description = integrationConfigYaml.description,
+            parameters = substituteConfigPath(integrationConfigYaml.parameters, configPath),
         )
     }
 
@@ -162,9 +180,12 @@ class FilesystemIntegrationConfigRepository(
  * YAML model for integration config files read from the filesystem.
  *
  * Both [name] and [integrationType] are required — a file missing either is skipped with a warning.
- * [parameters] is an arbitrary YAML object serialised verbatim as a [JsonNode]; no variable
- * substitution is performed. For credentials that vary per user, create a user-level overlay
- * via the API on top of this namespace-shared base.
+ * [parameters] is an arbitrary YAML object serialised verbatim as a [JsonNode]. The single
+ * exception is the `{{NAMESPACE_CONFIG_PATH}}` token (see
+ * [io.whozoss.agentos.plugin.filesystem.substituteConfigPath]), substituted by this namespace's
+ * `configPath` at parse time to make committed absolute paths portable across checkouts.
+ * For credentials that vary per user, create a user-level overlay via the API on top of this
+ * namespace-shared base.
  *
  * Example:
  * ```yaml

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigController.kt
@@ -279,7 +279,7 @@ class IntegrationConfigController(
         val entity =
             integrationConfigService.findById(id)
                 ?: throw ResourceNotFoundException("IntegrationConfig not found: $id")
-        val yaml = YAML_MAPPER.writeValueAsString(toExportModel(entity))
+        val yaml = PORTABILITY_COMMENT + YAML_MAPPER.writeValueAsString(toExportModel(entity))
         val filename = "${entity.name.lowercase().replace(Regex("[^a-z0-9]+"), "-")}.yaml"
         return ResponseEntity
             .ok()
@@ -312,6 +312,37 @@ class IntegrationConfigController(
     }
 
     companion object : KLogging() {
+        /**
+         * Comment block prefixed to every exported YAML file, explaining how to make the
+         * exported `parameters` paths portable across developer machines.
+         *
+         * Paths written through the UI/API are absolute and specific to the machine that
+         * entered them — there is no reverse substitution of `{{NAMESPACE_CONFIG_PATH}}` on
+         * export (the token is a one-way, load-time replacement performed by
+         * [io.whozoss.agentos.integrationConfig.FilesystemIntegrationConfigRepository] for files
+         * placed under `<namespace.configPath>/integrations/`; configs created via the API are
+         * not resolved through that path). Each line is a valid YAML comment, so the file remains
+         * directly reloadable without edits.
+         */
+        private val PORTABILITY_COMMENT: String =
+            """
+            |# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+            |# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+            |# that entered them.
+            |#
+            |# To make this file portable across developer machines, replace the part of each path
+            |# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+            |# It is resolved automatically at load time, only for files placed in
+            |# {configPath}/integrations/ (configs created through the API are not affected).
+            |#
+            |# Example: workingDirectory: /home/alice/repos/myproject
+            |#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+            |#
+            |# Relative path segments following the token are kept as-is, not normalised:
+            |# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+            |
+            """.trimMargin()
+
         /**
          * YAML mapper configured for clean, human-readable output:
          * - No `---` document start marker

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/plugin/filesystem/ConfigPathSubstitution.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/plugin/filesystem/ConfigPathSubstitution.kt
@@ -1,0 +1,54 @@
+package io.whozoss.agentos.plugin.filesystem
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
+
+/**
+ * Token substituted, at filesystem-YAML parse time only, by the owning namespace's
+ * `configPath`. Lets a committed `IntegrationConfig` YAML reference paths relative to
+ * wherever the repo happens to be checked out, instead of hardcoding an absolute path
+ * that is only valid on the machine that wrote it.
+ *
+ * Substitution is a plain textual replacement, positional and repeatable within a value
+ * (e.g. `--config={{NAMESPACE_CONFIG_PATH}}/settings.json`) — never a prefix-only rule.
+ * No path normalization is applied: `{{NAMESPACE_CONFIG_PATH}}/../scripts` resolves to
+ * `<configPath>/../scripts` literally. Downstream consumers (`Path.of`, `File`,
+ * `canonicalPath`, `BashConfigParser`'s own traversal check) resolve `..` themselves.
+ */
+const val NAMESPACE_CONFIG_PATH_TOKEN = "{{NAMESPACE_CONFIG_PATH}}"
+
+/** Replaces every occurrence of [NAMESPACE_CONFIG_PATH_TOKEN] in [text] with [configPath]. */
+fun substituteConfigPath(
+    text: String,
+    configPath: String,
+): String = text.replace(NAMESPACE_CONFIG_PATH_TOKEN, configPath)
+
+/**
+ * Returns a new [JsonNode] with [NAMESPACE_CONFIG_PATH_TOKEN] substituted by [configPath]
+ * in every text node, recursively through objects and arrays. Numbers, booleans and nulls
+ * are preserved as-is. The input [node] is never mutated — a fresh tree is built so the
+ * cached original stays safe to share.
+ *
+ * Returns [node] unchanged when either [node] or [configPath] is null.
+ */
+fun substituteConfigPath(
+    node: JsonNode?,
+    configPath: String?,
+): JsonNode? {
+    if (node == null || configPath == null) return node
+    return when (node) {
+        is TextNode -> TextNode.valueOf(substituteConfigPath(node.textValue(), configPath))
+        is ObjectNode ->
+            JsonNodeFactory.instance.objectNode().also { result ->
+                node.fields().forEach { (key, value) -> result.set<JsonNode>(key, substituteConfigPath(value, configPath)) }
+            }
+        is ArrayNode ->
+            JsonNodeFactory.instance.arrayNode().also { result ->
+                node.forEach { element -> result.add(substituteConfigPath(element, configPath)) }
+            }
+        else -> node
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/plugin/filesystem/FilesystemYamlCache.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/plugin/filesystem/FilesystemYamlCache.kt
@@ -89,6 +89,12 @@ class FilesystemYamlCache<T>(
  * Manages one [FilesystemYamlCache] per namespace directory, keyed by the resolved
  * directory [Path]. Caches are created lazily on first access and reused across calls.
  *
+ * [parser] receives the cache's root [directory] alongside each file it contains.
+ * The root directory is what lets a parser recover the owning namespace's `configPath`
+ * (e.g. `directory.parent` when the cache is rooted at `<configPath>/integrations`)
+ * regardless of how deep the file sits under a recursive `Files.walk` scan — deriving
+ * it from `file.parent` instead would be wrong for any nested subdirectory.
+ *
  * Use this when a single Spring bean needs to serve multiple namespaces, each with
  * its own configPath:
  * ```kotlin
@@ -97,11 +103,13 @@ class FilesystemYamlCache<T>(
  * ```
  */
 class FilesystemYamlCacheRegistry<T>(
-    private val parser: (Path) -> T?,
+    private val parser: (Path, Path) -> T?,
     private val ttl: Duration = FilesystemYamlCache.DEFAULT_TTL,
 ) {
     private val caches = ConcurrentHashMap<Path, FilesystemYamlCache<T>>()
 
     fun getAll(directory: Path): List<T> =
-        caches.computeIfAbsent(directory) { FilesystemYamlCache(it, parser, ttl) }.getAll()
+        caches
+            .computeIfAbsent(directory) { dir -> FilesystemYamlCache(dir, { file -> parser(dir, file) }, ttl) }
+            .getAll()
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/FilesystemIntegrationConfigRepositoryUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/FilesystemIntegrationConfigRepositoryUnitSpec.kt
@@ -304,6 +304,168 @@ class FilesystemIntegrationConfigRepositoryUnitSpec :
         }
 
         // -------------------------------------------------------------------------
+        // {{NAMESPACE_CONFIG_PATH}} token substitution in parameters
+        // -------------------------------------------------------------------------
+
+        "findByNamespaceId substitutes the NAMESPACE_CONFIG_PATH token in parameters" {
+            val root = tempDir()
+            writeYaml(
+                integrationsDir(root),
+                "bash.yaml",
+                integrationYaml(
+                    name = "BASH_repo",
+                    integrationType = "BASH",
+                    parameters = "  workingDirectory: \"{{NAMESPACE_CONFIG_PATH}}/../..\"",
+                ),
+            )
+
+            val delegate = mockk<IntegrationConfigRepository>()
+            val nsRepo = nsRepoWith(namespaceId, root.toString())
+            every { delegate.findByNamespaceId(namespaceId) } returns emptyList()
+
+            val result = buildRepo(delegate, nsRepo).findByNamespaceId(namespaceId).single()
+
+            result.parameters?.get("workingDirectory")?.textValue() shouldBe "${root}/../.."
+        }
+
+        "findByNamespaceId does not normalize the substituted path -- '..' is left literal" {
+            val root = tempDir()
+            writeYaml(
+                integrationsDir(root),
+                "bash.yaml",
+                integrationYaml(
+                    name = "BASH_repo",
+                    integrationType = "BASH",
+                    parameters = "  script: \"{{NAMESPACE_CONFIG_PATH}}/../scripts/build.sh\"",
+                ),
+            )
+
+            val delegate = mockk<IntegrationConfigRepository>()
+            val nsRepo = nsRepoWith(namespaceId, root.toString())
+            every { delegate.findByNamespaceId(namespaceId) } returns emptyList()
+
+            val result = buildRepo(delegate, nsRepo).findByNamespaceId(namespaceId).single()
+
+            result.parameters?.get("script")?.textValue() shouldBe "$root/../scripts/build.sh"
+        }
+
+        "findByNamespaceId substitutes the token embedded in an array element (MCP args case)" {
+            val root = tempDir()
+            writeYaml(
+                integrationsDir(root),
+                "mcp.yaml",
+                buildString {
+                    appendLine("name: MCP_repo")
+                    appendLine("integrationType: MCP_STDIO")
+                    appendLine("parameters:")
+                    appendLine("  args:")
+                    appendLine("    - --flag")
+                    appendLine("    - \"--config={{NAMESPACE_CONFIG_PATH}}/settings.json\"")
+                },
+            )
+
+            val delegate = mockk<IntegrationConfigRepository>()
+            val nsRepo = nsRepoWith(namespaceId, root.toString())
+            every { delegate.findByNamespaceId(namespaceId) } returns emptyList()
+
+            val result = buildRepo(delegate, nsRepo).findByNamespaceId(namespaceId).single()
+
+            result.parameters?.get("args")?.get(1)?.textValue() shouldBe "--config=$root/settings.json"
+        }
+
+        "findByNamespaceId substitutes the token nested in an array of objects (BASH tools[].command case)" {
+            val root = tempDir()
+            writeYaml(
+                integrationsDir(root),
+                "bash.yaml",
+                buildString {
+                    appendLine("name: BASH_repo")
+                    appendLine("integrationType: BASH")
+                    appendLine("parameters:")
+                    appendLine("  tools:")
+                    appendLine("    - name: build")
+                    appendLine("      description: Builds the project")
+                    appendLine("      command: \"{{NAMESPACE_CONFIG_PATH}}/../scripts/build.sh\"")
+                },
+            )
+
+            val delegate = mockk<IntegrationConfigRepository>()
+            val nsRepo = nsRepoWith(namespaceId, root.toString())
+            every { delegate.findByNamespaceId(namespaceId) } returns emptyList()
+
+            val result = buildRepo(delegate, nsRepo).findByNamespaceId(namespaceId).single()
+
+            result.parameters?.get("tools")?.get(0)?.get("command")?.textValue() shouldBe "$root/../scripts/build.sh"
+            result.parameters?.get("tools")?.get(0)?.get("name")?.textValue() shouldBe "build"
+        }
+
+        "findByNamespaceId does not substitute the token in name, integrationType, or description" {
+            val root = tempDir()
+            writeYaml(
+                integrationsDir(root),
+                "weird.yaml",
+                buildString {
+                    appendLine("name: \"{{NAMESPACE_CONFIG_PATH}}\"")
+                    appendLine("integrationType: BASH")
+                    appendLine("description: \"{{NAMESPACE_CONFIG_PATH}}\"")
+                },
+            )
+
+            val delegate = mockk<IntegrationConfigRepository>()
+            val nsRepo = nsRepoWith(namespaceId, root.toString())
+            every { delegate.findByNamespaceId(namespaceId) } returns emptyList()
+
+            val result = buildRepo(delegate, nsRepo).findByNamespaceId(namespaceId).single()
+
+            result.name shouldBe "{{NAMESPACE_CONFIG_PATH}}"
+            result.description shouldBe "{{NAMESPACE_CONFIG_PATH}}"
+        }
+
+        "findByNamespaceId resolves configPath from the cache root, not from a nested file's parent directory" {
+            val root = tempDir()
+            val nested = integrationsDir(root).resolve("team-a").also { Files.createDirectories(it) }
+            writeYaml(
+                nested,
+                "jira.yaml",
+                integrationYaml(
+                    name = "JIRA_nested",
+                    integrationType = "JIRA",
+                    parameters = "  path: \"{{NAMESPACE_CONFIG_PATH}}/x\"",
+                ),
+            )
+
+            val delegate = mockk<IntegrationConfigRepository>()
+            val nsRepo = nsRepoWith(namespaceId, root.toString())
+            every { delegate.findByNamespaceId(namespaceId) } returns emptyList()
+
+            val result = buildRepo(delegate, nsRepo).findByNamespaceId(namespaceId).single()
+
+            // must resolve to the namespace configPath (root), NOT to integrations/ or integrations/team-a/
+            result.parameters?.get("path")?.textValue() shouldBe "$root/x"
+        }
+
+        "findByNamespaceId leaves parameters without the token unchanged" {
+            val root = tempDir()
+            writeYaml(
+                integrationsDir(root),
+                "jira.yaml",
+                integrationYaml(
+                    name = "JIRA",
+                    integrationType = "JIRA",
+                    parameters = "  baseUrl: https://company.atlassian.net",
+                ),
+            )
+
+            val delegate = mockk<IntegrationConfigRepository>()
+            val nsRepo = nsRepoWith(namespaceId, root.toString())
+            every { delegate.findByNamespaceId(namespaceId) } returns emptyList()
+
+            val result = buildRepo(delegate, nsRepo).findByNamespaceId(namespaceId).single()
+
+            result.parameters?.get("baseUrl")?.textValue() shouldBe "https://company.atlassian.net"
+        }
+
+        // -------------------------------------------------------------------------
         // findByParent — delegates to findByNamespaceId
         // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/integrationConfig/IntegrationConfigControllerSpec.kt
@@ -1,10 +1,15 @@
 package io.whozoss.agentos.integrationConfig
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -433,5 +438,51 @@ class IntegrationConfigControllerSpec : StringSpec({
         shouldThrow<BadRequestException> {
             controller.list(namespaceId = "not-a-uuid-and-not-none", userId = null)
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // export — portability comment block
+    // -------------------------------------------------------------------------
+
+    "export prefixes the YAML body with a portability comment block mentioning the token" {
+        val exportParams = JsonNodeFactory.instance.objectNode().put("workingDirectory", "/home/alice/repos/myproject")
+        val cfg = config(name = "BASH_LOCAL", integrationType = "BASH").let {
+            it.copy(parameters = exportParams)
+        }
+        every { service.findById(cfg.metadata.id) } returns cfg
+
+        val response = controller.export(cfg.metadata.id)
+        val body = response.body!!
+
+        body shouldStartWith "# "
+        body shouldContain "{{NAMESPACE_CONFIG_PATH}}"
+    }
+
+    "export produces a body that re-parses to a valid YAML document with name, integrationType, parameters" {
+        val exportParams = JsonNodeFactory.instance.objectNode().put("workingDirectory", "/home/alice/repos/myproject")
+        val cfg = config(name = "BASH_LOCAL", integrationType = "BASH").let {
+            it.copy(parameters = exportParams)
+        }
+        every { service.findById(cfg.metadata.id) } returns cfg
+
+        val response = controller.export(cfg.metadata.id)
+        val body = response.body!!
+
+        val yamlMapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule.Builder().build())
+        val tree = yamlMapper.readTree(body)
+
+        tree.get("name").asText() shouldBe "BASH_LOCAL"
+        tree.get("integrationType").asText() shouldBe "BASH"
+        tree.get("parameters").get("workingDirectory").asText() shouldBe "/home/alice/repos/myproject"
+    }
+
+    "export keeps the existing Content-Disposition header and application/yaml content type" {
+        val cfg = config(name = "BASH_LOCAL", integrationType = "BASH")
+        every { service.findById(cfg.metadata.id) } returns cfg
+
+        val response = controller.export(cfg.metadata.id)
+
+        response.headers.contentDisposition.toString() shouldContain "bash-local.yaml"
+        response.headers.contentType.toString() shouldBe org.springframework.http.MediaType.APPLICATION_YAML_VALUE
     }
 })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/plugin/filesystem/ConfigPathSubstitutionUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/plugin/filesystem/ConfigPathSubstitutionUnitSpec.kt
@@ -1,0 +1,120 @@
+package io.whozoss.agentos.plugin.filesystem
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class ConfigPathSubstitutionUnitSpec :
+    StringSpec({
+
+        val configPath = "/home/alice/repos/myproject/.agentos"
+
+        // -------------------------------------------------------------------------
+        // String substitution
+        // -------------------------------------------------------------------------
+
+        "substitutes a token at the start of a value" {
+            substituteConfigPath("{{NAMESPACE_CONFIG_PATH}}/../..", configPath) shouldBe "$configPath/../.."
+        }
+
+        "substitutes a token embedded mid-value" {
+            substituteConfigPath("--config={{NAMESPACE_CONFIG_PATH}}/settings.json", configPath) shouldBe
+                "--config=$configPath/settings.json"
+        }
+
+        "substitutes multiple occurrences of the token in the same value" {
+            substituteConfigPath(
+                "{{NAMESPACE_CONFIG_PATH}}/a:{{NAMESPACE_CONFIG_PATH}}/b",
+                configPath,
+            ) shouldBe "$configPath/a:$configPath/b"
+        }
+
+        "does not normalize the resulting path -- '..' segments are left literal" {
+            substituteConfigPath("{{NAMESPACE_CONFIG_PATH}}/../scripts/build.sh", configPath) shouldBe
+                "$configPath/../scripts/build.sh"
+        }
+
+        "leaves a value without the token unchanged" {
+            substituteConfigPath("/absolute/unrelated/path", configPath) shouldBe "/absolute/unrelated/path"
+        }
+
+        // -------------------------------------------------------------------------
+        // JsonNode substitution
+        // -------------------------------------------------------------------------
+
+        "substitutes the token inside a top-level text field" {
+            val input = JsonNodeFactory.instance.objectNode().put("workingDirectory", "{{NAMESPACE_CONFIG_PATH}}/../..")
+
+            val result = substituteConfigPath(input, configPath)
+
+            result?.get("workingDirectory")?.textValue() shouldBe "$configPath/../.."
+        }
+
+        "substitutes the token inside an array element (MCP args case)" {
+            val args = JsonNodeFactory.instance.arrayNode().add("--flag").add("{{NAMESPACE_CONFIG_PATH}}/config.json")
+            val input = JsonNodeFactory.instance.objectNode().set<JsonNode>("args", args)
+
+            val result = substituteConfigPath(input, configPath)
+
+            result?.get("args")?.get(0)?.textValue() shouldBe "--flag"
+            result?.get("args")?.get(1)?.textValue() shouldBe "$configPath/config.json"
+        }
+
+        "substitutes the token inside a nested object (BASH tools[].command case)" {
+            val tool = JsonNodeFactory.instance.objectNode().also {
+                it.put("name", "build")
+                it.put("command", "{{NAMESPACE_CONFIG_PATH}}/../scripts/build.sh")
+            }
+            val tools = JsonNodeFactory.instance.arrayNode().add(tool)
+            val input = JsonNodeFactory.instance.objectNode().set<JsonNode>("tools", tools)
+
+            val result = substituteConfigPath(input, configPath)
+
+            result?.get("tools")?.get(0)?.get("command")?.textValue() shouldBe "$configPath/../scripts/build.sh"
+            result?.get("tools")?.get(0)?.get("name")?.textValue() shouldBe "build"
+        }
+
+        "preserves non-textual nodes (numbers, booleans, null) untouched" {
+            val input = JsonNodeFactory.instance.objectNode().also {
+                it.put("count", 42)
+                it.put("enabled", true)
+                it.putNull("nothing")
+            }
+
+            val result = substituteConfigPath(input, configPath)
+
+            result?.get("count")?.intValue() shouldBe 42
+            result?.get("enabled")?.booleanValue() shouldBe true
+            result?.get("nothing")?.isNull shouldBe true
+        }
+
+        "leaves a JsonNode without the token unchanged in content" {
+            val input = JsonNodeFactory.instance.objectNode().put("baseUrl", "https://company.atlassian.net")
+
+            val result = substituteConfigPath(input, configPath)
+
+            result?.get("baseUrl")?.textValue() shouldBe "https://company.atlassian.net"
+        }
+
+        "does not mutate the original JsonNode" {
+            val input = JsonNodeFactory.instance.objectNode().put("workingDirectory", "{{NAMESPACE_CONFIG_PATH}}/x")
+
+            substituteConfigPath(input, configPath)
+
+            input.get("workingDirectory").textValue() shouldBe "{{NAMESPACE_CONFIG_PATH}}/x"
+        }
+
+        "returns null when the input node is null" {
+            substituteConfigPath(null, configPath).shouldBeNull()
+        }
+
+        "returns the node unchanged when configPath is null" {
+            val input = JsonNodeFactory.instance.objectNode().put("workingDirectory", "{{NAMESPACE_CONFIG_PATH}}/x")
+
+            val result = substituteConfigPath(input, null)
+
+            result?.get("workingDirectory")?.textValue() shouldBe "{{NAMESPACE_CONFIG_PATH}}/x"
+        }
+    })

--- a/agentos/docs/plugin-system.md
+++ b/agentos/docs/plugin-system.md
@@ -33,6 +33,38 @@ Directory resolution order for each type:
 
 For agents, the `id` is derived from the YAML filename (lowercase, kebab-case, no extension). Supported fields include name, description, capabilities, contexts, tags, priority, status, and AI provider/model hints.
 
+## `{{NAMESPACE_CONFIG_PATH}}` Token in Filesystem IntegrationConfig
+
+A committed `IntegrationConfig` YAML under `<configPath>/integrations/` cannot hardcode an
+absolute path — every developer clones the project's repo at a different location. The
+`{{NAMESPACE_CONFIG_PATH}}` token, substituted only inside the `parameters` field at parse
+time, solves this by resolving to the owning namespace's `configPath`.
+
+```yaml
+name: BASH_repo
+integrationType: BASH
+parameters:
+  workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/../.."
+  tools:
+    - name: build
+      command: "{{NAMESPACE_CONFIG_PATH}}/../scripts/build.sh"
+```
+
+The token is a plain textual replacement — it can appear anywhere in a value, including
+embedded mid-string (`--config={{NAMESPACE_CONFIG_PATH}}/x.json`) or inside an array element,
+which is what lets a single token cover an MCP `args: List<String>` entry as well as a BASH
+command string. **No path normalization is applied**: the result of substituting into
+`{{NAMESPACE_CONFIG_PATH}}/../scripts` is the literal string `<configPath>/../scripts` — `..`
+segments are left for the consumer (`Path.of`, `File`, `canonicalPath`) to resolve.
+
+Scope: only `IntegrationConfig.parameters` loaded from the filesystem is substituted. `name`,
+`integrationType`, and `description` are never touched, and configs created through the API or
+persisted in Neo4j are entirely unaffected — a literal token saved through the API is stored
+and will simply fail at runtime, which is accepted power-user behaviour.
+
+Typical consumers: the **BASH** plugin (`workingDirectory`, tool `command`), **MCP_STDIO**
+(`cwd`, and paths embedded in `args`), and **FILE_ACCESS** (`rootPath`).
+
 ## Tool Registration
 
 When wrapping a `StandardTool` from a plugin as a Spring AI `ToolCallback`, always implement `ToolCallback` directly with `DefaultToolDefinition` — never use `MethodToolCallback`. `MethodToolCallback` reflects on the wrapper method signature and produces a wrong schema, causing the LLM to send empty arguments. Deserialization must happen inside the plugin classloader via `tool.executeWithJson(input)`.

--- a/integrations/CHROME.yaml
+++ b/integrations/CHROME.yaml
@@ -1,0 +1,25 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+name: "CHROME"
+integrationType: "MCP_STDIO"
+parameters:
+  command: "npx"
+  args:
+  - "chrome-devtools-mcp@latest"
+  env: ""
+  cwd: null
+  timeoutSeconds: 30
+  toolCallTimeoutSeconds: 60
+  idleTimeoutMinutes: 10

--- a/integrations/FETCH.yaml
+++ b/integrations/FETCH.yaml
@@ -1,0 +1,26 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+name: "FETCH"
+integrationType: "MCP_STDIO"
+parameters:
+  command: "npx"
+  args:
+  - "mcp-server-fetch"
+  - "--ignore-robots-txt"
+  env: ""
+  cwd: null
+  timeoutSeconds: 30
+  toolCallTimeoutSeconds: 60
+  idleTimeoutMinutes: 10

--- a/integrations/FETCH.yaml
+++ b/integrations/FETCH.yaml
@@ -15,8 +15,11 @@
 name: "FETCH"
 integrationType: "MCP_STDIO"
 parameters:
-  command: "npx"
+  command: "uvx"
   args:
+  # temporary fix because of the recent mcp package evolution to cover MCP spec change in v2
+  - "--with"
+  - "mcp<2"
   - "mcp-server-fetch"
   - "--ignore-robots-txt"
   env: ""

--- a/integrations/FILES.yaml
+++ b/integrations/FILES.yaml
@@ -1,0 +1,21 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+name: "FILES"
+integrationType: "FILE_ACCESS"
+parameters:
+  rootPath: "{{NAMESPACE_CONFIG_PATH}}"
+  readOnly: false
+  readMaxSizeMb: 10
+  extraDenyPatterns: []

--- a/integrations/GIT.yaml
+++ b/integrations/GIT.yaml
@@ -1,0 +1,27 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+name: "GIT"
+integrationType: "BASH"
+parameters:
+  workingDirectory: "{{NAMESPACE_CONFIG_PATH"
+  defaultTimeoutSeconds: 30
+  tools:
+  - name: "git"
+    description: "runs git with the given commands in parameters"
+    command: "git PARAMETERS"
+    parametersDescription: "the arguments for the git command, ex `commit -m \"fix\
+      \ something\"`, `log`, `reset --hard`"
+    path: null
+    timeoutSeconds: null

--- a/integrations/GITHUB.yaml
+++ b/integrations/GITHUB.yaml
@@ -1,0 +1,30 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+name: "GITHUB"
+integrationType: "MCP_STDIO"
+parameters:
+  command: "docker"
+  args:
+  - "run"
+  - "-i"
+  - "--rm"
+  - "-e"
+  - "GITHUB_PERSONAL_ACCESS_TOKEN"
+  - "ghcr.io/github/github-mcp-server"
+  env: {}
+  cwd: null
+  timeoutSeconds: 30
+  toolCallTimeoutSeconds: 60
+  idleTimeoutMinutes: 10

--- a/integrations/NX.yaml
+++ b/integrations/NX.yaml
@@ -1,0 +1,28 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+name: "NX"
+integrationType: "MCP_STDIO"
+parameters:
+  command: "npx"
+  args:
+  - "nx"
+  - "mcp"
+  - "--no-minimal"
+  - "--disableTelemetry"
+  env: ""
+  cwd: "{{NAMESPACE_CONFIG_PATH}}"
+  timeoutSeconds: 30
+  toolCallTimeoutSeconds: 60
+  idleTimeoutMinutes: 10

--- a/integrations/PLAYWRIGHT.yaml
+++ b/integrations/PLAYWRIGHT.yaml
@@ -1,0 +1,25 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+name: "PLAYWRIGHT"
+integrationType: "MCP_STDIO"
+parameters:
+  command: "npx"
+  args:
+  - "@playwright/mcp@latest"
+  env: ""
+  cwd: null
+  timeoutSeconds: 30
+  toolCallTimeoutSeconds: 60
+  idleTimeoutMinutes: 10

--- a/integrations/PROJECT_SCRIPTS.yaml
+++ b/integrations/PROJECT_SCRIPTS.yaml
@@ -1,0 +1,117 @@
+# This file was exported from a persisted IntegrationConfig. Paths under `parameters`
+# (e.g. workingDirectory, rootPath, cwd, args) are absolute and specific to the machine
+# that entered them.
+#
+# To make this file portable across developer machines, replace the part of each path
+# that matches the namespace's configPath with the token {{NAMESPACE_CONFIG_PATH}}.
+# It is resolved automatically at load time, only for files placed in
+# {configPath}/integrations/ (configs created through the API are not affected).
+#
+# Example: workingDirectory: /home/alice/repos/myproject
+#       -> workingDirectory: "{{NAMESPACE_CONFIG_PATH}}/.."
+#
+# Relative path segments following the token are kept as-is, not normalised:
+# "{{NAMESPACE_CONFIG_PATH}}/../scripts" works.
+#
+# Ported from the `scripts` section of coday.yaml (BASH plugin equivalent of the
+# legacy AssistantTools scripts). Keep both in sync manually until coday.yaml's
+# `scripts` mechanism is retired.
+name: "PROJECT_SCRIPTS"
+integrationType: "BASH"
+parameters:
+  workingDirectory: "{{NAMESPACE_CONFIG_PATH}}"
+  defaultTimeoutSeconds: 60
+  tools:
+  - name: "nx"
+    description: |
+      Run Nx commands for the monorepo. Nx is the build system orchestrating all projects.
+
+      Common targets:
+      - build: Compile a project (e.g., "nx build client")
+      - test: Run tests (e.g., "nx test server", "nx test agentos-service")
+      - lint: Run linter (e.g., "nx lint client")
+      - serve: Start dev server (e.g., "nx serve client")
+
+      Common commands:
+      - "test agentos-service" - Run all Kotlin tests for AgentOS service
+      - "test client" - Run all Angular client tests
+      - "lint server" - Lint the server code
+      - "build client" - Build the Angular client
+      - "run-many --target=test --all" - Run all tests in monorepo
+      - "run-many --target=build --all" - Build all projects
+      - "affected --target=test" - Test only affected projects
+      - "list" - List all projects in workspace
+      - "show project client" - Show project configuration
+
+      For Kotlin-specific test filtering (e.g., specific test class):
+      Use gradle directly: "cd agentos && ./gradlew :agentos-service:test --tests ChatClientProviderTest"
+
+      Note: Nx handles both TypeScript (Jest) and Kotlin (Gradle) projects seamlessly.
+
+      ⚠️ Do not run interactive commands!
+      ⚠️ Commands that modify dependencies require user confirmation.
+    command: "pnpm nx PARAMETERS"
+    parametersDescription: |
+      Nx command with arguments. Examples:
+      - "test agentos-service"
+      - "build client"
+      - "run-many --target=test --all"
+      - "affected --target=build --base=origin/master"
+    path: null
+    timeoutSeconds: 900
+  - name: "gradle"
+    description: |
+      Run Gradle commands for Kotlin/Java projects in the agentos/ directory.
+
+      Common commands:
+      - ":agentos-service:test" - Run all service tests
+      - ":agentos-service:test --tests ChatClientProviderTest" - Run specific test class
+      - ":agentos-service:build" - Build the service
+      - ":agentos-sdk:test" - Run SDK tests
+      - "test" - Run all tests in agentos/
+      - "build" - Build all Gradle projects
+
+      The command runs from agentos/ directory with optimized flags:
+      --no-build-cache --no-configuration-cache --no-daemon
+    command: "./gradlew PARAMETERS --no-build-cache --no-configuration-cache --no-daemon"
+    parametersDescription: |
+      Gradle task with arguments. Examples:
+      - ":agentos-service:test"
+      - ":agentos-service:test --tests ChatClientProviderTest"
+      - ":agentos-sdk:build"
+      - "test" (all tests)
+    path: "agentos"
+    timeoutSeconds: 900
+  - name: "setup"
+    description: |
+      Project setup script. Checks that required binaries (node, pnpm, java) are available on PATH,
+      then installs dependencies using pnpm with a frozen lockfile.
+      Works both in the main clone and in git worktrees.
+      Run this once after cloning or creating a new worktree.
+    command: "bash setup.sh"
+    timeoutSeconds: 300
+  - name: "web-dev"
+    description: |
+      Starts the full Coday dev stack (AgentOS + Express server + Angular client) in tmux sessions.
+      Ports are allocated dynamically to avoid collisions across worktrees.
+
+      Three tmux sessions are created (one process per session):
+        - agentos_<branch>_<port>   AgentOS Spring Boot backend
+        - server_<branch>_<port>    Express server
+        - client_<branch>_<port>    Angular dev server
+      Where <branch> is the first 12 chars of the last git branch segment.
+
+      Output includes a machine-readable block with allocated ports:
+        AGENTOS_PORT=<n>
+        SERVER_PORT=<n>
+        CLIENT_PORT=<n>
+
+      Ready signals to look for in tmux logs:
+        AgentOS  : "Started AgentOSApplication"
+        Server   : "Server is running on http://localhost:<port>"
+        Client   : "Local:   http://localhost:<port>"
+
+      Run with --help for full documentation:
+        bash scripts/web-dev-tmux.sh --help
+    command: "bash ./scripts/web-dev-tmux.sh"
+    timeoutSeconds: 60


### PR DESCRIPTION


A committed IntegrationConfig YAML under <configPath>/integrations/ cannot hardcode an absolute path: every developer clones the repo at a different location, while the BASH (workingDirectory, command), MCP_STDIO (cwd, args) and FILE_ACCESS (rootPath) plugins all require absolute paths.

Introduce a {{NAMESPACE_CONFIG_PATH}} token substituted by the namespace configPath, at filesystem YAML parse time only. Substitution is a plain textual replacement, positional and repeatable within a value, so a single token covers an MCP args array element as well as an embedded path in a bash command. No path normalization is applied: '..' segments are left for consumers (Path.of, File, canonicalPath) to resolve, as BashConfigParser already does.

Resolving at parse time rather than at runtime is deliberate:
- findEffective merges 4 overlay layers param by param, losing provenance; only the filesystem-namespace layer has a configPath, so a token has no meaning downstream
- there are two runtime consumption points (provideTools and describeNamespace), and every future one would need wiring; parse time is wired once, structurally
- FilesystemYamlCache memoizes parsed objects, so the cost is amortized to zero
- McpConfigHash covers command/args/env/cwd to identify a pooled connection; with unresolved tokens two developers would share a hash, hence the same MCP process pointing at the wrong directory

The configPath is not derivable from the file path, since FilesystemYamlCache walks recursively and a file may sit in integrations/team-a/jira.yaml. The FilesystemYamlCacheRegistry parser contract therefore becomes (Path, Path) -> T? (cache root, file), making directory.parent the configPath by construction.

Scope is limited to IntegrationConfig.parameters: name, integrationType and description are untouched, and configs created through the API are unaffected. A literal token persisted via the API is stored as-is and fails at runtime, which is accepted power-user behaviour.

AgentConfig docs keep their own mechanism (resolution relative to the YAML file, no token, '/' and '/*' suffixes preserved): docs has a known, fixed semantics inherited from Coday, whereas parameters are free-form and unknown in advance.

Substitution is one-way, so exporting a persisted config yields machine-local absolute paths. A YAML comment block prefixed to the export explains how to reintroduce the token.