### PR TITLE
fix: wz-33220 stop agent redirection ping-pong loops in CaseRuntime

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -385,6 +385,41 @@ class CaseRuntime(
 
                 is AgentSelectedEvent -> {
                     logger.info { "[CaseRuntime $id] Found AgentSelectedEvent for agent: ${event.agentName}" }
+
+                    // ── Anti-redirect-loop guard ─────────────────────────────────────────────
+                    // Count how many AgentSelectedEvents for this agent name exist in the
+                    // current turn (strictly after the last user MessageEvent). The current
+                    // event is included in the slice — intentional, see spec.
+                    val sliceStart = (lastUserMessageIndex + 1).coerceAtLeast(0)
+                    val sameAgentSelectionCount = events
+                        .subList(sliceStart, events.size)
+                        .count { it is AgentSelectedEvent && it.agentName == event.agentName }
+
+                    if (sameAgentSelectionCount >= MAX_SAME_AGENT_SELECTIONS_PER_TURN) {
+                        logger.warn {
+                            "[CaseRuntime $id] Redirect loop detected for agent '${event.agentName}': " +
+                                "$sameAgentSelectionCount selection(s) this turn (threshold=$MAX_SAME_AGENT_SELECTIONS_PER_TURN)"
+                        }
+                        storeAndEmitEvent(
+                            WarnEvent(
+                                namespaceId = namespaceId,
+                                caseId = id,
+                                message = "Agent ${event.agentName} could not complete the task, " +
+                                    "try rephrasing, precising or addressing another agent.",
+                            ),
+                        )
+                        storeAndEmitEvent(
+                            AgentFinishedEvent(
+                                namespaceId = namespaceId,
+                                caseId = id,
+                                agentId = event.agentId,
+                                agentName = event.agentName,
+                            ),
+                        )
+                        return StepResult.AGENT_FINISHED
+                    }
+                    // ────────────────────────────────────────────────────────────────────────
+
                     val userId = resolveUserId(events)
                     if (!isAgentAuthorized(event.agentName, userId)) {
                         logger.warn {
@@ -439,5 +474,25 @@ class CaseRuntime(
             .lastOrNull { it.actor.role == ActorRole.USER }
             ?.actor
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        /**
+         * Number of selections of the same agent within a single user turn above which
+         * the redirect chain becomes suspicious.
+         * Reserved for future use (early non-blocking warning); today it is the base
+         * for computing [MAX_SAME_AGENT_SELECTIONS_PER_TURN].
+         */
+        internal const val REDIRECT_SUSPICION_THRESHOLD = 3
+
+        /** Multiplier applied to [REDIRECT_SUSPICION_THRESHOLD] to derive the hard stop. */
+        private const val REDIRECT_FORCE_STOP_FACTOR = 3
+
+        /**
+         * Maximum number of times the same agent may be selected within a single user turn.
+         * When this count is reached the turn is closed with [CaseStatus.IDLE] — the case
+         * remains alive and the user can reformulate.
+         * Calibrated generously to never interrupt a legitimate orchestration chain.
+         */
+        internal const val MAX_SAME_AGENT_SELECTIONS_PER_TURN =
+            REDIRECT_SUSPICION_THRESHOLD * REDIRECT_FORCE_STOP_FACTOR
+    }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
@@ -764,6 +765,332 @@ class CaseRuntimeSpec : StringSpec() {
 
             runtime.statusFlow.value shouldBe CaseStatus.ERROR
         }
+
+        // -------------------------------------------------------------------------
+        // Anti-redirect-loop guard
+        // -------------------------------------------------------------------------
+
+        "redirect loop guard triggers at MAX_SAME_AGENT_SELECTIONS_PER_TURN" {
+            // Build a history with 1 user MessageEvent followed by exactly
+            // MAX_SAME_AGENT_SELECTIONS_PER_TURN AgentSelectedEvents for "AgentA".
+            // The guard must fire: WarnEvent + AgentFinishedEvent emitted, runAgent never called.
+            val agentName = "AgentA"
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val savedEvents = mutableListOf<CaseEvent>()
+
+            val userMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = userActor,
+                content = userMessage,
+            )
+            val selections = (1..CaseRuntime.MAX_SAME_AGENT_SELECTIONS_PER_TURN).map {
+                AgentSelectedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                )
+            }
+            val inputEvents: List<CaseEvent> = listOf(userMsg) + selections
+
+            lateinit var runtime: CaseRuntime
+            val runAgentCalled = mutableListOf<String>()
+            val isAgentAuthorizedCalled = mutableListOf<String>()
+
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = java.time.Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _ -> emptyList() },
+                isAgentAuthorized = { name, _ -> isAgentAuthorizedCalled.add(name); true },
+                runAgent = { name, _, _, _, _ -> runAgentCalled.add(name) },
+                inputEvents = inputEvents,
+            )
+
+            runtime.run()
+
+            // Guard must have fired: WarnEvent mentioning agentName
+            val warns = savedEvents.filterIsInstance<WarnEvent>()
+            warns.size shouldBe 1
+            warns[0].message shouldContain agentName
+            warns[0].message shouldContain "could not complete the task"
+
+            // AgentFinishedEvent must have been emitted for durability
+            val finished = savedEvents.filterIsInstance<AgentFinishedEvent>()
+            finished.size shouldBe 1
+            finished[0].agentName shouldBe agentName
+
+            // runAgent must never have been called
+            runAgentCalled shouldBe emptyList()
+
+            // isAgentAuthorized must never have been called (guard fires before authorization)
+            isAgentAuthorizedCalled shouldBe emptyList()
+
+            // Status must be IDLE, not ERROR
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "redirect loop guard does not trigger below MAX_SAME_AGENT_SELECTIONS_PER_TURN" {
+            // MAX_SAME_AGENT_SELECTIONS_PER_TURN - 1 occurrences: runAgent must be called normally.
+            val agentName = "AgentA"
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val savedEvents = mutableListOf<CaseEvent>()
+
+            val userMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = userActor,
+                content = userMessage,
+            )
+            // MAX - 1 prior selections (the guard counts the current one too, so
+            // the slice will have MAX - 1 entries when processNextStep runs, which is
+            // strictly below the threshold).
+            val priorSelections = (1 until CaseRuntime.MAX_SAME_AGENT_SELECTIONS_PER_TURN).map {
+                AgentSelectedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                )
+            }
+            val inputEvents: List<CaseEvent> = listOf(userMsg) + priorSelections
+
+            val runAgentCalled = mutableListOf<String>()
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = java.time.Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _ -> emptyList() },
+                isAgentAuthorized = { _, _ -> true },
+                runAgent = { name, _, _, _, _ ->
+                    runAgentCalled.add(name)
+                    // Push AgentFinishedEvent so the loop exits cleanly
+                    runtime.pushEvents(listOf(
+                        AgentFinishedEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            agentId = agentId,
+                            agentName = agentName,
+                        ),
+                    ))
+                },
+                inputEvents = inputEvents,
+            )
+
+            runtime.run()
+
+            // runAgent must have been called (no guard triggered)
+            runAgentCalled shouldBe listOf(agentName)
+
+            // No WarnEvent from the guard
+            savedEvents.filterIsInstance<WarnEvent>() shouldBe emptyList()
+
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "redirect loop guard does not produce cross-turn false positives" {
+            // MAX_SAME_AGENT_SELECTIONS_PER_TURN prior selections of AgentA in turn 1,
+            // then a new user MessageEvent, then 1 AgentSelectedEvent for AgentA in turn 2.
+            // The guard must NOT fire in turn 2 because the counter is scoped to the current turn.
+            val agentName = "AgentA"
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val savedEvents = mutableListOf<CaseEvent>()
+
+            val firstUserMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = userActor,
+                content = userMessage,
+            )
+            val previousTurnSelections = (1..CaseRuntime.MAX_SAME_AGENT_SELECTIONS_PER_TURN).map {
+                AgentSelectedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                )
+            }
+            val secondUserMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = userActor,
+                content = listOf(MessageContent.Text("second turn")),
+            )
+            // One selection in the new turn
+            val newTurnSelection = AgentSelectedEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+            )
+            val inputEvents: List<CaseEvent> =
+                listOf(firstUserMsg) + previousTurnSelections + listOf(secondUserMsg, newTurnSelection)
+
+            val runAgentCalled = mutableListOf<String>()
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = java.time.Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _ -> emptyList() },
+                isAgentAuthorized = { _, _ -> true },
+                runAgent = { name, _, _, _, _ ->
+                    runAgentCalled.add(name)
+                    runtime.pushEvents(listOf(
+                        AgentFinishedEvent(
+                            namespaceId = namespaceId,
+                            caseId = caseId,
+                            agentId = agentId,
+                            agentName = agentName,
+                        ),
+                    ))
+                },
+                inputEvents = inputEvents,
+            )
+
+            runtime.run()
+
+            // No guard triggered: only 1 selection in the current turn
+            runAgentCalled shouldBe listOf(agentName)
+            savedEvents.filterIsInstance<WarnEvent>() shouldBe emptyList()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "redirect loop guard counts per agent name, not globally" {
+            // MAX_SAME_AGENT_SELECTIONS_PER_TURN selections of AgentA interleaved with
+            // fewer-than-threshold selections of AgentB. Guard must fire for AgentA (the
+            // last event in the scan), not for AgentB.
+            val agentA = "AgentA"
+            val agentB = "AgentB"
+            val caseId = UUID.randomUUID()
+            val agentAId = UUID.nameUUIDFromBytes(agentA.toByteArray())
+            val agentBId = UUID.nameUUIDFromBytes(agentB.toByteArray())
+            val savedEvents = mutableListOf<CaseEvent>()
+
+            val userMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = userActor,
+                content = userMessage,
+            )
+
+            // Build interleaved list: A, B, A, B, ..., A (AgentA appears MAX times, AgentB fewer)
+            val maxA = CaseRuntime.MAX_SAME_AGENT_SELECTIONS_PER_TURN
+            val interleaved = mutableListOf<CaseEvent>()
+            for (i in 0 until maxA) {
+                interleaved.add(AgentSelectedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentAId,
+                    agentName = agentA,
+                ))
+                if (i < maxA - 1) { // AgentB appears maxA - 1 times, safely below threshold
+                    interleaved.add(AgentSelectedEvent(
+                        namespaceId = namespaceId,
+                        caseId = caseId,
+                        agentId = agentBId,
+                        agentName = agentB,
+                    ))
+                }
+            }
+            val inputEvents: List<CaseEvent> = listOf(userMsg) + interleaved
+
+            val runAgentCalled = mutableListOf<String>()
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = java.time.Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _ -> emptyList() },
+                isAgentAuthorized = { _, _ -> true },
+                runAgent = { name, _, _, _, _ -> runAgentCalled.add(name) },
+                inputEvents = inputEvents,
+            )
+
+            runtime.run()
+
+            // Guard must have fired for AgentA
+            val warns = savedEvents.filterIsInstance<WarnEvent>()
+            warns.size shouldBe 1
+            warns[0].message shouldContain agentA
+
+            // runAgent never called
+            runAgentCalled shouldBe emptyList()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "redirect loop guard: cut is durable without a new user message" {
+            // After the guard fires and emits AgentFinishedEvent, re-running the same
+            // runtime without a new user message must not call runAgent.
+            // The newly emitted AgentFinishedEvent is now the last event; processNextStep
+            // finds it first and returns AGENT_FINISHED without launching the agent.
+            val agentName = "AgentA"
+            val caseId = UUID.randomUUID()
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val savedEvents = mutableListOf<CaseEvent>()
+
+            val userMsg = MessageEvent(
+                namespaceId = namespaceId,
+                caseId = caseId,
+                actor = userActor,
+                content = userMessage,
+            )
+            val selections = (1..CaseRuntime.MAX_SAME_AGENT_SELECTIONS_PER_TURN).map {
+                AgentSelectedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                )
+            }
+            val inputEvents: List<CaseEvent> = listOf(userMsg) + selections
+
+            val runAgentCalled = mutableListOf<String>()
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = java.time.Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _ -> emptyList() },
+                isAgentAuthorized = { _, _ -> true },
+                runAgent = { name, _, _, _, _ -> runAgentCalled.add(name) },
+                inputEvents = inputEvents,
+            )
+
+            // First run: guard fires, emits WarnEvent + AgentFinishedEvent
+            runtime.run()
+            runAgentCalled shouldBe emptyList()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+
+            // Second run without a new user message: the AgentFinishedEvent is now last,
+            // processNextStep returns AGENT_FINISHED immediately — runAgent still not called.
+            runtime.run()
+            runAgentCalled shouldBe emptyList()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        // -------------------------------------------------------------------------
+        // Rehydration from AgentRunningEvent
+        // -------------------------------------------------------------------------
 
         "runAgent is called exactly once when AgentRunningEvent is already in the event list" {
             val agentName = "gemini-flash"


### PR DESCRIPTION
**Problème**

En production, des agents se renvoyaient la demande en boucle via le `RedirectTool` (A→B→A→B…, plus de 20 aller-retours observés). Chaque saut coûte un run d'agent complet — appels LLM pour l'intention, la génération de paramètres, la réponse — et l'utilisateur n'obtient jamais de réponse.

La détection de répétition existante (`AgentAdvanced.detectToolRepetition`) ne peut pas attraper ce cas : elle est interne à un run d'agent et sa clé `(toolName, args)` voit des args qui alternent (`{"agentName":"B"}` puis `{"agentName":"A"}`). La répétition d'outil est un problème *intra-agent*, la boucle de redirection est un problème *inter-agents*.

**Approche**

La redirection n'a pas de pile d'appel : `RedirectTool` lève `AgentInterrupt.Redirect`, l'agent émet `AgentFinishedEvent` puis `AgentSelectedEvent`, et le run se termine. Le cycle n'existe donc que dans la *séquence des sélections* — visible uniquement dans `CaseRuntime`, seul composant qui voit la chaîne complète.

Le garde est placé dans `processNextStep()`, branche `AgentSelectedEvent`, avant la vérification d'autorisation : inutile de vérifier les droits d'un agent qu'on ne lancera pas. Il compte les `AgentSelectedEvent` portant le **même** `agentName` depuis le dernier message utilisateur, et coupe le tour au-delà du seuil.

**Deux invariants non évidents**

1. *L'`AgentFinishedEvent` émis est indispensable.* La queue d'événements d'une redirection est `[…, AgentFinishedEvent, AgentSelectedEvent]` : l'`AgentSelectedEvent` cyclique est le dernier event persisté. Sans un nouvel `AgentFinishedEvent` postérieur, la prochaine réhydratation du runtime le retrouverait par son scan arrière et relancerait la boucle.

2. *Le statut final est `IDLE`, pas `ERROR`.* `ERROR` est terminal (éviction du runtime, watcher annulé) et détruirait un case parfaitement récupérable. Un désaccord de routage entre agents n'est pas un runtime cassé — `ERROR` reste réservé au dépassement de `maxIterations`. Le case reste actif, le flux SSE ouvert, l'utilisateur peut reformuler.

**Scoping et stickiness**

Le comptage est scopé après le dernier `MessageEvent` utilisateur, ce qui évite les faux positifs d'un tour sur l'autre — exactement le bug qui avait dû être corrigé a posteriori dans `detectToolRepetition`. La sélection d'agent restant *sticky* (`CaseServiceImpl.selectAgent`, règle de réutilisation du dernier agent), le même agent est légitimement re-sélectionné et relancé après un nouveau message utilisateur : c'est le comportement attendu, garanti par ce scoping.

**Seuils**

Le seuil d'arrêt est dérivé d'un seuil de suspicion (`REDIRECT_SUSPICION_THRESHOLD * REDIRECT_FORCE_STOP_FACTOR`) plutôt qu'écrit en dur, afin qu'un avertissement précoce non bloquant puisse s'y brancher ultérieurement sans recalibrage.

**Périmètre**

Aucune signature de callback modifiée, `CaseServiceImpl` intouché, `AgentAdvanced` et `RedirectTool` intouchés. Deux fichiers au total.

**Différé, volontairement hors de cette PR**

- Relancer l'agent en lui retirant son outil de redirection, pour qu'il soit forcé de répondre — seul levier qui donnerait réellement une réponse à l'utilisateur, mais qui implique de faire descendre un flag jusqu'à la résolution du toolset.
- Les `WarnEvent` sont invisibles pour le LLM (`AgentAdvancedContext.convertEventsToMessages` a un `else -> emptyList()`). Cela concerne *tous* les `WarnEvent` du système, pas seulement ce garde.
- Détection des chaînes sans répétition (A→B→C→D→E) : écartée, toujours couverte — imparfaitement — par `maxIterations`.

**Tests**

5 cas ajoutés dans `CaseRuntimeSpec.kt` : déclenchement au seuil, absence de déclenchement en-dessous, absence de faux positif cross-turn, comptage par nom d'agent et non global, durabilité de la coupure en l'absence de nouveau message utilisateur.