### PR TITLE
feat: #1174 check AgentOS JAR availability and probe download chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,29 +252,37 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="release/${{ needs.release.outputs.new_version }}"
+          VERSION="${{ needs.release.outputs.new_version }}"
 
-          # Collect all JARs into a staging directory with stable, version-less names.
-          # The stable naming is a deliberate contract: consumers resolve assets by
-          # exact name, never by version-prefix matching.
+          # Collect all JARs into a staging directory with versioned names.
+          # Naming contract: "<artifactId>-<version>.jar" — same convention as deployPlugins
+          # in agentos/build.gradle.kts, which identifies artifacts by splitting on the first
+          # "-<digit>" boundary. Consumers MUST use this same split to derive the artifactId
+          # and version from the filename, never by version-prefix glob matching.
+          #
+          # agentos-service: bootJar forces archiveFileName="agentos-service.jar" (no version).
+          # We rename it explicitly here using the release version from needs.release.outputs.
+          # Plugins already produce versioned names from Gradle (e.g. agentos-bash-plugin-0.239.0.jar);
+          # we copy them as-is without renaming.
           mkdir -p /tmp/agentos-jars
-          cp agentos/agentos-service/build/libs/agentos-service.jar /tmp/agentos-jars/
-          cp agentos/agentos-bash-plugin/build/libs/agentos-bash-plugin-*.jar /tmp/agentos-jars/agentos-bash-plugin.jar
-          cp agentos/agentos-file-plugin/build/libs/agentos-file-plugin-*.jar /tmp/agentos-jars/agentos-file-plugin.jar
-          cp agentos/agentos-mcp-plugin/build/libs/agentos-mcp-plugin-*.jar /tmp/agentos-jars/agentos-mcp-plugin.jar
-          cp agentos/agentos-tmux-plugin/build/libs/agentos-tmux-plugin-*.jar /tmp/agentos-jars/agentos-tmux-plugin.jar
+          cp agentos/agentos-service/build/libs/agentos-service.jar "/tmp/agentos-jars/agentos-service-${VERSION}.jar"
+          cp agentos/agentos-bash-plugin/build/libs/agentos-bash-plugin-*.jar /tmp/agentos-jars/
+          cp agentos/agentos-file-plugin/build/libs/agentos-file-plugin-*.jar /tmp/agentos-jars/
+          cp agentos/agentos-mcp-plugin/build/libs/agentos-mcp-plugin-*.jar /tmp/agentos-jars/
+          cp agentos/agentos-tmux-plugin/build/libs/agentos-tmux-plugin-*.jar /tmp/agentos-jars/
 
-          # Generate checksums manifest, keyed by the stable asset names above
+          # Generate checksums manifest keyed by the versioned filenames above
           cd /tmp/agentos-jars
           sha256sum *.jar > checksums.sha256
           cat checksums.sha256
           cd -
 
           gh release upload "$TAG" \
-            /tmp/agentos-jars/agentos-service.jar \
-            /tmp/agentos-jars/agentos-bash-plugin.jar \
-            /tmp/agentos-jars/agentos-file-plugin.jar \
-            /tmp/agentos-jars/agentos-mcp-plugin.jar \
-            /tmp/agentos-jars/agentos-tmux-plugin.jar \
+            "/tmp/agentos-jars/agentos-service-${VERSION}.jar" \
+            /tmp/agentos-jars/agentos-bash-plugin-*.jar \
+            /tmp/agentos-jars/agentos-file-plugin-*.jar \
+            /tmp/agentos-jars/agentos-mcp-plugin-*.jar \
+            /tmp/agentos-jars/agentos-tmux-plugin-*.jar \
             /tmp/agentos-jars/checksums.sha256 \
             --clobber
 

