### PR TITLE
fix: #1211 replace AGENTOS_HOSTNAME with validated AGENTOS_URL

### DIFF
--- a/agentos/.env.example
+++ b/agentos/.env.example
@@ -13,6 +13,10 @@ MCP_ENABLED=false
 # Server Configuration
 SERVER_PORT=8080
 
+# Express proxy target for the AgentOS backend.
+# Must be a complete URL including scheme. Defaults to http://localhost:<AGENTOS_PORT> when unset.
+# AGENTOS_URL=http://localhost:8124
+
 # Plugin Configuration
 PLUGINS_DIR=plugins
 PLUGINS_AUTO_LOAD=true

--- a/agentos/docs/running.md
+++ b/agentos/docs/running.md
@@ -16,7 +16,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 nx bootRun agentos-service
 ```
 
-The service starts on **port 8080**. Ready signal in logs: `Started AgentOSApplication`.
+The service starts on **port 8124** by default (see `server.port` in `application.yml`). Ready signal in logs: `Started AgentOSApplication`.
 
 ## Filesystem Plugin Directories
 

--- a/apps/server/src/lib/validate-agentos-url.spec.ts
+++ b/apps/server/src/lib/validate-agentos-url.spec.ts
@@ -1,0 +1,45 @@
+import { validateAgentOsUrl } from './validate-agentos-url'
+
+describe('validateAgentOsUrl', () => {
+  describe('valid URLs', () => {
+    it('accepts http with localhost and port', () => {
+      expect(() => validateAgentOsUrl('http://localhost:8124')).not.toThrow()
+    })
+
+    it('accepts https with a named host', () => {
+      expect(() => validateAgentOsUrl('https://agentos.internal')).not.toThrow()
+    })
+
+    it('accepts a URL carrying a base path', () => {
+      expect(() => validateAgentOsUrl('https://example.com/agentos')).not.toThrow()
+    })
+  })
+
+  describe('invalid URLs', () => {
+    it('rejects a bare hostname without scheme', () => {
+      expect(() => validateAgentOsUrl('my-host')).toThrow('Invalid AGENTOS_URL: "my-host"')
+    })
+
+    it('rejects localhost:port without scheme (parsed as scheme=localhost:)', () => {
+      expect(() => validateAgentOsUrl('localhost:8124')).toThrow('Invalid AGENTOS_URL: "localhost:8124"')
+    })
+
+    it('rejects a doubled scheme (http://http://...)', () => {
+      expect(() => validateAgentOsUrl('http://http://localhost:8124')).toThrow(
+        'Invalid AGENTOS_URL: "http://http://localhost:8124"'
+      )
+    })
+
+    it('rejects a non-http scheme such as ftp://', () => {
+      expect(() => validateAgentOsUrl('ftp://localhost:8124')).toThrow('Invalid AGENTOS_URL: "ftp://localhost:8124"')
+    })
+
+    it('error message names the offending value', () => {
+      expect(() => validateAgentOsUrl('bad-value')).toThrow('"bad-value"')
+    })
+
+    it('error message shows a valid example', () => {
+      expect(() => validateAgentOsUrl('bad-value')).toThrow('http://localhost:8124')
+    })
+  })
+})

--- a/apps/server/src/lib/validate-agentos-url.ts
+++ b/apps/server/src/lib/validate-agentos-url.ts
@@ -1,0 +1,29 @@
+/**
+ * Validates that a string is a well-formed http(s) URL suitable for use as
+ * the AgentOS proxy target.
+ *
+ * `new URL()` alone is too permissive: `new URL('localhost:8124')` succeeds
+ * by treating `localhost:` as the scheme, which is the most likely migration
+ * mistake when a user copies a bare hostname from the old AGENTOS_HOSTNAME var.
+ * This helper adds an explicit protocol and hostname assertion.
+ *
+ * A pathname starting with '//' signals a doubled scheme
+ * (e.g. 'http://http://localhost' parses as hostname='http', pathname='//localhost').
+ *
+ * Throws an Error with a descriptive message if the URL is invalid.
+ */
+export function validateAgentOsUrl(url: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(
+      `Invalid AGENTOS_URL: "${url}". Must be a complete URL including scheme, e.g. "http://localhost:8124".`
+    )
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname || parsed.pathname.startsWith('//')) {
+    throw new Error(
+      `Invalid AGENTOS_URL: "${url}". Expected an http(s) URL with a hostname, e.g. "http://localhost:8124".`
+    )
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -74,9 +74,17 @@ let promptExecutionService: PromptExecutionService
 // Registered synchronously and BEFORE express.json() to avoid body-parser
 // consuming the request body before it can be forwarded.
 const AGENTOS_PORT = process.env.AGENTOS_PORT ? parseInt(process.env.AGENTOS_PORT) : 8124
-const AGENTOS_HOSTNAME = process.env.AGENTOS_HOSTNAME ?? 'localhost'
 const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
-const AGENTOS_URL = `http://${AGENTOS_HOSTNAME}:${AGENTOS_PORT}`
+const AGENTOS_URL = process.env.AGENTOS_URL ?? `http://localhost:${AGENTOS_PORT}`
+
+// Fail fast on malformed configuration rather than surfacing it as a 504 later.
+try {
+  new URL(AGENTOS_URL)
+} catch {
+  throw new Error(
+    `Invalid AGENTOS_URL: "${AGENTOS_URL}". Must be a complete URL including scheme, e.g. "http://localhost:8124".`
+  )
+}
 app.use(
   '/api/agentos',
   (req, _res, next) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -35,6 +35,7 @@ import { ProjectFileRepository } from '@coday/repository'
 import { McpInstancePool } from '@coday/mcp'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
+import { validateAgentOsUrl } from './lib/validate-agentos-url'
 
 const app = express()
 const DEFAULT_PORT = process.env.PORT
@@ -78,13 +79,9 @@ const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
 const AGENTOS_URL = process.env.AGENTOS_URL ?? `http://localhost:${AGENTOS_PORT}`
 
 // Fail fast on malformed configuration rather than surfacing it as a 504 later.
-try {
-  new URL(AGENTOS_URL)
-} catch {
-  throw new Error(
-    `Invalid AGENTOS_URL: "${AGENTOS_URL}". Must be a complete URL including scheme, e.g. "http://localhost:8124".`
-  )
-}
+// Note: `new URL` alone is too permissive — it accepts 'localhost:8124' by reading
+// 'localhost:' as the scheme, which is the most likely migration mistake here.
+validateAgentOsUrl(AGENTOS_URL)
 app.use(
   '/api/agentos',
   (req, _res, next) => {


### PR DESCRIPTION
Closes #1211

## Problem

All `/api/agentos/*` requests were failing with **504 Gateway Timeout** while the Express proxy log showed the request arriving normally. The startup log held the answer:

```
AgentOS proxy configured: /api/agentos → http://http://localhost:8124
```

`server.ts` built the proxy target by prepending a scheme to a bare-hostname env var:

```ts
const AGENTOS_HOSTNAME = process.env.AGENTOS_HOSTNAME ?? 'localhost'
const AGENTOS_URL = `http://${AGENTOS_HOSTNAME}:${AGENTOS_PORT}`
```

When `AGENTOS_HOSTNAME` already contained a scheme, the result was a doubled one. `http-proxy-middleware` then tried to resolve a literal host named `http:`, which never connects — producing a slow timeout instead of a fast, legible error. The "bare hostname, no scheme" contract was undocumented and unvalidated.

## Approach

Rather than hardening the bare-hostname variable by stripping schemes, this replaces it with a single `AGENTOS_URL` holding a **complete URL**. A bare hostname is an inexpressive abstraction: it cannot carry a scheme (no `https` for a remote AgentOS), nor a base path. Papering over the symptom would have set up the same incident again the day TLS is needed.

```ts
const AGENTOS_URL = process.env.AGENTOS_URL ?? `http://localhost:${AGENTOS_PORT}`
validateAgentOsUrl(AGENTOS_URL)
```

Validation runs at module load, so a misconfiguration is now a startup failure with an explicit message naming the offending value — not a 504 discovered much later.

`AGENTOS_PORT` is retained as the fallback, since `scripts/web-dev-tmux.sh` allocates ports dynamically to let multiple git worktrees run concurrently.

## Validation is deliberately stricter than `new URL()`

`new URL()` alone is too permissive to catch the mistake this change most invites. Anyone migrating by copying their old value across (`AGENTOS_HOSTNAME=my-host` → `AGENTOS_URL=my-host`) would otherwise sail straight through:

- `new URL('localhost:8124')` does **not** throw — it reads `localhost:` as the scheme and `8124` as the path.
- `new URL('http://http://localhost:8124')` does **not** throw — it parses as hostname `http` with pathname `//localhost:8124`.

So `validateAgentOsUrl` additionally asserts the protocol is `http:`/`https:`, that a hostname is present, and that the pathname does not start with `//` (the reliable signal of a doubled scheme). Note it deliberately does *not* blacklist `http`/`https` as hostnames, since those are syntactically legitimate (`https://http.example.com` is a valid host).

| Input | Outcome |
|---|---|
| `http://localhost:8124` | accepted |
| `https://agentos.internal` | accepted |
| `https://example.com/agentos` | accepted |
| `my-host` | rejected |
| `localhost:8124` | rejected |
| `http://http://localhost:8124` | rejected |
| `ftp://localhost:8124` | rejected |

## ⚠️ Breaking change

`AGENTOS_HOSTNAME` is **removed**. Any deployment setting it must migrate to `AGENTOS_URL` with the full URL **including the scheme**:

```diff
- AGENTOS_HOSTNAME=agentos.internal
+ AGENTOS_URL=https://agentos.internal
```

Deployments not setting it are unaffected — the default remains `http://localhost:${AGENTOS_PORT}`.

## On the port default question

The issue flagged an apparent inconsistency: `server.ts` defaults to `8124` while `web-dev-tmux.sh` scans from `8123`. Investigated and left unchanged — it is not a real discrepancy. `8124` is genuinely AgentOS's default (`server.port` in `application.yml`, and `${AGENTOS_PORT:8124}` in `application-docker.yml`); `8123` in the script is a *scan starting point*, and the script always passes the port it actually found to Express explicitly, so neither default is consulted in that path. `agentos/docs/running.md` did state a stale `8080` and has been corrected to `8124`.

## Known limitation: the new test does not run in CI

`apps/server/src/lib/validate-agentos-url.spec.ts` passes when jest is invoked directly, but **is not picked up by `nx affected -t test`** — the `server` project has no `test` target in Nx at all, so `nx test server` fails with "Cannot find configuration for task". The pre-existing `apps/server/src/lib/resolve-username.spec.ts` has the same problem and has never run in CI either.

This is a test-infrastructure gap independent of this fix, and wiring a `test` target for `server` here risks surfacing unrelated pre-existing failures in a change that should stay narrowly scoped. Tracked separately — see the follow-up issue referenced below.

## Verification

| Command | Result |
|---|---|
| `pnpm nx run server:build` | ✅ pass |
| `pnpm nx affected -t lint` | ✅ pass (server, web) |
| `pnpm exec jest validate-agentos-url.spec.ts` | ✅ 9/9 pass |
| `pnpm nx affected -t test` | no test targets affected (see limitation above) |

## Files changed

| File | Change |
|---|---|
| `apps/server/src/server.ts` | Removed `AGENTOS_HOSTNAME`; `AGENTOS_URL` now read from env with fail-fast validation |
| `apps/server/src/lib/validate-agentos-url.ts` | New validation helper |
| `apps/server/src/lib/validate-agentos-url.spec.ts` | Unit tests covering the accept/reject matrix above |
| `agentos/.env.example` | Documented `AGENTOS_URL` and its scheme requirement |
| `agentos/docs/running.md` | Corrected stale default port 8080 → 8124 |