### PR TITLE
build: #1174 upload AgentOS JARs as GitHub Release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,66 @@ jobs:
             echo "Warning: Coday Twin PKG not found"
           fi
 
-  # Job 3: Resolve the list of JVM projects to publish from the platform:jvm tag
+  # Job 3: Build and upload AgentOS JARs as GitHub Release assets
+  upload-agentos-jars:
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.new_version
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release.outputs.release_sha }}
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        working-directory: agentos
+        run: chmod +x gradlew
+
+      - name: Build AgentOS JARs
+        working-directory: agentos
+        run: |
+          ./gradlew :agentos-service:bootJar :agentos-bash-plugin:jar :agentos-file-plugin:jar :agentos-mcp-plugin:jar :agentos-tmux-plugin:jar --no-daemon
+
+      - name: Upload JARs to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="release/${{ needs.release.outputs.new_version }}"
+
+          # Collect all JARs into a staging directory with stable, version-less names.
+          # The stable naming is a deliberate contract: consumers resolve assets by
+          # exact name, never by version-prefix matching.
+          mkdir -p /tmp/agentos-jars
+          cp agentos/agentos-service/build/libs/agentos-service.jar /tmp/agentos-jars/
+          cp agentos/agentos-bash-plugin/build/libs/agentos-bash-plugin-*.jar /tmp/agentos-jars/agentos-bash-plugin.jar
+          cp agentos/agentos-file-plugin/build/libs/agentos-file-plugin-*.jar /tmp/agentos-jars/agentos-file-plugin.jar
+          cp agentos/agentos-mcp-plugin/build/libs/agentos-mcp-plugin-*.jar /tmp/agentos-jars/agentos-mcp-plugin.jar
+          cp agentos/agentos-tmux-plugin/build/libs/agentos-tmux-plugin-*.jar /tmp/agentos-jars/agentos-tmux-plugin.jar
+
+          # Generate checksums manifest, keyed by the stable asset names above
+          cd /tmp/agentos-jars
+          sha256sum *.jar > checksums.sha256
+          cat checksums.sha256
+          cd -
+
+          gh release upload "$TAG" \
+            /tmp/agentos-jars/agentos-service.jar \
+            /tmp/agentos-jars/agentos-bash-plugin.jar \
+            /tmp/agentos-jars/agentos-file-plugin.jar \
+            /tmp/agentos-jars/agentos-mcp-plugin.jar \
+            /tmp/agentos-jars/agentos-tmux-plugin.jar \
+            /tmp/agentos-jars/checksums.sha256 \
+            --clobber
+
+  # Job 4: Resolve the list of JVM projects to publish from the platform:jvm tag
   compute-jvm-projects:
     runs-on: ubuntu-latest
     needs: release
@@ -250,7 +309,7 @@ jobs:
           PROJECTS=$(npx nx show projects --projects="tag:platform:jvm" --json --quiet | jq -c '.' || echo '[]')
           echo "projects=$PROJECTS" >> $GITHUB_OUTPUT
 
-  # Job 4: Publish all JVM artifacts to GitHub Packages
+  # Job 5: Publish all JVM artifacts to GitHub Packages
   publish-agentos-artifacts:
     name: publish ${{ matrix.project }} to github packages
     runs-on: ubuntu-latest


### PR DESCRIPTION
Part of #1174

## Objectif

Ajouter un unique job CI (`upload-agentos-jars`) qui build les JARs AgentOS et les uploade comme assets de la GitHub Release, accompagnés d'un manifeste `checksums.sha256`. Cette PR est délibérément minimale et sans consommateur : on merge, la prochaine release produit les assets, on vérifie d'un coup d'œil sur la page de release. Rien ne peut être cassé.

## Contexte — tentatives précédentes rollbackées (PR #1206)

Deux approches ont échoué sur l'issue #1174 :

- **Bundler les JARs dans le tarball npm** : impossible. `agentos-service.jar` pèse 227 Mo à lui seul, ~256 Mo au total — hors limites npm.
- **Script `postinstall` qui télécharge les JARs** : a cassé la CI et les postes de dev. La cause : `apps/server/package.json` sert à la fois de manifeste du projet workspace Nx **et** de manifeste du package publié. Ajouter `scripts.postinstall` y a branché le téléchargement sur **chaque** `pnpm install` du monorepo, pas seulement à l'install du package publié.

## Pourquoi cette décomposition

Ce job est la seule partie du système observable sans consommateur. Le téléchargement et la consommation des JARs feront l'objet de PRs séparées, une fois le débat d'arbitrage tranché (voir Suites).

## Validation empirique

Ce job est exactement celui qui a produit avec succès les 5 JARs + `checksums.sha256` sur la release **0.238.0**. Son fonctionnement est déjà prouvé empiriquement.

## Convention de nommage des assets (contrat)

Les assets sont uploadés sous des noms **stables et sans version** :

```
agentos-service.jar
agentos-bash-plugin.jar
agentos-file-plugin.jar
agentos-mcp-plugin.jar
agentos-tmux-plugin.jar
checksums.sha256
```

Les futurs consommateurs devront résoudre les assets par **nom exact**, jamais par correspondance de préfixe de version. C'est précisément l'ambiguïté qui avait produit un bug silencieux dans la tentative précédente : le workflow uploadait `agentos-bash-plugin.jar` alors que le `postinstall` cherchait le préfixe `agentos-bash-plugin-`, ce qui faisait échouer silencieusement les 4 plugins. Un commentaire dans le YAML fige désormais cette règle.

## Le manifeste `checksums.sha256`

Non consommé dans cette PR — c'est volontaire. Il est gratuit à générer maintenant et servira de socle d'intégrité à la future PR de download.

## Périmètre strict

**Un seul fichier modifié** : `.github/workflows/release.yml` (+61 / -2).

Aucune modification de :
- `apps/server/package.json` (pas de `scripts.postinstall`, pas de champ `files`)
- `apps/server/project.json`
- `scripts/release.ts`

Aucune réintroduction de `postinstall.js` ni `agentos-lifecycle.ts`. Le monorepo reste immunisé contre le piège du postinstall.

## Suites connues (hors périmètre)

- **Arbitrage à trancher** : téléchargement des JARs à l'install npm vs au premier démarrage d'AgentOS. Les 227 Mo de `agentos-service.jar` plaident pour le premier démarrage : retry naturel, feedback utilisateur, dégradation gracieuse.
- `agentos-lifecycle.ts`, supprimé par le rollback PR #1206, sera à réintroduire dans la PR qui consommera les JARs.
- **Contrainte d'ordonnancement** : `releasePublish()` s'exécute dans le job `release`, donc avant cet upload. Sans conséquence ici puisque rien ne consomme les assets, mais cette contrainte devra être levée si le choix se porte sur un téléchargement à l'install.