--- a/apps/server/src/lib/agentos-download.ts
+++ b/apps/server/src/lib/agentos-download.ts
@@ -1,0 +1,340 @@
+/**
+ * agentos-download.ts
+ *
+ * Attempt to download a single AgentOS JAR from the GitHub Release assets.
+ *
+ * SCOPE: one artefact only — agentos-bash-plugin — to validate the download
+ * chain end-to-end (URL reachability, public access without auth, checksum
+ * verification, atomic write to disk). Extending to other artefacts is
+ * intentionally left for a later iteration once the chain is validated.
+ *
+ * NAMING CONTRACT NOTE:
+ *   The release 0.239.0 (and earlier) published assets with version-less names:
+ *   "agentos-bash-plugin.jar", "checksums.sha256", etc.
+ *   Starting from the NEXT release, assets will use versioned names:
+ *   "agentos-bash-plugin-<version>.jar", etc.
+ *   The code below builds URLs with versioned names (the target contract).
+ *   On the current release this will produce 404s — that is EXPECTED and logged
+ *   as a known transition artefact, NOT a bug. The 404s will disappear once the
+ *   first release with the new naming lands.
+ *
+ * INVARIANTS (same as the rest of this module family):
+ *   - Never throws. Every error is caught, logged, and returned as a structured result.
+ *   - No side effects at import time.
+ *   - No new npm dependencies (uses Node 24 built-in fetch + node:crypto + node:fs).
+ *   - No process spawn.
+ *   - No network access unless the JAR is absent or at the wrong version.
+ */
+
+import * as crypto from 'crypto'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { debugLog } from './log'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * The only artefact we attempt to download in this initial probe.
+ * Deliberately limited to the smallest JAR (~35 KB) to validate the chain
+ * without risking a 227 MB download (agentos-service.jar) at server startup.
+ */
+const PROBE_ARTIFACT_ID = 'agentos-bash-plugin'
+
+/**
+ * Timeout for each individual HTTP request (JAR download + manifest download).
+ * 10 s is generous for a ~35 KB file on a normal connection; it avoids hanging
+ * the server startup indefinitely on a slow or unreachable network.
+ */
+const FETCH_TIMEOUT_MS = 10_000
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type DownloadOutcome =
+  | 'skipped:already-present' // JAR already at the expected version — no network access
+  | 'skipped:dev-version' // getCodayVersion() returned 'dev' — no release to download from
+  | 'error:manifest-unavailable' // checksums.sha256 returned non-2xx
+  | 'error:manifest-parse' // checksums.sha256 could not be parsed
+  | 'error:jar-unavailable' // JAR URL returned non-2xx (e.g. 404 during naming transition)
+  | 'error:checksum-mismatch' // Downloaded JAR hash does not match manifest
+  | 'error:write' // Filesystem error during atomic write
+  | 'error:network' // fetch threw (DNS failure, timeout, AbortError, etc.)
+  | 'success' // JAR downloaded, checksum verified, written to disk
+
+export interface DownloadResult {
+  outcome: DownloadOutcome
+  /** Absolute path of the JAR (set even on failure if destination was determined). */
+  destPath?: string
+  /** HTTP status received for the JAR URL, if a request was made. */
+  jarHttpStatus?: number
+  /** HTTP status received for the manifest URL, if a request was made. */
+  manifestHttpStatus?: number
+  /** SHA-256 hash of the downloaded bytes, if computed. */
+  downloadedHash?: string
+  /** SHA-256 hash expected from the manifest, if found. */
+  expectedHash?: string
+  /** Size of the downloaded JAR in bytes, if received. */
+  downloadedBytes?: number
+  /** Human-readable description of the outcome. */
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the GitHub Release download URL for a versioned JAR asset.
+ *
+ * URL pattern: https://github.com/whoz-oss/coday/releases/download/release/<version>/<artifactId>-<version>.jar
+ * Tag pattern confirmed in .github/workflows/release.yml: TAG="release/${VERSION}"
+ */
+function buildJarUrl(artifactId: string, version: string): string {
+  return `https://github.com/whoz-oss/coday/releases/download/release/${version}/${artifactId}-${version}.jar`
+}
+
+/**
+ * Build the GitHub Release download URL for the checksums manifest.
+ *
+ * NOTE: The manifest filename follows the same naming convention as the JARs.
+ * For releases <= 0.239.0: "checksums.sha256" (version-less, old contract).
+ * For releases after the naming change: "checksums.sha256" (unchanged — the
+ * manifest filename itself has no version).
+ */
+function buildManifestUrl(version: string): string {
+  return `https://github.com/whoz-oss/coday/releases/download/release/${version}/checksums.sha256`
+}
+
+/**
+ * Parse the checksums.sha256 manifest and extract the hash for a given filename.
+ *
+ * Format (generated by `sha256sum *.jar`):
+ *   <64-hex-chars>  <filename>\n
+ * (two spaces between hash and filename)
+ *
+ * The filename in the manifest matches the asset name as uploaded — which may
+ * be versioned ("agentos-bash-plugin-0.240.0.jar") or version-less
+ * ("agentos-bash-plugin.jar") depending on the release.
+ * We search for a line whose filename component matches `targetFilename` exactly.
+ */
+function extractHashFromManifest(manifestText: string, targetFilename: string): string | null {
+  for (const line of manifestText.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    // sha256sum format: "<hash>  <filename>" (two spaces)
+    const spaceIdx = trimmed.indexOf('  ')
+    if (spaceIdx === -1) continue
+    const hash = trimmed.slice(0, spaceIdx).trim()
+    const filename = trimmed.slice(spaceIdx + 2).trim()
+    if (filename === targetFilename && hash.length === 64) {
+      return hash
+    }
+  }
+  return null
+}
+
+/**
+ * Compute the SHA-256 hash of a Buffer and return the hex digest.
+ */
+function sha256hex(data: Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex')
+}
+
+/**
+ * Attempt to download agentos-bash-plugin from the GitHub Release assets,
+ * verify its SHA-256 checksum, and write it atomically to ~/.coday/agentos/.
+ *
+ * Conditions under which NO network access is attempted:
+ *   - The JAR is already present at `destDir/<artifactId>-<version>.jar`
+ *   - The resolved version is the sentinel 'dev'
+ *
+ * @param expectedVersion  Version string from getCodayVersion().
+ * @param jarAlreadyPresent  True when checkAgentosJars() found the JAR at the expected version.
+ * @returns A structured DownloadResult describing every step taken.
+ */
+export async function downloadProbeJar(expectedVersion: string, jarAlreadyPresent: boolean): Promise<DownloadResult> {
+  const destDir = path.join(os.homedir(), '.coday', 'agentos')
+  const jarFilename = `${PROBE_ARTIFACT_ID}-${expectedVersion}.jar`
+  const destPath = path.join(destDir, jarFilename)
+
+  // --- Guard: skip if already present at the correct version ---
+  if (jarAlreadyPresent) {
+    debugLog(
+      'AGENTOS',
+      `[DOWNLOAD] ${PROBE_ARTIFACT_ID}: already present at version ${expectedVersion} — skipping download`
+    )
+    return { outcome: 'skipped:already-present', destPath, message: `Already present at ${destPath}` }
+  }
+
+  // --- Guard: skip if version is the 'dev' sentinel ---
+  if (expectedVersion === 'dev') {
+    debugLog('AGENTOS', `[DOWNLOAD] ${PROBE_ARTIFACT_ID}: version is 'dev' sentinel — no release to download from`)
+    return { outcome: 'skipped:dev-version', message: "Version is 'dev' sentinel — no release URL available" }
+  }
+
+  const jarUrl = buildJarUrl(PROBE_ARTIFACT_ID, expectedVersion)
+  const manifestUrl = buildManifestUrl(expectedVersion)
+
+  debugLog('AGENTOS', `[DOWNLOAD] ${PROBE_ARTIFACT_ID}: initiating probe download`)
+  debugLog('AGENTOS', `[DOWNLOAD]   JAR URL:      ${jarUrl}`)
+  debugLog('AGENTOS', `[DOWNLOAD]   Manifest URL: ${manifestUrl}`)
+  debugLog(
+    'AGENTOS',
+    `[DOWNLOAD]   NOTE: on releases <= 0.239.0 the JAR URL will return 404 (old naming contract).
+` + `[DOWNLOAD]         This is expected during the naming transition and will resolve on the next release.`
+  )
+
+  // --- Step 1: Fetch the checksums manifest ---
+  let manifestText: string
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    let manifestRes: Response
+    try {
+      manifestRes = await fetch(manifestUrl, { signal: controller.signal })
+    } finally {
+      clearTimeout(timer)
+    }
+
+    debugLog('AGENTOS', `[DOWNLOAD]   manifest HTTP ${manifestRes.status}`)
+
+    if (!manifestRes.ok) {
+      return {
+        outcome: 'error:manifest-unavailable',
+        manifestHttpStatus: manifestRes.status,
+        message: `Manifest request failed with HTTP ${manifestRes.status} — cannot verify JAR integrity, aborting download`,
+      }
+    }
+    manifestText = await manifestRes.text()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    debugLog('AGENTOS', `[DOWNLOAD]   manifest fetch error: ${msg}`)
+    return {
+      outcome: 'error:network',
+      message: `Network error fetching manifest: ${msg}`,
+    }
+  }
+
+  // --- Step 2: Extract the expected hash from the manifest ---
+  // The manifest may list the JAR under its versioned name (new releases) or
+  // version-less name (releases <= 0.239.0). Try both.
+  const versionedFilename = jarFilename // e.g. "agentos-bash-plugin-0.239.0.jar"
+  const versionlessFilename = `${PROBE_ARTIFACT_ID}.jar` // e.g. "agentos-bash-plugin.jar"
+
+  let expectedHash = extractHashFromManifest(manifestText, versionedFilename)
+  let hashSource = versionedFilename
+  if (!expectedHash) {
+    expectedHash = extractHashFromManifest(manifestText, versionlessFilename)
+    hashSource = versionlessFilename
+  }
+
+  if (!expectedHash) {
+    debugLog(
+      'AGENTOS',
+      `[DOWNLOAD]   manifest does not contain an entry for '${versionedFilename}' or '${versionlessFilename}'`
+    )
+    return {
+      outcome: 'error:manifest-parse',
+      message: `Could not find hash for ${versionedFilename} (or ${versionlessFilename}) in manifest`,
+    }
+  }
+  debugLog('AGENTOS', `[DOWNLOAD]   expected SHA-256 (from manifest entry '${hashSource}'): ${expectedHash}`)
+
+  // --- Step 3: Fetch the JAR ---
+  let jarBuffer: Buffer
+  let jarHttpStatus: number
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    let jarRes: Response
+    try {
+      jarRes = await fetch(jarUrl, { signal: controller.signal })
+    } finally {
+      clearTimeout(timer)
+    }
+
+    jarHttpStatus = jarRes.status
+    debugLog('AGENTOS', `[DOWNLOAD]   JAR HTTP ${jarHttpStatus}`)
+
+    if (!jarRes.ok) {
+      return {
+        outcome: 'error:jar-unavailable',
+        jarHttpStatus,
+        message: `JAR request failed with HTTP ${jarHttpStatus} — likely naming transition (expected on releases <= 0.239.0)`,
+      }
+    }
+
+    const arrayBuffer = await jarRes.arrayBuffer()
+    jarBuffer = Buffer.from(arrayBuffer)
+    debugLog('AGENTOS', `[DOWNLOAD]   received ${jarBuffer.length} bytes`)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    debugLog('AGENTOS', `[DOWNLOAD]   JAR fetch error: ${msg}`)
+    return {
+      outcome: 'error:network',
+      message: `Network error fetching JAR: ${msg}`,
+    }
+  }
+
+  // --- Step 4: Verify checksum ---
+  const downloadedHash = sha256hex(jarBuffer)
+  debugLog('AGENTOS', `[DOWNLOAD]   computed  SHA-256: ${downloadedHash}`)
+  debugLog('AGENTOS', `[DOWNLOAD]   expected  SHA-256: ${expectedHash}`)
+
+  if (downloadedHash !== expectedHash) {
+    debugLog('AGENTOS', `[DOWNLOAD]   CHECKSUM MISMATCH — discarding downloaded bytes`)
+    return {
+      outcome: 'error:checksum-mismatch',
+      jarHttpStatus,
+      downloadedHash,
+      expectedHash,
+      downloadedBytes: jarBuffer.length,
+      destPath,
+      message: `Checksum mismatch for ${jarFilename} — downloaded bytes discarded`,
+    }
+  }
+  debugLog('AGENTOS', `[DOWNLOAD]   checksum OK`)
+
+  // --- Step 5: Atomic write to disk ---
+  // Write to a temp file first, then rename, so an interrupted download
+  // never leaves a truncated JAR that would be mistaken for valid on next startup.
+  const tmpPath = `${destPath}.tmp`
+  try {
+    fs.mkdirSync(destDir, { recursive: true })
+    fs.writeFileSync(tmpPath, jarBuffer)
+    fs.renameSync(tmpPath, destPath)
+    debugLog('AGENTOS', `[DOWNLOAD]   written to ${destPath} (${jarBuffer.length} bytes)`)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    debugLog('AGENTOS', `[DOWNLOAD]   write error: ${msg}`)
+    // Best-effort cleanup of the temp file
+    try {
+      fs.unlinkSync(tmpPath)
+    } catch {
+      /* ignore */
+    }
+    return {
+      outcome: 'error:write',
+      jarHttpStatus,
+      downloadedHash,
+      expectedHash,
+      downloadedBytes: jarBuffer.length,
+      destPath,
+      message: `Failed to write JAR to disk: ${msg}`,
+    }
+  }
+
+  return {
+    outcome: 'success',
+    jarHttpStatus,
+    downloadedHash,
+    expectedHash,
+    downloadedBytes: jarBuffer.length,
+    destPath,
+    message: `Successfully downloaded and verified ${jarFilename} (${jarBuffer.length} bytes)`,
+  }
+}

--- a/apps/server/src/lib/agentos-lifecycle.ts
+++ b/apps/server/src/lib/agentos-lifecycle.ts
@@ -1,0 +1,160 @@
+/**
+ * agentos-lifecycle.ts
+ *
+ * Minimal JAR presence check for AgentOS.
+ *
+ * THIS MODULE HAS NO SIDE EFFECTS AT IMPORT TIME.
+ * All filesystem access is strictly inside the exported function.
+ *
+ * Current scope: check and log whether the expected JARs are present on disk.
+ * No download, no Java detection, no process spawn, no network access.
+ */
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { debugLog } from './log'
+
+// ---------------------------------------------------------------------------
+// JAR manifest
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable, version-less names of the AgentOS JARs.
+ *
+ * CONTRACT: these names are fixed by the CI job `upload-agentos-jars` in
+ * .github/workflows/release.yml, which copies built artifacts to stable names
+ * before uploading them as GitHub Release assets.
+ * NEVER use version-prefix matching (e.g. "agentos-bash-plugin-*.jar").
+ * Resolution MUST be by exact name only.
+ */
+const AGENTOS_JARS = [
+  'agentos-service.jar',
+  'agentos-bash-plugin.jar',
+  'agentos-file-plugin.jar',
+  'agentos-mcp-plugin.jar',
+  'agentos-tmux-plugin.jar',
+] as const
+
+type AgentosJarName = (typeof AGENTOS_JARS)[number]
+
+// ---------------------------------------------------------------------------
+// Candidate directories
+// ---------------------------------------------------------------------------
+
+/**
+ * Ordered list of directories where we look for the JARs.
+ *
+ * The list is intentionally easy to extend: add new entries here and the
+ * check loop will pick them up automatically.
+ *
+ * - `__dirname` / 'agentos' : historical location when JARs were bundled
+ *   inside the npm tarball (dist/agentos/).  No longer populated, kept as a
+ *   reference sentinel so we can confirm the old path is absent.
+ * - `~/.coday/agentos`      : natural cache location aligned with the rest of
+ *   Coday's persistence model (~/.coday/).  This is the intended home for
+ *   on-demand downloaded JARs in a future iteration.
+ */
+function getCandidateDirectories(): string[] {
+  // Resolve the directory of this module in a way that works both with:
+  //   - tsx (ESM native, no __dirname)
+  //   - esbuild bundle (injects a __dirname shim via the `banner` option in project.json)
+  // Using import.meta.url is the portable ESM approach; it is available in both contexts.
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+
+  return [
+    // Historical bundle location (relative to compiled output)
+    path.resolve(moduleDir, 'agentos'),
+    // User-level cache location (aligned with ~/.coday persistence model)
+    path.join(os.homedir(), '.coday', 'agentos'),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface JarCheckResult {
+  /** Name of the JAR file (stable, version-less). */
+  name: AgentosJarName
+  /** Absolute path where the JAR was found, or null if absent everywhere. */
+  foundAt: string | null
+}
+
+export interface AgentosJarStatus {
+  /** True only when every expected JAR was found in at least one candidate directory. */
+  allPresent: boolean
+  /** Per-JAR detail: name + where it was found (or null). */
+  jars: JarCheckResult[]
+  /** Candidate directories that were inspected. */
+  inspectedDirectories: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the AgentOS JARs are present on disk and log the result.
+ *
+ * - Never throws: all I/O errors are caught and logged.
+ * - No network access.
+ * - No process spawn.
+ * - Safe to call at any point during server startup.
+ *
+ * @returns A structured status describing what was found and where.
+ */
+export async function checkAgentosJars(): Promise<AgentosJarStatus> {
+  const candidates = getCandidateDirectories()
+  const candidateCount = candidates.length
+  debugLog(
+    'AGENTOS',
+    `Checking JAR availability in ${candidateCount} candidate director${candidateCount === 1 ? 'y' : 'ies'}:`
+  )
+  for (const dir of candidates) {
+    debugLog('AGENTOS', `  * ${dir}`)
+  }
+
+  const results: JarCheckResult[] = []
+
+  for (const jarName of AGENTOS_JARS) {
+    let foundAt: string | null = null
+
+    for (const dir of candidates) {
+      const fullPath = path.join(dir, jarName)
+      try {
+        fs.accessSync(fullPath, fs.constants.R_OK)
+        // File exists and is readable
+        foundAt = fullPath
+        break // First match wins; no need to check further candidates
+      } catch {
+        // Not found or not readable at this location — try the next candidate
+      }
+    }
+
+    results.push({ name: jarName, foundAt })
+
+    if (foundAt) {
+      debugLog('AGENTOS', `  [OK] ${jarName} — found at ${foundAt}`)
+    } else {
+      debugLog('AGENTOS', `  [MISSING] ${jarName} — not found in any candidate directory`)
+    }
+  }
+
+  const allPresent = results.every((r) => r.foundAt !== null)
+  const presentCount = results.filter((r) => r.foundAt !== null).length
+
+  debugLog(
+    'AGENTOS',
+    allPresent
+      ? `JAR check complete: all ${AGENTOS_JARS.length} JARs present.`
+      : `JAR check complete: ${presentCount}/${AGENTOS_JARS.length} JARs present — AgentOS will not start until the missing JARs are available.`
+  )
+
+  return {
+    allPresent,
+    jars: results,
+    inspectedDirectories: candidates,
+  }
+}

--- a/apps/server/src/lib/agentos-lifecycle.ts
+++ b/apps/server/src/lib/agentos-lifecycle.ts
@@ -1,13 +1,14 @@
 /**
  * agentos-lifecycle.ts
  *
- * Minimal JAR presence check for AgentOS.
+ * JAR presence and version check for AgentOS.
  *
  * THIS MODULE HAS NO SIDE EFFECTS AT IMPORT TIME.
- * All filesystem access is strictly inside the exported function.
+ * All filesystem access is strictly inside the exported functions.
  *
- * Current scope: check and log whether the expected JARs are present on disk.
- * No download, no Java detection, no process spawn, no network access.
+ * Current scope: scan candidate directories, identify AgentOS JARs by their
+ * versioned filename, compare found versions against the expected version, and
+ * log the result. No download, no Java detection, no process spawn, no network.
  */
 
 import * as fs from 'fs'
@@ -17,76 +18,130 @@ import { fileURLToPath } from 'url'
 import { debugLog } from './log'
 
 // ---------------------------------------------------------------------------
-// JAR manifest
+// Artifact manifest
 // ---------------------------------------------------------------------------
 
 /**
- * Stable, version-less names of the AgentOS JARs.
+ * Canonical artifact IDs for the AgentOS JARs we own.
  *
- * CONTRACT: these names are fixed by the CI job `upload-agentos-jars` in
- * .github/workflows/release.yml, which copies built artifacts to stable names
- * before uploading them as GitHub Release assets.
- * NEVER use version-prefix matching (e.g. "agentos-bash-plugin-*.jar").
- * Resolution MUST be by exact name only.
+ * NAMING CONTRACT — versioned filenames, same convention as `deployPlugins` in
+ * agentos/build.gradle.kts:
+ *
+ *   "<artifactId>-<version>.jar"
+ *
+ * The artifactId NEVER contains a digit immediately after a hyphen, which makes
+ * the split unambiguous: cut at the first "-<digit>" boundary.
+ * Example: "agentos-bash-plugin-0.239.0.jar"
+ *          └── artifactId: "agentos-bash-plugin"   version: "0.239.0"
+ *
+ * WHY version-prefix matching is now the expected approach (and why it must
+ * be done correctly):
+ *   The historical bug was NOT in using prefixes per se — it was an inconsistency
+ *   between the producer (CI renamed to version-less names) and the consumer
+ *   (code expected version-less names). Now both sides agree: versioned names,
+ *   split on "-<digit>". Use `parseJarFilename()` to derive artifactId and version;
+ *   NEVER use a raw `startsWith('agentos-bash-plugin-')` without the digit check.
  */
-const AGENTOS_JARS = [
-  'agentos-service.jar',
-  'agentos-bash-plugin.jar',
-  'agentos-file-plugin.jar',
-  'agentos-mcp-plugin.jar',
-  'agentos-tmux-plugin.jar',
+export const AGENTOS_ARTIFACT_IDS = [
+  'agentos-service',
+  'agentos-bash-plugin',
+  'agentos-file-plugin',
+  'agentos-mcp-plugin',
+  'agentos-tmux-plugin',
 ] as const
 
-type AgentosJarName = (typeof AGENTOS_JARS)[number]
+export type AgentosArtifactId = (typeof AGENTOS_ARTIFACT_IDS)[number]
+
+// ---------------------------------------------------------------------------
+// Filename parsing — pure function, exported for unit testing
+// ---------------------------------------------------------------------------
+
+export interface ParsedJarFilename {
+  /** The artifact ID derived from the filename (part before first "-<digit>"). */
+  artifactId: string
+  /**
+   * The version string derived from the filename (part after first "-<digit>"),
+   * or null if the filename has no version component.
+   */
+  version: string | null
+}
+
+/**
+ * Parse a JAR filename into its artifactId and version components.
+ *
+ * Convention (from deployPlugins in agentos/build.gradle.kts):
+ *   "<artifactId>-<version>.jar"
+ * where the artifactId never contains a digit immediately after a hyphen.
+ * The split point is the first "-<digit>" boundary.
+ *
+ * Examples:
+ *   "agentos-bash-plugin-0.239.0.jar"  → { artifactId: "agentos-bash-plugin", version: "0.239.0" }
+ *   "agentos-service-0.239.0.jar"      → { artifactId: "agentos-service",      version: "0.239.0" }
+ *   "my-custom-plugin-1.2.3.jar"       → { artifactId: "my-custom-plugin",     version: "1.2.3" }
+ *   "something.jar"                    → { artifactId: "something",            version: null }
+ *
+ * @param filename  Basename of the JAR file (with or without `.jar` extension).
+ */
+export function parseJarFilename(filename: string): ParsedJarFilename {
+  // Strip .jar extension if present
+  const nameWithoutExt = filename.endsWith('.jar') ? filename.slice(0, -4) : filename
+
+  // Split on the first "-<digit>" boundary
+  const match = nameWithoutExt.match(/^(.*?)-([0-9].*)$/)
+  if (!match) {
+    return { artifactId: nameWithoutExt, version: null }
+  }
+
+  return { artifactId: match[1]!, version: match[2]! }
+}
 
 // ---------------------------------------------------------------------------
 // Candidate directories
 // ---------------------------------------------------------------------------
 
 /**
- * Ordered list of directories where we look for the JARs.
+ * Ordered list of directories to scan for AgentOS JARs.
  *
- * The list is intentionally easy to extend: add new entries here and the
- * check loop will pick them up automatically.
+ * Easy to extend: add new entries here and the check loop picks them up.
  *
- * - `__dirname` / 'agentos' : historical location when JARs were bundled
- *   inside the npm tarball (dist/agentos/).  No longer populated, kept as a
- *   reference sentinel so we can confirm the old path is absent.
- * - `~/.coday/agentos`      : natural cache location aligned with the rest of
- *   Coday's persistence model (~/.coday/).  This is the intended home for
- *   on-demand downloaded JARs in a future iteration.
+ * - `moduleDir/agentos`  : historical location when JARs were bundled inside
+ *   the npm tarball (dist/agentos/). No longer populated; kept as a sentinel
+ *   so logs confirm the old path is absent.
+ * - `~/.coday/agentos`   : user-level cache aligned with Coday's persistence
+ *   model (~/.coday/). Intended home for on-demand downloaded JARs.
  */
 function getCandidateDirectories(): string[] {
-  // Resolve the directory of this module in a way that works both with:
-  //   - tsx (ESM native, no __dirname)
-  //   - esbuild bundle (injects a __dirname shim via the `banner` option in project.json)
-  // Using import.meta.url is the portable ESM approach; it is available in both contexts.
+  // Portable ESM-compatible path resolution — works with tsx (no __dirname)
+  // and with the esbuild bundle (which injects a __dirname shim via `banner`).
   const moduleDir = path.dirname(fileURLToPath(import.meta.url))
 
-  return [
-    // Historical bundle location (relative to compiled output)
-    path.resolve(moduleDir, 'agentos'),
-    // User-level cache location (aligned with ~/.coday persistence model)
-    path.join(os.homedir(), '.coday', 'agentos'),
-  ]
+  return [path.resolve(moduleDir, 'agentos'), path.join(os.homedir(), '.coday', 'agentos')]
 }
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
-export interface JarCheckResult {
-  /** Name of the JAR file (stable, version-less). */
-  name: AgentosJarName
-  /** Absolute path where the JAR was found, or null if absent everywhere. */
+export interface ArtifactCheckResult {
+  /** Canonical artifact ID (e.g. "agentos-bash-plugin"). */
+  artifactId: AgentosArtifactId
+  /** Absolute path of the JAR file found, or null if absent. */
   foundAt: string | null
+  /** Version string parsed from the filename, or null if not found. */
+  foundVersion: string | null
+  /** True when the found version matches the expected version. */
+  versionMatch: boolean
 }
 
 export interface AgentosJarStatus {
-  /** True only when every expected JAR was found in at least one candidate directory. */
+  /** True only when every expected artifact was found with the expected version. */
   allPresent: boolean
-  /** Per-JAR detail: name + where it was found (or null). */
-  jars: JarCheckResult[]
+  /** Expected version (from getCodayVersion()). */
+  expectedVersion: string
+  /** Per-artifact detail. */
+  artifacts: ArtifactCheckResult[]
+  /** JARs present in scanned directories that are NOT one of our artifact IDs. */
+  unknownJars: string[]
   /** Candidate directories that were inspected. */
   inspectedDirectories: string[]
 }
@@ -96,65 +151,94 @@ export interface AgentosJarStatus {
 // ---------------------------------------------------------------------------
 
 /**
- * Check whether the AgentOS JARs are present on disk and log the result.
+ * Scan candidate directories for AgentOS JARs, compare versions, and log.
  *
  * - Never throws: all I/O errors are caught and logged.
- * - No network access.
- * - No process spawn.
+ * - No network access, no process spawn.
  * - Safe to call at any point during server startup.
  *
+ * @param expectedVersion  Version string to compare against found JARs.
  * @returns A structured status describing what was found and where.
  */
-export async function checkAgentosJars(): Promise<AgentosJarStatus> {
+export async function checkAgentosJars(expectedVersion: string): Promise<AgentosJarStatus> {
   const candidates = getCandidateDirectories()
-  const candidateCount = candidates.length
-  debugLog(
-    'AGENTOS',
-    `Checking JAR availability in ${candidateCount} candidate director${candidateCount === 1 ? 'y' : 'ies'}:`
-  )
+  debugLog('AGENTOS', `Checking JAR availability (expected version: ${expectedVersion})`)
+  debugLog('AGENTOS', `Scanning ${candidates.length} candidate director${candidates.length === 1 ? 'y' : 'ies'}:`)
   for (const dir of candidates) {
     debugLog('AGENTOS', `  * ${dir}`)
   }
 
-  const results: JarCheckResult[] = []
+  // Build a map: artifactId → { path, version } for the first match found
+  const found = new Map<string, { filePath: string; version: string | null }>()
+  const unknownJars: string[] = []
 
-  for (const jarName of AGENTOS_JARS) {
-    let foundAt: string | null = null
-
-    for (const dir of candidates) {
-      const fullPath = path.join(dir, jarName)
-      try {
-        fs.accessSync(fullPath, fs.constants.R_OK)
-        // File exists and is readable
-        foundAt = fullPath
-        break // First match wins; no need to check further candidates
-      } catch {
-        // Not found or not readable at this location — try the next candidate
-      }
+  for (const dir of candidates) {
+    let entries: string[]
+    try {
+      entries = fs.readdirSync(dir).filter((f) => f.endsWith('.jar'))
+    } catch {
+      // Directory does not exist or is not readable — expected for absent candidates
+      continue
     }
 
-    results.push({ name: jarName, foundAt })
+    for (const filename of entries) {
+      const { artifactId, version } = parseJarFilename(filename)
+      const isOurs = (AGENTOS_ARTIFACT_IDS as readonly string[]).includes(artifactId)
 
-    if (foundAt) {
-      debugLog('AGENTOS', `  [OK] ${jarName} — found at ${foundAt}`)
-    } else {
-      debugLog('AGENTOS', `  [MISSING] ${jarName} — not found in any candidate directory`)
+      if (!isOurs) {
+        const fullPath = path.join(dir, filename)
+        unknownJars.push(fullPath)
+        debugLog('AGENTOS', `  [UNKNOWN] ${filename} — not one of our artifacts (${fullPath})`)
+        continue
+      }
+
+      // First match per artifactId wins (candidates are ordered by priority)
+      if (!found.has(artifactId)) {
+        found.set(artifactId, { filePath: path.join(dir, filename), version })
+      }
     }
   }
 
-  const allPresent = results.every((r) => r.foundAt !== null)
-  const presentCount = results.filter((r) => r.foundAt !== null).length
+  // Build per-artifact results
+  const artifacts: ArtifactCheckResult[] = AGENTOS_ARTIFACT_IDS.map((artifactId) => {
+    const entry = found.get(artifactId) ?? null
+    const foundVersion = entry?.version ?? null
+    const versionMatch = foundVersion === expectedVersion
+
+    if (!entry) {
+      debugLog('AGENTOS', `  [MISSING]  ${artifactId} — not found in any candidate directory`)
+    } else if (!versionMatch) {
+      debugLog(
+        'AGENTOS',
+        `  [MISMATCH] ${artifactId} — found ${foundVersion} at ${entry.filePath} (expected ${expectedVersion})`
+      )
+    } else {
+      debugLog('AGENTOS', `  [OK]       ${artifactId}-${foundVersion}.jar — ${entry.filePath}`)
+    }
+
+    return {
+      artifactId,
+      foundAt: entry?.filePath ?? null,
+      foundVersion,
+      versionMatch,
+    }
+  })
+
+  const allPresent = artifacts.every((a) => a.versionMatch)
+  const presentCount = artifacts.filter((a) => a.versionMatch).length
 
   debugLog(
     'AGENTOS',
     allPresent
-      ? `JAR check complete: all ${AGENTOS_JARS.length} JARs present.`
-      : `JAR check complete: ${presentCount}/${AGENTOS_JARS.length} JARs present — AgentOS will not start until the missing JARs are available.`
+      ? `JAR check complete: all ${AGENTOS_ARTIFACT_IDS.length} JARs present at version ${expectedVersion}.`
+      : `JAR check complete: ${presentCount}/${AGENTOS_ARTIFACT_IDS.length} JARs match version ${expectedVersion} — AgentOS will not start until all JARs are available at the expected version.`
   )
 
   return {
     allPresent,
-    jars: results,
+    expectedVersion,
+    artifacts,
+    unknownJars,
     inspectedDirectories: candidates,
   }
 }

--- a/apps/server/src/lib/version.ts
+++ b/apps/server/src/lib/version.ts
@@ -1,0 +1,89 @@
+/**
+ * version.ts
+ *
+ * Single source of truth for the Coday server version at runtime.
+ *
+ * Resolution: reads `version` from the nearest `package.json` at one of two
+ * deterministic paths that correspond to the two real execution contexts:
+ *
+ *   PROD (esbuild bundle):
+ *     esbuild inlines all modules into `dist/server.js`.
+ *     `import.meta.url` resolves to `file://.../dist/server.js`.
+ *     `package.json` is copied to `dist/package.json` by the `build` target
+ *     (`cp apps/server/package.json apps/server/dist/package.json`).
+ *     Candidate: `<moduleDir>/package.json`  (same directory as the bundle)
+ *
+ *   DEV (tsx watch):
+ *     `tsx watch apps/server/src/server.ts` runs from the monorepo root.
+ *     `import.meta.url` for this file resolves to
+ *     `file://.../apps/server/src/lib/version.ts`.
+ *     `package.json` lives at `apps/server/package.json`.
+ *     Candidate: `<moduleDir>/../../package.json`  (two levels up from src/lib/)
+ *
+ * If neither candidate yields a valid version string, returns the sentinel 'dev'
+ * rather than throwing or returning an empty string.
+ *
+ * NO SIDE EFFECTS AT IMPORT TIME — all resolution happens inside the function.
+ * The result is memoized after first call to avoid repeated filesystem reads.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { debugLog } from './log'
+
+let _resolved: string | null = null
+
+/**
+ * Return the Coday server version string.
+ *
+ * Memoized: filesystem access happens at most once per process.
+ * Never throws.
+ */
+export function getCodayVersion(): string {
+  if (_resolved !== null) return _resolved
+
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+
+  // Ordered list of candidate package.json paths, one per execution context.
+  // See module-level JSDoc for the rationale behind each path.
+  const candidates: Array<{ filePath: string; context: string }> = [
+    {
+      // PROD: bundle lives in dist/, package.json is copied there by the build target
+      filePath: path.join(moduleDir, 'package.json'),
+      context: 'prod bundle (dist/)',
+    },
+    {
+      // DEV: source file is at src/lib/version.ts, package.json is at apps/server/
+      filePath: path.join(moduleDir, '..', '..', 'package.json'),
+      context: 'dev tsx (apps/server/)',
+    },
+  ]
+
+  for (const { filePath, context } of candidates) {
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8')
+      const pkg: unknown = JSON.parse(raw)
+      if (
+        pkg !== null &&
+        typeof pkg === 'object' &&
+        'version' in pkg &&
+        typeof (pkg as Record<string, unknown>).version === 'string'
+      ) {
+        const v = (pkg as Record<string, string>).version
+        if (v) {
+          _resolved = v
+          debugLog('VERSION', `Resolved from ${filePath} (${context}): ${v}`)
+          return v
+        }
+      }
+    } catch {
+      // File absent or unreadable in this context — try next candidate
+    }
+  }
+
+  // Sentinel: never return an empty string, never throw
+  _resolved = 'dev'
+  debugLog('VERSION', `Could not resolve version from any candidate — using sentinel 'dev'`)
+  return _resolved
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -37,6 +37,7 @@ import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
 import { checkAgentosJars } from './lib/agentos-lifecycle'
 import { getCodayVersion } from './lib/version'
+import { downloadProbeJar } from './lib/agentos-download'
 
 const app = express()
 const DEFAULT_PORT = process.env.PORT
@@ -435,9 +436,18 @@ PORT_PROMISE.then(async (PORT) => {
   // A failure here must never prevent the server from starting.
   try {
     const codayVersion = getCodayVersion()
-    await checkAgentosJars(codayVersion)
+    const jarStatus = await checkAgentosJars(codayVersion)
+
+    // Attempt to download agentos-bash-plugin if absent or at the wrong version.
+    // This is a probe to validate the GitHub Release download chain end-to-end.
+    // Only agentos-bash-plugin is attempted (smallest JAR, ~35 KB).
+    // No download occurs if the JAR is already present at the expected version.
+    const bashPluginResult = jarStatus.artifacts.find((a) => a.artifactId === 'agentos-bash-plugin')
+    const bashPluginPresent = bashPluginResult?.versionMatch === true
+    const downloadResult = await downloadProbeJar(codayVersion, bashPluginPresent)
+    debugLog('AGENTOS', `[DOWNLOAD] outcome: ${downloadResult.outcome} — ${downloadResult.message}`)
   } catch (error) {
-    debugLog('AGENTOS', 'Unexpected error during JAR check (non-fatal):', error)
+    debugLog('AGENTOS', 'Unexpected error during JAR check/download (non-fatal):', error)
   }
 
   // Start thread cleanup service after server is running

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -36,6 +36,7 @@ import { McpInstancePool } from '@coday/mcp'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
 import { checkAgentosJars } from './lib/agentos-lifecycle'
+import { getCodayVersion } from './lib/version'
 
 const app = express()
 const DEFAULT_PORT = process.env.PORT
@@ -433,7 +434,8 @@ PORT_PROMISE.then(async (PORT) => {
   // Check AgentOS JAR availability at startup (log only — no side effects).
   // A failure here must never prevent the server from starting.
   try {
-    await checkAgentosJars()
+    const codayVersion = getCodayVersion()
+    await checkAgentosJars(codayVersion)
   } catch (error) {
     debugLog('AGENTOS', 'Unexpected error during JAR check (non-fatal):', error)
   }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -35,6 +35,7 @@ import { ProjectFileRepository } from '@coday/repository'
 import { McpInstancePool } from '@coday/mcp'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
+import { checkAgentosJars } from './lib/agentos-lifecycle'
 
 const app = express()
 const DEFAULT_PORT = process.env.PORT
@@ -428,6 +429,14 @@ PORT_PROMISE.then(async (PORT) => {
   app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`)
   })
+
+  // Check AgentOS JAR availability at startup (log only — no side effects).
+  // A failure here must never prevent the server from starting.
+  try {
+    await checkAgentosJars()
+  } catch (error) {
+    debugLog('AGENTOS', 'Unexpected error during JAR check (non-fatal):', error)
+  }
 
   // Start thread cleanup service after server is running
   try {


### PR DESCRIPTION
Closes partially #1174.

## Contexte

Les JARs d'AgentOS doivent etre disponibles pour le package npm `@whoz-oss/coday-server`. Deux tentatives precedentes ont echoue et ont ete rollbackees par #1206 :

- **Bundler les JARs dans le tarball npm** : impossible, ~256 Mo au total dont 227 Mo pour `agentos-service.jar` seul.
- **Un script `postinstall` de telechargement** : a casse la CI et les postes de dev. `apps/server/package.json` sert a la fois de manifeste du projet workspace **et** de manifeste du package publie — y ajouter `scripts.postinstall` a branche le telechargement sur **chaque** `pnpm install` du monorepo.

#1207 a ensuite reintroduit uniquement le job CI `upload-agentos-jars`, qui publie les JARs comme assets de GitHub Release avec un manifeste `checksums.sha256`.

Cette PR pose les fondations du **telechargement au demarrage du serveur** (et non a l'install npm), en trois etapes progressives et verifiables.

## Ce que fait cette PR

### 1. Verification de presence des JARs (`agentos-lifecycle.ts`)

Au demarrage du serveur, scan des repertoires candidats et log de ce qui est trouve. Quatre etats distincts : `[OK]`, `[MISMATCH]`, `[MISSING]`, `[UNKNOWN]`.

Les repertoires inspectes sont `<moduleDir>/agentos` (emplacement historique du bundling, garde comme sentinelle) et `~/.coday/agentos` (cache utilisateur, aligne sur le modele de persistance Coday).

Les JARs presents mais non reconnus comme l'un de nos artefacts sont logges avec leur chemin complet — ce sont des plugins tiers a ne jamais toucher, information necessaire a la future logique de remplacement.

### 2. Resolution par nom versionne

**Inversion d'un contrat etabli par #1207.** Les assets etaient uploades sous des noms stables sans version, ce qui rendait impossible de savoir *quelle version* de JAR etait presente sur le disque : un utilisateur passant de 0.239.0 a 0.245.0 aurait un check disant "5/5 presents" sur des JARs obsoletes.

Les assets sont desormais uploades sous `<artifactId>-<version>.jar`, et la resolution derive artifactId + version du nom de fichier, avec la **meme regle de decoupe que la tache Gradle `deployPlugins`** (`agentos/build.gradle.kts`) : coupe a la premiere frontiere `-<chiffre>`. Cela permettra de remplacer les anciennes versions de nos artefacts sans toucher aux plugins tiers.

Nuance importante documentee dans le code : le matching par prefixe devient la methode attendue, mais via cette regle de decoupe, jamais via un `startsWith()` naif. Le bug historique venait d'une incoherence producteur/consommateur, pas du principe du prefixe.

Cas particulier traite : `bootJar` force `archiveFileName="agentos-service.jar"` sans version. Le renommage est fait dans la CI plutot que dans Gradle, car `archiveFileName` est consomme par `bootRun`, la generation de spec OpenAPI et les tests.

### 3. Version disponible au runtime (`version.ts`)

Resolution de la version depuis `package.json` a un chemin deterministe, avec deux candidats explicites correspondant aux deux contextes reels d'execution (bundle esbuild en prod, `tsx` en dev) et une sentinelle `'dev'` en dernier recours. Memoisee, sans effet de bord a l'import.

Elle sert de version attendue pour la detection de derive, et de composant de l'URL de telechargement.

### 4. Sonde de telechargement (`agentos-download.ts`)

Tentative de telechargement d'**un seul** JAR — `agentos-bash-plugin` (~35 Ko) — pour valider la chaine de bout en bout sans jamais tirer les 227 Mo. Verification du checksum SHA-256 contre le manifeste de release, ecriture atomique via fichier temporaire puis `rename`.

Le telechargement est **conditionne** : il ne part que si le JAR est absent ou en version incorrecte. Un serveur deja provisionne demarre sans aucun acces reseau.

## Invariants respectes

- **Aucun effet de bord a l'import** de ces modules — toute l'I/O est dans le corps des fonctions.
- **Ne throw jamais** : toute erreur (reseau, 404, timeout, checksum invalide, disque) est capturee et logee, et retournee comme resultat structure. L'appel dans `server.ts` reste protege par try/catch en ceinture redondante.
- **Aucun changement fonctionnel** : le resultat est uniquement logge. Ni le proxy AgentOS, ni les ports, ni le demarrage ne sont modifies.
- **Aucune nouvelle dependance npm.** `fetch` global (Node 24), `node:crypto`, `node:fs`.
- **Aucun spawn de processus.** Rien n'est demarre.
- **Pas de `postinstall`** — la regression historique n'est pas reproduite.

## Verification d'innocuite CI

Point d'attention explicite de cette PR, d'autant plus que du reseau est introduit :

| Commande | Resultat | Logs AGENTOS/VERSION | Acces reseau |
|---|---|---|---|
| `nx run server:build` | exit 0 | aucun | aucun |
| `nx run server:lint` | exit 0 | aucun | aucun |
| `nx run-many -t build` | exit 0 | aucun | aucun |
| `nx affected -t lint test` | exit 0 | aucun | aucun |

Le code n'est appele que dans `PORT_PROMISE.then()`, au demarrage effectif du process Node. `esbuild` bundle sans executer, et ni `validate.yml` ni `release.yml` n'invoquent `serve`.

## Validation observee

URLs testees manuellement sur la release 0.239.0 :

| URL | Code |
|---|---|
| `agentos-bash-plugin-0.239.0.jar` | **404** (attendu — transition de nommage) |
| `agentos-bash-plugin.jar` | 302 -> 200 |
| `checksums.sha256` | 302 -> 200 |

Le 404 sur le nom versionne est **attendu et temporaire** : la release 0.239.0 porte encore l'ancien nommage. Le changement de CI ne prendra effet qu'a la prochaine release. Ce point est documente dans un commentaire du code pour qu'un futur lecteur voyant des 404 dans ses logs comprenne pourquoi. La validation checksum de bout en bout se fera naturellement a la prochaine release.

Les trois scenarios de demarrage ont ete verifies par les logs : JAR absent (tentative de telechargement), JAR present a la bonne version (**zero acces reseau**), JAR en derive de version (tentative de telechargement).

## Limites connues avant d'etendre a `agentos-service` (227 Mo)

La sonde valide le principe, mais trois points devront etre traites avant de cibler le gros artefact :

1. **`arrayBuffer()` bufferise integralement en RAM.** Negligeable pour 35 Ko, risque pour 227 Mo au demarrage. Necessitera un streaming de `Response.body` vers le fichier temporaire avec hash calcule a la volee.
2. **Le timeout de 10 s est un timeout total.** Suffisant pour 35 Ko (~0.4 s observe), tres insuffisant pour 227 Mo (~3 min a 10 Mbps). Un timeout d'inactivite serait plus adapte qu'un timeout global.
3. **Pas de retry ni de reprise.** Un echec a 90% forcerait un telechargement complet, et bloquerait le demarrage d'autant. Un telechargement en tache de fond, ou une reprise via header `Range:`, sera a considerer.

La structure est prete pour cette evolution : la logique de telechargement est isolee et l'artefact cible est une seule constante.

## Hors perimetre volontairement

- **Version cote front Angular** : le projet n'a ni `environment.ts` ni `fileReplacements`, et l'exposer necessiterait de modifier la configuration de build pour une valeur que rien n'affiche encore. Le placement UI est une decision produit non tranchee.
- **Tests unitaires** : le projet `server` n'a pas de runner configure, et l'outiller en ESM est un sujet a part entiere. La fonction de parsing est exportee et prete a etre testee quand le projet sera outille.
- **Logique de remplacement/nettoyage** des anciennes versions.
- **Demarrage d'AgentOS**, detection de Java, health check.