### PR TITLE
feat: wz-330620 scheduler initiate cases

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/scheduledPrompt/ScheduledPromptDto.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/scheduledPrompt/ScheduledPromptDto.kt
@@ -61,7 +61,7 @@ data class RecurrenceDto(
  * [startDate] is the earliest date on which a firing may occur.
  * [endType] controls termination:
  * - NEVER: runs indefinitely.
- * - ON_DATE: stops after [endDate] (required, must be strictly after [startDate]).
+ * - ON_DATE: stops before [endDate] at 00:00 UTC (exclusive, required, must be strictly after [startDate]).
  * - OCCURRENCES: stops after [maxOccurrenceCount] executions (required, > 0).
  */
 @Schema(name = "Planning")

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/scheduledPrompt/ScheduledPromptDto.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/scheduledPrompt/ScheduledPromptDto.kt
@@ -26,7 +26,7 @@ enum class SchedulerUnit { WEEK, MONTH }
 enum class SchedulerEndType {
     /** Runs indefinitely. */
     NEVER,
-    /** Stops on [PlanningDto.endDate] (inclusive). Must be after [PlanningDto.startDate]. */
+    /** Stops before [PlanningDto.endDate] (exclusive). The run scheduled on endDate itself does NOT fire. Must be strictly after [PlanningDto.startDate]. */
     ON_DATE,
     /** Stops after [PlanningDto.maxOccurrenceCount] executions. */
     OCCURRENCES,

--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -243,6 +243,10 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // Neo4j embedded + Spring context caching across 2500+ tests requires more heap
+    // than Gradle's default 512m. 2g gives comfortable headroom for the embedded engine,
+    // cached Spring contexts, and parallel coroutine execution (Dispatchers.IO).
+    maxHeapSize = "2g"
     // Docker Engine 29.x raised its minimum API version to 1.40.
     // Testcontainers 1.x / docker-java 3.4.x defaults to API v1.32 which is
     // rejected with HTTP 400. Force a supported version until Testcontainers

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jPersistenceConfiguration.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/config/Neo4jPersistenceConfiguration.kt
@@ -11,19 +11,9 @@ import io.whozoss.agentos.aiModel.Neo4JAiModelRepository
 import io.whozoss.agentos.aiProvider.AiProviderNodeNeo4jRepository
 import io.whozoss.agentos.aiProvider.AiProviderRepository
 import io.whozoss.agentos.aiProvider.Neo4jAiProviderRepository
-import io.whozoss.agentos.scheduledPrompt.Neo4jScheduledPromptRepository
-import io.whozoss.agentos.scheduledPrompt.Neo4jScheduledPromptRunRepository
-import io.whozoss.agentos.scheduledPrompt.ScheduledPromptNodeNeo4jRepository
-import io.whozoss.agentos.scheduledPrompt.ScheduledPromptRepository
-import io.whozoss.agentos.scheduledPrompt.ScheduledPromptRunNodeNeo4jRepository
-import io.whozoss.agentos.scheduledPrompt.ScheduledPromptRunRepository
 import io.whozoss.agentos.authSetting.AuthSettingNodeNeo4jRepository
 import io.whozoss.agentos.authSetting.AuthSettingRepository
 import io.whozoss.agentos.authSetting.Neo4jAuthSettingRepository
-import io.whozoss.agentos.credential.CredentialNodeNeo4jRepository
-import io.whozoss.agentos.credential.CredentialRepository
-import io.whozoss.agentos.credential.Neo4jCredentialRepository
-import io.whozoss.agentos.encryption.FieldEncryptor
 import io.whozoss.agentos.caseEvent.CaseEventNodeMapper
 import io.whozoss.agentos.caseEvent.CaseEventNodeNeo4jRepository
 import io.whozoss.agentos.caseEvent.CaseEventRepository
@@ -32,6 +22,10 @@ import io.whozoss.agentos.caseEvent.Neo4jCaseEventRepository
 import io.whozoss.agentos.caseFlow.CaseNodeNeo4jRepository
 import io.whozoss.agentos.caseFlow.CaseRepository
 import io.whozoss.agentos.caseFlow.Neo4jCaseRepository
+import io.whozoss.agentos.credential.CredentialNodeNeo4jRepository
+import io.whozoss.agentos.credential.CredentialRepository
+import io.whozoss.agentos.credential.Neo4jCredentialRepository
+import io.whozoss.agentos.encryption.FieldEncryptor
 import io.whozoss.agentos.feedback.FeedbackNodeNeo4jRepository
 import io.whozoss.agentos.feedback.FeedbackRepository
 import io.whozoss.agentos.feedback.Neo4jFeedbackRepository
@@ -51,6 +45,15 @@ import io.whozoss.agentos.persistence.Neo4jChildLinkService
 import io.whozoss.agentos.prompt.Neo4jPromptRepository
 import io.whozoss.agentos.prompt.PromptNodeNeo4jRepository
 import io.whozoss.agentos.prompt.PromptRepository
+import io.whozoss.agentos.scheduledPrompt.Neo4jScheduledPromptRepository
+import io.whozoss.agentos.scheduledPrompt.Neo4jScheduledPromptRunRepository
+import io.whozoss.agentos.scheduledPrompt.Neo4jScheduledPromptUserRunRepository
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptNodeNeo4jRepository
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptRepository
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptRunNodeNeo4jRepository
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptRunRepository
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptUserRunNodeNeo4jRepository
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptUserRunRepository
 import io.whozoss.agentos.user.Neo4jUserRepository
 import io.whozoss.agentos.user.UserNodeNeo4jRepository
 import io.whozoss.agentos.user.UserRepository
@@ -279,6 +282,14 @@ class Neo4jPersistenceConfiguration {
     ): ScheduledPromptRunRepository {
         logger.info { "[Persistence] Neo4jScheduledPromptRunRepository active" }
         return Neo4jScheduledPromptRunRepository(scheduledPromptRunNodeNeo4jRepository)
+    }
+
+    @Bean
+    fun neo4jScheduledPromptUserRunRepository(
+        scheduledPromptUserRunNodeNeo4jRepository: ScheduledPromptUserRunNodeNeo4jRepository,
+    ): ScheduledPromptUserRunRepository {
+        logger.info { "[Persistence] Neo4jScheduledPromptUserRunRepository active" }
+        return Neo4jScheduledPromptUserRunRepository(scheduledPromptUserRunNodeNeo4jRepository)
     }
 
     companion object : KLogging()

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
@@ -47,6 +47,9 @@ open class Neo4jScheduledPromptRunRepository(
     override fun findById(id: UUID): ScheduledPromptRun? =
         neo4jRepository.findById(id.toString()).orElse(null)?.toDomain()
 
+    override fun countCompletedRuns(scheduledPromptId: UUID): Int =
+        neo4jRepository.countCompletedRuns(scheduledPromptId.toString())
+
     private fun isSlotKeyConflict(e: DataIntegrityViolationException): Boolean {
         val haystack = generateSequence<Throwable>(e) { it.cause }
             .mapNotNull { it.message }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
@@ -54,6 +54,9 @@ open class Neo4jScheduledPromptRunRepository(
         neo4jRepository.findByStatusAndCreatedBefore(RunStatus.CLAIMED.name, olderThan)
             .map { it.toDomain() }
 
+    override fun findSettledRunning(): List<ScheduledPromptRun> =
+        neo4jRepository.findSettledRunning().map { it.toDomain() }
+
     private fun isSlotKeyConflict(e: DataIntegrityViolationException): Boolean {
         val haystack = generateSequence<Throwable>(e) { it.cause }
             .mapNotNull { it.message }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.scheduledPrompt
 
 import mu.KLogging
 import org.springframework.dao.DataIntegrityViolationException
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -26,6 +27,25 @@ open class Neo4jScheduledPromptRunRepository(
 
     override fun hasActive(scheduledPromptId: UUID): Boolean =
         neo4jRepository.existsActiveByScheduledPromptId(scheduledPromptId.toString())
+
+    override fun updateStatus(
+        id: UUID,
+        status: RunStatus,
+        finishedAt: Instant?,
+        error: String?,
+    ): Boolean {
+        val updated = neo4jRepository.updateStatus(
+            id = id.toString(),
+            status = status.name,
+            finishedAt = finishedAt,
+            error = error,
+            now = Instant.now(),
+        )
+        return updated > 0
+    }
+
+    override fun findById(id: UUID): ScheduledPromptRun? =
+        neo4jRepository.findById(id.toString()).orElse(null)?.toDomain()
 
     private fun isSlotKeyConflict(e: DataIntegrityViolationException): Boolean {
         val haystack = generateSequence<Throwable>(e) { it.cause }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
@@ -50,6 +50,10 @@ open class Neo4jScheduledPromptRunRepository(
     override fun countCompletedRuns(scheduledPromptId: UUID): Int =
         neo4jRepository.countCompletedRuns(scheduledPromptId.toString())
 
+    override fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun> =
+        neo4jRepository.findByStatusAndCreatedBefore(RunStatus.CLAIMED.name, olderThan)
+            .map { it.toDomain() }
+
     private fun isSlotKeyConflict(e: DataIntegrityViolationException): Boolean {
         val haystack = generateSequence<Throwable>(e) { it.cause }
             .mapNotNull { it.message }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
@@ -9,8 +9,9 @@ import java.util.UUID
  * Neo4j-backed implementation of [ScheduledPromptRunRepository].
  *
  * [insert] wraps the SDN save in a constraint-violation detector: if Neo4j rejects the write
- * because [ScheduledPromptRunNode.slotKey] is already taken, the [DataIntegrityViolationException]
- * is caught and translated to a [DuplicateRunException] so callers can handle it gracefully.
+ * because the composite `(scheduledPromptId, scheduledFor)` constraint is violated, the
+ * [DataIntegrityViolationException] is caught and translated to a [DuplicateRunException]
+ * so callers can handle it gracefully.
  */
 open class Neo4jScheduledPromptRunRepository(
     private val neo4jRepository: ScheduledPromptRunNodeNeo4jRepository,
@@ -20,7 +21,7 @@ open class Neo4jScheduledPromptRunRepository(
         try {
             neo4jRepository.save(ScheduledPromptRunNode.fromDomain(run)).toDomain()
         } catch (e: DataIntegrityViolationException) {
-            if (!isSlotKeyConflict(e)) throw e
+            if (!isSlotConflict(e)) throw e
             logger.warn { "[Neo4jScheduledPromptRunRepository] Duplicate slot: sp=${run.scheduledPromptId} for=${run.scheduledFor}" }
             throw DuplicateRunException(run.scheduledPromptId, run.scheduledFor)
         }
@@ -57,15 +58,18 @@ open class Neo4jScheduledPromptRunRepository(
     override fun findSettledRunning(): List<ScheduledPromptRun> =
         neo4jRepository.findSettledRunning().map { it.toDomain() }
 
-    private fun isSlotKeyConflict(e: DataIntegrityViolationException): Boolean {
+    private fun isSlotConflict(e: DataIntegrityViolationException): Boolean {
         val haystack = generateSequence<Throwable>(e) { it.cause }
             .mapNotNull { it.message }
             .joinToString(separator = " | ")
-        return SLOT_KEY_CONSTRAINT_NAME in haystack || SLOT_KEY_PROPERTY in haystack
+        return SLOT_CONSTRAINT_NAME in haystack ||
+            SLOT_PROPERTY_A in haystack ||
+            SLOT_PROPERTY_B in haystack
     }
 
     companion object : KLogging() {
-        private const val SLOT_KEY_CONSTRAINT_NAME = "scheduled_prompt_run_slot_key_unique"
-        private const val SLOT_KEY_PROPERTY = "slotKey"
+        private const val SLOT_CONSTRAINT_NAME = "scheduled_prompt_run_slot_unique"
+        private const val SLOT_PROPERTY_A = "scheduledPromptId"
+        private const val SLOT_PROPERTY_B = "scheduledFor"
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
@@ -8,10 +8,9 @@ import java.util.UUID
 /**
  * Neo4j-backed implementation of [ScheduledPromptRunRepository].
  *
- * [insert] wraps the SDN save in a constraint-violation detector: if Neo4j rejects the write
- * because the composite `(scheduledPromptId, scheduledFor)` constraint is violated, the
- * [DataIntegrityViolationException] is caught and translated to a [DuplicateRunException]
- * so callers can handle it gracefully.
+ * [insert] catches [DataIntegrityViolationException] and translates it to [DuplicateRunException].
+ * The only UNIQUE constraint on [ScheduledPromptRunNode] is the composite
+ * `(scheduledPromptId, scheduledFor)`, so any integrity violation from insert is a duplicate slot.
  */
 open class Neo4jScheduledPromptRunRepository(
     private val neo4jRepository: ScheduledPromptRunNodeNeo4jRepository,
@@ -21,7 +20,8 @@ open class Neo4jScheduledPromptRunRepository(
         try {
             neo4jRepository.save(ScheduledPromptRunNode.fromDomain(run)).toDomain()
         } catch (e: DataIntegrityViolationException) {
-            if (!isSlotConflict(e)) throw e
+            // The only UNIQUE constraint on ScheduledPromptRun is (scheduledPromptId, scheduledFor).
+            // Any DataIntegrityViolationException from insert is a duplicate slot.
             logger.warn { "[Neo4jScheduledPromptRunRepository] Duplicate slot: sp=${run.scheduledPromptId} for=${run.scheduledFor}" }
             throw DuplicateRunException(run.scheduledPromptId, run.scheduledFor)
         }
@@ -58,18 +58,5 @@ open class Neo4jScheduledPromptRunRepository(
     override fun findSettledRunning(): List<ScheduledPromptRun> =
         neo4jRepository.findSettledRunning().map { it.toDomain() }
 
-    private fun isSlotConflict(e: DataIntegrityViolationException): Boolean {
-        val haystack = generateSequence<Throwable>(e) { it.cause }
-            .mapNotNull { it.message }
-            .joinToString(separator = " | ")
-        return SLOT_CONSTRAINT_NAME in haystack ||
-            SLOT_PROPERTY_A in haystack ||
-            SLOT_PROPERTY_B in haystack
-    }
-
-    companion object : KLogging() {
-        private const val SLOT_CONSTRAINT_NAME = "scheduled_prompt_run_slot_unique"
-        private const val SLOT_PROPERTY_A = "scheduledPromptId"
-        private const val SLOT_PROPERTY_B = "scheduledFor"
-    }
+    companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
@@ -96,8 +96,11 @@ open class Neo4jScheduledPromptUserRunRepository(
             statuses.map { it.name },
         )
 
+    override fun hasAnyActive(runId: UUID): Boolean =
+        neo4jRepository.findOneActive(runId.toString()) != null
+
     override fun hasAnyFailed(runId: UUID): Boolean =
-        neo4jRepository.hasAnyFailed(runId.toString())
+        neo4jRepository.findOneFailed(runId.toString()) != null
 
     companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.scheduledPrompt
 
 import mu.KLogging
+import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 import java.time.Instant
@@ -24,13 +25,13 @@ import java.util.UUID
  * Reads up to `limit` claimable candidates via [ScheduledPromptUserRunNodeNeo4jRepository.findClaimable],
  * then saves each with SDN's optimistic lock. "Claimable" means PENDING, or RUNNING with an
  * expired lease (crash recovery). Concurrent instances that race on the same node will get an
- * [org.springframework.dao.OptimisticLockingFailureException] and skip that entry.
+ * [OptimisticLockingFailureException] and skip that entry.
  *
  * ### markTerminal
  *
  * Loads the node, mutates the relevant fields, and saves via SDN. The [ScheduledPromptUserRunNode.version]
  * field triggers SDN's optimistic-locking check; callers must handle
- * [org.springframework.dao.OptimisticLockingFailureException] when two instances race.
+ * [OptimisticLockingFailureException] when two instances race.
  */
 open class Neo4jScheduledPromptUserRunRepository(
     private val neo4jRepository: ScheduledPromptUserRunNodeNeo4jRepository,
@@ -59,7 +60,7 @@ open class Neo4jScheduledPromptUserRunRepository(
                     leaseUntil = leaseUntil,
                 )
                 neo4jRepository.save(claimed).toDomain()
-            } catch (e: org.springframework.dao.OptimisticLockingFailureException) {
+            } catch (e: OptimisticLockingFailureException) {
                 logger.debug {
                     "[Neo4jScheduledPromptUserRunRepository] Optimistic lock conflict on UserRun=${node.id}" +
                         " — skipped (another instance claimed it)"

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
@@ -16,9 +16,9 @@ import java.util.UUID
  *
  * ### materialize
  *
- * Delegates to a single Cypher INSERT-SELECT `@Query` that traverses the deployment
- * graph (AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User) and MERGEs one
- * PENDING [ScheduledPromptUserRunNode] per distinct target user in a single transaction.
+ * Delegates to a single Cypher INSERT-SELECT `@Query` that resolves all deployment-target
+ * users via two paths (UserGroup deployment, Namespace deployment) and MERGEs one PENDING
+ * [ScheduledPromptUserRunNode] per distinct target user in a single transaction.
  *
  * ### claimBatch
  *

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptUserRunRepository.kt
@@ -1,0 +1,103 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import mu.KLogging
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Neo4j-backed implementation of [ScheduledPromptUserRunRepository].
+ *
+ * All Cypher queries live in [ScheduledPromptUserRunNodeNeo4jRepository]; this class
+ * handles Domain ↔ Node mapping and coordination (lease computation, optimistic lock
+ * via SDN save).
+ *
+ * ### materialize
+ *
+ * Delegates to a single Cypher INSERT-SELECT `@Query` that traverses the deployment
+ * graph (AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User) and MERGEs one
+ * PENDING [ScheduledPromptUserRunNode] per distinct target user in a single transaction.
+ *
+ * ### claimBatch
+ *
+ * Reads up to `limit` claimable candidates via [ScheduledPromptUserRunNodeNeo4jRepository.findClaimable],
+ * then saves each with SDN's optimistic lock. "Claimable" means PENDING, or RUNNING with an
+ * expired lease (crash recovery). Concurrent instances that race on the same node will get an
+ * [org.springframework.dao.OptimisticLockingFailureException] and skip that entry.
+ *
+ * ### markTerminal
+ *
+ * Loads the node, mutates the relevant fields, and saves via SDN. The [ScheduledPromptUserRunNode.version]
+ * field triggers SDN's optimistic-locking check; callers must handle
+ * [org.springframework.dao.OptimisticLockingFailureException] when two instances race.
+ */
+open class Neo4jScheduledPromptUserRunRepository(
+    private val neo4jRepository: ScheduledPromptUserRunNodeNeo4jRepository,
+) : ScheduledPromptUserRunRepository {
+
+    override fun materialize(runId: UUID, agentConfigId: UUID, namespaceId: UUID): Int =
+        neo4jRepository.materialize(
+            runId = runId.toString(),
+            agentConfigId = agentConfigId.toString(),
+            namespaceId = namespaceId.toString(),
+        ).also { count ->
+            logger.info {
+                "[Neo4jScheduledPromptUserRunRepository] materialize runId=$runId " +
+                    "agentConfigId=$agentConfigId namespaceId=$namespaceId \u2192 $count UserRun(s) created"
+            }
+        }
+
+    override fun claimBatch(leaseDuration: Duration, limit: Int): List<ScheduledPromptUserRun> {
+        val now = Instant.now()
+        val leaseUntil = now.plus(leaseDuration)
+        val candidates = neo4jRepository.findClaimable(now, limit)
+        return candidates.mapNotNull { node ->
+            try {
+                val claimed = node.copy(
+                    status = UserRunStatus.RUNNING.name,
+                    leaseUntil = leaseUntil,
+                )
+                neo4jRepository.save(claimed).toDomain()
+            } catch (e: org.springframework.dao.OptimisticLockingFailureException) {
+                logger.debug {
+                    "[Neo4jScheduledPromptUserRunRepository] Optimistic lock conflict on UserRun=${node.id}" +
+                        " — skipped (another instance claimed it)"
+                }
+                null
+            }
+        }
+    }
+
+    @Transactional
+    override fun markTerminal(
+        id: UUID,
+        status: UserRunStatus,
+        now: Instant,
+        error: String?,
+    ): ScheduledPromptUserRun {
+        val node = neo4jRepository.findById(id.toString())
+            .orElseThrow { NoSuchElementException("ScheduledPromptUserRun not found: $id") }
+        val updated = node.copy(
+            status = status.name,
+            finishedAt = now,
+            error = error,
+            leaseUntil = null,
+        )
+        return neo4jRepository.save(updated).toDomain()
+    }
+
+    override fun findByRunId(runId: UUID): List<ScheduledPromptUserRun> =
+        neo4jRepository.findByRunId(runId.toString()).map { it.toDomain() }
+
+    override fun countByRunIdAndStatus(runId: UUID, vararg statuses: UserRunStatus): Int =
+        neo4jRepository.countByRunIdAndStatuses(
+            runId.toString(),
+            statuses.map { it.name },
+        )
+
+    override fun hasAnyFailed(runId: UUID): Boolean =
+        neo4jRepository.hasAnyFailed(runId.toString())
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -300,7 +300,7 @@ class ScheduledPromptExecutor(
             val case = caseService.create(
                 Case(
                     namespaceId = namespaceId,
-                    title = buildCaseTitle(scheduledPrompt.name, user.displayName()),
+                    title = scheduledPrompt.name,
                 ),
             )
             val caseId = case.id
@@ -467,11 +467,7 @@ class ScheduledPromptExecutor(
         }
     }
 
-    private fun buildCaseTitle(scheduledPromptName: String, userDisplayName: String): String =
-        "$scheduledPromptName — $userDisplayName".take(MAX_TITLE_LENGTH)
-
     companion object : KLogging() {
-        private const val MAX_TITLE_LENGTH = 100
         private const val POLL_INTERVAL_MS = 2_000L
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -52,8 +52,11 @@ import java.util.UUID
  *    [CaseService.addMessage]. The Executor resolves content itself rather than using
  *    a `/slash-command` because PromptCommandParser requires the text to start with `/`,
  *    which is incompatible with the leading `@mention`.
- * 5. Collect the runtime's [CaseRuntime.statusFlow] until the Case reaches IDLE or a
- *    terminal status, then close the UserRun.
+ * 5. Await the Case launch: collect the runtime's [CaseRuntime.statusFlow] for up to
+ *    [SchedulerProperties.launchTimeoutSeconds] seconds to detect immediate failures.
+ *    If the Case reaches IDLE or is still RUNNING after the timeout, the UserRun is
+ *    closed as DONE (the Case continues independently). Only an immediate terminal
+ *    status (ERROR/KILLED) marks the UserRun as FAILED.
  *
  * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
  * each batch contains at most that many UserRuns, and all are launched as structured
@@ -196,7 +199,7 @@ class ScheduledPromptExecutor(
                     }
 
                     launch {
-                        executeUserRun(userRun)
+                        processUserRun(userRun)
                     }
                 }
             }
@@ -209,10 +212,10 @@ class ScheduledPromptExecutor(
     }
 
     // -------------------------------------------------------------------------
-    // Single UserRun execution
+    // Single UserRun processing
     // -------------------------------------------------------------------------
 
-    private suspend fun executeUserRun(userRun: ScheduledPromptUserRun) {
+    private suspend fun processUserRun(userRun: ScheduledPromptUserRun) {
         val now = Instant.now(clock)
         val runId = userRun.runId
         val userId = userRun.userId
@@ -334,14 +337,16 @@ class ScheduledPromptExecutor(
                 "[Executor] UserRun=${userRun.id} — Case $caseId created and message injected for user=$userId"
             }
 
-            // Step 5: Collect the runtime's statusFlow until IDLE or terminal.
+            // Step 5: Await launch — detect immediate failures.
             // The runtime is guaranteed to exist in activeRuntimes right after create().
+            // If the Case is still RUNNING after the timeout, it's healthy — close as DONE.
+            // Only an immediate terminal status (ERROR/KILLED) means the launch failed.
             val runtime = caseService.findActiveRuntime(caseId)
             if (runtime == null) {
                 // Runtime already evicted (terminal status reached before we got here)
                 closeUserRun(userRun.id, caseService.findById(caseId)?.status, caseId)
             } else {
-                awaitCaseCompletion(userRun.id, caseId, runtime)
+                monitorLaunch(userRun.id, caseId, runtime)
             }
         } catch (e: Exception) {
             logger.error(e) {
@@ -356,31 +361,34 @@ class ScheduledPromptExecutor(
     // -------------------------------------------------------------------------
 
     /**
-     * Collect the runtime's [CaseRuntime.statusFlow] until the Case reaches IDLE or a terminal status.
+     * Await the Case launch and detect immediate failures.
      *
-     * [kotlinx.coroutines.flow.StateFlow.first] suspends reactively until the predicate
-     * matches — zero polling, zero delay. The lease duration is enforced via
-     * [withTimeoutOrNull]; on timeout the UserRun is marked FAILED and the next tick's
-     * [claimBatch] will reclaim expired RUNNING UserRuns.
+     * Collects [CaseRuntime.statusFlow] for up to [SchedulerProperties.launchTimeoutSeconds]
+     * seconds. This is a **health check**, not a completion wait:
+     * - IDLE → agent finished its turn quickly → DONE
+     * - Timeout (still RUNNING) → Case is healthy, just slow → DONE
+     * - ERROR/KILLED → immediate crash → FAILED
+     *
+     * The Case continues running independently after this method returns.
+     * The lease on the UserRun is only relevant for crash recovery (instance down
+     * between Case creation and this point).
      */
-    private suspend fun awaitCaseCompletion(
+    private suspend fun monitorLaunch(
         userRunId: UUID,
         caseId: UUID,
         runtime: CaseRuntime,
     ) {
-        val leaseMs = Duration.ofMinutes(properties.leaseMinutes).toMillis()
+        val timeoutMs = Duration.ofSeconds(properties.launchTimeoutSeconds).toMillis()
 
-        val finalStatus = withTimeoutOrNull(leaseMs) {
+        val finalStatus = withTimeoutOrNull(timeoutMs) {
             runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
         }
 
-        if (finalStatus == null) {
-            logger.warn {
-                "[Executor] UserRun=$userRunId lease expired while waiting for Case $caseId — marking FAILED"
-            }
-            markFailed(userRunId, Instant.now(clock), "Lease expired waiting for Case $caseId")
-        } else {
+        if (finalStatus != null && finalStatus.isTerminal()) {
             closeUserRun(userRunId, finalStatus, caseId)
+        } else {
+            // IDLE or timeout (still RUNNING) — Case launched successfully
+            closeUserRun(userRunId, CaseStatus.IDLE, caseId)
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -22,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import kotlinx.coroutines.sync.Semaphore
 import java.util.UUID
-import java.util.concurrent.Semaphore
 
 /**
  * Executes [ScheduledPromptRun]s in two phases.
@@ -52,7 +52,9 @@ import java.util.concurrent.Semaphore
  *    which is incompatible with the leading `@mention`.
  * 5. Poll the runtime status until the Case leaves RUNNING/PENDING, then close the UserRun.
  *
- * A [Semaphore] caps concurrent in-flight coroutines to [SchedulerProperties.maxConcurrentExecutions].
+ * A [kotlinx.coroutines.sync.Semaphore] caps concurrent in-flight coroutines to
+ * [SchedulerProperties.maxConcurrentExecutions]. Unlike `java.util.concurrent.Semaphore`,
+ * [acquire][Semaphore.acquire] **suspends** instead of blocking an OS thread.
  * A [delay] of [SchedulerProperties.staggerDelayMs] ms separates each launch.
  *
  * ### Completion check
@@ -146,8 +148,9 @@ class ScheduledPromptExecutor(
      * coroutine inside [coroutineScope]; the scope suspends until all launched children
      * finish before the next batch is claimed.
      *
-     * A [Semaphore] caps concurrent in-flight coroutines to
-     * [SchedulerProperties.maxConcurrentExecutions].
+     * A [kotlinx.coroutines.sync.Semaphore] caps concurrent in-flight coroutines to
+     * [SchedulerProperties.maxConcurrentExecutions]. Its [acquire][Semaphore.acquire]
+     * suspends instead of blocking an OS thread.
      *
      * ### Delivery guarantee: at-least-once
      *

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -99,8 +99,8 @@ class ScheduledPromptExecutor(
     /**
      * Materialise [ScheduledPromptUserRun]s for all target users of [run].
      *
-     * Delegates to a single Cypher INSERT-SELECT that traverses the deployment graph
-     * (AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User) and MERGEs one
+     * Delegates to a single Cypher INSERT-SELECT that resolves all deployment-target
+     * users via two paths (UserGroup deployment, Namespace deployment) and MERGEs one
      * PENDING UserRun per distinct user — entirely inside Neo4j, no JVM heap pressure.
      *
      * Safe to call multiple times for the same Run (idempotent via MERGE).

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -282,6 +282,10 @@ class ScheduledPromptExecutor(
 
         try {
             // Step 1: Create the Case.
+            // No idempotence key links this Case to the UserRun — if the instance crashes
+            // after this point but before markTerminal(), the lease expires and another
+            // instance will create a second Case for the same user (at-least-once).
+            // Exactly-once would require a UNIQUE constraint on Case keyed by userRunKey.
             val case = caseService.create(
                 Case(
                     namespaceId = namespaceId,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -1,0 +1,444 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.whozoss.agentos.agentConfig.AgentConfigService
+import io.whozoss.agentos.caseFlow.Case
+import io.whozoss.agentos.caseFlow.CaseService
+import io.whozoss.agentos.permissions.EntityType
+import io.whozoss.agentos.permissions.PermissionRelation
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.prompt.PromptService
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
+import io.whozoss.agentos.user.UserService
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import mu.KLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.Semaphore
+
+/**
+ * Executes [ScheduledPromptRun]s in two phases.
+ *
+ * ### Phase A — Materialisation (fast, no throttle)
+ *
+ * Called by [SchedulerScanner] immediately after a Run is CLAIMED.
+ * Resolves all target users AND creates PENDING [ScheduledPromptUserRun]s in a **single
+ * Cypher INSERT-SELECT** via [ScheduledPromptUserRunRepository.materialize]. No users are
+ * loaded into JVM heap — the traversal and inserts happen entirely inside Neo4j.
+ *
+ * Re-entrant: if the service crashed mid-materialisation, calling [materialize] again is
+ * safe because the MERGE is idempotent.
+ *
+ * ### Phase B — Consumption (throttled)
+ *
+ * Called by [SchedulerScanner.tickConsume] on every consume tick.
+ * Loops over [ScheduledPromptUserRunRepository.claimBatch] until the queue is empty.
+ * Each claimed [ScheduledPromptUserRun] is executed in a background coroutine:
+ * 1. Create a [Case] in the prompt's namespace.
+ * 2. Grant ADMIN on the Case to the target user via [PermissionService.grantPermission].
+ * 3. Build an [Actor] with `role = USER`.
+ * 4. Resolve the prompt content directly and inject `"@agentName <content>"` via
+ *    [CaseService.addMessage]. The Executor resolves content itself rather than using
+ *    a `/slash-command` because PromptCommandParser requires the text to start with `/`,
+ *    which is incompatible with the leading `@mention`.
+ * 5. Poll the runtime status until the Case leaves RUNNING/PENDING, then close the UserRun.
+ *
+ * A [Semaphore] caps concurrent in-flight coroutines to [SchedulerProperties.maxConcurrentExecutions].
+ * A [delay] of [SchedulerProperties.staggerDelayMs] ms separates each launch.
+ *
+ * ### Completion check
+ *
+ * After each UserRun closes, the parent Run is checked:
+ * `count(PENDING) == 0 && count(RUNNING) == 0` → DONE (or FAILED if any UserRun failed).
+ * Only RUNNING Runs are inspected — the CLAIMED→RUNNING transition in Phase A acts as
+ * the guard ensuring all UserRuns have been materialised before completion is evaluated.
+ */
+@Component
+@ConditionalOnProperty(name = ["scheduler.enabled"], havingValue = "true")
+class ScheduledPromptExecutor(
+    private val scheduledPromptRepository: ScheduledPromptRepository,
+    private val runRepository: ScheduledPromptRunRepository,
+    private val userRunRepository: ScheduledPromptUserRunRepository,
+    private val promptService: PromptService,
+    private val agentConfigService: AgentConfigService,
+    private val caseService: CaseService,
+    private val permissionService: PermissionService,
+    private val userService: UserService,
+    private val properties: SchedulerProperties,
+    private val clock: Clock,
+) {
+
+    // -------------------------------------------------------------------------
+    // Phase A — Materialisation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Materialise [ScheduledPromptUserRun]s for all target users of [run].
+     *
+     * Delegates to a single Cypher INSERT-SELECT that traverses the deployment graph
+     * (AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User) and MERGEs one
+     * PENDING UserRun per distinct user — entirely inside Neo4j, no JVM heap pressure.
+     *
+     * Safe to call multiple times for the same Run (idempotent via MERGE).
+     * Transitions the Run to [RunStatus.RUNNING] once materialisation is complete.
+     */
+    fun materialize(run: ScheduledPromptRun, scheduledPrompt: ScheduledPrompt) {
+        logger.info {
+            "[Executor] Phase A: materialising run=${run.id} sp=${scheduledPrompt.id}"
+        }
+
+        val namespaceId = scheduledPrompt.namespaceId
+        val count = when {
+            namespaceId == null -> {
+                logger.debug {
+                    "[Executor] Platform-scope sp=${scheduledPrompt.id} — no users to materialise"
+                }
+                0
+            }
+            else -> runCatching {
+                userRunRepository.materialize(run.id, scheduledPrompt.agentConfigId, namespaceId)
+            }.onFailure { e ->
+                logger.error(e) {
+                    "[Executor] materialize failed for run=${run.id} sp=${scheduledPrompt.id}"
+                }
+            }.getOrDefault(0)
+        }
+
+        // Transition to RUNNING — Phase B's checkCompletion only inspects RUNNING Runs,
+        // so this transition acts as the guard that was previously served by the
+        // materialized flag. A Run only becomes RUNNING after materialize() completes.
+        runRepository.updateStatus(run.id, RunStatus.RUNNING)
+
+        logger.info {
+            "[Executor] Phase A complete: run=${run.id} — $count UserRun(s) created"
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase B — Consumption
+    // -------------------------------------------------------------------------
+
+    /**
+     * Claim and execute all currently available [ScheduledPromptUserRun]s.
+     *
+     * Suspends until ALL UserRuns from ALL batches have finished executing, so the
+     * caller ([SchedulerScanner.tickConsume] via `runBlocking`) is truly blocked for
+     * the full duration. Spring `fixedDelay` on [SchedulerScanner.tickConsume] then
+     * prevents a new consume tick from starting before this one completes.
+     *
+     * Each batch is claimed via [ScheduledPromptUserRunRepository.claimBatch], which
+     * uses SDN `@Version` optimistic locking so concurrent instances cannot double-claim
+     * the same UserRun. Within a batch, each UserRun is launched as a structured
+     * coroutine inside [coroutineScope]; the scope suspends until all launched children
+     * finish before the next batch is claimed.
+     *
+     * A [Semaphore] caps concurrent in-flight coroutines to
+     * [SchedulerProperties.maxConcurrentExecutions].
+     *
+     * ### Delivery guarantee: at-least-once
+     *
+     * If an instance crashes after creating a Case but before [markTerminal], the
+     * UserRun's [ScheduledPromptUserRun.leaseUntil] will expire and a subsequent
+     * [claimBatch] will reclaim it, creating a **second** Case for the same user.
+     * This is acceptable for the scheduled-prompt use case (duplicate conversation,
+     * no data corruption). Exactly-once would require an idempotence key on Case
+     * creation (e.g. a UNIQUE constraint on `runId|userId` carried by the Case).
+     */
+    suspend fun consumeAvailable() {
+        val semaphore = Semaphore(properties.maxConcurrentExecutions)
+        val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
+
+        coroutineScope {
+            var batch: List<ScheduledPromptUserRun>
+            do {
+                batch = userRunRepository.claimBatch(leaseDuration, properties.maxConcurrentExecutions)
+                for (userRun in batch) {
+                    logger.info {
+                        "[Executor] Phase B: claimed UserRun=${userRun.id} runId=${userRun.runId} userId=${userRun.userId}"
+                    }
+
+                    semaphore.acquire()
+                    launch {
+                        try {
+                            executeUserRun(userRun)
+                        } finally {
+                            semaphore.release()
+                        }
+                    }
+
+                    delay(properties.staggerDelayMs)
+                }
+            } while (batch.isNotEmpty())
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Single UserRun execution
+    // -------------------------------------------------------------------------
+
+    private suspend fun executeUserRun(userRun: ScheduledPromptUserRun) {
+        val now = Instant.now(clock)
+        val runId = userRun.runId
+        val userId = userRun.userId
+
+        // --- Resolve context ---
+
+        val run = runRepository.findById(runId)
+        if (run == null) {
+            logger.warn { "[Executor] Run $runId not found for UserRun=${userRun.id} — marking FAILED" }
+            markFailed(userRun.id, now, "Parent Run $runId not found")
+            return
+        }
+
+        val scheduledPrompt = scheduledPromptRepository.findByIds(listOf(run.scheduledPromptId))
+            .firstOrNull()
+        if (scheduledPrompt == null) {
+            logger.warn { "[Executor] ScheduledPrompt ${run.scheduledPromptId} not found — marking UserRun=${userRun.id} FAILED" }
+            markFailed(userRun.id, now, "ScheduledPrompt ${run.scheduledPromptId} not found")
+            checkCompletion(runId)
+            return
+        }
+
+        val namespaceId = scheduledPrompt.namespaceId
+        if (namespaceId == null) {
+            logger.warn { "[Executor] Platform-scope ScheduledPrompt ${scheduledPrompt.id} — skipping UserRun=${userRun.id}" }
+            markFailed(userRun.id, now, "Platform-scope ScheduledPrompt cannot be executed per-user")
+            checkCompletion(runId)
+            return
+        }
+
+        val user = userService.findById(userId)
+        if (user == null) {
+            logger.warn { "[Executor] User $userId not found — marking UserRun=${userRun.id} FAILED" }
+            markFailed(userRun.id, now, "User $userId not found")
+            checkCompletion(runId)
+            return
+        }
+
+        // Resolve the prompt content directly — the Executor is the consumer of the prompt
+        // and has the full context (userId, namespaceId, scheduling metadata) needed to
+        // resolve it. Injecting a /slash-command would fail because addMessage's
+        // PromptCommandParser requires text to start with '/' but the @mention prefix
+        // prevents that.
+        val prompt = promptService.findById(scheduledPrompt.promptTemplateId)
+        if (prompt == null) {
+            logger.warn {
+                "[Executor] PromptTemplate ${scheduledPrompt.promptTemplateId} not found " +
+                    "— marking UserRun=${userRun.id} FAILED"
+            }
+            markFailed(userRun.id, now, "PromptTemplate ${scheduledPrompt.promptTemplateId} not found")
+            checkCompletion(runId)
+            return
+        }
+
+        // Mono-line content (enforced by ScheduledPromptService validation).
+        // Future: resolve {{placeholders}} here with execution context (user name, date, etc.)
+        val promptContent = prompt.content.firstOrNull()
+        if (promptContent.isNullOrBlank()) {
+            logger.warn {
+                "[Executor] PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content " +
+                    "— marking UserRun=${userRun.id} FAILED"
+            }
+            markFailed(userRun.id, now, "PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content")
+            checkCompletion(runId)
+            return
+        }
+
+        // Resolve the agent name — prepended as @mention so selectAgent picks it up
+        // via the normal @mention resolution path (no special-casing in the runtime).
+        val agentName = agentConfigService.findById(scheduledPrompt.agentConfigId)?.name
+        if (agentName == null) {
+            logger.warn {
+                "[Executor] AgentConfig ${scheduledPrompt.agentConfigId} not found " +
+                    "— marking UserRun=${userRun.id} FAILED"
+            }
+            markFailed(userRun.id, now, "AgentConfig ${scheduledPrompt.agentConfigId} not found")
+            checkCompletion(runId)
+            return
+        }
+
+        // Inject resolved content with @mention — selectAgent resolves the agent,
+        // PromptCommandParser sees no /command and passes text through unchanged.
+        val message = "@$agentName $promptContent"
+
+        // --- Execute ---
+
+        try {
+            // Step 1: Create the Case.
+            val case = caseService.create(
+                Case(
+                    namespaceId = namespaceId,
+                    title = buildCaseTitle(scheduledPrompt.name, user.displayName()),
+                ),
+            )
+            val caseId = case.id
+
+            // Step 2: Grant ADMIN to the target user.
+            permissionService.grantPermission(
+                userId.toString(),
+                EntityType.CASE,
+                caseId.toString(),
+                PermissionRelation.ADMIN,
+            )
+
+            // Step 3: Build Actor.
+            val actor = Actor(
+                id = userId.toString(),
+                displayName = user.displayName(),
+                role = ActorRole.USER,
+            )
+
+            // Step 4: Inject the prompt message.
+            // addMessage internally launches runtime.run() in CaseServiceImpl.scope.
+            caseService.addMessage(
+                caseId = caseId,
+                actor = actor,
+                content = listOf(MessageContent.Text(message)),
+            )
+
+            logger.info {
+                "[Executor] UserRun=${userRun.id} — Case $caseId created and message injected for user=$userId"
+            }
+
+            // Step 5: Wait for the Case to finish, then close the UserRun.
+            waitForCaseAndClose(userRun.id, caseId, runId)
+
+        } catch (e: Exception) {
+            logger.error(e) {
+                "[Executor] UserRun=${userRun.id} failed during Case creation/launch for user=$userId"
+            }
+            markFailed(userRun.id, now, e.message ?: "Unknown error")
+            checkCompletion(runId)
+        }
+    }
+
+    /**
+     * Poll the Case status until it leaves RUNNING/PENDING, then close the UserRun.
+     *
+     * Polling interval: [POLL_INTERVAL_MS]. Gives up (marks FAILED) when the elapsed
+     * time exceeds the configured lease duration — the next tick's [claimBatch] will
+     * reclaim expired RUNNING UserRuns.
+     */
+    private suspend fun waitForCaseAndClose(
+        userRunId: UUID,
+        caseId: UUID,
+        runId: UUID,
+    ) {
+        val deadline = Instant.now(clock).plusMillis(Duration.ofMinutes(properties.leaseMinutes).toMillis())
+
+        while (true) {
+            val now = Instant.now(clock)
+
+            if (now.isAfter(deadline)) {
+                logger.warn {
+                    "[Executor] UserRun=$userRunId lease expired while waiting for Case $caseId — marking FAILED"
+                }
+                markFailed(userRunId, now, "Lease expired waiting for Case $caseId")
+                checkCompletion(runId)
+                return
+            }
+
+            val runtime = caseService.findActiveRuntime(caseId)
+
+            when {
+                // Runtime evicted — Case has reached a terminal status.
+                runtime == null -> {
+                    val case = caseService.findById(caseId)
+                    val caseStatus = case?.status
+                    val terminalUserRunStatus = when (caseStatus) {
+                        CaseStatus.KILLED, CaseStatus.ERROR -> UserRunStatus.FAILED
+                        else -> UserRunStatus.DONE
+                    }
+                    val error = if (terminalUserRunStatus == UserRunStatus.FAILED) {
+                        "Case reached terminal status $caseStatus"
+                    } else {
+                        null
+                    }
+                    userRunRepository.markTerminal(userRunId, terminalUserRunStatus, now, error)
+                    logger.info {
+                        "[Executor] UserRun=$userRunId closed as $terminalUserRunStatus " +
+                            "(caseId=$caseId status=$caseStatus)"
+                    }
+                    checkCompletion(runId)
+                    return
+                }
+
+                // Case is IDLE and not running — agent turn complete.
+                runtime.statusFlow.value == CaseStatus.IDLE && !runtime.isRunning() -> {
+                    userRunRepository.markTerminal(userRunId, UserRunStatus.DONE, now)
+                    logger.info {
+                        "[Executor] UserRun=$userRunId closed as DONE (caseId=$caseId IDLE)"
+                    }
+                    checkCompletion(runId)
+                    return
+                }
+
+                // Case still active — poll again.
+                else -> delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Completion check
+    // -------------------------------------------------------------------------
+
+    /**
+     * Transition the parent [ScheduledPromptRun] to DONE (or FAILED) once all
+     * UserRuns are settled.
+     *
+     * Condition: `count(PENDING) == 0 && count(RUNNING) == 0`.
+     * Only inspects RUNNING Runs — a Run only reaches RUNNING after Phase A completes,
+     * so the CLAIMED→RUNNING transition is the guard that was previously served by the
+     * `materialized` flag.
+     * The Run is FAILED when at least one UserRun failed; DONE otherwise.
+     */
+    private fun checkCompletion(runId: UUID) {
+        val run = runRepository.findById(runId) ?: return
+        if (run.status != RunStatus.RUNNING && run.status != RunStatus.CLAIMED) return
+
+        val pendingCount = userRunRepository.countByRunIdAndStatus(runId, UserRunStatus.PENDING)
+        val runningCount = userRunRepository.countByRunIdAndStatus(runId, UserRunStatus.RUNNING)
+
+        if (pendingCount == 0 && runningCount == 0) {
+            val finalStatus = when {
+                userRunRepository.hasAnyFailed(runId) -> RunStatus.FAILED
+                else -> RunStatus.DONE
+            }
+            runRepository.updateStatus(runId, finalStatus, Instant.now(clock))
+            logger.info { "[Executor] Run=$runId → $finalStatus" }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun markFailed(
+        userRunId: UUID,
+        now: Instant,
+        error: String,
+    ) {
+        runCatching {
+            userRunRepository.markTerminal(userRunId, UserRunStatus.FAILED, now, error)
+        }.onFailure { e ->
+            logger.error(e) { "[Executor] Could not mark UserRun=$userRunId as FAILED" }
+        }
+    }
+
+    private fun buildCaseTitle(scheduledPromptName: String, userDisplayName: String): String =
+        "$scheduledPromptName — $userDisplayName".take(MAX_TITLE_LENGTH)
+
+    companion object : KLogging() {
+        private const val MAX_TITLE_LENGTH = 100
+        private const val POLL_INTERVAL_MS = 2_000L
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -30,13 +30,14 @@ import java.util.UUID
  *
  * ### Phase A — Materialisation (fast, no throttle)
  *
- * Called by [SchedulerScanner] immediately after a Run is CLAIMED.
- * Resolves all target users AND creates PENDING [ScheduledPromptUserRun]s in a **single
- * Cypher INSERT-SELECT** via [ScheduledPromptUserRunRepository.materialize]. No users are
- * loaded into JVM heap — the traversal and inserts happen entirely inside Neo4j.
+ * [materialize] is called by [SchedulerScanner.claim] after the Run has been inserted.
+ * It resolves all target users and creates PENDING [ScheduledPromptUserRun]s via a single
+ * Cypher INSERT-SELECT, then transitions the Run to RUNNING — all in a single
+ * `@Transactional` boundary.
  *
- * Re-entrant: if the service crashed mid-materialisation, calling [materialize] again is
- * safe because the MERGE is idempotent.
+ * If the service crashes between the Run insert in [SchedulerScanner.claim] and the
+ * [materialize] call, the Run remains CLAIMED forever. [SchedulerScanner.recoverOrphanedClaimedRuns]
+ * detects such orphans on the next tick and marks them FAILED, unblocking the overlap guard.
  *
  * ### Phase B — Consumption (throttled)
  *
@@ -93,9 +94,13 @@ class ScheduledPromptExecutor(
      * Safe to call multiple times for the same Run (idempotent via MERGE).
      * Transitions the Run to [RunStatus.RUNNING] once materialisation is complete.
      *
-     * The MERGE and the CLAIMED→RUNNING transition run in a single transaction: if the
-     * service crashes between the two, neither a set of orphaned PENDING UserRuns (never
+     * The MERGE and the CLAIMED→RUNNING transition run in a single `@Transactional`:
+     * if the service crashes between the two, neither orphaned PENDING UserRuns (never
      * consumed) nor a RUNNING Run with no UserRuns can result.
+     *
+     * Note: the Run insert happens in [SchedulerScanner.claim], **outside** this transaction.
+     * A crash between the insert and this call leaves an orphaned CLAIMED Run, which
+     * [SchedulerScanner.recoverOrphanedClaimedRuns] detects and marks FAILED on the next tick.
      */
     @Transactional
     fun materialize(run: ScheduledPromptRun, scheduledPrompt: ScheduledPrompt) {
@@ -409,9 +414,11 @@ class ScheduledPromptExecutor(
      * UserRuns are settled.
      *
      * Condition: `count(PENDING) == 0 && count(RUNNING) == 0`.
-     * Only inspects RUNNING Runs — a Run only reaches RUNNING after Phase A completes,
-     * so the CLAIMED→RUNNING transition is the guard that was previously served by the
-     * `materialized` flag.
+     * Only inspects RUNNING Runs — a Run only reaches RUNNING after [materialize]
+     * completes, so the CLAIMED→RUNNING transition acts as the completion guard
+     * (a CLAIMED Run whose [materialize] has not yet finished is never prematurely
+     * evaluated). Orphaned CLAIMED Runs (crash before [materialize]) are swept to
+     * FAILED by [SchedulerScanner.recoverOrphanedClaimedRuns] and never reach this path.
      * The Run is FAILED when at least one UserRun failed; DONE otherwise.
      */
     private fun checkCompletion(runId: UUID) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -352,8 +352,12 @@ class ScheduledPromptExecutor(
      * Collects [CaseRuntime.statusFlow] for up to [SchedulerProperties.launchTimeoutSeconds]
      * seconds. This is a **health check**, not a completion wait:
      * - IDLE → agent finished its turn quickly → DONE
-     * - Timeout (still RUNNING) → Case is healthy, just slow → DONE
+     * - Timeout (still RUNNING) → Case is healthy but slow; monitoring released → TIMEOUT
      * - ERROR/KILLED → immediate crash → FAILED
+     *
+     * On timeout the UserRun is closed as [UserRunStatus.TIMEOUT] via a direct
+     * [ScheduledPromptUserRunRepository.markTerminal] call, bypassing [closeUserRun] and
+     * [toUserRunOutcome] (which only map [CaseStatus] values).
      *
      * The Case continues running independently after this method returns.
      * The lease on the UserRun is only relevant for crash recovery (instance down
@@ -371,10 +375,17 @@ class ScheduledPromptExecutor(
         }
 
         if (finalStatus != null && finalStatus.isTerminal()) {
+            // Immediate terminal status (ERROR/KILLED) — execution failed.
             closeUserRun(userRunId, finalStatus, caseId)
-        } else {
-            // IDLE or timeout (still RUNNING) — Case launched successfully
+        } else if (finalStatus == CaseStatus.IDLE) {
+            // Agent finished its turn before the timeout — clean completion.
             closeUserRun(userRunId, CaseStatus.IDLE, caseId)
+        } else {
+            // Timeout — Case is still RUNNING; monitoring released, Case continues independently.
+            userRunRepository.markTerminal(userRunId, UserRunStatus.TIMEOUT, Instant.now(clock))
+            logger.info {
+                "[Executor] UserRun=$userRunId timed out (caseId=$caseId still running) — monitoring released"
+            }
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -80,7 +80,7 @@ import java.util.UUID
  * the guard ensuring all UserRuns have been materialised before completion is evaluated.
  */
 @Component
-@ConditionalOnProperty(name = ["scheduler.enabled"], havingValue = "true")
+@ConditionalOnProperty(name = ["agentos.prompt.scheduler.enabled"], havingValue = "true")
 class ScheduledPromptExecutor(
     private val scheduledPromptRepository: ScheduledPromptRepository,
     private val runRepository: ScheduledPromptRunRepository,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -89,7 +90,12 @@ class ScheduledPromptExecutor(
      *
      * Safe to call multiple times for the same Run (idempotent via MERGE).
      * Transitions the Run to [RunStatus.RUNNING] once materialisation is complete.
+     *
+     * The MERGE and the CLAIMED→RUNNING transition run in a single transaction: if the
+     * service crashes between the two, neither a set of orphaned PENDING UserRuns (never
+     * consumed) nor a RUNNING Run with no UserRuns can result.
      */
+    @Transactional
     fun materialize(run: ScheduledPromptRun, scheduledPrompt: ScheduledPrompt) {
         logger.info {
             "[Executor] Phase A: materialising run=${run.id} sp=${scheduledPrompt.id}"

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -228,83 +228,54 @@ class ScheduledPromptExecutor(
         val runId = userRun.runId
         val userId = userRun.userId
 
-        // --- Resolve context ---
-
-        val run = runRepository.findById(runId)
-        if (run == null) {
-            logger.warn { "[Executor] Run $runId not found for UserRun=${userRun.id} — marking FAILED" }
-            markFailed(userRun.id, now, "Parent Run $runId not found")
-            return
-        }
-
-        val scheduledPrompt = scheduledPromptRepository.findByIds(listOf(run.scheduledPromptId))
-            .firstOrNull()
-        if (scheduledPrompt == null) {
-            logger.warn { "[Executor] ScheduledPrompt ${run.scheduledPromptId} not found — marking UserRun=${userRun.id} FAILED" }
-            markFailed(userRun.id, now, "ScheduledPrompt ${run.scheduledPromptId} not found")
-            return
-        }
-
-        val namespaceId = scheduledPrompt.namespaceId
-        if (namespaceId == null) {
-            logger.warn { "[Executor] Platform-scope ScheduledPrompt ${scheduledPrompt.id} — skipping UserRun=${userRun.id}" }
-            markFailed(userRun.id, now, "Platform-scope ScheduledPrompt cannot be executed per-user")
-            return
-        }
-
-        val user = userService.findById(userId)
-        if (user == null) {
-            logger.warn { "[Executor] User $userId not found — marking UserRun=${userRun.id} FAILED" }
-            markFailed(userRun.id, now, "User $userId not found")
-            return
-        }
-
-        // Resolve the prompt content directly — the Executor is the consumer of the prompt
-        // and has the full context (userId, namespaceId, scheduling metadata) needed to
-        // resolve it. Injecting a /slash-command would fail because addMessage's
-        // PromptCommandParser requires text to start with '/' but the @mention prefix
-        // prevents that.
-        val prompt = promptService.findById(scheduledPrompt.promptTemplateId)
-        if (prompt == null) {
-            logger.warn {
-                "[Executor] PromptTemplate ${scheduledPrompt.promptTemplateId} not found " +
-                    "— marking UserRun=${userRun.id} FAILED"
-            }
-            markFailed(userRun.id, now, "PromptTemplate ${scheduledPrompt.promptTemplateId} not found")
-            return
-        }
-
-        // Mono-line content (enforced by ScheduledPromptService validation).
-        // Future: resolve {{placeholders}} here with execution context (user name, date, etc.)
-        val promptContent = prompt.content.firstOrNull()
-        if (promptContent.isNullOrBlank()) {
-            logger.warn {
-                "[Executor] PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content " +
-                    "— marking UserRun=${userRun.id} FAILED"
-            }
-            markFailed(userRun.id, now, "PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content")
-            return
-        }
-
-        // Resolve the agent name — prepended as @mention so selectAgent picks it up
-        // via the normal @mention resolution path (no special-casing in the runtime).
-        val agentName = agentConfigService.findById(scheduledPrompt.agentConfigId)?.name
-        if (agentName == null) {
-            logger.warn {
-                "[Executor] AgentConfig ${scheduledPrompt.agentConfigId} not found " +
-                    "— marking UserRun=${userRun.id} FAILED"
-            }
-            markFailed(userRun.id, now, "AgentConfig ${scheduledPrompt.agentConfigId} not found")
-            return
-        }
-
-        // Inject resolved content with @mention — selectAgent resolves the agent,
-        // PromptCommandParser sees no /command and passes text through unchanged.
-        val message = "@$agentName $promptContent"
-
-        // --- Execute ---
-
         try {
+            // --- Resolve context ---
+            // Each check is required: the resolved value is consumed below to create the Case,
+            // build the Actor, or compose the message. IllegalStateException on missing data
+            // is caught by the outer try/catch and marks the UserRun FAILED with a diagnostic.
+
+            val run = checkNotNull(runRepository.findById(runId)) {
+                "Parent Run $runId not found"
+            }
+
+            val scheduledPrompt = scheduledPromptRepository.findByIds(listOf(run.scheduledPromptId))
+                .firstOrNull()
+                ?: error("ScheduledPrompt ${run.scheduledPromptId} not found")
+
+            val namespaceId = checkNotNull(scheduledPrompt.namespaceId) {
+                "Platform-scope ScheduledPrompt cannot be executed per-user"
+            }
+
+            val user = checkNotNull(userService.findById(userId)) {
+                "User $userId not found"
+            }
+
+            // Resolve the prompt content directly — the Executor is the consumer of the prompt
+            // and has the full context (userId, namespaceId, scheduling metadata) needed to
+            // resolve it. Injecting a /slash-command would fail because addMessage's
+            // PromptCommandParser requires text to start with '/' but the @mention prefix
+            // prevents that.
+            val prompt = checkNotNull(promptService.findById(scheduledPrompt.promptTemplateId)) {
+                "PromptTemplate ${scheduledPrompt.promptTemplateId} not found"
+            }
+
+            // Mono-line content (enforced by ScheduledPromptService validation).
+            // Future: resolve {{placeholders}} here with execution context (user name, date, etc.)
+            val promptContent = prompt.content.firstOrNull()?.takeIf { it.isNotBlank() }
+                ?: error("PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content")
+
+            // Resolve the agent name — prepended as @mention so selectAgent picks it up
+            // via the normal @mention resolution path (no special-casing in the runtime).
+            val agentName = checkNotNull(agentConfigService.findById(scheduledPrompt.agentConfigId)?.name) {
+                "AgentConfig ${scheduledPrompt.agentConfigId} not found"
+            }
+
+            // Inject resolved content with @mention — selectAgent resolves the agent,
+            // PromptCommandParser sees no /command and passes text through unchanged.
+            val message = "@$agentName $promptContent"
+
+            // --- Execute ---
+
             // Step 1: Create the Case.
             // No idempotence key links this Case to the UserRun — if the instance crashes
             // after this point but before markTerminal(), the lease expires and another
@@ -358,7 +329,7 @@ class ScheduledPromptExecutor(
             }
         } catch (e: Exception) {
             logger.error(e) {
-                "[Executor] UserRun=${userRun.id} failed during Case creation/launch for user=$userId"
+                "[Executor] UserRun=${userRun.id} failed for user=$userId"
             }
             markFailed(userRun.id, now, e.message ?: "Unknown error")
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -14,7 +14,9 @@ import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.user.UserService
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
@@ -51,7 +53,8 @@ import java.util.UUID
  *    [CaseService.addMessage]. The Executor resolves content itself rather than using
  *    a `/slash-command` because PromptCommandParser requires the text to start with `/`,
  *    which is incompatible with the leading `@mention`.
- * 5. Poll the runtime status until the Case leaves RUNNING/PENDING, then close the UserRun.
+ * 5. Collect the runtime's [CaseRuntime.statusFlow] until the Case reaches IDLE or a
+ *    terminal status, then close the UserRun.
  *
  * A [kotlinx.coroutines.sync.Semaphore] caps concurrent in-flight coroutines to
  * [SchedulerProperties.maxConcurrentExecutions]. Unlike `java.util.concurrent.Semaphore`,
@@ -337,8 +340,15 @@ class ScheduledPromptExecutor(
                 "[Executor] UserRun=${userRun.id} — Case $caseId created and message injected for user=$userId"
             }
 
-            // Step 5: Wait for the Case to finish, then close the UserRun.
-            waitForCaseAndClose(userRun.id, caseId)
+            // Step 5: Collect the runtime's statusFlow until IDLE or terminal.
+            // The runtime is guaranteed to exist in activeRuntimes right after create().
+            val runtime = caseService.findActiveRuntime(caseId)
+            if (runtime == null) {
+                // Runtime already evicted (terminal status reached before we got here)
+                closeCaseTerminal(userRun.id, caseId)
+            } else {
+                awaitCaseCompletion(userRun.id, caseId, runtime)
+            }
 
         } catch (e: Exception) {
             logger.error(e) {
@@ -349,65 +359,79 @@ class ScheduledPromptExecutor(
     }
 
     /**
-     * Poll the Case status until it leaves RUNNING/PENDING, then close the UserRun.
+     * Collect the runtime's [statusFlow] until the Case reaches IDLE or a terminal status.
      *
-     * Polling interval: [POLL_INTERVAL_MS]. Gives up (marks FAILED) when the elapsed
-     * time exceeds the configured lease duration — the next tick's [claimBatch] will
-     * reclaim expired RUNNING UserRuns.
+     * Replaces the former polling loop: [kotlinx.coroutines.flow.StateFlow.first] suspends
+     * reactively until the predicate matches — zero polling, zero delay. The lease duration
+     * is enforced via [withTimeoutOrNull]; on timeout the UserRun is marked FAILED and the
+     * next tick's [claimBatch] will reclaim expired RUNNING UserRuns.
      */
-    private suspend fun waitForCaseAndClose(
+    private suspend fun awaitCaseCompletion(
         userRunId: UUID,
         caseId: UUID,
+        runtime: io.whozoss.agentos.caseFlow.CaseRuntime,
     ) {
-        val deadline = Instant.now(clock).plusMillis(Duration.ofMinutes(properties.leaseMinutes).toMillis())
+        val leaseMs = Duration.ofMinutes(properties.leaseMinutes).toMillis()
 
-        while (true) {
-            val now = Instant.now(clock)
+        val finalStatus = withTimeoutOrNull(leaseMs) {
+            runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
+        }
 
-            if (now.isAfter(deadline)) {
+        val now = Instant.now(clock)
+        when {
+            finalStatus == null -> {
                 logger.warn {
                     "[Executor] UserRun=$userRunId lease expired while waiting for Case $caseId — marking FAILED"
                 }
                 markFailed(userRunId, now, "Lease expired waiting for Case $caseId")
-                return
             }
-
-            val runtime = caseService.findActiveRuntime(caseId)
-
-            when {
-                // Runtime evicted — Case has reached a terminal status.
-                runtime == null -> {
-                    val case = caseService.findById(caseId)
-                    val caseStatus = case?.status
-                    val terminalUserRunStatus = when (caseStatus) {
-                        CaseStatus.KILLED, CaseStatus.ERROR -> UserRunStatus.FAILED
-                        else -> UserRunStatus.DONE
-                    }
-                    val error = if (terminalUserRunStatus == UserRunStatus.FAILED) {
-                        "Case reached terminal status $caseStatus"
-                    } else {
-                        null
-                    }
-                    userRunRepository.markTerminal(userRunId, terminalUserRunStatus, now, error)
-                    logger.info {
-                        "[Executor] UserRun=$userRunId closed as $terminalUserRunStatus " +
-                            "(caseId=$caseId status=$caseStatus)"
-                    }
-                    return
+            finalStatus.isTerminal() -> {
+                val terminalUserRunStatus = when (finalStatus) {
+                    CaseStatus.KILLED, CaseStatus.ERROR -> UserRunStatus.FAILED
+                    else -> UserRunStatus.DONE
                 }
-
-                // Case is IDLE and not running — agent turn complete.
-                runtime.statusFlow.value == CaseStatus.IDLE && !runtime.isRunning() -> {
-                    userRunRepository.markTerminal(userRunId, UserRunStatus.DONE, now)
-                    logger.info {
-                        "[Executor] UserRun=$userRunId closed as DONE (caseId=$caseId IDLE)"
-                    }
-                    return
+                val error = if (terminalUserRunStatus == UserRunStatus.FAILED) {
+                    "Case reached terminal status $finalStatus"
+                } else {
+                    null
                 }
-
-                // Case still active — poll again.
-                else -> delay(POLL_INTERVAL_MS)
+                userRunRepository.markTerminal(userRunId, terminalUserRunStatus, now, error)
+                logger.info {
+                    "[Executor] UserRun=$userRunId closed as $terminalUserRunStatus " +
+                        "(caseId=$caseId status=$finalStatus)"
+                }
             }
+            else -> {
+                // IDLE — agent turn complete
+                userRunRepository.markTerminal(userRunId, UserRunStatus.DONE, now)
+                logger.info {
+                    "[Executor] UserRun=$userRunId closed as DONE (caseId=$caseId IDLE)"
+                }
+            }
+        }
+    }
+
+    /**
+     * Close a UserRun when the runtime was already evicted before we could collect its flow.
+     * Falls back to reading the persisted Case status.
+     */
+    private fun closeCaseTerminal(userRunId: UUID, caseId: UUID) {
+        val now = Instant.now(clock)
+        val case = caseService.findById(caseId)
+        val caseStatus = case?.status
+        val terminalUserRunStatus = when (caseStatus) {
+            CaseStatus.KILLED, CaseStatus.ERROR -> UserRunStatus.FAILED
+            else -> UserRunStatus.DONE
+        }
+        val error = if (terminalUserRunStatus == UserRunStatus.FAILED) {
+            "Case reached terminal status $caseStatus"
+        } else {
+            null
+        }
+        userRunRepository.markTerminal(userRunId, terminalUserRunStatus, now, error)
+        logger.info {
+            "[Executor] UserRun=$userRunId closed as $terminalUserRunStatus " +
+                "(caseId=$caseId status=$caseStatus, runtime already evicted)"
         }
     }
 
@@ -464,7 +488,5 @@ class ScheduledPromptExecutor(
         }
     }
 
-    companion object : KLogging() {
-        private const val POLL_INTERVAL_MS = 2_000L
-    }
+    companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -13,10 +13,12 @@ import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.user.UserService
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -171,6 +173,11 @@ class ScheduledPromptExecutor(
      * coroutine inside [coroutineScope]; the scope suspends until all launched children
      * finish before the next batch is claimed.
      *
+     * Runs on [Dispatchers.IO] so the coroutines launched inside [coroutineScope] execute on
+     * the IO thread pool (default 64 threads) rather than being serialised on the caller's
+     * single thread. This is required because [processUserRun] calls blocking Spring services
+     * (Neo4j, CaseService, PermissionService) that would otherwise starve the coroutine dispatcher.
+     *
      * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
      * each batch contains at most that many UserRuns, all launched as structured coroutines
      * within a single [coroutineScope]. A short [SchedulerProperties.launchStaggerMs] delay
@@ -187,7 +194,7 @@ class ScheduledPromptExecutor(
      * no data corruption). Exactly-once would require an idempotence key on Case
      * creation (e.g. a UNIQUE constraint on `runId|userId` carried by the Case).
      */
-    suspend fun consumeAvailable() {
+    suspend fun consumeAvailable() = withContext(Dispatchers.IO) {
         val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
 
         var batch: List<ScheduledPromptUserRun>

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -60,8 +60,10 @@ import java.util.UUID
  *
  * ### Completion check
  *
- * After each UserRun closes, the parent Run is checked:
- * `count(PENDING) == 0 && count(RUNNING) == 0` → DONE (or FAILED if any UserRun failed).
+ * After each UserRun closes, the parent Run is checked via two EXISTS queries:
+ * 1. [ScheduledPromptUserRunRepository.hasAnyActive] — fast-path exit when work is still in flight.
+ * 2. [ScheduledPromptUserRunRepository.hasAnyFailed] — only reached when all UserRuns are terminal.
+ * Result: FAILED if any UserRun failed, DONE otherwise.
  * Only RUNNING Runs are inspected — the CLAIMED→RUNNING transition in Phase A acts as
  * the guard ensuring all UserRuns have been materialised before completion is evaluated.
  */
@@ -419,7 +421,10 @@ class ScheduledPromptExecutor(
      * Transition the parent [ScheduledPromptRun] to DONE (or FAILED) once all
      * UserRuns are settled.
      *
-     * Condition: `count(PENDING) == 0 && count(RUNNING) == 0`.
+     * Fast-path: [ScheduledPromptUserRunRepository.hasAnyActive] exits immediately
+     * (EXISTS query, stops at first match) when work is still in flight.
+     * Only when no active UserRuns remain does it check for failures.
+     *
      * Only inspects RUNNING Runs — a Run only reaches RUNNING after [materialize]
      * completes, so the CLAIMED→RUNNING transition acts as the completion guard
      * (a CLAIMED Run whose [materialize] has not yet finished is never prematurely
@@ -438,17 +443,11 @@ class ScheduledPromptExecutor(
         val run = runRepository.findById(runId) ?: return
         if (run.status != RunStatus.RUNNING && run.status != RunStatus.CLAIMED) return
 
-        val pendingCount = userRunRepository.countByRunIdAndStatus(runId, UserRunStatus.PENDING)
-        val runningCount = userRunRepository.countByRunIdAndStatus(runId, UserRunStatus.RUNNING)
+        if (userRunRepository.hasAnyActive(runId)) return
 
-        if (pendingCount == 0 && runningCount == 0) {
-            val finalStatus = when {
-                userRunRepository.hasAnyFailed(runId) -> RunStatus.FAILED
-                else -> RunStatus.DONE
-            }
-            runRepository.updateStatus(runId, finalStatus, Instant.now(clock))
-            logger.info { "[Executor] Run=$runId → $finalStatus" }
-        }
+        val finalStatus = if (userRunRepository.hasAnyFailed(runId)) RunStatus.FAILED else RunStatus.DONE
+        runRepository.updateStatus(runId, finalStatus, Instant.now(clock))
+        logger.info { "[Executor] Run=$runId → $finalStatus" }
     }
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -32,8 +32,8 @@ import java.util.UUID
  *
  * [materialize] is called by [SchedulerScanner.claim] after the Run has been inserted.
  * It resolves all target users and creates PENDING [ScheduledPromptUserRun]s via a single
- * Cypher INSERT-SELECT, then transitions the Run to RUNNING — all in a single
- * `@Transactional` boundary.
+ * Cypher INSERT-SELECT, then transitions the Run to RUNNING (when UserRuns were created)
+ * or directly to DONE (when no target users exist) — all in a single `@Transactional` boundary.
  *
  * If the service crashes between the Run insert in [SchedulerScanner.claim] and the
  * [materialize] call, the Run remains CLAIMED forever. [SchedulerScanner.recoverOrphanedClaimedRuns]
@@ -92,7 +92,8 @@ class ScheduledPromptExecutor(
      * PENDING UserRun per distinct user — entirely inside Neo4j, no JVM heap pressure.
      *
      * Safe to call multiple times for the same Run (idempotent via MERGE).
-     * Transitions the Run to [RunStatus.RUNNING] once materialisation is complete.
+     * Transitions the Run to [RunStatus.RUNNING] when UserRuns are created, or directly
+     * to [RunStatus.DONE] when no target users exist (e.g. platform-scope ScheduledPrompt).
      *
      * The MERGE and the CLAIMED→RUNNING transition run in a single `@Transactional`:
      * if the service crashes between the two, neither orphaned PENDING UserRuns (never
@@ -125,13 +126,18 @@ class ScheduledPromptExecutor(
             }.getOrDefault(0)
         }
 
-        // Transition to RUNNING — Phase B's checkCompletion only inspects RUNNING Runs,
-        // so this transition acts as the guard that was previously served by the
-        // materialized flag. A Run only becomes RUNNING after materialize() completes.
-        runRepository.updateStatus(run.id, RunStatus.RUNNING)
+        // Transition based on whether any UserRuns were created:
+        // - RUNNING when count > 0 — Phase B will consume the UserRuns and checkCompletion
+        //   will close the Run once all are terminal.
+        // - DONE when count == 0 — no UserRuns to consume (platform-scope ScheduledPrompt
+        //   with no target users, or namespace with no deployed users). Transitioning to
+        //   RUNNING would leave the Run stuck forever since checkCompletion requires at
+        //   least one UserRun closure to trigger.
+        val finalStatus = if (count > 0) RunStatus.RUNNING else RunStatus.DONE
+        runRepository.updateStatus(run.id, finalStatus, if (count == 0) Instant.now(clock) else null)
 
         logger.info {
-            "[Executor] Phase A complete: run=${run.id} — $count UserRun(s) created"
+            "[Executor] Phase A complete: run=${run.id} — $count UserRun(s) created, status=$finalStatus"
         }
     }
 
@@ -420,6 +426,13 @@ class ScheduledPromptExecutor(
      * evaluated). Orphaned CLAIMED Runs (crash before [materialize]) are swept to
      * FAILED by [SchedulerScanner.recoverOrphanedClaimedRuns] and never reach this path.
      * The Run is FAILED when at least one UserRun failed; DONE otherwise.
+     *
+     * ### Crash window
+     *
+     * If the instance crashes after the last [ScheduledPromptUserRunRepository.markTerminal]
+     * but before this method runs, the Run stays RUNNING forever — no subsequent UserRun
+     * closure will re-trigger this check. [SchedulerScanner.recoverOrphanedRunningRuns]
+     * handles this by re-evaluating the completion condition on every tick.
      */
     private fun checkCompletion(runId: UUID) {
         val run = runRepository.findById(runId) ?: return

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -14,6 +14,7 @@ import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.user.UserService
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -60,9 +61,10 @@ import java.util.UUID
  *
  * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
  * each batch contains at most that many UserRuns, and all are launched as structured
- * coroutines within a single [coroutineScope]. No additional semaphore is needed.
- * Burst control is delegated to Spring AI's `RetryTemplate` on each `ChatModel`
- * (exponential backoff on 429 rate-limit responses).
+ * coroutines within a single [coroutineScope]. A short stagger delay
+ * ([SchedulerProperties.launchStaggerMs]) between each `launch` spreads the initial
+ * burst to reduce memory pressure. Further burst control is delegated to Spring AI's `RetryTemplate`
+ * on each `ChatModel` (exponential backoff on 429 rate-limit responses).
  *
  * ### Completion check
  *
@@ -171,8 +173,9 @@ class ScheduledPromptExecutor(
      *
      * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
      * each batch contains at most that many UserRuns, all launched as structured coroutines
-     * within a single [coroutineScope]. No additional semaphore is needed — the batch size
-     * IS the concurrency cap. Burst control is delegated to Spring AI's `RetryTemplate`
+     * within a single [coroutineScope]. A short [SchedulerProperties.launchStaggerMs] delay
+     * between each `launch` spreads the initial burst to reduce memory pressure (OOM observed
+     * on CI without stagger). Further burst control is delegated to Spring AI's `RetryTemplate`
      * (exponential backoff on 429 responses).
      *
      * ### Delivery guarantee: at-least-once
@@ -201,6 +204,11 @@ class ScheduledPromptExecutor(
                     launch {
                         processUserRun(userRun)
                     }
+
+                    // Stagger launches to spread the initial burst and reduce memory pressure.
+                    // Without this delay, simultaneous Case+Runtime creation for a full batch
+                    // causes OOM on CI. Once launched, coroutines run concurrently.
+                    delay(properties.launchStaggerMs)
                 }
             }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -16,8 +16,6 @@ import io.whozoss.agentos.user.UserService
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -57,11 +55,11 @@ import java.util.UUID
  * 5. Collect the runtime's [CaseRuntime.statusFlow] until the Case reaches IDLE or a
  *    terminal status, then close the UserRun.
  *
- * A [Semaphore] caps concurrent in-flight coroutines to
- * [SchedulerProperties.maxConcurrentExecutions]. Unlike `java.util.concurrent.Semaphore`,
- * [Semaphore.acquire] **suspends** instead of blocking an OS thread.
- * Burst control is not needed at this level: Spring AI's `RetryTemplate` on each
- * `ChatModel` handles 429 (rate-limit) responses with exponential backoff.
+ * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
+ * each batch contains at most that many UserRuns, and all are launched as structured
+ * coroutines within a single [coroutineScope]. No additional semaphore is needed.
+ * Burst control is delegated to Spring AI's `RetryTemplate` on each `ChatModel`
+ * (exponential backoff on 429 rate-limit responses).
  *
  * ### Completion check
  *
@@ -168,11 +166,11 @@ class ScheduledPromptExecutor(
      * coroutine inside [coroutineScope]; the scope suspends until all launched children
      * finish before the next batch is claimed.
      *
-     * A [Semaphore] caps concurrent in-flight coroutines to
-     * [SchedulerProperties.maxConcurrentExecutions]. [Semaphore.withPermit] acquires
-     * before the block and releases in a finally — exception-safe by construction.
-     * Burst control is delegated to Spring AI's `RetryTemplate` (exponential backoff
-     * on 429 responses) — no artificial stagger delay between launches.
+     * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
+     * each batch contains at most that many UserRuns, all launched as structured coroutines
+     * within a single [coroutineScope]. No additional semaphore is needed — the batch size
+     * IS the concurrency cap. Burst control is delegated to Spring AI's `RetryTemplate`
+     * (exponential backoff on 429 responses).
      *
      * ### Delivery guarantee: at-least-once
      *
@@ -184,12 +182,11 @@ class ScheduledPromptExecutor(
      * creation (e.g. a UNIQUE constraint on `runId|userId` carried by the Case).
      */
     suspend fun consumeAvailable() {
-        val semaphore = Semaphore(properties.maxConcurrentExecutions)
         val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
 
         var batch: List<ScheduledPromptUserRun>
         do {
-            batch = userRunRepository.claimBatch(leaseDuration, properties.maxConcurrentExecutions)
+            batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)
             val runIds = batch.map { it.runId }.toSet()
 
             coroutineScope {
@@ -199,9 +196,7 @@ class ScheduledPromptExecutor(
                     }
 
                     launch {
-                        semaphore.withPermit {
-                            executeUserRun(userRun)
-                        }
+                        executeUserRun(userRun)
                     }
                 }
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -14,7 +14,6 @@ import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.user.UserService
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
@@ -61,7 +60,8 @@ import java.util.UUID
  * A [Semaphore] caps concurrent in-flight coroutines to
  * [SchedulerProperties.maxConcurrentExecutions]. Unlike `java.util.concurrent.Semaphore`,
  * [Semaphore.acquire] **suspends** instead of blocking an OS thread.
- * A [delay] of [SchedulerProperties.staggerDelayMs] ms separates each launch.
+ * Burst control is not needed at this level: Spring AI's `RetryTemplate` on each
+ * `ChatModel` handles 429 (rate-limit) responses with exponential backoff.
  *
  * ### Completion check
  *
@@ -171,6 +171,8 @@ class ScheduledPromptExecutor(
      * A [Semaphore] caps concurrent in-flight coroutines to
      * [SchedulerProperties.maxConcurrentExecutions]. [Semaphore.withPermit] acquires
      * before the block and releases in a finally — exception-safe by construction.
+     * Burst control is delegated to Spring AI's `RetryTemplate` (exponential backoff
+     * on 429 responses) — no artificial stagger delay between launches.
      *
      * ### Delivery guarantee: at-least-once
      *
@@ -201,8 +203,6 @@ class ScheduledPromptExecutor(
                             executeUserRun(userRun)
                         }
                     }
-
-                    delay(properties.staggerDelayMs)
                 }
             }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -280,7 +280,7 @@ class ScheduledPromptExecutor(
             // No idempotence key links this Case to the UserRun — if the instance crashes
             // after this point but before markTerminal(), the lease expires and another
             // instance will create a second Case for the same user (at-least-once).
-            // Exactly-once would require a UNIQUE constraint on Case keyed by userRunKey.
+            // Exactly-once would require a UNIQUE constraint on Case keyed by (runId, userId).
             val case = caseService.create(
                 Case(
                     namespaceId = namespaceId,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -60,7 +60,9 @@ import java.util.UUID
  *
  * ### Completion check
  *
- * After each UserRun closes, the parent Run is checked via two EXISTS queries:
+ * After each batch of UserRuns finishes, the distinct Runs touched in that batch are
+ * checked via [checkCompletion] — one call per Run, not per UserRun. Each check uses
+ * two LIMIT 1 queries:
  * 1. [ScheduledPromptUserRunRepository.hasAnyActive] — fast-path exit when work is still in flight.
  * 2. [ScheduledPromptUserRunRepository.hasAnyFailed] — only reached when all UserRuns are terminal.
  * Result: FAILED if any UserRun failed, DONE otherwise.
@@ -178,10 +180,12 @@ class ScheduledPromptExecutor(
         val semaphore = Semaphore(properties.maxConcurrentExecutions)
         val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
 
-        coroutineScope {
-            var batch: List<ScheduledPromptUserRun>
-            do {
-                batch = userRunRepository.claimBatch(leaseDuration, properties.maxConcurrentExecutions)
+        var batch: List<ScheduledPromptUserRun>
+        do {
+            batch = userRunRepository.claimBatch(leaseDuration, properties.maxConcurrentExecutions)
+            val runIds = batch.map { it.runId }.toSet()
+
+            coroutineScope {
                 for (userRun in batch) {
                     logger.info {
                         "[Executor] Phase B: claimed UserRun=${userRun.id} runId=${userRun.runId} userId=${userRun.userId}"
@@ -198,8 +202,13 @@ class ScheduledPromptExecutor(
 
                     delay(properties.staggerDelayMs)
                 }
-            } while (batch.isNotEmpty())
-        }
+            }
+
+            // All UserRuns in this batch have finished — check completion once per Run.
+            // The sweep recoverOrphanedRunningRuns covers crashes between markTerminal
+            // and this point.
+            runIds.forEach { checkCompletion(it) }
+        } while (batch.isNotEmpty())
     }
 
     // -------------------------------------------------------------------------
@@ -225,7 +234,6 @@ class ScheduledPromptExecutor(
         if (scheduledPrompt == null) {
             logger.warn { "[Executor] ScheduledPrompt ${run.scheduledPromptId} not found — marking UserRun=${userRun.id} FAILED" }
             markFailed(userRun.id, now, "ScheduledPrompt ${run.scheduledPromptId} not found")
-            checkCompletion(runId)
             return
         }
 
@@ -233,7 +241,6 @@ class ScheduledPromptExecutor(
         if (namespaceId == null) {
             logger.warn { "[Executor] Platform-scope ScheduledPrompt ${scheduledPrompt.id} — skipping UserRun=${userRun.id}" }
             markFailed(userRun.id, now, "Platform-scope ScheduledPrompt cannot be executed per-user")
-            checkCompletion(runId)
             return
         }
 
@@ -241,7 +248,6 @@ class ScheduledPromptExecutor(
         if (user == null) {
             logger.warn { "[Executor] User $userId not found — marking UserRun=${userRun.id} FAILED" }
             markFailed(userRun.id, now, "User $userId not found")
-            checkCompletion(runId)
             return
         }
 
@@ -257,7 +263,6 @@ class ScheduledPromptExecutor(
                     "— marking UserRun=${userRun.id} FAILED"
             }
             markFailed(userRun.id, now, "PromptTemplate ${scheduledPrompt.promptTemplateId} not found")
-            checkCompletion(runId)
             return
         }
 
@@ -270,7 +275,6 @@ class ScheduledPromptExecutor(
                     "— marking UserRun=${userRun.id} FAILED"
             }
             markFailed(userRun.id, now, "PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content")
-            checkCompletion(runId)
             return
         }
 
@@ -283,7 +287,6 @@ class ScheduledPromptExecutor(
                     "— marking UserRun=${userRun.id} FAILED"
             }
             markFailed(userRun.id, now, "AgentConfig ${scheduledPrompt.agentConfigId} not found")
-            checkCompletion(runId)
             return
         }
 
@@ -335,14 +338,13 @@ class ScheduledPromptExecutor(
             }
 
             // Step 5: Wait for the Case to finish, then close the UserRun.
-            waitForCaseAndClose(userRun.id, caseId, runId)
+            waitForCaseAndClose(userRun.id, caseId)
 
         } catch (e: Exception) {
             logger.error(e) {
                 "[Executor] UserRun=${userRun.id} failed during Case creation/launch for user=$userId"
             }
             markFailed(userRun.id, now, e.message ?: "Unknown error")
-            checkCompletion(runId)
         }
     }
 
@@ -356,7 +358,6 @@ class ScheduledPromptExecutor(
     private suspend fun waitForCaseAndClose(
         userRunId: UUID,
         caseId: UUID,
-        runId: UUID,
     ) {
         val deadline = Instant.now(clock).plusMillis(Duration.ofMinutes(properties.leaseMinutes).toMillis())
 
@@ -368,7 +369,6 @@ class ScheduledPromptExecutor(
                     "[Executor] UserRun=$userRunId lease expired while waiting for Case $caseId — marking FAILED"
                 }
                 markFailed(userRunId, now, "Lease expired waiting for Case $caseId")
-                checkCompletion(runId)
                 return
             }
 
@@ -393,7 +393,6 @@ class ScheduledPromptExecutor(
                         "[Executor] UserRun=$userRunId closed as $terminalUserRunStatus " +
                             "(caseId=$caseId status=$caseStatus)"
                     }
-                    checkCompletion(runId)
                     return
                 }
 
@@ -403,7 +402,6 @@ class ScheduledPromptExecutor(
                     logger.info {
                         "[Executor] UserRun=$userRunId closed as DONE (caseId=$caseId IDLE)"
                     }
-                    checkCompletion(runId)
                     return
                 }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -163,9 +163,9 @@ class ScheduledPromptExecutor(
      * Claim and execute all currently available [ScheduledPromptUserRun]s.
      *
      * Suspends until ALL UserRuns from ALL batches have finished executing, so the
-     * caller ([SchedulerScanner.tickConsume] via `runBlocking`) is truly blocked for
-     * the full duration. Spring `fixedDelay` on [SchedulerScanner.tickConsume] then
-     * prevents a new consume tick from starting before this one completes.
+     * caller ([SchedulerScanner.tickConsume]) suspends for the full duration.
+     * Spring `fixedDelay` on [SchedulerScanner.tickConsume] prevents a new consume
+     * tick from starting before this one completes.
      *
      * Each batch is claimed via [ScheduledPromptUserRunRepository.claimBatch], which
      * uses SDN `@Version` optimistic locking so concurrent instances cannot double-claim

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.scheduledPrompt
 
 import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseFlow.Case
+import io.whozoss.agentos.caseFlow.CaseRuntime
 import io.whozoss.agentos.caseFlow.CaseService
 import io.whozoss.agentos.permissions.EntityType
 import io.whozoss.agentos.permissions.PermissionRelation
@@ -16,6 +17,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -24,7 +27,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import kotlinx.coroutines.sync.Semaphore
 import java.util.UUID
 
 /**
@@ -56,9 +58,9 @@ import java.util.UUID
  * 5. Collect the runtime's [CaseRuntime.statusFlow] until the Case reaches IDLE or a
  *    terminal status, then close the UserRun.
  *
- * A [kotlinx.coroutines.sync.Semaphore] caps concurrent in-flight coroutines to
+ * A [Semaphore] caps concurrent in-flight coroutines to
  * [SchedulerProperties.maxConcurrentExecutions]. Unlike `java.util.concurrent.Semaphore`,
- * [acquire][Semaphore.acquire] **suspends** instead of blocking an OS thread.
+ * [Semaphore.acquire] **suspends** instead of blocking an OS thread.
  * A [delay] of [SchedulerProperties.staggerDelayMs] ms separates each launch.
  *
  * ### Completion check
@@ -166,9 +168,9 @@ class ScheduledPromptExecutor(
      * coroutine inside [coroutineScope]; the scope suspends until all launched children
      * finish before the next batch is claimed.
      *
-     * A [kotlinx.coroutines.sync.Semaphore] caps concurrent in-flight coroutines to
-     * [SchedulerProperties.maxConcurrentExecutions]. Its [acquire][Semaphore.acquire]
-     * suspends instead of blocking an OS thread.
+     * A [Semaphore] caps concurrent in-flight coroutines to
+     * [SchedulerProperties.maxConcurrentExecutions]. [Semaphore.withPermit] acquires
+     * before the block and releases in a finally — exception-safe by construction.
      *
      * ### Delivery guarantee: at-least-once
      *
@@ -194,12 +196,9 @@ class ScheduledPromptExecutor(
                         "[Executor] Phase B: claimed UserRun=${userRun.id} runId=${userRun.runId} userId=${userRun.userId}"
                     }
 
-                    semaphore.acquire()
                     launch {
-                        try {
+                        semaphore.withPermit {
                             executeUserRun(userRun)
-                        } finally {
-                            semaphore.release()
                         }
                     }
 
@@ -345,11 +344,10 @@ class ScheduledPromptExecutor(
             val runtime = caseService.findActiveRuntime(caseId)
             if (runtime == null) {
                 // Runtime already evicted (terminal status reached before we got here)
-                closeCaseTerminal(userRun.id, caseId)
+                closeUserRun(userRun.id, caseService.findById(caseId)?.status, caseId)
             } else {
                 awaitCaseCompletion(userRun.id, caseId, runtime)
             }
-
         } catch (e: Exception) {
             logger.error(e) {
                 "[Executor] UserRun=${userRun.id} failed during Case creation/launch for user=$userId"
@@ -358,18 +356,22 @@ class ScheduledPromptExecutor(
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Case completion
+    // -------------------------------------------------------------------------
+
     /**
-     * Collect the runtime's [statusFlow] until the Case reaches IDLE or a terminal status.
+     * Collect the runtime's [CaseRuntime.statusFlow] until the Case reaches IDLE or a terminal status.
      *
-     * Replaces the former polling loop: [kotlinx.coroutines.flow.StateFlow.first] suspends
-     * reactively until the predicate matches — zero polling, zero delay. The lease duration
-     * is enforced via [withTimeoutOrNull]; on timeout the UserRun is marked FAILED and the
-     * next tick's [claimBatch] will reclaim expired RUNNING UserRuns.
+     * [kotlinx.coroutines.flow.StateFlow.first] suspends reactively until the predicate
+     * matches — zero polling, zero delay. The lease duration is enforced via
+     * [withTimeoutOrNull]; on timeout the UserRun is marked FAILED and the next tick's
+     * [claimBatch] will reclaim expired RUNNING UserRuns.
      */
     private suspend fun awaitCaseCompletion(
         userRunId: UUID,
         caseId: UUID,
-        runtime: io.whozoss.agentos.caseFlow.CaseRuntime,
+        runtime: CaseRuntime,
     ) {
         val leaseMs = Duration.ofMinutes(properties.leaseMinutes).toMillis()
 
@@ -377,61 +379,30 @@ class ScheduledPromptExecutor(
             runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
         }
 
-        val now = Instant.now(clock)
-        when {
-            finalStatus == null -> {
-                logger.warn {
-                    "[Executor] UserRun=$userRunId lease expired while waiting for Case $caseId — marking FAILED"
-                }
-                markFailed(userRunId, now, "Lease expired waiting for Case $caseId")
+        if (finalStatus == null) {
+            logger.warn {
+                "[Executor] UserRun=$userRunId lease expired while waiting for Case $caseId — marking FAILED"
             }
-            finalStatus.isTerminal() -> {
-                val terminalUserRunStatus = when (finalStatus) {
-                    CaseStatus.KILLED, CaseStatus.ERROR -> UserRunStatus.FAILED
-                    else -> UserRunStatus.DONE
-                }
-                val error = if (terminalUserRunStatus == UserRunStatus.FAILED) {
-                    "Case reached terminal status $finalStatus"
-                } else {
-                    null
-                }
-                userRunRepository.markTerminal(userRunId, terminalUserRunStatus, now, error)
-                logger.info {
-                    "[Executor] UserRun=$userRunId closed as $terminalUserRunStatus " +
-                        "(caseId=$caseId status=$finalStatus)"
-                }
-            }
-            else -> {
-                // IDLE — agent turn complete
-                userRunRepository.markTerminal(userRunId, UserRunStatus.DONE, now)
-                logger.info {
-                    "[Executor] UserRun=$userRunId closed as DONE (caseId=$caseId IDLE)"
-                }
-            }
+            markFailed(userRunId, Instant.now(clock), "Lease expired waiting for Case $caseId")
+        } else {
+            closeUserRun(userRunId, finalStatus, caseId)
         }
     }
 
     /**
-     * Close a UserRun when the runtime was already evicted before we could collect its flow.
-     * Falls back to reading the persisted Case status.
+     * Close a UserRun based on the final [CaseStatus].
+     *
+     * Maps [CaseStatus] to [UserRunStatus] via [toUserRunOutcome]:
+     * - IDLE or any non-error terminal → DONE
+     * - KILLED, ERROR → FAILED with diagnostic message
+     * - null (Case not found) → DONE (defensive, Case was likely cleaned up)
      */
-    private fun closeCaseTerminal(userRunId: UUID, caseId: UUID) {
+    private fun closeUserRun(userRunId: UUID, caseStatus: CaseStatus?, caseId: UUID) {
         val now = Instant.now(clock)
-        val case = caseService.findById(caseId)
-        val caseStatus = case?.status
-        val terminalUserRunStatus = when (caseStatus) {
-            CaseStatus.KILLED, CaseStatus.ERROR -> UserRunStatus.FAILED
-            else -> UserRunStatus.DONE
-        }
-        val error = if (terminalUserRunStatus == UserRunStatus.FAILED) {
-            "Case reached terminal status $caseStatus"
-        } else {
-            null
-        }
-        userRunRepository.markTerminal(userRunId, terminalUserRunStatus, now, error)
+        val (userRunStatus, error) = caseStatus.toUserRunOutcome()
+        userRunRepository.markTerminal(userRunId, userRunStatus, now, error)
         logger.info {
-            "[Executor] UserRun=$userRunId closed as $terminalUserRunStatus " +
-                "(caseId=$caseId status=$caseStatus, runtime already evicted)"
+            "[Executor] UserRun=$userRunId closed as $userRunStatus (caseId=$caseId status=$caseStatus)"
         }
     }
 
@@ -488,5 +459,16 @@ class ScheduledPromptExecutor(
         }
     }
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        /**
+         * Maps a [CaseStatus] (possibly null when the Case was already cleaned up)
+         * to the corresponding [UserRunStatus] and optional error message.
+         */
+        private fun CaseStatus?.toUserRunOutcome(): Pair<UserRunStatus, String?> = when (this) {
+            CaseStatus.KILLED, CaseStatus.ERROR ->
+                UserRunStatus.FAILED to "Case reached terminal status $this"
+            else ->
+                UserRunStatus.DONE to null
+        }
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRun.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRun.kt
@@ -23,7 +23,7 @@ enum class RunStatus {
  * Represents a single execution attempt of a [ScheduledPrompt].
  *
  * One [ScheduledPromptRun] is created per scheduler tick that processes a given prompt.
- * The [slotKey] = `"$scheduledPromptId|$scheduledFor"` is UNIQUE in Neo4j — it acts as an
+ * A composite UNIQUE constraint on `(scheduledPromptId, scheduledFor)` in Neo4j acts as an
  * optimistic distributed lock preventing duplicate firings for the same slot.
  *
  * ### Lifecycle

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNode.kt
@@ -14,11 +14,11 @@ import java.util.UUID
 /**
  * Spring Data Neo4j projection for [ScheduledPromptRun].
  *
- * ### slotKey
+ * ### Uniqueness
  *
- * Denormalised unique discriminator: `"$scheduledPromptId|$scheduledForEpochMilli"`. The UNIQUE
- * constraint on [slotKey] acts as the distributed lock preventing double-firing for the same slot.
- * Inserting a duplicate throws a [DuplicateRunException] in [Neo4jScheduledPromptRunRepository].
+ * A composite UNIQUE constraint on `(scheduledPromptId, scheduledFor)` acts as the
+ * distributed lock preventing double-firing for the same slot. Inserting a duplicate
+ * throws a [DuplicateRunException] in [Neo4jScheduledPromptRunRepository].
  *
  * ### Soft-delete
  *
@@ -35,8 +35,6 @@ data class ScheduledPromptRunNode(
     val attempt: Int = 0,
     val finishedAt: Instant? = null,
     val error: String? = null,
-    /** Unique slot key: "$scheduledPromptId|$scheduledForEpochMilli" */
-    val slotKey: String,
     @Version val version: Long? = null,
     @CreatedDate val created: Instant = Instant.now(),
     @CreatedBy val createdBy: String? = null,
@@ -65,9 +63,6 @@ data class ScheduledPromptRunNode(
         )
 
     companion object {
-        fun slotKey(scheduledPromptId: UUID, scheduledFor: Instant): String =
-            "$scheduledPromptId|${scheduledFor.toEpochMilli()}"
-
         fun fromDomain(run: ScheduledPromptRun): ScheduledPromptRunNode =
             ScheduledPromptRunNode(
                 id = run.id.toString(),
@@ -78,7 +73,6 @@ data class ScheduledPromptRunNode(
                 attempt = run.attempt,
                 finishedAt = run.finishedAt,
                 error = run.error,
-                slotKey = slotKey(run.scheduledPromptId, run.scheduledFor),
                 version = run.metadata.version,
                 created = run.metadata.created,
                 createdBy = run.metadata.createdBy,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -60,4 +60,26 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     @Query($$"MATCH (r:ScheduledPromptRun) WHERE r.status = $status AND r.created < $before RETURN r ORDER BY r.created")
     fun findByStatusAndCreatedBefore(status: String, before: Instant): List<ScheduledPromptRunNode>
 
+    /**
+     * Find RUNNING Runs whose UserRuns are all terminal (none in PENDING or RUNNING).
+     *
+     * A Run qualifies when it is in RUNNING status, not removed, and has no UserRun
+     * in PENDING or RUNNING status. Runs with zero UserRuns never reach RUNNING status
+     * (they are transitioned directly to DONE in [ScheduledPromptExecutor.materialize]).
+     */
+    @Query(
+        """
+        MATCH (r:ScheduledPromptRun)
+        WHERE r.status = 'RUNNING'
+          AND NOT COALESCE(r.removed, false)
+          AND NOT EXISTS {
+              MATCH (ur:ScheduledPromptUserRun)
+              WHERE ur.runId = r.id AND ur.status IN ['PENDING', 'RUNNING']
+          }
+        RETURN r
+        ORDER BY r.created
+        """,
+    )
+    fun findSettledRunning(): List<ScheduledPromptRunNode>
+
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -40,4 +40,18 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     )
     fun updateStatus(id: String, status: String, finishedAt: Instant?, error: String?, now: Instant): Int
 
+    /**
+     * Count non-SKIPPED runs for a given ScheduledPrompt.
+     */
+    @Query(
+        $$"""
+        MATCH (r:ScheduledPromptRun)
+        WHERE r.scheduledPromptId = $scheduledPromptId
+          AND r.status <> 'SKIPPED'
+          AND NOT COALESCE(r.removed, false)
+        RETURN count(r)
+        """,
+    )
+    fun countCompletedRuns(scheduledPromptId: String): Int
+
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -54,4 +54,10 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     )
     fun countCompletedRuns(scheduledPromptId: String): Int
 
+    /**
+     * Find all runs in [status] created before [before], ordered by creation time.
+     */
+    @Query($$"MATCH (r:ScheduledPromptRun) WHERE r.status = $status AND r.created < $before RETURN r ORDER BY r.created")
+    fun findByStatusAndCreatedBefore(status: String, before: Instant): List<ScheduledPromptRunNode>
+
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.scheduledPrompt
 
 import org.springframework.data.neo4j.repository.Neo4jRepository
 import org.springframework.data.neo4j.repository.query.Query
+import java.time.Instant
 
 /**
  * Spring Data Neo4j repository for [ScheduledPromptRunNode].
@@ -22,4 +23,21 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
         """,
     )
     fun existsActiveByScheduledPromptId(scheduledPromptId: String): Boolean
+
+    /**
+     * Update status (and optionally finishedAt + error) of a Run by id.
+     * Returns the count of updated nodes (0 if not found).
+     */
+    @Query(
+        $$"""
+        MATCH (r:ScheduledPromptRun {id: $id})
+        SET r.status = $status,
+            r.finishedAt = $finishedAt,
+            r.error = $error,
+            r.modified = $now
+        RETURN count(r)
+        """,
+    )
+    fun updateStatus(id: String, status: String, finishedAt: Instant?, error: String?, now: Instant): Int
+
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -57,4 +57,17 @@ interface ScheduledPromptRunRepository {
      * to unblock the overlap guard and leave a diagnostic trace.
      */
     fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun>
+
+    /**
+     * Find RUNNING Runs whose UserRuns are ALL in a terminal status (DONE or FAILED).
+     *
+     * A Run is "settled" when none of its UserRuns are in PENDING or RUNNING status.
+     * Runs with zero UserRuns (platform-scope or no target users) are directly transitioned
+     * to DONE in [ScheduledPromptExecutor.materialize] and never reach RUNNING status.
+     *
+     * These Runs are presumed orphaned — the instance that processed the last UserRun
+     * crashed after [ScheduledPromptUserRunRepository.markTerminal] but before
+     * [ScheduledPromptExecutor]'s `checkCompletion()` could transition the parent Run.
+     */
+    fun findSettledRunning(): List<ScheduledPromptRun>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -41,4 +41,11 @@ interface ScheduledPromptRunRepository {
 
     /** Find a single Run by its id, or null if not found. */
     fun findById(id: UUID): ScheduledPromptRun?
+
+    /**
+     * Count completed (non-SKIPPED) runs for a given ScheduledPrompt.
+     * Counts DONE, FAILED, CLAIMED, and RUNNING — everything except SKIPPED,
+     * since SKIPPED runs are overlap-guards that never actually executed.
+     */
+    fun countCompletedRuns(scheduledPromptId: UUID): Int
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -48,4 +48,13 @@ interface ScheduledPromptRunRepository {
      * since SKIPPED runs are overlap-guards that never actually executed.
      */
     fun countCompletedRuns(scheduledPromptId: UUID): Int
+
+    /**
+     * Find all Runs in CLAIMED status created before [olderThan].
+     *
+     * These are presumed orphaned — the instance that inserted them crashed before
+     * calling [ScheduledPromptExecutor.materialize]. The caller marks them FAILED
+     * to unblock the overlap guard and leave a diagnostic trace.
+     */
+    fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -16,7 +16,7 @@ interface ScheduledPromptRunRepository {
      * Persist a new [ScheduledPromptRun].
      *
      * @throws DuplicateRunException if a run for the same `(scheduledPromptId, scheduledFor)` slot
-     *   already exists (UNIQUE constraint on [ScheduledPromptRunNode.slotKey]).
+     *   already exists (composite UNIQUE constraint on those two fields).
      */
     fun insert(run: ScheduledPromptRun): ScheduledPromptRun
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.scheduledPrompt
 
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -24,4 +25,20 @@ interface ScheduledPromptRunRepository {
      * (CLAIMED or RUNNING). Used to detect overlapping executions.
      */
     fun hasActive(scheduledPromptId: UUID): Boolean
+
+    /**
+     * Update the status of a Run, optionally setting [finishedAt] and [error].
+     *
+     * Returns true if the update was applied (the Run existed and was not already in the
+     * target status), false otherwise.
+     */
+    fun updateStatus(
+        id: UUID,
+        status: RunStatus,
+        finishedAt: Instant? = null,
+        error: String? = null,
+    ): Boolean
+
+    /** Find a single Run by its id, or null if not found. */
+    fun findById(id: UUID): ScheduledPromptRun?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunSchemaInitializer.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunSchemaInitializer.kt
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component
  * Idempotent Neo4j schema initialiser for [ScheduledPromptRun].
  *
  * Creates:
- * - A UNIQUE constraint on [ScheduledPromptRunNode.slotKey] to prevent double-firing for the
- *   same `(scheduledPromptId, scheduledFor)` slot.
+ * - A composite UNIQUE constraint on `(scheduledPromptId, scheduledFor)` to prevent
+ *   double-firing for the same slot.
  * - Auxiliary indexes on [ScheduledPromptRunNode.scheduledPromptId] and
  *   [ScheduledPromptRunNode.status] to back the [ScheduledPromptRunNodeNeo4jRepository.existsActiveByScheduledPromptId]
  *   query.
@@ -26,18 +26,18 @@ class ScheduledPromptRunSchemaInitializer(
     private val neo4jClient: Neo4jClient,
 ) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
-        ensureSlotKeyUniqueConstraint()
+        ensureSlotUniqueConstraint()
         ensureScheduledPromptIdIndex()
         ensureStatusIndex()
     }
 
-    private fun ensureSlotKeyUniqueConstraint() {
+    private fun ensureSlotUniqueConstraint() {
         neo4jClient
             .query(
-                "CREATE CONSTRAINT scheduled_prompt_run_slot_key_unique IF NOT EXISTS " +
-                    "FOR (r:ScheduledPromptRun) REQUIRE r.slotKey IS UNIQUE",
+                "CREATE CONSTRAINT scheduled_prompt_run_slot_unique IF NOT EXISTS " +
+                    "FOR (r:ScheduledPromptRun) REQUIRE (r.scheduledPromptId, r.scheduledFor) IS UNIQUE",
             ).run()
-        logger.info { "[ScheduledPromptRunSchema] constraint 'scheduled_prompt_run_slot_key_unique' ensured" }
+        logger.info { "[ScheduledPromptRunSchema] constraint 'scheduled_prompt_run_slot_unique' ensured" }
     }
 
     private fun ensureScheduledPromptIdIndex() {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptServiceImpl.kt
@@ -230,26 +230,17 @@ class ScheduledPromptServiceImpl(
         try {
             repository.save(entity)
         } catch (e: DataIntegrityViolationException) {
-            if (!isTripleKeyConflict(e)) throw e
+            // The only UNIQUE constraint on ScheduledPrompt is tripleKey (namespaceId, userId, name).
+            // Any DataIntegrityViolationException from save is a name conflict in this scope.
             logger.warn {
                 "[ScheduledPromptService] tripleKey conflict (ns=${entity.namespaceId}, user=${entity.userId}, name='${entity.name}')"
             }
             throw ConflictException(conflictMessage(entity), e)
         }
 
-    private fun isTripleKeyConflict(e: DataIntegrityViolationException): Boolean {
-        val haystack = generateSequence<Throwable>(e) { it.cause }
-            .mapNotNull { it.message }
-            .joinToString(separator = " | ")
-        return TRIPLE_KEY_CONSTRAINT_NAME in haystack || TRIPLE_KEY_PROPERTY in haystack
-    }
-
     private fun conflictMessage(entity: ScheduledPrompt): String =
         "A ScheduledPrompt named '${entity.name}' already exists in this scope " +
             "(namespaceId=${entity.namespaceId ?: "platform"}, userId=${entity.userId})"
 
-    companion object : KLogging() {
-        private const val TRIPLE_KEY_CONSTRAINT_NAME = "scheduled_prompt_triple_key_unique"
-        private const val TRIPLE_KEY_PROPERTY = "tripleKey"
-    }
+    companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRun.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRun.kt
@@ -13,6 +13,12 @@ enum class UserRunStatus {
     RUNNING,
     /** Case reached a terminal status (IDLE or KILLED). */
     DONE,
+    /**
+     * Monitoring was released before the Case finished — [ScheduledPromptExecutor.monitorLaunch]
+     * reached [SchedulerProperties.launchTimeoutSeconds] while the Case was still RUNNING.
+     * The Case continues executing independently; the UserRun is closed for audit purposes.
+     */
+    TIMEOUT,
     /** Execution failed (Case creation, permission grant, or Case ERROR). */
     FAILED,
 }
@@ -27,6 +33,7 @@ enum class UserRunStatus {
  * ### Lifecycle
  *
  * PENDING → RUNNING → DONE (happy path)
+ *                   → TIMEOUT (monitoring released; Case still running)
  *                   → FAILED (execution error)
  *
  * RUNNING entries whose [leaseUntil] has expired are re-claimed by the next tick

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRun.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRun.kt
@@ -21,7 +21,7 @@ enum class UserRunStatus {
  * Tracks the execution of a single [ScheduledPromptRun] for a single target user.
  *
  * One [ScheduledPromptUserRun] is created per `(run, user)` pair during the materialization
- * phase. The [userRunKey] = `"$runId|$userId"` is UNIQUE in Neo4j — it acts as a distributed
+ * phase. A composite UNIQUE constraint on `(runId, userId)` in Neo4j acts as a distributed
  * lock preventing duplicate per-user launches.
  *
  * ### Lifecycle

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRun.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRun.kt
@@ -1,0 +1,55 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.whozoss.agentos.sdk.entity.Entity
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import java.time.Instant
+import java.util.UUID
+
+/** Lifecycle status of a single [ScheduledPromptUserRun]. */
+enum class UserRunStatus {
+    /** Materialised by the scheduler; not yet processed. */
+    PENDING,
+    /** Case created and agent is executing; a lease is held to detect crashes. */
+    RUNNING,
+    /** Case reached a terminal status (IDLE or KILLED). */
+    DONE,
+    /** Execution failed (Case creation, permission grant, or Case ERROR). */
+    FAILED,
+}
+
+/**
+ * Tracks the execution of a single [ScheduledPromptRun] for a single target user.
+ *
+ * One [ScheduledPromptUserRun] is created per `(run, user)` pair during the materialization
+ * phase. The [userRunKey] = `"$runId|$userId"` is UNIQUE in Neo4j — it acts as a distributed
+ * lock preventing duplicate per-user launches.
+ *
+ * ### Lifecycle
+ *
+ * PENDING → RUNNING → DONE (happy path)
+ *                   → FAILED (execution error)
+ *
+ * RUNNING entries whose [leaseUntil] has expired are re-claimed by the next tick
+ * (crash-recovery without a separate ApplicationRunner).
+ *
+ * ### Immutability
+ *
+ * Like [ScheduledPromptRun], this is an append-only audit record. Only [status],
+ * [error], [startedAt], [finishedAt], and [leaseUntil] are ever mutated after creation.
+ */
+data class ScheduledPromptUserRun(
+    override val metadata: EntityMetadata = EntityMetadata(),
+    /** Parent [ScheduledPromptRun]. */
+    val runId: UUID,
+    /** Target user. */
+    val userId: UUID,
+    val status: UserRunStatus,
+    /** Error message if FAILED. */
+    val error: String? = null,
+    /** When the Case was created (transition to RUNNING). */
+    val startedAt: Instant? = null,
+    /** When the Case reached a terminal status (transition to DONE/FAILED). */
+    val finishedAt: Instant? = null,
+    /** Lease expiry for the RUNNING status; used to detect crashes and re-claim stale entries. */
+    val leaseUntil: Instant? = null,
+) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNode.kt
@@ -1,0 +1,97 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.annotation.Version
+import org.springframework.data.neo4j.core.schema.Id
+import org.springframework.data.neo4j.core.schema.Node
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Spring Data Neo4j projection for [ScheduledPromptUserRun].
+ *
+ * ### userRunKey
+ *
+ * Denormalised unique discriminator: `"$runId|$userId"`. The UNIQUE constraint on [userRunKey]
+ * acts as the distributed lock preventing duplicate per-user launches within the same Run.
+ * The [materialize][ScheduledPromptUserRunNodeNeo4jRepository.materialize] Cypher uses MERGE,
+ * so duplicates are silently absorbed — no exception is thrown.
+ *
+ * ### leaseUntil
+ *
+ * Populated when [status] = `"RUNNING"`. The next tick's [findClaimable][ScheduledPromptUserRunNodeNeo4jRepository.findClaimable]
+ * query will pick up entries whose lease has expired, providing crash recovery without a
+ * separate ApplicationRunner.
+ *
+ * ### Soft-delete
+ *
+ * UserRuns are never soft-deleted — they are immutable audit records. [removed] is kept for
+ * structural consistency with the entity framework but is always null.
+ */
+@Node("ScheduledPromptUserRun")
+data class ScheduledPromptUserRunNode(
+    @Id val id: String,
+    val runId: String,
+    val userId: String,
+    val status: String,
+    val error: String? = null,
+    val startedAt: Instant? = null,
+    val finishedAt: Instant? = null,
+    /** Lease expiry for RUNNING status; null for non-RUNNING entries. */
+    val leaseUntil: Instant? = null,
+    /** UNIQUE constraint key: "$runId|$userId". */
+    val userRunKey: String,
+    @Version val version: Long? = null,
+    @CreatedDate val created: Instant = Instant.now(),
+    @CreatedBy val createdBy: String? = null,
+    @LastModifiedDate val modified: Instant = Instant.now(),
+    @LastModifiedBy val modifiedBy: String? = null,
+    val removed: Boolean? = null,
+) {
+    fun toDomain(): ScheduledPromptUserRun =
+        ScheduledPromptUserRun(
+            metadata = EntityMetadata(
+                id = UUID.fromString(id),
+                created = created,
+                createdBy = createdBy,
+                modified = modified,
+                modifiedBy = modifiedBy,
+                removed = removed ?: false,
+                version = version,
+            ),
+            runId = UUID.fromString(runId),
+            userId = UUID.fromString(userId),
+            status = UserRunStatus.valueOf(status),
+            error = error,
+            startedAt = startedAt,
+            finishedAt = finishedAt,
+            leaseUntil = leaseUntil,
+        )
+
+    companion object {
+        fun userRunKey(runId: UUID, userId: UUID): String = "$runId|$userId"
+
+        fun fromDomain(userRun: ScheduledPromptUserRun): ScheduledPromptUserRunNode =
+            ScheduledPromptUserRunNode(
+                id = userRun.id.toString(),
+                runId = userRun.runId.toString(),
+                userId = userRun.userId.toString(),
+                status = userRun.status.name,
+                error = userRun.error,
+                startedAt = userRun.startedAt,
+                finishedAt = userRun.finishedAt,
+                leaseUntil = userRun.leaseUntil,
+                userRunKey = userRunKey(userRun.runId, userRun.userId),
+                version = userRun.metadata.version,
+                created = userRun.metadata.created,
+                createdBy = userRun.metadata.createdBy,
+                modified = userRun.metadata.modified,
+                modifiedBy = userRun.metadata.modifiedBy,
+                removed = userRun.metadata.removed.takeIf { it },
+            )
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNode.kt
@@ -14,12 +14,12 @@ import java.util.UUID
 /**
  * Spring Data Neo4j projection for [ScheduledPromptUserRun].
  *
- * ### userRunKey
+ * ### Uniqueness
  *
- * Denormalised unique discriminator: `"$runId|$userId"`. The UNIQUE constraint on [userRunKey]
- * acts as the distributed lock preventing duplicate per-user launches within the same Run.
- * The [materialize][ScheduledPromptUserRunNodeNeo4jRepository.materialize] Cypher uses MERGE,
- * so duplicates are silently absorbed — no exception is thrown.
+ * A composite UNIQUE constraint on `(runId, userId)` acts as the distributed lock
+ * preventing duplicate per-user launches within the same Run. The
+ * [materialize][ScheduledPromptUserRunNodeNeo4jRepository.materialize] Cypher uses MERGE
+ * on these two fields, so duplicates are silently absorbed — no exception is thrown.
  *
  * ### leaseUntil
  *
@@ -43,8 +43,6 @@ data class ScheduledPromptUserRunNode(
     val finishedAt: Instant? = null,
     /** Lease expiry for RUNNING status; null for non-RUNNING entries. */
     val leaseUntil: Instant? = null,
-    /** UNIQUE constraint key: "$runId|$userId". */
-    val userRunKey: String,
     @Version val version: Long? = null,
     @CreatedDate val created: Instant = Instant.now(),
     @CreatedBy val createdBy: String? = null,
@@ -73,8 +71,6 @@ data class ScheduledPromptUserRunNode(
         )
 
     companion object {
-        fun userRunKey(runId: UUID, userId: UUID): String = "$runId|$userId"
-
         fun fromDomain(userRun: ScheduledPromptUserRun): ScheduledPromptUserRunNode =
             ScheduledPromptUserRunNode(
                 id = userRun.id.toString(),
@@ -85,7 +81,6 @@ data class ScheduledPromptUserRunNode(
                 startedAt = userRun.startedAt,
                 finishedAt = userRun.finishedAt,
                 leaseUntil = userRun.leaseUntil,
-                userRunKey = userRunKey(userRun.runId, userRun.userId),
                 version = userRun.metadata.version,
                 created = userRun.metadata.created,
                 createdBy = userRun.metadata.createdBy,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
@@ -89,15 +89,34 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
     )
     fun countByRunIdAndStatuses(runId: String, statuses: List<String>): Int
 
-    /** Returns true if at least one UserRun for [runId] has status FAILED. */
+    /**
+     * Returns a single UserRun for [runId] that is still active (PENDING or RUNNING),
+     * or null if none exists. LIMIT 1 lets Neo4j stop at the first match.
+     * The caller maps non-null → true.
+     */
+    @Query(
+        $$"""
+        MATCH (ur:ScheduledPromptUserRun)
+        WHERE ur.runId = $runId
+          AND ur.status IN ['PENDING', 'RUNNING']
+          AND NOT COALESCE(ur.removed, false)
+        RETURN ur LIMIT 1
+        """,
+    )
+    fun findOneActive(runId: String): ScheduledPromptUserRunNode?
+
+    /**
+     * Returns a single FAILED UserRun for [runId], or null if none exists.
+     * LIMIT 1 lets Neo4j stop at the first match. The caller maps non-null → true.
+     */
     @Query(
         $$"""
         MATCH (ur:ScheduledPromptUserRun)
         WHERE ur.runId = $runId
           AND ur.status = 'FAILED'
           AND NOT COALESCE(ur.removed, false)
-        RETURN count(ur) > 0
+        RETURN ur LIMIT 1
         """,
     )
-    fun hasAnyFailed(runId: String): Boolean
+    fun findOneFailed(runId: String): ScheduledPromptUserRunNode?
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
@@ -1,0 +1,103 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import org.springframework.data.neo4j.repository.Neo4jRepository
+import org.springframework.data.neo4j.repository.query.Query
+import java.time.Instant
+
+/**
+ * Spring Data Neo4j repository for [ScheduledPromptUserRunNode].
+ */
+interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromptUserRunNode, String> {
+
+    /**
+     * Traverses the deployment graph and materialises PENDING UserRuns in a single query.
+     *
+     * Finds all non-removed Users that are MEMBER or ADMIN of any UserGroup to which
+     * [agentConfigId] is DEPLOYED_TO within [namespaceId], then MERGEs a PENDING
+     * [ScheduledPromptUserRunNode] for each distinct user.
+     *
+     * Safe to replay on crash — MERGE is idempotent on the UNIQUE `userRunKey` constraint.
+     *
+     * Returns the number of UserRuns created (0 when all already existed or no users found).
+     */
+    @Query(
+        $$"""
+        MATCH (a:AgentConfig {id: $agentConfigId})-[:DEPLOYED_TO]->(g:UserGroup)
+        MATCH (g)-[:BELONGS_TO]->(ns:Namespace {id: $namespaceId})
+        MATCH (u:User)-[:MEMBER|ADMIN]->(g)
+        WHERE NOT COALESCE(a.removed, false)
+          AND NOT COALESCE(g.removed, false)
+          AND NOT COALESCE(u.removed, false)
+        WITH DISTINCT u.id AS userId
+        MERGE (ur:ScheduledPromptUserRun {userRunKey: $runId + '|' + userId})
+        ON CREATE SET
+            ur.id         = randomUUID(),
+            ur.runId      = $runId,
+            ur.userId     = userId,
+            ur.status     = 'PENDING',
+            ur.userRunKey = $runId + '|' + userId,
+            ur.version    = 0,
+            ur.created    = datetime(),
+            ur.modified   = datetime(),
+            ur.removed    = null
+        RETURN count(ur)
+        """,
+    )
+    fun materialize(runId: String, agentConfigId: String, namespaceId: String): Int
+
+    /**
+     * Read-only query returning up to [limit] claimable UserRuns, ordered oldest-first.
+     *
+     * "Claimable" means:
+     * - status = 'PENDING', OR
+     * - status = 'RUNNING' AND leaseUntil < now (expired lease — crash recovery).
+     *
+     * The caller (Neo4jScheduledPromptUserRunRepository.claimBatch) transitions each node
+     * to RUNNING via SDN `save()`, which enforces the `@Version` optimistic lock and
+     * prevents two instances from claiming the same entry.
+     */
+    @Query(
+        $$"""
+        MATCH (ur:ScheduledPromptUserRun)
+        WHERE (ur.status = 'PENDING' OR (ur.status = 'RUNNING' AND ur.leaseUntil < $now))
+          AND NOT COALESCE(ur.removed, false)
+        RETURN ur ORDER BY ur.created ASC LIMIT $limit
+        """,
+    )
+    fun findClaimable(now: Instant, limit: Int): List<ScheduledPromptUserRunNode>
+
+    /** All UserRuns for a given Run, ordered by creation time. */
+    @Query(
+        $$"""
+        MATCH (ur:ScheduledPromptUserRun)
+        WHERE ur.runId = $runId
+          AND NOT COALESCE(ur.removed, false)
+        RETURN ur ORDER BY ur.created ASC
+        """,
+    )
+    fun findByRunId(runId: String): List<ScheduledPromptUserRunNode>
+
+    /** Count of UserRuns for [runId] in one of the given statuses. */
+    @Query(
+        $$"""
+        MATCH (ur:ScheduledPromptUserRun)
+        WHERE ur.runId = $runId
+          AND ur.status IN $statuses
+          AND NOT COALESCE(ur.removed, false)
+        RETURN count(ur)
+        """,
+    )
+    fun countByRunIdAndStatuses(runId: String, statuses: List<String>): Int
+
+    /** Returns true if at least one UserRun for [runId] has status FAILED. */
+    @Query(
+        $$"""
+        MATCH (ur:ScheduledPromptUserRun)
+        WHERE ur.runId = $runId
+          AND ur.status = 'FAILED'
+          AND NOT COALESCE(ur.removed, false)
+        RETURN count(ur) > 0
+        """,
+    )
+    fun hasAnyFailed(runId: String): Boolean
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
@@ -27,7 +27,7 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
      * Both paths are resolved via OPTIONAL MATCH and collected into a single set.
      * Then MERGEs a PENDING [ScheduledPromptUserRunNode] for each distinct eligible user.
      *
-     * Safe to replay on crash — MERGE is idempotent on the UNIQUE `userRunKey` constraint.
+     * Safe to replay on crash — MERGE is idempotent on the composite UNIQUE `(runId, userId)` constraint.
      *
      * Returns the number of UserRuns created (0 when all already existed or no users found).
      */
@@ -51,17 +51,14 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
                 )
             )
         WITH DISTINCT u.id AS userId
-        MERGE (ur:ScheduledPromptUserRun {userRunKey: $runId + '|' + userId})
+        MERGE (ur:ScheduledPromptUserRun {runId: $runId, userId: userId})
         ON CREATE SET
-            ur.id         = randomUUID(),
-            ur.runId      = $runId,
-            ur.userId     = userId,
-            ur.status     = 'PENDING',
-            ur.userRunKey = $runId + '|' + userId,
-            ur.version    = 0,
-            ur.created    = datetime(),
-            ur.modified   = datetime(),
-            ur.removed    = null
+            ur.id       = randomUUID(),
+            ur.status   = 'PENDING',
+            ur.version  = 0,
+            ur.created  = datetime(),
+            ur.modified = datetime(),
+            ur.removed  = null
         RETURN count(ur)
         """,
     )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
@@ -12,9 +12,20 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
     /**
      * Traverses the deployment graph and materialises PENDING UserRuns in a single query.
      *
-     * Finds all non-removed Users that are MEMBER or ADMIN of any UserGroup to which
-     * [agentConfigId] is DEPLOYED_TO within [namespaceId], then MERGEs a PENDING
-     * [ScheduledPromptUserRunNode] for each distinct user.
+     * Resolves all non-removed Users that are **deployment targets** of [agentConfigId]
+     * in [namespaceId] via two paths:
+     *
+     * 1. **UserGroup deployment**: `AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User`,
+     *    where the UserGroup `[:BELONGS_TO]` the namespace.
+     * 2. **Namespace deployment**: `AgentConfig -[:DEPLOYED_TO]-> Namespace <-[:MEMBER|ADMIN]- User`.
+     *
+     * Super-admins are intentionally **excluded** unless they are also members of a
+     * deployed UserGroup or namespace. `isAdmin` grants the ability to *use* any agent
+     * (access control), but scheduled prompts target users who are *deployed to* the
+     * agent — being an admin is not the same as being a target audience.
+     *
+     * Both paths are resolved via OPTIONAL MATCH and collected into a single set.
+     * Then MERGEs a PENDING [ScheduledPromptUserRunNode] for each distinct eligible user.
      *
      * Safe to replay on crash — MERGE is idempotent on the UNIQUE `userRunKey` constraint.
      *
@@ -22,12 +33,23 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
      */
     @Query(
         $$"""
-        MATCH (a:AgentConfig {id: $agentConfigId})-[:DEPLOYED_TO]->(g:UserGroup)
-        MATCH (g)-[:BELONGS_TO]->(ns:Namespace {id: $namespaceId})
-        MATCH (u:User)-[:MEMBER|ADMIN]->(g)
-        WHERE NOT COALESCE(a.removed, false)
-          AND NOT COALESCE(g.removed, false)
-          AND NOT COALESCE(u.removed, false)
+        MATCH (a:AgentConfig {id: $agentConfigId})
+          WHERE NOT COALESCE(a.removed, false) AND a.enabled = true
+        MATCH (ns:Namespace {id: $namespaceId})
+          WHERE NOT COALESCE(ns.removed, false)
+        MATCH (u:User)
+          WHERE NOT COALESCE(u.removed, false)
+            AND (
+                EXISTS {
+                    MATCH (u)-[:MEMBER|ADMIN]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+                    WHERE NOT COALESCE(g.removed, false)
+                    MATCH (a)-[:DEPLOYED_TO]->(g)
+                }
+                OR (
+                    EXISTS { MATCH (a)-[:DEPLOYED_TO]->(ns) }
+                    AND EXISTS { MATCH (u)-[:MEMBER|ADMIN]->(ns) }
+                )
+            )
         WITH DISTINCT u.id AS userId
         MERGE (ur:ScheduledPromptUserRun {userRunKey: $runId + '|' + userId})
         ON CREATE SET

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
@@ -1,0 +1,91 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Repository for [ScheduledPromptUserRun] persistence.
+ *
+ * Intentionally does not extend [io.whozoss.agentos.sdk.entity.EntityRepository] because
+ * UserRuns are append-only audit records, not editable entities — same as
+ * [ScheduledPromptRunRepository].
+ *
+ * ### Concurrency contract
+ *
+ * [materialize] resolves target users via a single Cypher INSERT-SELECT that traverses the
+ * deployment graph and MERGEs PENDING UserRuns atomically. Safe to replay on crash — MERGE
+ * is idempotent on the UNIQUE `userRunKey` constraint.
+ *
+ * [claimBatch] reads candidates via a read-only query then saves each via SDN with the
+ * [ScheduledPromptUserRunNode.version] optimistic lock, so concurrent instances cannot
+ * double-claim the same UserRun.
+ *
+ * [markTerminal] uses the [ScheduledPromptUserRunNode.version] optimistic lock; callers must
+ * handle [org.springframework.dao.OptimisticLockingFailureException] when two instances
+ * attempt to close the same UserRun concurrently.
+ *
+ * ### Delivery guarantee: at-least-once
+ *
+ * If an instance crashes after creating a Case but before [markTerminal], the UserRun's
+ * lease expires and a subsequent [claimBatch] reclaims it — potentially creating a
+ * duplicate Case for the same user. This is acceptable for the scheduled-prompt use case
+ * (duplicate conversation, no data corruption). Exactly-once would require an idempotence
+ * key on Case creation (e.g. a UNIQUE constraint on `runId|userId` carried by the Case).
+ */
+interface ScheduledPromptUserRunRepository {
+
+    /**
+     * Traverses the deployment graph and materialises ALL PENDING UserRuns in one query.
+     *
+     * Finds all non-removed Users that are MEMBER or ADMIN of any UserGroup to which
+     * [agentConfigId] is DEPLOYED_TO within [namespaceId], then MERGEs a PENDING
+     * [ScheduledPromptUserRun] for each distinct user.
+     *
+     * Safe to replay on crash — MERGE is idempotent on the UNIQUE `userRunKey` constraint.
+     *
+     * Returns the number of UserRuns created (0 when all already existed or no users found).
+     */
+    fun materialize(runId: UUID, agentConfigId: UUID, namespaceId: UUID): Int
+
+    /**
+     * Claim up to [limit] available UserRuns for execution.
+     *
+     * Selects the oldest PENDING entries, OR RUNNING entries whose [leaseUntil] has expired
+     * (crash recovery), transitions each to RUNNING via SDN `save()` with the `@Version`
+     * optimistic lock. Concurrent instances racing to claim the same UserRun will each get
+     * an [org.springframework.dao.OptimisticLockingFailureException] on the save; those are
+     * silently skipped so only one winner claims each entry.
+     *
+     * Returns an empty list when no claimable UserRuns exist.
+     */
+    fun claimBatch(leaseDuration: Duration, limit: Int): List<ScheduledPromptUserRun>
+
+    /**
+     * Transition a UserRun to a terminal status (DONE or FAILED).
+     *
+     * Populates [ScheduledPromptUserRun.finishedAt] = [now] and [ScheduledPromptUserRun.error]
+     * when [status] is FAILED.
+     *
+     * @throws org.springframework.dao.OptimisticLockingFailureException if the node was
+     *   concurrently modified by another instance (treat as idempotent: it is already closed).
+     */
+    fun markTerminal(
+        id: UUID,
+        status: UserRunStatus,
+        now: Instant,
+        error: String? = null,
+    ): ScheduledPromptUserRun
+
+    /** All UserRuns belonging to the given Run, in creation order. */
+    fun findByRunId(runId: UUID): List<ScheduledPromptUserRun>
+
+    /**
+     * Count of UserRuns for [runId] whose status is one of [statuses].
+     * Used to determine whether the parent Run is complete.
+     */
+    fun countByRunIdAndStatus(runId: UUID, vararg statuses: UserRunStatus): Int
+
+    /** Returns true if at least one UserRun for [runId] is in FAILED status. */
+    fun hasAnyFailed(runId: UUID): Boolean
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
@@ -38,9 +38,14 @@ interface ScheduledPromptUserRunRepository {
     /**
      * Traverses the deployment graph and materialises ALL PENDING UserRuns in one query.
      *
-     * Finds all non-removed Users that are MEMBER or ADMIN of any UserGroup to which
-     * [agentConfigId] is DEPLOYED_TO within [namespaceId], then MERGEs a PENDING
-     * [ScheduledPromptUserRun] for each distinct user.
+     * Resolves all non-removed Users that are deployment targets of [agentConfigId] in
+     * [namespaceId] via two paths:
+     * 1. UserGroup deployment (`AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User`)
+     * 2. Namespace deployment (`AgentConfig -[:DEPLOYED_TO]-> Namespace <-[:MEMBER|ADMIN]- User`)
+     *
+     * Super-admins are excluded unless they are also members of a deployed group/namespace.
+     *
+     * Then MERGEs a PENDING [ScheduledPromptUserRun] for each distinct user.
      *
      * Safe to replay on crash — MERGE is idempotent on the UNIQUE `userRunKey` constraint.
      *

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
@@ -86,6 +86,12 @@ interface ScheduledPromptUserRunRepository {
      */
     fun countByRunIdAndStatus(runId: UUID, vararg statuses: UserRunStatus): Int
 
+    /**
+     * Returns true if at least one UserRun for [runId] is still active (PENDING or RUNNING).
+     * Used as a fast-path exit in completion checks — avoids counting when work is still in flight.
+     */
+    fun hasAnyActive(runId: UUID): Boolean
+
     /** Returns true if at least one UserRun for [runId] is in FAILED status. */
     fun hasAnyFailed(runId: UUID): Boolean
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
@@ -67,10 +67,11 @@ interface ScheduledPromptUserRunRepository {
     fun claimBatch(leaseDuration: Duration, limit: Int): List<ScheduledPromptUserRun>
 
     /**
-     * Transition a UserRun to a terminal status (DONE or FAILED).
+     * Transition a UserRun to a terminal status (DONE, TIMEOUT, or FAILED).
      *
      * Populates [ScheduledPromptUserRun.finishedAt] = [now] and [ScheduledPromptUserRun.error]
-     * when [status] is FAILED.
+     * when [status] is FAILED. For [UserRunStatus.TIMEOUT], [error] is null — the Case is
+     * still running independently; the UserRun is closed only for audit visibility.
      *
      * @throws org.springframework.dao.OptimisticLockingFailureException if the node was
      *   concurrently modified by another instance (treat as idempotent: it is already closed).
@@ -93,10 +94,17 @@ interface ScheduledPromptUserRunRepository {
 
     /**
      * Returns true if at least one UserRun for [runId] is still active (PENDING or RUNNING).
+     * [UserRunStatus.TIMEOUT] is NOT active — the UserRun is terminal even though the Case
+     * continues running independently.
      * Used as a fast-path exit in completion checks — avoids counting when work is still in flight.
      */
     fun hasAnyActive(runId: UUID): Boolean
 
-    /** Returns true if at least one UserRun for [runId] is in FAILED status. */
+    /**
+     * Returns true if at least one UserRun for [runId] is in FAILED status.
+     * [UserRunStatus.TIMEOUT] is NOT a failure — it indicates monitoring was released, not that
+     * execution failed. A Run with all UserRuns in DONE/TIMEOUT/FAILED transitions to DONE
+     * unless at least one is FAILED.
+     */
     fun hasAnyFailed(runId: UUID): Boolean
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
@@ -15,7 +15,7 @@ import java.util.UUID
  *
  * [materialize] resolves target users via a single Cypher INSERT-SELECT that traverses the
  * deployment graph and MERGEs PENDING UserRuns atomically. Safe to replay on crash — MERGE
- * is idempotent on the UNIQUE `userRunKey` constraint.
+ * is idempotent on the composite UNIQUE `(runId, userId)` constraint.
  *
  * [claimBatch] reads candidates via a read-only query then saves each via SDN with the
  * [ScheduledPromptUserRunNode.version] optimistic lock, so concurrent instances cannot
@@ -47,7 +47,7 @@ interface ScheduledPromptUserRunRepository {
      *
      * Then MERGEs a PENDING [ScheduledPromptUserRun] for each distinct user.
      *
-     * Safe to replay on crash — MERGE is idempotent on the UNIQUE `userRunKey` constraint.
+     * Safe to replay on crash — MERGE is idempotent on the composite UNIQUE `(runId, userId)` constraint.
      *
      * Returns the number of UserRuns created (0 when all already existed or no users found).
      */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunSchemaInitializer.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunSchemaInitializer.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
  * Idempotent Neo4j schema initialiser for [ScheduledPromptUserRun].
  *
  * Creates:
- * - A UNIQUE constraint on [ScheduledPromptUserRunNode.userRunKey] — the distributed lock
+ * - A composite UNIQUE constraint on `(runId, userId)` — the distributed lock
  *   preventing duplicate per-user launches within the same Run.
  * - Auxiliary indexes on [ScheduledPromptUserRunNode.status], [ScheduledPromptUserRunNode.runId],
  *   and [ScheduledPromptUserRunNode.userId] to back the
@@ -26,19 +26,19 @@ class ScheduledPromptUserRunSchemaInitializer(
     private val neo4jClient: Neo4jClient,
 ) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
-        ensureUserRunKeyUniqueConstraint()
+        ensureUserRunUniqueConstraint()
         ensureStatusIndex()
         ensureRunIdIndex()
         ensureUserIdIndex()
     }
 
-    private fun ensureUserRunKeyUniqueConstraint() {
+    private fun ensureUserRunUniqueConstraint() {
         neo4jClient
             .query(
-                "CREATE CONSTRAINT sp_user_run_key_unique IF NOT EXISTS " +
-                    "FOR (ur:ScheduledPromptUserRun) REQUIRE ur.userRunKey IS UNIQUE",
+                "CREATE CONSTRAINT sp_user_run_unique IF NOT EXISTS " +
+                    "FOR (ur:ScheduledPromptUserRun) REQUIRE (ur.runId, ur.userId) IS UNIQUE",
             ).run()
-        logger.info { "[ScheduledPromptUserRunSchema] constraint 'sp_user_run_key_unique' ensured" }
+        logger.info { "[ScheduledPromptUserRunSchema] constraint 'sp_user_run_unique' ensured" }
     }
 
     private fun ensureStatusIndex() {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunSchemaInitializer.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunSchemaInitializer.kt
@@ -1,0 +1,69 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import mu.KLogging
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.data.neo4j.core.Neo4jClient
+import org.springframework.stereotype.Component
+
+/**
+ * Idempotent Neo4j schema initialiser for [ScheduledPromptUserRun].
+ *
+ * Creates:
+ * - A UNIQUE constraint on [ScheduledPromptUserRunNode.userRunKey] — the distributed lock
+ *   preventing duplicate per-user launches within the same Run.
+ * - Auxiliary indexes on [ScheduledPromptUserRunNode.status], [ScheduledPromptUserRunNode.runId],
+ *   and [ScheduledPromptUserRunNode.userId] to back the
+ *   [ScheduledPromptUserRunNodeNeo4jRepository] queries.
+ */
+@Component
+@ConditionalOnExpression(
+    "'\${agentos.persistence.mode:in-memory}' == 'neo4j' " +
+        "or '\${agentos.persistence.mode:in-memory}' == 'embedded-neo4j'",
+)
+class ScheduledPromptUserRunSchemaInitializer(
+    private val neo4jClient: Neo4jClient,
+) : ApplicationRunner {
+    override fun run(args: ApplicationArguments) {
+        ensureUserRunKeyUniqueConstraint()
+        ensureStatusIndex()
+        ensureRunIdIndex()
+        ensureUserIdIndex()
+    }
+
+    private fun ensureUserRunKeyUniqueConstraint() {
+        neo4jClient
+            .query(
+                "CREATE CONSTRAINT sp_user_run_key_unique IF NOT EXISTS " +
+                    "FOR (ur:ScheduledPromptUserRun) REQUIRE ur.userRunKey IS UNIQUE",
+            ).run()
+        logger.info { "[ScheduledPromptUserRunSchema] constraint 'sp_user_run_key_unique' ensured" }
+    }
+
+    private fun ensureStatusIndex() {
+        neo4jClient
+            .query(
+                "CREATE INDEX sp_user_run_status IF NOT EXISTS FOR (ur:ScheduledPromptUserRun) ON (ur.status)",
+            ).run()
+        logger.info { "[ScheduledPromptUserRunSchema] index 'sp_user_run_status' ensured" }
+    }
+
+    private fun ensureRunIdIndex() {
+        neo4jClient
+            .query(
+                "CREATE INDEX sp_user_run_run_id IF NOT EXISTS FOR (ur:ScheduledPromptUserRun) ON (ur.runId)",
+            ).run()
+        logger.info { "[ScheduledPromptUserRunSchema] index 'sp_user_run_run_id' ensured" }
+    }
+
+    private fun ensureUserIdIndex() {
+        neo4jClient
+            .query(
+                "CREATE INDEX sp_user_run_user_id IF NOT EXISTS FOR (ur:ScheduledPromptUserRun) ON (ur.userId)",
+            ).run()
+        logger.info { "[ScheduledPromptUserRunSchema] index 'sp_user_run_user_id' ensured" }
+    }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -10,8 +10,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | Property | Env var | Default | Description |
  * |---|---|---|---|
  * | `scheduler.enabled` | `SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
- * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between claim ticks (ms) |
- * | `scheduler.consume-interval-ms` | `SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) |
+ * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 30000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class |
+ * | `scheduler.consume-interval-ms` | `SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) — read directly by `@Scheduled`, not via this class |
  * | `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
  * | `scheduler.launch-timeout-seconds` | `SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
@@ -20,14 +20,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class SchedulerProperties(
     /** Disabled by default; enable in production via env var SCHEDULER_ENABLED=true. */
     val enabled: Boolean = false,
-    /** Interval between scanner ticks in milliseconds. */
-    val tickIntervalMs: Long = 60_000L,
     /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
     val batchSize: Int = 20,
     /** Max seconds to wait for a Case to reach IDLE or terminal after launch. Beyond this the UserRun is closed as DONE (Case continues running independently). */
     val launchTimeoutSeconds: Long = 30L,
     /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */
     val leaseMinutes: Long = 30L,
-    /** Interval between consume ticks in milliseconds. */
-    val consumeIntervalMs: Long = 10_000L,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -9,17 +9,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *
  * | Property | Env var | Default | Description |
  * |---|---|---|---|
- * | `scheduler.enabled` | `SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
- * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 30000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class |
- * | `scheduler.consume-interval-ms` | `SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) — read directly by `@Scheduled`, not via this class |
- * | `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
- * | `scheduler.launch-stagger-ms` | `SCHEDULER_LAUNCH_STAGGER_MS` | 50 | Delay (ms) between consecutive Case launches within a batch |
- * | `scheduler.launch-timeout-seconds` | `SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
- * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
+ * | `agentos.prompt.scheduler.enabled` | `AGENTOS_PROMPT_SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
+ * | `agentos.prompt.scheduler.tick-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS` | 30000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class |
+ * | `agentos.prompt.scheduler.consume-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) — read directly by `@Scheduled`, not via this class |
+ * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
+ * | `agentos.prompt.scheduler.launch-stagger-ms` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_STAGGER_MS` | 50 | Delay (ms) between consecutive Case launches within a batch |
+ * | `agentos.prompt.scheduler.launch-timeout-seconds` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
+ * | `agentos.prompt.scheduler.lease-minutes` | `AGENTOS_PROMPT_SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
-@ConfigurationProperties(prefix = "scheduler")
+@ConfigurationProperties(prefix = "agentos.prompt.scheduler")
 data class SchedulerProperties(
-    /** Disabled by default; enable in production via env var SCHEDULER_ENABLED=true. */
+    /** Disabled by default; enable in production via env var AGENTOS_PROMPT_SCHEDULER_ENABLED=true. */
     val enabled: Boolean = false,
     /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
     val batchSize: Int = 20,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -10,7 +10,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | Property | Env var | Default | Description |
  * |---|---|---|---|
  * | `scheduler.enabled` | `SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
- * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between scanner ticks (ms) |
+ * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between claim ticks (ms) |
+ * | `scheduler.consume-interval-ms` | `SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) |
  * | `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
  * | `scheduler.launch-timeout-seconds` | `SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -11,7 +11,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * |---|---|---|---|
  * | `scheduler.enabled` | `SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
  * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between scanner ticks (ms) |
- * | `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed per batch |
+ * | `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
+ * | `scheduler.launch-timeout-seconds` | `SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
 @ConfigurationProperties(prefix = "scheduler")
@@ -20,8 +21,10 @@ data class SchedulerProperties(
     val enabled: Boolean = false,
     /** Interval between scanner ticks in milliseconds. */
     val tickIntervalMs: Long = 60_000L,
-    /** Maximum number of UserRuns claimed per batch. */
+    /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
     val batchSize: Int = 20,
+    /** Max seconds to wait for a Case to reach IDLE or terminal after launch. Beyond this the UserRun is closed as DONE (Case continues running independently). */
+    val launchTimeoutSeconds: Long = 30L,
     /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */
     val leaseMinutes: Long = 30L,
     /** Interval between consume ticks in milliseconds. */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * |---|---|---|---|
  * | `scheduler.enabled` | `SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
  * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between scanner ticks (ms) |
- * | `scheduler.max-concurrent-executions` | `SCHEDULER_MAX_CONCURRENT_EXECUTIONS` | 20 | Max concurrent Case launches per tick |
+ * | `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed per batch |
  * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
 @ConfigurationProperties(prefix = "scheduler")
@@ -20,8 +20,8 @@ data class SchedulerProperties(
     val enabled: Boolean = false,
     /** Interval between scanner ticks in milliseconds. */
     val tickIntervalMs: Long = 60_000L,
-    /** Maximum number of concurrent Case launches per tick (Semaphore permit count). */
-    val maxConcurrentExecutions: Int = 20,
+    /** Maximum number of UserRuns claimed per batch. */
+    val batchSize: Int = 20,
     /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */
     val leaseMinutes: Long = 30L,
     /** Interval between consume ticks in milliseconds. */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -13,6 +13,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 30000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class |
  * | `scheduler.consume-interval-ms` | `SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) — read directly by `@Scheduled`, not via this class |
  * | `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
+ * | `scheduler.launch-stagger-ms` | `SCHEDULER_LAUNCH_STAGGER_MS` | 50 | Delay (ms) between consecutive Case launches within a batch |
  * | `scheduler.launch-timeout-seconds` | `SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
@@ -22,6 +23,8 @@ data class SchedulerProperties(
     val enabled: Boolean = false,
     /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
     val batchSize: Int = 20,
+    /** Delay (ms) between consecutive Case launches within a batch. Spreads the initial burst to reduce peak memory pressure. */
+    val launchStaggerMs: Long = 50L,
     /** Max seconds to wait for a Case to reach IDLE or terminal after launch. Beyond this the UserRun is closed as DONE (Case continues running independently). */
     val launchTimeoutSeconds: Long = 30L,
     /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -9,12 +9,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *
  * | Property | Env var | Default | Description |
  * |---|---|---|---|
+ * | `scheduler.enabled` | `SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
  * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between scanner ticks (ms) |
+ * | `scheduler.max-concurrent-executions` | `SCHEDULER_MAX_CONCURRENT_EXECUTIONS` | 20 | Max concurrent Case launches per tick |
+ * | `scheduler.stagger-delay-ms` | `SCHEDULER_STAGGER_DELAY_MS` | 500 | Delay between launching each Case (ms) |
+ * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
 @ConfigurationProperties(prefix = "scheduler")
 data class SchedulerProperties(
-    /** Set to false to disable the scheduler (useful in tests). */
-    val enabled: Boolean = true,
+    /** Disabled by default; enable in production via env var SCHEDULER_ENABLED=true. */
+    val enabled: Boolean = false,
     /** Interval between scanner ticks in milliseconds. */
     val tickIntervalMs: Long = 60_000L,
+    /** Maximum number of concurrent Case launches per tick (Semaphore permit count). */
+    val maxConcurrentExecutions: Int = 20,
+    /** Delay in milliseconds between launching each per-user Case — staggered execution. */
+    val staggerDelayMs: Long = 500L,
+    /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */
+    val leaseMinutes: Long = 30L,
+    /** Interval between consume ticks in milliseconds. */
+    val consumeIntervalMs: Long = 10_000L,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -12,7 +12,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | `scheduler.enabled` | `SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
  * | `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between scanner ticks (ms) |
  * | `scheduler.max-concurrent-executions` | `SCHEDULER_MAX_CONCURRENT_EXECUTIONS` | 20 | Max concurrent Case launches per tick |
- * | `scheduler.stagger-delay-ms` | `SCHEDULER_STAGGER_DELAY_MS` | 500 | Delay between launching each Case (ms) |
  * | `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
 @ConfigurationProperties(prefix = "scheduler")
@@ -23,8 +22,6 @@ data class SchedulerProperties(
     val tickIntervalMs: Long = 60_000L,
     /** Maximum number of concurrent Case launches per tick (Semaphore permit count). */
     val maxConcurrentExecutions: Int = 20,
-    /** Delay in milliseconds between launching each per-user Case — staggered execution. */
-    val staggerDelayMs: Long = 500L,
     /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */
     val leaseMinutes: Long = 30L,
     /** Interval between consume ticks in milliseconds. */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -1,38 +1,49 @@
 package io.whozoss.agentos.scheduledPrompt
 
 import io.whozoss.agentos.agentConfig.AgentConfigService
+import kotlinx.coroutines.runBlocking
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import jakarta.annotation.PostConstruct
 import java.time.Clock
 import java.time.Instant
 
 /**
- * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them.
+ * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them,
+ * and a separate tick that consumes available [ScheduledPromptUserRun]s.
  *
- * ### Tick logic
+ * ### Two-tick architecture
  *
- * Every [SchedulerProperties.tickIntervalMs] milliseconds:
+ * **[tickClaim]** (Phase A, every [SchedulerProperties.tickIntervalMs]):
  * 1. Query [ScheduledPromptRepository.findDue] for all prompts whose `nextRunAt <= now`.
- * 2. For each prompt, call [claim].
- * 3. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt] after claiming — this is
- *    the self-healing mechanism that prevents a stuck prompt from blocking the queue on every tick.
+ * 2. For each prompt, call [claim] — which inserts a CLAIMED run and synchronously
+ *    calls [ScheduledPromptExecutor.materialize] to create PENDING UserRuns.
+ * 3. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
+ *
+ * **[tickConsume]** (Phase B, every [SchedulerProperties.consumeIntervalMs]):
+ * Calls [ScheduledPromptExecutor.consumeAvailable] via `runBlocking`, which suspends
+ * until ALL UserRuns from ALL batches have finished executing. Spring `fixedDelay`
+ * guarantees no overlap between consecutive consume ticks.
+ *
+ * Both ticks are fully blocking — Spring's `@Scheduled(fixedDelay)` ensures no tick
+ * overlaps with its own successor. No fire-and-forget coroutines are used at the
+ * Scanner level.
  *
  * ### Claim logic
  *
  * For a given [ScheduledPrompt]:
  * - If [ScheduledPromptRunRepository.hasActive] is true → insert a SKIPPED run (overlap).
- * - Otherwise → insert a CLAIMED run.
- * - In all cases, attempt [ScheduledPromptRunRepository.insert]; if [DuplicateRunException] is
- *   thrown (concurrent tick won the race), log and continue — the advance still happens.
+ * - Otherwise → insert a CLAIMED run and synchronously materialize UserRuns.
+ * - In all cases, attempt [ScheduledPromptRunRepository.insert]; if [DuplicateRunException]
+ *   is thrown (concurrent tick won the race), log and continue.
  * - After the insert (or on [DuplicateRunException]), advance `nextRunAt` via CAS.
- * - If the run was CLAIMED: log “TODO execute” (no-op for now).
  *
  * The [clock] is injected so tests can freeze time.
  */
 @Component
-@ConditionalOnProperty(name = ["scheduler.enabled"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = ["scheduler.enabled"], havingValue = "true")
 class SchedulerScanner(
     private val scheduledPromptRepository: ScheduledPromptRepository,
     private val runRepository: ScheduledPromptRunRepository,
@@ -40,16 +51,40 @@ class SchedulerScanner(
     private val properties: SchedulerProperties,
     private val clock: Clock,
     private val nextRunCalculatorService: NextRunCalculatorService,
+    private val executor: ScheduledPromptExecutor,
 ) {
+    @PostConstruct
+    fun logStartup() {
+        logger.info {
+            "[SchedulerScanner] Scheduler enabled — tickClaim every ${properties.tickIntervalMs}ms, " +
+                "tickConsume every ${properties.consumeIntervalMs}ms"
+        }
+    }
+
+    /**
+     * Phase A: Discover due ScheduledPrompts, claim them, and materialize UserRuns.
+     * Fully blocking — materialize runs synchronously within the tick.
+     * Spring fixedDelay guarantees no overlap between ticks.
+     */
     @Scheduled(fixedDelayString = "\${scheduler.tick-interval-ms:60000}")
-    fun tick() {
+    fun tickClaim() {
         val now = Instant.now(clock)
         scheduledPromptRepository.findDue(now)
             .also { due ->
-                if (due.isEmpty()) logger.debug { "[SchedulerScanner] tick: no due prompts" }
-                else logger.info { "[SchedulerScanner] tick: ${due.size} due prompt(s)" }
+                if (due.isEmpty()) logger.debug { "[SchedulerScanner] tickClaim: no due prompts" }
+                else logger.info { "[SchedulerScanner] tickClaim: ${due.size} due prompt(s)" }
             }
             .forEach { sp -> claim(sp) }
+    }
+
+    /**
+     * Phase B: Consume available UserRuns.
+     * Fully blocking — returns only when all claimed UserRuns have finished executing.
+     * Spring fixedDelay guarantees no overlap between ticks.
+     */
+    @Scheduled(fixedDelayString = "\${scheduler.consume-interval-ms:10000}")
+    fun tickConsume() {
+        runBlocking { executor.consumeAvailable() }
     }
 
     private fun claim(scheduledPrompt: ScheduledPrompt) {
@@ -82,11 +117,12 @@ class SchedulerScanner(
             correlationId = correlationId,
         )
 
-        try {
+        val insertedRun = try {
             runRepository.insert(run)
-            logger.info { "[SchedulerScanner] Inserted run correlationId=$correlationId status=$status" }
+                .also { logger.info { "[SchedulerScanner] Inserted run correlationId=$correlationId status=$status" } }
         } catch (e: DuplicateRunException) {
             logger.info { "[SchedulerScanner] Duplicate slot for sp=${scheduledPrompt.id} slot=$slot — another tick won the race" }
+            null
         }
 
         // Always advance nextRunAt — auto-repairing even on duplicate or skip.
@@ -98,8 +134,8 @@ class SchedulerScanner(
             logger.debug { "[SchedulerScanner] CAS miss for sp=${scheduledPrompt.id} (another tick advanced first)" }
         }
 
-        if (status == RunStatus.CLAIMED) {
-            logger.info { "[SchedulerScanner] TODO execute sp=${scheduledPrompt.id} correlationId=$correlationId" }
+        if (status == RunStatus.CLAIMED && insertedRun != null) {
+            executor.materialize(insertedRun, scheduledPrompt)
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.scheduledPrompt
 
 import io.whozoss.agentos.agentConfig.AgentConfigService
+import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerEndType
 import kotlinx.coroutines.runBlocking
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component
 import jakarta.annotation.PostConstruct
 import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 
 /**
  * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them,
@@ -102,6 +104,16 @@ class SchedulerScanner(
             return
         }
 
+        // Guard: disable if the end condition is already reached before executing.
+        if (isEndConditionReached(scheduledPrompt)) {
+            logger.info {
+                "[SchedulerScanner] End condition already reached for sp=${scheduledPrompt.id} " +
+                    "(${scheduledPrompt.planning.endType}) \u2014 disabling without execution"
+            }
+            scheduledPromptRepository.save(scheduledPrompt.copy(enabled = false))
+            return
+        }
+
         val status = when {
             runRepository.hasActive(scheduledPrompt.id) -> {
                 logger.warn { "[SchedulerScanner] OVERLAP sp=${scheduledPrompt.id} has active run → SKIPPED" }
@@ -134,8 +146,74 @@ class SchedulerScanner(
             logger.debug { "[SchedulerScanner] CAS miss for sp=${scheduledPrompt.id} (another tick advanced first)" }
         }
 
+        // Check if the end condition will be reached after this run.
+        // If so, disable the ScheduledPrompt — no future run should fire.
+        checkEndConditionAfterAdvance(scheduledPrompt, nextSlot)
+
         if (status == RunStatus.CLAIMED && insertedRun != null) {
             executor.materialize(insertedRun, scheduledPrompt)
+        }
+    }
+
+    /**
+     * Check if the end condition is already reached BEFORE executing.
+     *
+     * - **ON_DATE**: the current slot (nextRunAt) falls after [Planning.endDate] at [Recurrence.timeUtc].
+     * - **OCCURRENCES**: the number of completed (non-SKIPPED) runs has already reached
+     *   [Planning.maxOccurrenceCount].
+     * - **NEVER**: never reached.
+     */
+    private fun isEndConditionReached(scheduledPrompt: ScheduledPrompt): Boolean {
+        val planning = scheduledPrompt.planning
+        return when (planning.endType) {
+            SchedulerEndType.NEVER -> false
+            SchedulerEndType.ON_DATE -> {
+                val endInstant = planning.endDate
+                    ?.atTime(scheduledPrompt.recurrence.timeUtc)
+                    ?.toInstant(ZoneOffset.UTC)
+                endInstant != null && scheduledPrompt.nextRunAt.isAfter(endInstant)
+            }
+            SchedulerEndType.OCCURRENCES -> {
+                val max = planning.maxOccurrenceCount ?: return false
+                val completed = runRepository.countCompletedRuns(scheduledPrompt.id)
+                completed >= max
+            }
+        }
+    }
+
+    /**
+     * Disable the [ScheduledPrompt] if the end condition will be reached after this run.
+     *
+     * Called after advancing nextRunAt. Checks the NEXT slot, not the current one.
+     *
+     * - **ON_DATE**: the next slot falls after [Planning.endDate] at [Recurrence.timeUtc].
+     * - **OCCURRENCES**: the number of completed (non-SKIPPED) runs (including the one just
+     *   inserted) has reached [Planning.maxOccurrenceCount].
+     * - **NEVER**: no end condition, never disables.
+     */
+    private fun checkEndConditionAfterAdvance(scheduledPrompt: ScheduledPrompt, nextSlot: Instant) {
+        val planning = scheduledPrompt.planning
+        val shouldDisable = when (planning.endType) {
+            SchedulerEndType.NEVER -> false
+            SchedulerEndType.ON_DATE -> {
+                val endInstant = planning.endDate
+                    ?.atTime(scheduledPrompt.recurrence.timeUtc)
+                    ?.toInstant(ZoneOffset.UTC)
+                endInstant != null && nextSlot.isAfter(endInstant)
+            }
+            SchedulerEndType.OCCURRENCES -> {
+                val max = planning.maxOccurrenceCount ?: return
+                val completed = runRepository.countCompletedRuns(scheduledPrompt.id)
+                completed >= max
+            }
+        }
+
+        if (shouldDisable) {
+            logger.info {
+                "[SchedulerScanner] End condition reached after advance for sp=${scheduledPrompt.id} " +
+                    "(${planning.endType}) \u2014 disabling"
+            }
+            scheduledPromptRepository.save(scheduledPrompt.copy(enabled = false))
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -2,7 +2,6 @@ package io.whozoss.agentos.scheduledPrompt
 
 import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerEndType
-import kotlinx.coroutines.runBlocking
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
@@ -28,13 +27,13 @@ import java.time.ZoneOffset
  * 4. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
  *
  * **[tickConsume]** (Phase B, every `scheduler.consume-interval-ms`):
- * Calls [ScheduledPromptExecutor.consumeAvailable] via `runBlocking`, which suspends
+ * Declared `suspend` — Spring Framework 6.1+ natively supports suspend functions on
+ * `@Scheduled` methods. Calls [ScheduledPromptExecutor.consumeAvailable] which suspends
  * until ALL UserRuns from ALL batches have finished executing. Spring `fixedDelay`
  * guarantees no overlap between consecutive consume ticks.
  *
- * Both ticks are fully blocking — Spring's `@Scheduled(fixedDelay)` ensures no tick
- * overlaps with its own successor. No fire-and-forget coroutines are used at the
- * Scanner level.
+ * Both ticks use Spring's `@Scheduled(fixedDelay)` to ensure no tick overlaps with its
+ * own successor. No fire-and-forget coroutines are used at the Scanner level.
  *
  * ### Claim logic
  *
@@ -169,12 +168,17 @@ class SchedulerScanner(
 
     /**
      * Phase B: Consume available UserRuns.
-     * Fully blocking — returns only when all claimed UserRuns have finished executing.
+     * Declared `suspend` — Spring Framework 6.1+ natively dispatches suspend `@Scheduled`
+     * methods on the application's coroutine scheduler.
+     * Returns only when all claimed UserRuns have finished executing.
      * Spring fixedDelay guarantees no overlap between ticks.
+     *
+     * The IO dispatcher is managed by [ScheduledPromptExecutor.consumeAvailable] itself
+     * via [kotlinx.coroutines.withContext].
      */
     @Scheduled(fixedDelayString = "\${scheduler.consume-interval-ms:10000}")
-    fun tickConsume() {
-        runBlocking { executor.consumeAvailable() }
+    suspend fun tickConsume() {
+        executor.consumeAvailable()
     }
 
     private fun claim(scheduledPrompt: ScheduledPrompt) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -256,7 +256,7 @@ class SchedulerScanner(
     /**
      * Check if the end condition is already reached BEFORE executing.
      *
-     * - **ON_DATE**: the current slot (nextRunAt) falls after [Planning.endDate] at [Recurrence.timeUtc].
+     * - **ON_DATE**: the current slot (nextRunAt) falls on or after [Planning.endDate] (exclusive boundary) at [Recurrence.timeUtc].
      * - **OCCURRENCES**: the number of completed (non-SKIPPED) runs has already reached
      *   [Planning.maxOccurrenceCount].
      * - **NEVER**: never reached.
@@ -269,7 +269,7 @@ class SchedulerScanner(
                 val endInstant = planning.endDate
                     ?.atTime(scheduledPrompt.recurrence.timeUtc)
                     ?.toInstant(ZoneOffset.UTC)
-                endInstant != null && scheduledPrompt.nextRunAt.isAfter(endInstant)
+                endInstant != null && !scheduledPrompt.nextRunAt.isBefore(endInstant)
             }
             SchedulerEndType.OCCURRENCES -> {
                 val max = planning.maxOccurrenceCount ?: return false
@@ -284,7 +284,7 @@ class SchedulerScanner(
      *
      * Called after advancing nextRunAt. Checks the NEXT slot, not the current one.
      *
-     * - **ON_DATE**: the next slot falls after [Planning.endDate] at [Recurrence.timeUtc].
+     * - **ON_DATE**: the next slot falls on or after [Planning.endDate] (exclusive boundary) at [Recurrence.timeUtc].
      * - **OCCURRENCES**: the number of completed (non-SKIPPED) runs (including the one just
      *   inserted) has reached [Planning.maxOccurrenceCount].
      * - **NEVER**: no end condition, never disables.
@@ -297,7 +297,7 @@ class SchedulerScanner(
                 val endInstant = planning.endDate
                     ?.atTime(scheduledPrompt.recurrence.timeUtc)
                     ?.toInstant(ZoneOffset.UTC)
-                endInstant != null && nextSlot.isAfter(endInstant)
+                endInstant != null && !nextSlot.isBefore(endInstant)
             }
             SchedulerEndType.OCCURRENCES -> {
                 val max = planning.maxOccurrenceCount ?: return

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import jakarta.annotation.PostConstruct
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 
@@ -19,10 +20,12 @@ import java.time.ZoneOffset
  * ### Two-tick architecture
  *
  * **[tickClaim]** (Phase A, every [SchedulerProperties.tickIntervalMs]):
- * 1. Query [ScheduledPromptRepository.findDue] for all prompts whose `nextRunAt <= now`.
- * 2. For each prompt, call [claim] — which inserts a CLAIMED run and synchronously
+ * 1. Sweep orphaned CLAIMED runs via [recoverOrphanedClaimedRuns] — handles the crash
+ *    window between Run insert and [ScheduledPromptExecutor.materialize] in [claim].
+ * 2. Query [ScheduledPromptRepository.findDue] for all prompts whose `nextRunAt <= now`.
+ * 3. For each prompt, call [claim] — which inserts a CLAIMED or SKIPPED Run and then
  *    calls [ScheduledPromptExecutor.materialize] to create PENDING UserRuns.
- * 3. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
+ * 4. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
  *
  * **[tickConsume]** (Phase B, every [SchedulerProperties.consumeIntervalMs]):
  * Calls [ScheduledPromptExecutor.consumeAvailable] via `runBlocking`, which suspends
@@ -36,14 +39,21 @@ import java.time.ZoneOffset
  * ### Claim logic
  *
  * For a given [ScheduledPrompt]:
- * - If [ScheduledPromptRunRepository.hasActive] is true → insert a SKIPPED run (overlap).
- * - Otherwise → insert a CLAIMED run and synchronously materialize UserRuns.
- * - In all cases, attempt [ScheduledPromptRunRepository.insert]; if [DuplicateRunException]
- *   is thrown (concurrent tick won the race), log and continue.
- * - After the insert (or on [DuplicateRunException]), advance `nextRunAt` via CAS.
+ * - If [ScheduledPromptRunRepository.hasActive] is true → insert a SKIPPED run (audit record).
+ * - Otherwise → insert a CLAIMED Run, then call [ScheduledPromptExecutor.materialize]
+ *   (MERGE + RUNNING transition in a single `@Transactional` boundary).
+ * - Catch [DuplicateRunException] for both SKIPPED and CLAIMED (concurrent tick won the race).
+ * - After the insert (or on duplicate), advance `nextRunAt` via CAS.
+ *
+ * ### Orphan recovery
+ *
+ * A CLAIMED Run older than [ORPHAN_THRESHOLD] is presumed orphaned (crash between insert
+ * and materialize). [recoverOrphanedClaimedRuns] marks such runs FAILED at the start of
+ * each tick, unblocking the [ScheduledPromptRunRepository.hasActive] overlap guard.
  *
  * The [clock] is injected so tests can freeze time.
  */
+
 @Component
 @ConditionalOnProperty(name = ["scheduler.enabled"], havingValue = "true")
 class SchedulerScanner(
@@ -71,12 +81,51 @@ class SchedulerScanner(
     @Scheduled(fixedDelayString = "\${scheduler.tick-interval-ms:60000}")
     fun tickClaim() {
         val now = Instant.now(clock)
+
+        // Sweep: abandon orphaned CLAIMED runs that were never materialised.
+        // This handles the crash window between Run insert and materialize() in claim().
+        // A CLAIMED Run older than the tick interval is presumed orphaned — materialize()
+        // normally completes in seconds. Marking it FAILED unblocks the hasActive() overlap
+        // guard so subsequent slots are not stuck in SKIPPED.
+        recoverOrphanedClaimedRuns(now)
+
         scheduledPromptRepository.findDue(now)
             .also { due ->
                 if (due.isEmpty()) logger.debug { "[SchedulerScanner] tickClaim: no due prompts" }
                 else logger.info { "[SchedulerScanner] tickClaim: ${due.size} due prompt(s)" }
             }
             .forEach { sp -> claim(sp) }
+    }
+
+    /**
+     * Mark orphaned CLAIMED runs as FAILED.
+     *
+     * A Run stays CLAIMED only during the brief window between [ScheduledPromptRunRepository.insert]
+     * and [ScheduledPromptExecutor.materialize] in [claim]. If the instance crashes in that window,
+     * the Run remains CLAIMED forever — no UserRuns were created, the slot is lost.
+     *
+     * This sweep detects CLAIMED Runs older than [ORPHAN_THRESHOLD] and marks them FAILED with
+     * an explanatory error. This:
+     * - Unblocks [ScheduledPromptRunRepository.hasActive] so subsequent slots are not stuck in SKIPPED
+     * - Leaves a diagnostic trace in the Run's error field
+     * - Is safe in multi-instance: multiple instances may race to update the same orphan,
+     *   but updateStatus is idempotent (second call is a no-op)
+     */
+    private fun recoverOrphanedClaimedRuns(now: Instant) {
+        val threshold = now.minus(ORPHAN_THRESHOLD)
+        val orphans = runRepository.findOrphanedClaimed(threshold)
+        orphans.forEach { run ->
+            logger.warn {
+                "[SchedulerScanner] Orphaned CLAIMED run=${run.id} sp=${run.scheduledPromptId} " +
+                    "created=${run.metadata.created} — marking FAILED (crash recovery)"
+            }
+            runRepository.updateStatus(
+                id = run.id,
+                status = RunStatus.FAILED,
+                finishedAt = now,
+                error = "Orphaned CLAIMED — materialize never completed (crash recovery)",
+            )
+        }
     }
 
     /**
@@ -224,5 +273,8 @@ class SchedulerScanner(
         }
     }
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        /** CLAIMED Runs older than this are presumed orphaned (crash between insert and materialize). */
+        private val ORPHAN_THRESHOLD = Duration.ofMinutes(5)
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -105,6 +105,13 @@ class SchedulerScanner(
         }
 
         // Guard: disable if the end condition is already reached before executing.
+        // This is a crash-recovery safety net: if the server was down while the end condition
+        // expired, or if a previous tick crashed between advanceNextRunAt and the post-advance
+        // disable, the ScheduledPrompt may still be enabled with nextRunAt past the endDate
+        // (or with completed runs already at maxOccurrenceCount). Without this guard, each
+        // tick would keep creating SKIPPED or CLAIMED runs indefinitely.
+        // In multi-instance deployments, only one instance needs to win the disable — the
+        // others will see enabled=false on their next findDue() and skip naturally.
         if (isEndConditionReached(scheduledPrompt)) {
             logger.info {
                 "[SchedulerScanner] End condition already reached for sp=${scheduledPrompt.id} " +

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -256,7 +256,7 @@ class SchedulerScanner(
     /**
      * Check if the end condition is already reached BEFORE executing.
      *
-     * - **ON_DATE**: the current slot (nextRunAt) falls on or after [Planning.endDate] (exclusive boundary) at [Recurrence.timeUtc].
+     * - **ON_DATE**: the current slot (nextRunAt) falls on or after [Planning.endDate] at 00:00 UTC (exclusive — the prompt does not run from endDate onwards).
      * - **OCCURRENCES**: the number of completed (non-SKIPPED) runs has already reached
      *   [Planning.maxOccurrenceCount].
      * - **NEVER**: never reached.
@@ -267,7 +267,7 @@ class SchedulerScanner(
             SchedulerEndType.NEVER -> false
             SchedulerEndType.ON_DATE -> {
                 val endInstant = planning.endDate
-                    ?.atTime(scheduledPrompt.recurrence.timeUtc)
+                    ?.atStartOfDay()
                     ?.toInstant(ZoneOffset.UTC)
                 endInstant != null && !scheduledPrompt.nextRunAt.isBefore(endInstant)
             }
@@ -284,7 +284,7 @@ class SchedulerScanner(
      *
      * Called after advancing nextRunAt. Checks the NEXT slot, not the current one.
      *
-     * - **ON_DATE**: the next slot falls on or after [Planning.endDate] (exclusive boundary) at [Recurrence.timeUtc].
+     * - **ON_DATE**: the next slot falls on or after [Planning.endDate] at 00:00 UTC (exclusive — the prompt does not run from endDate onwards).
      * - **OCCURRENCES**: the number of completed (non-SKIPPED) runs (including the one just
      *   inserted) has reached [Planning.maxOccurrenceCount].
      * - **NEVER**: no end condition, never disables.
@@ -295,7 +295,7 @@ class SchedulerScanner(
             SchedulerEndType.NEVER -> false
             SchedulerEndType.ON_DATE -> {
                 val endInstant = planning.endDate
-                    ?.atTime(scheduledPrompt.recurrence.timeUtc)
+                    ?.atStartOfDay()
                     ?.toInstant(ZoneOffset.UTC)
                 endInstant != null && !nextSlot.isBefore(endInstant)
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -18,7 +18,7 @@ import java.time.ZoneOffset
  *
  * ### Two-tick architecture
  *
- * **[tickClaim]** (Phase A, every `scheduler.tick-interval-ms`):
+ * **[tickClaim]** (Phase A, every `agentos.prompt.scheduler.tick-interval-ms`):
  * 1. Sweep orphaned CLAIMED runs via [recoverOrphanedClaimedRuns] — handles the crash
  *    window between Run insert and [ScheduledPromptExecutor.materialize] in [claim].
  * 2. Query [ScheduledPromptRepository.findDue] for all prompts whose `nextRunAt <= now`.
@@ -26,7 +26,7 @@ import java.time.ZoneOffset
  *    calls [ScheduledPromptExecutor.materialize] to create PENDING UserRuns.
  * 4. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
  *
- * **[tickConsume]** (Phase B, every `scheduler.consume-interval-ms`):
+ * **[tickConsume]** (Phase B, every `agentos.prompt.scheduler.consume-interval-ms`):
  * Declared `suspend` — Spring Framework 6.1+ natively supports suspend functions on
  * `@Scheduled` methods. Calls [ScheduledPromptExecutor.consumeAvailable] which suspends
  * until ALL UserRuns from ALL batches have finished executing. Spring `fixedDelay`
@@ -59,7 +59,7 @@ import java.time.ZoneOffset
  */
 
 @Component
-@ConditionalOnProperty(name = ["scheduler.enabled"], havingValue = "true")
+@ConditionalOnProperty(name = ["agentos.prompt.scheduler.enabled"], havingValue = "true")
 class SchedulerScanner(
     private val scheduledPromptRepository: ScheduledPromptRepository,
     private val runRepository: ScheduledPromptRunRepository,
@@ -80,7 +80,7 @@ class SchedulerScanner(
      * Fully blocking — materialize runs synchronously within the tick.
      * Spring fixedDelay guarantees no overlap between ticks.
      */
-    @Scheduled(fixedDelayString = "\${scheduler.tick-interval-ms:30000}")
+    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:30000}")
     fun tickClaim() {
         val now = Instant.now(clock)
 
@@ -176,7 +176,7 @@ class SchedulerScanner(
      * The IO dispatcher is managed by [ScheduledPromptExecutor.consumeAvailable] itself
      * via [kotlinx.coroutines.withContext].
      */
-    @Scheduled(fixedDelayString = "\${scheduler.consume-interval-ms:10000}")
+    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.consume-interval-ms:10000}")
     suspend fun tickConsume() {
         executor.consumeAvailable()
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -51,6 +51,11 @@ import java.time.ZoneOffset
  * and materialize). [recoverOrphanedClaimedRuns] marks such runs FAILED at the start of
  * each tick, unblocking the [ScheduledPromptRunRepository.hasActive] overlap guard.
  *
+ * A RUNNING Run whose UserRuns are all terminal but whose completion check was never
+ * called is handled by [recoverOrphanedRunningRuns], also called at the start of each
+ * tick. This covers the crash window between [ScheduledPromptUserRunRepository.markTerminal]
+ * and [ScheduledPromptExecutor.checkCompletion].
+ *
  * The [clock] is injected so tests can freeze time.
  */
 
@@ -59,6 +64,7 @@ import java.time.ZoneOffset
 class SchedulerScanner(
     private val scheduledPromptRepository: ScheduledPromptRepository,
     private val runRepository: ScheduledPromptRunRepository,
+    private val userRunRepository: ScheduledPromptUserRunRepository,
     private val agentConfigService: AgentConfigService,
     private val properties: SchedulerProperties,
     private val clock: Clock,
@@ -88,6 +94,11 @@ class SchedulerScanner(
         // normally completes in seconds. Marking it FAILED unblocks the hasActive() overlap
         // guard so subsequent slots are not stuck in SKIPPED.
         recoverOrphanedClaimedRuns(now)
+
+        // Sweep: close RUNNING runs whose UserRuns are all settled but whose completion
+        // check was missed. This handles the crash window between markTerminal() and
+        // checkCompletion() in ScheduledPromptExecutor.
+        recoverOrphanedRunningRuns(now)
 
         scheduledPromptRepository.findDue(now)
             .also { due ->
@@ -125,6 +136,37 @@ class SchedulerScanner(
                 finishedAt = now,
                 error = "Orphaned CLAIMED — materialize never completed (crash recovery)",
             )
+        }
+    }
+
+    /**
+     * Close RUNNING Runs whose UserRuns are all settled but whose completion check was missed.
+     *
+     * This handles the crash window where the last [ScheduledPromptUserRunRepository.markTerminal]
+     * completed but the instance crashed before [ScheduledPromptExecutor]'s `checkCompletion()`
+     * could transition the parent Run. Without this sweep, the Run would stay RUNNING forever
+     * — no subsequent UserRun closure will re-trigger the check.
+     *
+     * Uses a single [ScheduledPromptRunRepository.findSettledRunning] query that filters
+     * directly in the database: only RUNNING Runs with no UserRun in PENDING or RUNNING
+     * status are returned. In normal operation this returns an empty list (no N+1 queries).
+     * Only in crash recovery scenarios are results expected.
+     *
+     * Safe in multi-instance: [ScheduledPromptRunRepository.updateStatus] is idempotent
+     * (second call is a no-op when the Run is already in the target status).
+     */
+    private fun recoverOrphanedRunningRuns(now: Instant) {
+        val settledRuns = runRepository.findSettledRunning()
+        for (run in settledRuns) {
+            val finalStatus = when {
+                userRunRepository.hasAnyFailed(run.id) -> RunStatus.FAILED
+                else -> RunStatus.DONE
+            }
+            runRepository.updateStatus(run.id, finalStatus, now)
+            logger.warn {
+                "[SchedulerScanner] Orphaned RUNNING run=${run.id} sp=${run.scheduledPromptId} " +
+                    "— all UserRuns settled, closing as $finalStatus (crash recovery)"
+            }
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -19,7 +19,7 @@ import java.time.ZoneOffset
  *
  * ### Two-tick architecture
  *
- * **[tickClaim]** (Phase A, every [SchedulerProperties.tickIntervalMs]):
+ * **[tickClaim]** (Phase A, every `scheduler.tick-interval-ms`):
  * 1. Sweep orphaned CLAIMED runs via [recoverOrphanedClaimedRuns] — handles the crash
  *    window between Run insert and [ScheduledPromptExecutor.materialize] in [claim].
  * 2. Query [ScheduledPromptRepository.findDue] for all prompts whose `nextRunAt <= now`.
@@ -27,7 +27,7 @@ import java.time.ZoneOffset
  *    calls [ScheduledPromptExecutor.materialize] to create PENDING UserRuns.
  * 4. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
  *
- * **[tickConsume]** (Phase B, every [SchedulerProperties.consumeIntervalMs]):
+ * **[tickConsume]** (Phase B, every `scheduler.consume-interval-ms`):
  * Calls [ScheduledPromptExecutor.consumeAvailable] via `runBlocking`, which suspends
  * until ALL UserRuns from ALL batches have finished executing. Spring `fixedDelay`
  * guarantees no overlap between consecutive consume ticks.
@@ -73,10 +73,7 @@ class SchedulerScanner(
 ) {
     @PostConstruct
     fun logStartup() {
-        logger.info {
-            "[SchedulerScanner] Scheduler enabled — tickClaim every ${properties.tickIntervalMs}ms, " +
-                "tickConsume every ${properties.consumeIntervalMs}ms"
-        }
+        logger.info { "[SchedulerScanner] Scheduler enabled" }
     }
 
     /**
@@ -84,7 +81,7 @@ class SchedulerScanner(
      * Fully blocking — materialize runs synchronously within the tick.
      * Spring fixedDelay guarantees no overlap between ticks.
      */
-    @Scheduled(fixedDelayString = "\${scheduler.tick-interval-ms:60000}")
+    @Scheduled(fixedDelayString = "\${scheduler.tick-interval-ms:30000}")
     fun tickClaim() {
         val now = Instant.now(clock)
 
@@ -237,6 +234,7 @@ class SchedulerScanner(
 
         // Always advance nextRunAt — auto-repairing even on duplicate or skip.
         val nextSlot = nextRunCalculatorService.nextAfter(recurrence = scheduledPrompt.recurrence, planning = scheduledPrompt.planning, after = slot)
+        logger.info { "[DEBUG] slot=$slot nextSlot=$nextSlot" }
         val advanced = scheduledPromptRepository.advanceNextRunAt(scheduledPrompt.id, slot, nextSlot)
         if (advanced) {
             logger.debug { "[SchedulerScanner] Advanced sp=${scheduledPrompt.id} nextRunAt=$nextSlot" }

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -207,15 +207,15 @@ agentos:
     #   neo4j                    - standalone Neo4j server (requires spring.neo4j.* config)
     # Override with env var: AGENTOS_PERSISTENCE_MODE
     mode: ${AGENTOS_PERSISTENCE_MODE:embedded-neo4j}
-
-scheduler:
-  # Enable/disable the scheduler. Enabled by default for production.
-  # Dev profiles (embedded-neo4j, docker) disable it to prevent accidental Case creation.
-  # Override with env var: SCHEDULER_ENABLED
-  enabled: ${SCHEDULER_ENABLED:true}
-  # Interval between claim ticks in milliseconds.
-  # Override with env var: SCHEDULER_TICK_INTERVAL_MS
-  tick-interval-ms: ${SCHEDULER_TICK_INTERVAL_MS:30000}
+  prompt:
+    scheduler:
+      # Enable/disable the scheduler. Enabled by default for production.
+      # Dev profiles (embedded-neo4j, docker) disable it to prevent accidental Case creation.
+      # Override with env var: AGENTOS_PROMPT_SCHEDULER_ENABLED
+      enabled: ${AGENTOS_PROMPT_SCHEDULER_ENABLED:true}
+      # Interval between claim ticks in milliseconds.
+      # Override with env var: AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS
+      tick-interval-ms: ${AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS:30000}
 
 springdoc:
   writer-with-order-by-keys: true

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -209,12 +209,13 @@ agentos:
     mode: ${AGENTOS_PERSISTENCE_MODE:embedded-neo4j}
 
 scheduler:
-  # Enable/disable the scheduler. Disabled by default to prevent accidental
-  # Case creation in dev. Enable in production via env var: SCHEDULER_ENABLED=true
-  enabled: ${SCHEDULER_ENABLED:false}
-  # Interval between scanner ticks in milliseconds.
+  # Enable/disable the scheduler. Enabled by default for production.
+  # Dev profiles (embedded-neo4j, docker) disable it to prevent accidental Case creation.
+  # Override with env var: SCHEDULER_ENABLED
+  enabled: ${SCHEDULER_ENABLED:true}
+  # Interval between claim ticks in milliseconds.
   # Override with env var: SCHEDULER_TICK_INTERVAL_MS
-  tick-interval-ms: ${SCHEDULER_TICK_INTERVAL_MS:60000}
+  tick-interval-ms: ${SCHEDULER_TICK_INTERVAL_MS:30000}
 
 springdoc:
   writer-with-order-by-keys: true

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -209,6 +209,9 @@ agentos:
     mode: ${AGENTOS_PERSISTENCE_MODE:embedded-neo4j}
 
 scheduler:
+  # Enable/disable the scheduler. Disabled by default to prevent accidental
+  # Case creation in dev. Enable in production via env var: SCHEDULER_ENABLED=true
+  enabled: ${SCHEDULER_ENABLED:false}
   # Interval between scanner ticks in milliseconds.
   # Override with env var: SCHEDULER_TICK_INTERVAL_MS
   tick-interval-ms: ${SCHEDULER_TICK_INTERVAL_MS:60000}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
@@ -1,0 +1,434 @@
+package io.whozoss.agentos.persistence.neo4j
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.agentConfig.AgentConfig
+import io.whozoss.agentos.agentConfig.AgentConfigRepository
+import io.whozoss.agentos.config.TestAuditConfiguration
+import io.whozoss.agentos.namespace.Namespace
+import io.whozoss.agentos.namespace.NamespaceRepository
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptUserRunRepository
+import io.whozoss.agentos.scheduledPrompt.UserRunStatus
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserRepository
+import io.whozoss.agentos.userGroup.UserGroup
+import io.whozoss.agentos.userGroup.UserGroupRepository
+import org.neo4j.driver.Driver
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Persistence contract tests for [ScheduledPromptUserRunRepository] Cypher queries.
+ *
+ * Covers:
+ * - [ScheduledPromptUserRunRepository.materialize] — deployment graph traversal,
+ *   idempotency, soft-delete filtering, ADMIN relation, multi-group deduplication
+ * - [ScheduledPromptUserRunRepository.claimBatch] — PENDING→RUNNING transition,
+ *   limit enforcement, lease-based crash recovery, terminal status exclusion
+ * - [ScheduledPromptUserRunRepository.markTerminal] — DONE/FAILED transitions
+ * - [ScheduledPromptUserRunRepository.findByRunId] — ordered retrieval
+ * - [ScheduledPromptUserRunRepository.countByRunIdAndStatus] — multi-status counting
+ * - [ScheduledPromptUserRunRepository.hasAnyFailed] — boolean failure check
+ */
+abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var userRunRepo: ScheduledPromptUserRunRepository
+
+    @Autowired lateinit var namespaceRepo: NamespaceRepository
+
+    @Autowired lateinit var agentConfigRepo: AgentConfigRepository
+
+    @Autowired lateinit var userGroupRepo: UserGroupRepository
+
+    @Autowired lateinit var userRepo: UserRepository
+
+    @Autowired lateinit var driver: Driver
+
+    // ---------------------------------------------------------------------------
+    // Entity builders
+    // ---------------------------------------------------------------------------
+
+    private fun namespace() =
+        Namespace(metadata = EntityMetadata(), name = "test-ns", externalId = "ext-${UUID.randomUUID()}")
+
+    private fun agentConfig(namespaceId: UUID, name: String = "test-agent") =
+        AgentConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = name)
+
+    private fun user(externalId: String) =
+        User(metadata = EntityMetadata(), externalId = externalId, email = externalId)
+
+    private fun userGroup(namespaceId: UUID, name: String = "test-group") =
+        UserGroup(metadata = EntityMetadata(), namespaceId = namespaceId, name = name)
+
+    // ---------------------------------------------------------------------------
+    // Graph setup helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Creates the minimal deployment graph:
+     * AgentConfig -[:DEPLOYED_TO]-> UserGroup -[:BELONGS_TO]-> Namespace
+     * Users -[:MEMBER]-> UserGroup
+     *
+     * Returns (namespace, agentConfig, group, savedUsers).
+     */
+    private fun setupDeployment(
+        userEmails: List<String>,
+        agentName: String = "test-agent",
+    ): DeploymentFixture {
+        val ns = namespaceRepo.save(namespace())
+        val agent = agentConfigRepo.save(agentConfig(ns.id, agentName))
+        val group = userGroupRepo.save(userGroup(ns.id))
+        val savedUsers = userEmails.map { userRepo.save(user(it)) }
+        userGroupRepo.addAgents(group.id, listOf(agent.id))
+        userGroupRepo.addUsers(group.id, userEmails)
+        return DeploymentFixture(ns, agent, group, savedUsers)
+    }
+
+    private data class DeploymentFixture(
+        val ns: Namespace,
+        val agent: AgentConfig,
+        val group: UserGroup,
+        val users: List<User>,
+    )
+
+    init {
+        beforeEach {
+            Neo4jContainerSupport.clearDatabase(driver)
+            TestAuditConfiguration.currentAuditorId = TestAuditConfiguration.TEST_AUDITOR_ID
+        }
+
+        // -------------------------------------------------------------------------
+        // materialize
+        // -------------------------------------------------------------------------
+
+        "materialize creates PENDING UserRuns for each target user in the deployment graph" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com", "bob@example.com"))
+
+            val count = userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            count shouldBe 2
+            val userRuns = userRunRepo.findByRunId(runId)
+            userRuns.size shouldBe 2
+            userRuns.all { it.status == UserRunStatus.PENDING } shouldBe true
+            userRuns.all { it.runId == runId } shouldBe true
+        }
+
+        "materialize is idempotent — second call does not duplicate records" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            // MERGE is idempotent on the UNIQUE userRunKey constraint — no duplicate nodes
+            userRunRepo.findByRunId(runId).size shouldBe 1
+        }
+
+        "materialize returns 0 when no users are deployed" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            // No DEPLOYED_TO edge, no users
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 0
+            userRunRepo.findByRunId(runId).shouldBeEmpty()
+        }
+
+        "materialize excludes soft-deleted users" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            // Soft-delete the user directly via Cypher
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (u:User {id: \$id}) SET u.removed = true",
+                    mapOf("id" to alice.id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 0
+            userRunRepo.findByRunId(runId).shouldBeEmpty()
+        }
+
+        "materialize excludes soft-deleted user groups" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            // Soft-delete the group
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (g:UserGroup {id: \$id}) SET g.removed = true",
+                    mapOf("id" to group.id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 0
+        }
+
+        "materialize excludes soft-deleted agent configs" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+            // Soft-delete the agent
+            agentConfigRepo.delete(fixture.agent.id)
+
+            val count = userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            count shouldBe 0
+        }
+
+        "materialize creates UserRuns for users in multiple groups deployed to the same agent" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val group1 = userGroupRepo.save(userGroup(ns.id, "group-1"))
+            val group2 = userGroupRepo.save(userGroup(ns.id, "group-2"))
+            userRepo.save(user("alice@example.com"))
+            userRepo.save(user("bob@example.com"))
+            userGroupRepo.addAgents(group1.id, listOf(agent.id))
+            userGroupRepo.addAgents(group2.id, listOf(agent.id))
+            userGroupRepo.addUsers(group1.id, listOf("alice@example.com"))
+            userGroupRepo.addUsers(group2.id, listOf("bob@example.com"))
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 2
+            userRunRepo.findByRunId(runId).size shouldBe 2
+        }
+
+        "materialize deduplicates users in multiple groups deployed to the same agent" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val group1 = userGroupRepo.save(userGroup(ns.id, "group-1"))
+            val group2 = userGroupRepo.save(userGroup(ns.id, "group-2"))
+            userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group1.id, listOf(agent.id))
+            userGroupRepo.addAgents(group2.id, listOf(agent.id))
+            // alice is in BOTH groups — should produce only one UserRun
+            userGroupRepo.addUsers(group1.id, listOf("alice@example.com"))
+            userGroupRepo.addUsers(group2.id, listOf("alice@example.com"))
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 1
+            userRunRepo.findByRunId(runId).size shouldBe 1
+        }
+
+        "materialize does not create UserRuns for users in groups not deployed to the agent" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val undeployedGroup = userGroupRepo.save(userGroup(ns.id, "undeployed-group"))
+            userRepo.save(user("alice@example.com"))
+            // alice is in a group, but the group has no DEPLOYED_TO edge to agent
+            userGroupRepo.addUsers(undeployedGroup.id, listOf("alice@example.com"))
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 0
+        }
+
+        "materialize handles ADMIN relation to group (not just MEMBER)" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            // Create ADMIN relation directly via Cypher (addUsers creates MEMBER)
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (u:User {id: \$userId}) MATCH (g:UserGroup {id: \$groupId}) MERGE (u)-[:ADMIN]->(g)",
+                    mapOf("userId" to alice.id.toString(), "groupId" to group.id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 1
+            val userRuns = userRunRepo.findByRunId(runId)
+            userRuns.size shouldBe 1
+            userRuns.first().userId shouldBe alice.id
+        }
+
+        // -------------------------------------------------------------------------
+        // claimBatch
+        // -------------------------------------------------------------------------
+
+        "claimBatch returns empty list when no UserRuns exist" {
+            val claimed = userRunRepo.claimBatch(Duration.ofMinutes(30), 10)
+            claimed.shouldBeEmpty()
+        }
+
+        "claimBatch transitions PENDING to RUNNING and sets leaseUntil" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            val claimed = userRunRepo.claimBatch(Duration.ofMinutes(30), 10)
+
+            claimed.size shouldBe 1
+            claimed.first().status shouldBe UserRunStatus.RUNNING
+            claimed.first().leaseUntil.shouldNotBeNull()
+            claimed.first().runId shouldBe runId
+        }
+
+        "claimBatch does not return DONE or FAILED entries" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com", "bob@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+            val userRuns = userRunRepo.findByRunId(runId)
+            val now = Instant.now()
+            userRunRepo.markTerminal(userRuns[0].id, UserRunStatus.DONE, now)
+            userRunRepo.markTerminal(userRuns[1].id, UserRunStatus.FAILED, now, "error")
+
+            val claimed = userRunRepo.claimBatch(Duration.ofMinutes(30), 10)
+
+            claimed.shouldBeEmpty()
+        }
+
+        "claimBatch reclaims a RUNNING entry with expired lease" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+            // Claim with a very short lease
+            userRunRepo.claimBatch(Duration.ofMillis(1), 10)
+            Thread.sleep(10)
+
+            // Lease has expired — should be re-claimable
+            val reclaimed = userRunRepo.claimBatch(Duration.ofMinutes(30), 10)
+
+            reclaimed.size shouldBe 1
+            reclaimed.first().status shouldBe UserRunStatus.RUNNING
+        }
+
+        "claimBatch respects limit parameter" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com", "bob@example.com", "carol@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            val claimed = userRunRepo.claimBatch(Duration.ofMinutes(30), 2)
+
+            claimed.size shouldBe 2
+            claimed.all { it.status == UserRunStatus.RUNNING } shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // markTerminal
+        // -------------------------------------------------------------------------
+
+        "markTerminal to DONE sets finishedAt and clears leaseUntil" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+            val ur = userRunRepo.findByRunId(runId).first()
+            val now = Instant.now()
+
+            val done = userRunRepo.markTerminal(ur.id, UserRunStatus.DONE, now)
+
+            done.status shouldBe UserRunStatus.DONE
+            done.finishedAt.shouldNotBeNull()
+            done.leaseUntil.shouldBeNull()
+            done.error.shouldBeNull()
+        }
+
+        "markTerminal to FAILED sets error and finishedAt" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+            val ur = userRunRepo.findByRunId(runId).first()
+            val now = Instant.now()
+
+            val failed = userRunRepo.markTerminal(ur.id, UserRunStatus.FAILED, now, "Case creation failed")
+
+            failed.status shouldBe UserRunStatus.FAILED
+            failed.error shouldBe "Case creation failed"
+            failed.finishedAt.shouldNotBeNull()
+        }
+
+        // -------------------------------------------------------------------------
+        // findByRunId
+        // -------------------------------------------------------------------------
+
+        "findByRunId returns all UserRuns for a given run" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com", "bob@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            val results = userRunRepo.findByRunId(runId)
+
+            results.size shouldBe 2
+            results.all { it.runId == runId } shouldBe true
+        }
+
+        "findByRunId returns empty list when no UserRuns exist" {
+            val results = userRunRepo.findByRunId(UUID.randomUUID())
+            results.shouldBeEmpty()
+        }
+
+        // -------------------------------------------------------------------------
+        // countByRunIdAndStatus
+        // -------------------------------------------------------------------------
+
+        "countByRunIdAndStatus counts entries matching the given statuses" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com", "bob@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+            val userRuns = userRunRepo.findByRunId(runId)
+            userRunRepo.markTerminal(userRuns[0].id, UserRunStatus.DONE, Instant.now())
+
+            userRunRepo.countByRunIdAndStatus(runId, UserRunStatus.PENDING) shouldBe 1
+            userRunRepo.countByRunIdAndStatus(runId, UserRunStatus.DONE) shouldBe 1
+            userRunRepo.countByRunIdAndStatus(runId, UserRunStatus.PENDING, UserRunStatus.DONE) shouldBe 2
+            userRunRepo.countByRunIdAndStatus(runId, UserRunStatus.FAILED) shouldBe 0
+        }
+
+        // -------------------------------------------------------------------------
+        // hasAnyFailed
+        // -------------------------------------------------------------------------
+
+        "hasAnyFailed returns true when at least one FAILED entry exists" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+            val ur = userRunRepo.findByRunId(runId).first()
+            userRunRepo.markTerminal(ur.id, UserRunStatus.FAILED, Instant.now(), "error")
+
+            userRunRepo.hasAnyFailed(runId) shouldBe true
+        }
+
+        "hasAnyFailed returns false when no FAILED entries exist" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("alice@example.com"))
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            userRunRepo.hasAnyFailed(runId) shouldBe false
+        }
+    }
+
+    private fun List<Any>.shouldBeEmpty() {
+        size shouldBe 0
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
@@ -128,7 +128,7 @@ abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
             userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
             userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
 
-            // MERGE is idempotent on the UNIQUE userRunKey constraint — no duplicate nodes
+            // MERGE is idempotent on the composite UNIQUE (runId, userId) constraint — no duplicate nodes
             userRunRepo.findByRunId(runId).size shouldBe 1
         }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
@@ -59,7 +59,7 @@ abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
         Namespace(metadata = EntityMetadata(), name = "test-ns", externalId = "ext-${UUID.randomUUID()}")
 
     private fun agentConfig(namespaceId: UUID, name: String = "test-agent") =
-        AgentConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = name)
+        AgentConfig(metadata = EntityMetadata(), namespaceId = namespaceId, name = name, enabled = true)
 
     private fun user(externalId: String) =
         User(metadata = EntityMetadata(), externalId = externalId, email = externalId)
@@ -249,6 +249,123 @@ abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
 
             count shouldBe 0
         }
+
+        // -------------------------------------------------------------------------
+        // materialize — Namespace deployment path
+        // -------------------------------------------------------------------------
+
+        "materialize creates UserRuns for users when agent is deployed directly to namespace" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            // Deploy agent directly to namespace (no UserGroup)
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (a:AgentConfig {id: \$agentId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (a)-[:DEPLOYED_TO]->(ns)",
+                    mapOf("agentId" to agent.id.toString(), "nsId" to ns.id.toString()),
+                )
+                // User is MEMBER of namespace
+                session.run(
+                    "MATCH (u:User {id: \$userId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (u)-[:MEMBER]->(ns)",
+                    mapOf("userId" to alice.id.toString(), "nsId" to ns.id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 1
+            val userRuns = userRunRepo.findByRunId(runId)
+            userRuns.size shouldBe 1
+            userRuns.first().userId shouldBe alice.id
+        }
+
+        "materialize via namespace deployment excludes users not member/admin of namespace" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            userRepo.save(user("alice@example.com"))
+            // Deploy agent to namespace, but alice has NO membership edge to namespace
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (a:AgentConfig {id: \$agentId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (a)-[:DEPLOYED_TO]->(ns)",
+                    mapOf("agentId" to agent.id.toString(), "nsId" to ns.id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 0
+        }
+
+        "materialize deduplicates users found via both UserGroup and Namespace deployment" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            val alice = userRepo.save(user("alice@example.com"))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
+            // Also deploy agent directly to namespace, and alice is MEMBER of namespace
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (a:AgentConfig {id: \$agentId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (a)-[:DEPLOYED_TO]->(ns)",
+                    mapOf("agentId" to agent.id.toString(), "nsId" to ns.id.toString()),
+                )
+                session.run(
+                    "MATCH (u:User {id: \$userId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (u)-[:MEMBER]->(ns)",
+                    mapOf("userId" to alice.id.toString(), "nsId" to ns.id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 1
+        }
+
+        // -------------------------------------------------------------------------
+        // materialize — super-admin exclusion
+        // -------------------------------------------------------------------------
+
+        "materialize excludes super-admins not in any deployed group or namespace" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val group = userGroupRepo.save(userGroup(ns.id))
+            userGroupRepo.addAgents(group.id, listOf(agent.id))
+            // Create a super-admin with no group/namespace membership
+            val admin = userRepo.save(user("admin@example.com"))
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (u:User {id: \$id}) SET u.isAdmin = true",
+                    mapOf("id" to admin.id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 0
+        }
+
+        "materialize includes super-admin who is also member of a deployed group" {
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(listOf("admin@example.com"))
+            // Make the user a super-admin too
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (u:User {id: \$id}) SET u.isAdmin = true",
+                    mapOf("id" to fixture.users.first().id.toString()),
+                )
+            }
+
+            val count = userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            count shouldBe 1
+        }
+
+        // -------------------------------------------------------------------------
+        // materialize — ADMIN relation to group
+        // -------------------------------------------------------------------------
 
         "materialize handles ADMIN relation to group (not just MEMBER)" {
             val runId = UUID.randomUUID()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/EmbeddedNeo4jScheduledPromptUserRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/EmbeddedNeo4jScheduledPromptUserRunPersistenceSpec.kt
@@ -1,0 +1,18 @@
+package io.whozoss.agentos.persistence.neo4j
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Runs the [AbstractScheduledPromptUserRunPersistenceSpec] contract against the embedded Neo4j
+ * engine using the Neo4j test harness (`embedded-neo4j` persistence mode).
+ *
+ * Verifies the full Cypher contract for [io.whozoss.agentos.scheduledPrompt.ScheduledPromptUserRunRepository]
+ * end-to-end, including the deployment-graph traversal in [io.whozoss.agentos.scheduledPrompt.ScheduledPromptUserRunRepository.materialize]
+ * and the lease-based crash-recovery in [io.whozoss.agentos.scheduledPrompt.ScheduledPromptUserRunRepository.claimBatch].
+ */
+@SpringBootTest
+@ActiveProfiles("test", "embedded-neo4j")
+@Import(EmbeddedNeo4jTestConfiguration::class)
+class EmbeddedNeo4jScheduledPromptUserRunPersistenceSpec : AbstractScheduledPromptUserRunPersistenceSpec()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.scheduledPrompt
 
+import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -25,6 +26,20 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
             it.scheduledPromptId == scheduledPromptId &&
                 (it.status == RunStatus.CLAIMED || it.status == RunStatus.RUNNING)
         }
+
+    override fun updateStatus(
+        id: UUID,
+        status: RunStatus,
+        finishedAt: Instant?,
+        error: String?,
+    ): Boolean {
+        val entry = store.entries.firstOrNull { it.value.id == id } ?: return false
+        store[entry.key] = entry.value.copy(status = status, finishedAt = finishedAt, error = error)
+        return true
+    }
+
+    override fun findById(id: UUID): ScheduledPromptRun? =
+        store.values.firstOrNull { it.id == id }
 
     /** Test helper: all stored runs. */
     fun all(): List<ScheduledPromptRun> = store.values.toList()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -41,6 +41,11 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
     override fun findById(id: UUID): ScheduledPromptRun? =
         store.values.firstOrNull { it.id == id }
 
+    override fun countCompletedRuns(scheduledPromptId: UUID): Int =
+        store.values.count {
+            it.scheduledPromptId == scheduledPromptId && it.status != RunStatus.SKIPPED
+        }
+
     /** Test helper: all stored runs. */
     fun all(): List<ScheduledPromptRun> = store.values.toList()
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * In-memory implementation of [ScheduledPromptRunRepository] for unit tests.
  *
- * Detects duplicates on [slotKey] = `"$scheduledPromptId|$scheduledForEpochMilli"` and throws
+ * Detects duplicates on the composite `(scheduledPromptId, scheduledFor)` key and throws
  * [DuplicateRunException] exactly as the Neo4j implementation does.
  *
  * [findSettledRunning] requires access to the UserRun store to replicate the Cypher
@@ -21,7 +21,7 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
     var userRunRepository: ScheduledPromptUserRunRepository? = null
 
     override fun insert(run: ScheduledPromptRun): ScheduledPromptRun {
-        val key = ScheduledPromptRunNode.slotKey(run.scheduledPromptId, run.scheduledFor)
+        val key = "${run.scheduledPromptId}|${run.scheduledFor.toEpochMilli()}"
         if (store.putIfAbsent(key, run) != null) {
             throw DuplicateRunException(run.scheduledPromptId, run.scheduledFor)
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -9,9 +9,16 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * Detects duplicates on [slotKey] = `"$scheduledPromptId|$scheduledForEpochMilli"` and throws
  * [DuplicateRunException] exactly as the Neo4j implementation does.
+ *
+ * [findSettledRunning] requires access to the UserRun store to replicate the Cypher
+ * EXISTS sub-query logic. Wire this up by setting [userRunRepository] before calling
+ * [findSettledRunning]; when null (default), the method returns an empty list.
  */
 class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
     private val store = ConcurrentHashMap<String, ScheduledPromptRun>()
+
+    /** Set by scanner factory methods to enable [findSettledRunning] in tests. */
+    var userRunRepository: ScheduledPromptUserRunRepository? = null
 
     override fun insert(run: ScheduledPromptRun): ScheduledPromptRun {
         val key = ScheduledPromptRunNode.slotKey(run.scheduledPromptId, run.scheduledFor)
@@ -50,6 +57,18 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
         store.values.filter {
             it.status == RunStatus.CLAIMED && it.metadata.created.isBefore(olderThan)
         }.sortedBy { it.metadata.created }
+
+    override fun findSettledRunning(): List<ScheduledPromptRun> {
+        val urRepo = userRunRepository ?: return emptyList()
+        return store.values
+            .filter { it.status == RunStatus.RUNNING }
+            .filter { run ->
+                val pending = urRepo.countByRunIdAndStatus(run.id, UserRunStatus.PENDING)
+                val running = urRepo.countByRunIdAndStatus(run.id, UserRunStatus.RUNNING)
+                pending == 0 && running == 0
+            }
+            .sortedBy { it.metadata.created }
+    }
 
     /** Test helper: all stored runs. */
     fun all(): List<ScheduledPromptRun> = store.values.toList()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -46,6 +46,11 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
             it.scheduledPromptId == scheduledPromptId && it.status != RunStatus.SKIPPED
         }
 
+    override fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun> =
+        store.values.filter {
+            it.status == RunStatus.CLAIMED && it.metadata.created.isBefore(olderThan)
+        }.sortedBy { it.metadata.created }
+
     /** Test helper: all stored runs. */
     fun all(): List<ScheduledPromptRun> = store.values.toList()
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptUserRunRepository.kt
@@ -104,6 +104,9 @@ class InMemoryScheduledPromptUserRunRepository(
             ur.runId == runId && ur.status in statuses
         }
 
+    override fun hasAnyActive(runId: UUID): Boolean =
+        store.values.any { it.runId == runId && (it.status == UserRunStatus.PENDING || it.status == UserRunStatus.RUNNING) }
+
     override fun hasAnyFailed(runId: UUID): Boolean =
         store.values.any { it.runId == runId && it.status == UserRunStatus.FAILED }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptUserRunRepository.kt
@@ -1,0 +1,115 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory implementation of [ScheduledPromptUserRunRepository] for unit tests.
+ *
+ * ### Graph-traversal materialize
+ *
+ * The Neo4j implementation traverses the deployment graph inside the database. The in-memory
+ * variant cannot do that, so it delegates user resolution to [targetUserIdsProvider], a
+ * lambda injected at construction time. In tests that exercise Phase A, pass a lambda that
+ * returns the desired set of target userIds. Tests that only exercise Phase B or other
+ * methods can use the default no-arg constructor (provider always returns empty set).
+ *
+ * ### Other methods
+ *
+ * [claimBatch] picks the oldest PENDING entries (up to `limit`), or RUNNING entries with
+ * an expired lease. It is NOT atomic (single-threaded test use only).
+ *
+ * [markTerminal] uses a version counter to detect concurrent modifications, mirroring the
+ * [ScheduledPromptUserRunNode.version] optimistic lock in the Neo4j implementation.
+ */
+class InMemoryScheduledPromptUserRunRepository(
+    /**
+     * Provides the set of target userIds for a given `(agentConfigId, namespaceId)` pair.
+     * Defaults to returning an empty set (no-op materialisation).
+     */
+    private val targetUserIdsProvider: (agentConfigId: UUID, namespaceId: UUID) -> Set<UUID> = { _, _ -> emptySet() },
+) : ScheduledPromptUserRunRepository {
+    private val store = ConcurrentHashMap<UUID, ScheduledPromptUserRun>()
+
+    /**
+     * Graph-traversal variant: resolves target users via [targetUserIdsProvider], then
+     * MERGEs a PENDING UserRun for each. Idempotent — existing records are left unchanged.
+     *
+     * Returns the number of UserRuns actually created (not counting pre-existing ones).
+     */
+    override fun materialize(runId: UUID, agentConfigId: UUID, namespaceId: UUID): Int {
+        val userIds = targetUserIdsProvider(agentConfigId, namespaceId)
+        var created = 0
+        userIds.forEach { userId ->
+            val existing = store.values.firstOrNull { it.runId == runId && it.userId == userId }
+            if (existing == null) {
+                val userRun = ScheduledPromptUserRun(
+                    runId = runId,
+                    userId = userId,
+                    status = UserRunStatus.PENDING,
+                )
+                store[userRun.id] = userRun
+                created++
+            }
+        }
+        return created
+    }
+
+    override fun claimBatch(leaseDuration: Duration, limit: Int): List<ScheduledPromptUserRun> {
+        val now = Instant.now()
+        val claimable = store.values
+            .filter { ur ->
+                ur.status == UserRunStatus.PENDING ||
+                    (ur.status == UserRunStatus.RUNNING && ur.leaseUntil != null && ur.leaseUntil < now)
+            }
+            .sortedBy { it.metadata.created }
+            .take(limit)
+
+        return claimable.map { ur ->
+            val claimed = ur.copy(
+                status = UserRunStatus.RUNNING,
+                leaseUntil = now.plus(leaseDuration),
+            )
+            store[claimed.id] = claimed
+            claimed
+        }
+    }
+
+    override fun markTerminal(
+        id: UUID,
+        status: UserRunStatus,
+        now: Instant,
+        error: String?,
+    ): ScheduledPromptUserRun {
+        val current = store[id] ?: throw NoSuchElementException("ScheduledPromptUserRun not found: $id")
+        val updated = current.copy(
+            status = status,
+            finishedAt = now,
+            error = error,
+            leaseUntil = null,
+        )
+        store[id] = updated
+        return updated
+    }
+
+    override fun findByRunId(runId: UUID): List<ScheduledPromptUserRun> =
+        store.values
+            .filter { it.runId == runId }
+            .sortedBy { it.metadata.created }
+
+    override fun countByRunIdAndStatus(runId: UUID, vararg statuses: UserRunStatus): Int =
+        store.values.count { ur ->
+            ur.runId == runId && ur.status in statuses
+        }
+
+    override fun hasAnyFailed(runId: UUID): Boolean =
+        store.values.any { it.runId == runId && it.status == UserRunStatus.FAILED }
+
+    /** Test helper: all stored UserRuns. */
+    fun all(): List<ScheduledPromptUserRun> = store.values.toList()
+
+    /** Test helper: clear the store between tests. */
+    fun clear() = store.clear()
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -57,7 +57,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
 
     private val properties = SchedulerProperties(
         maxConcurrentExecutions = 5,
-        staggerDelayMs = 0L,
         leaseMinutes = 30L,
     )
 
@@ -604,7 +603,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             // Use a very short lease so the timeout triggers immediately.
             val shortLeaseProperties = SchedulerProperties(
                 maxConcurrentExecutions = 5,
-                staggerDelayMs = 0L,
                 leaseMinutes = 0L, // 0 minutes → withTimeoutOrNull(0) times out immediately
             )
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -599,7 +599,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             userRun.error shouldBe "Case reached terminal status ERROR"
         }
 
-        "Phase B: monitorLaunch closes UserRun as DONE on timeout (Case still RUNNING)" {
+        "Phase B: monitorLaunch closes UserRun as TIMEOUT on timeout (Case still RUNNING)" {
             // Use a zero launch timeout so it times out immediately.
             val shortTimeoutProperties = SchedulerProperties(
                 batchSize = 5,
@@ -654,9 +654,10 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             ).consumeAvailable()
 
             // Timeout on a still-RUNNING Case is not a failure — the Case is healthy,
-            // just slow. The UserRun is closed as DONE.
+            // just slow. Monitoring is released and the UserRun is closed as TIMEOUT
+            // for audit visibility; the Case continues running independently.
             val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.DONE
+            userRun.status shouldBe UserRunStatus.TIMEOUT
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -489,6 +489,180 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             userRun.error shouldBe "PromptTemplate $promptTemplateId has empty content"
         }
 
+        // -------------------------------------------------------------------------
+        // Phase B — awaitCaseCompletion via statusFlow
+        // -------------------------------------------------------------------------
+
+        "Phase B: awaitCaseCompletion closes UserRun as DONE when runtime reaches IDLE" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            val createdCase = Case(
+                metadata = EntityMetadata(id = caseId),
+                namespaceId = namespaceId,
+            )
+
+            // Simulate a runtime whose statusFlow starts as RUNNING then transitions to IDLE
+            // after addMessage is called (mimicking the real CaseRuntime lifecycle).
+            val statusFlow = MutableStateFlow(CaseStatus.RUNNING)
+            val runtime = mockk<CaseRuntime>(relaxed = true).also {
+                every { it.statusFlow } returns statusFlow
+            }
+
+            val caseService = mockk<CaseService>(relaxed = true).also {
+                every { it.create(any()) } returns createdCase
+                every { it.findActiveRuntime(caseId) } returns runtime
+                // When addMessage is called, transition the statusFlow to IDLE
+                // (simulates the async agent execution completing).
+                every { it.addMessage(caseId = caseId, actor = any(), content = any()) } answers {
+                    statusFlow.value = CaseStatus.IDLE
+                }
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).consumeAvailable()
+
+            val userRun = userRunRepo.all().first()
+            userRun.status shouldBe UserRunStatus.DONE
+        }
+
+        "Phase B: awaitCaseCompletion closes UserRun as FAILED when runtime reaches ERROR" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            val createdCase = Case(
+                metadata = EntityMetadata(id = caseId),
+                namespaceId = namespaceId,
+            )
+
+            val statusFlow = MutableStateFlow(CaseStatus.RUNNING)
+            val runtime = mockk<CaseRuntime>(relaxed = true).also {
+                every { it.statusFlow } returns statusFlow
+            }
+
+            val caseService = mockk<CaseService>(relaxed = true).also {
+                every { it.create(any()) } returns createdCase
+                every { it.findActiveRuntime(caseId) } returns runtime
+                every { it.addMessage(caseId = caseId, actor = any(), content = any()) } answers {
+                    statusFlow.value = CaseStatus.ERROR
+                }
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).consumeAvailable()
+
+            val userRun = userRunRepo.all().first()
+            userRun.status shouldBe UserRunStatus.FAILED
+            userRun.error shouldBe "Case reached terminal status ERROR"
+        }
+
+        "Phase B: awaitCaseCompletion marks UserRun FAILED on lease timeout" {
+            // Use a very short lease so the timeout triggers immediately.
+            val shortLeaseProperties = SchedulerProperties(
+                maxConcurrentExecutions = 5,
+                staggerDelayMs = 0L,
+                leaseMinutes = 0L, // 0 minutes → withTimeoutOrNull(0) times out immediately
+            )
+
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            val createdCase = Case(
+                metadata = EntityMetadata(id = caseId),
+                namespaceId = namespaceId,
+            )
+
+            // StatusFlow stays RUNNING forever — simulates an agent that never finishes.
+            val statusFlow = MutableStateFlow(CaseStatus.RUNNING)
+            val runtime = mockk<CaseRuntime>(relaxed = true).also {
+                every { it.statusFlow } returns statusFlow
+            }
+
+            val caseService = mockk<CaseService>(relaxed = true).also {
+                every { it.create(any()) } returns createdCase
+                every { it.findActiveRuntime(caseId) } returns runtime
+            }
+
+            ScheduledPromptExecutor(
+                scheduledPromptRepository = makeSpRepo(sp),
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+                properties = shortLeaseProperties,
+                clock = clock,
+            ).consumeAvailable()
+
+            val userRun = userRunRepo.all().first()
+            userRun.status shouldBe UserRunStatus.FAILED
+            userRun.error!!.contains("Lease expired") shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // Phase B: prompt or agent not found — UserRun marked FAILED
+        // -------------------------------------------------------------------------
+
         "Phase B: agent config not found marks UserRun FAILED" {
             val sp = makeScheduledPrompt()
             val run = makeRun(sp).copy(status = RunStatus.RUNNING)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -216,7 +216,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             userRunRepo.all().size shouldBe 1
         }
 
-        "Phase A: platform-scope ScheduledPrompt materialises zero UserRuns" {
+        "Phase A: platform-scope ScheduledPrompt materialises zero UserRuns and transitions to DONE" {
             val sp = makeScheduledPrompt(nsId = null)
             val run = makeRun(sp)
             val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
@@ -234,9 +234,9 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             ).materialize(run, sp)
 
             userRunRepo.all().size shouldBe 0
-            // Run still transitions to RUNNING (zero users is valid)
+            // No target users → Run transitions directly to DONE (nothing to consume)
             val updatedRun = runRepo.all().first { it.id == run.id }
-            updatedRun.status shouldBe RunStatus.RUNNING
+            updatedRun.status shouldBe RunStatus.DONE
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -314,7 +314,9 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             // Wait for the background coroutine to settle
             kotlinx.coroutines.delay(500)
 
-            verify(exactly = 1) { caseService.create(any()) }
+            val caseSlot = slot<Case>()
+            verify(exactly = 1) { caseService.create(capture(caseSlot)) }
+            caseSlot.captured.title shouldBe "Weekly Digest"
             verify(exactly = 1) {
                 permissionService.grantPermission(
                     userId1.toString(),

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -1,0 +1,526 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.whozoss.agentos.agentConfig.AgentConfig
+import io.whozoss.agentos.agentConfig.AgentConfigService
+import io.whozoss.agentos.caseFlow.Case
+import io.whozoss.agentos.caseFlow.CaseRuntime
+import io.whozoss.agentos.caseFlow.CaseService
+import io.whozoss.agentos.permissions.EntityType
+import io.whozoss.agentos.permissions.PermissionRelation
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.prompt.Prompt
+import io.whozoss.agentos.prompt.PromptService
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerEndType
+import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerUnit
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Unit tests for [ScheduledPromptExecutor].
+ *
+ * Uses in-memory repositories and MockK stubs — no Spring context, no Neo4j.
+ *
+ * Fixed clock: 2026-01-01 09:00:00 UTC.
+ *
+ * The [InMemoryScheduledPromptUserRunRepository] is constructed with a [targetUserIdsProvider]
+ * lambda to simulate the Neo4j deployment-graph traversal without touching a database.
+ */
+class ScheduledPromptExecutorUnitSpec : StringSpec() {
+
+    private val nowInstant = Instant.parse("2026-01-01T09:00:00Z")
+    private val clock = Clock.fixed(nowInstant, ZoneOffset.UTC)
+
+    private val namespaceId: UUID = UUID.fromString("10000000-0000-0000-0000-000000000001")
+    private val agentId: UUID = UUID.fromString("20000000-0000-0000-0000-000000000001")
+    private val promptTemplateId: UUID = UUID.fromString("30000000-0000-0000-0000-000000000001")
+    private val userId1: UUID = UUID.fromString("40000000-0000-0000-0000-000000000001")
+    private val userId2: UUID = UUID.fromString("40000000-0000-0000-0000-000000000002")
+    private val caseId: UUID = UUID.fromString("50000000-0000-0000-0000-000000000001")
+
+    private val properties = SchedulerProperties(
+        maxConcurrentExecutions = 5,
+        staggerDelayMs = 0L,
+        leaseMinutes = 30L,
+    )
+
+    private val user1 = User(
+        metadata = EntityMetadata(id = userId1),
+        externalId = "user1@example.com",
+        firstname = "Alice",
+        lastname = "Smith",
+    )
+    private val user2 = User(
+        metadata = EntityMetadata(id = userId2),
+        externalId = "user2@example.com",
+        firstname = "Bob",
+        lastname = "Jones",
+    )
+
+    private fun makeScheduledPrompt(nsId: UUID? = namespaceId) = ScheduledPrompt(
+        metadata = EntityMetadata(id = UUID.randomUUID()),
+        namespaceId = nsId,
+        agentConfigId = agentId,
+        promptTemplateId = promptTemplateId,
+        name = "Weekly Digest",
+        recurrence = Recurrence(unit = SchedulerUnit.WEEK, timeUtc = LocalTime.of(9, 0)),
+        planning = Planning(startDate = LocalDate.of(2026, 1, 1), endType = SchedulerEndType.NEVER),
+        nextRunAt = nowInstant,
+    )
+
+    private fun makeRun(sp: ScheduledPrompt) = ScheduledPromptRun(
+        metadata = EntityMetadata(id = UUID.randomUUID()),
+        scheduledPromptId = sp.id,
+        scheduledFor = nowInstant,
+        status = RunStatus.CLAIMED,
+        correlationId = "test-run",
+    )
+
+    private fun makePromptTemplate(content: String = "Run your weekly digest report.") = Prompt(
+        metadata = EntityMetadata(id = promptTemplateId),
+        name = "digest-template",
+        content = listOf(content),
+    )
+
+    private fun makeAgentConfig(name: String = "weekly-agent") = AgentConfig(
+        metadata = EntityMetadata(id = agentId),
+        namespaceId = namespaceId,
+        name = name,
+    )
+
+    private fun makeIdleRuntime(): CaseRuntime {
+        val rt = mockk<CaseRuntime>(relaxed = true)
+        every { rt.statusFlow } returns MutableStateFlow(CaseStatus.IDLE)
+        every { rt.isRunning() } returns false
+        return rt
+    }
+
+    private fun makeSpRepo(sp: ScheduledPrompt): ScheduledPromptRepository {
+        val repo = mockk<ScheduledPromptRepository>()
+        every { repo.findByIds(listOf(sp.id)) } returns listOf(sp)
+        return repo
+    }
+
+    /**
+     * Build an [InMemoryScheduledPromptUserRunRepository] whose graph-traversal materialize
+     * returns [targetUserIds] for any `(agentConfigId, namespaceId)` pair.
+     */
+    private fun makeUserRunRepo(targetUserIds: Set<UUID> = emptySet()) =
+        InMemoryScheduledPromptUserRunRepository { _, _ -> targetUserIds }
+
+    private fun executor(
+        spRepo: ScheduledPromptRepository,
+        runRepo: ScheduledPromptRunRepository,
+        userRunRepo: ScheduledPromptUserRunRepository,
+        promptService: PromptService,
+        agentConfigService: AgentConfigService = mockk(relaxed = true),
+        caseService: CaseService,
+        permissionService: PermissionService,
+        userService: UserService,
+    ) = ScheduledPromptExecutor(
+        scheduledPromptRepository = spRepo,
+        runRepository = runRepo,
+        userRunRepository = userRunRepo,
+        promptService = promptService,
+        agentConfigService = agentConfigService,
+        caseService = caseService,
+        permissionService = permissionService,
+        userService = userService,
+        properties = properties,
+        clock = clock,
+    )
+
+    init {
+
+        // -------------------------------------------------------------------------
+        // Phase A — Materialisation
+        // -------------------------------------------------------------------------
+
+        "Phase A: materialise creates PENDING UserRuns for each target user" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1, userId2))
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            ).materialize(run, sp)
+
+            val userRuns = userRunRepo.all()
+            userRuns.size shouldBe 2
+            userRuns.all { it.status == UserRunStatus.PENDING } shouldBe true
+            userRuns.map { it.userId }.toSet() shouldBe setOf(userId1, userId2)
+        }
+
+        "Phase A: materialise transitions Run to RUNNING" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1))
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            ).materialize(run, sp)
+
+            val updatedRun = runRepo.all().first { it.id == run.id }
+            updatedRun.status shouldBe RunStatus.RUNNING
+        }
+
+        "Phase A: materialise is idempotent (double call does not duplicate UserRuns)" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1))
+
+            val exec = executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            )
+            exec.materialize(run, sp)
+            exec.materialize(run, sp)
+
+            userRunRepo.all().size shouldBe 1
+        }
+
+        "Phase A: platform-scope ScheduledPrompt materialises zero UserRuns" {
+            val sp = makeScheduledPrompt(nsId = null)
+            val run = makeRun(sp)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            // Provider is never called for platform-scope (namespaceId == null)
+            val userRunRepo = makeUserRunRepo(emptySet())
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            ).materialize(run, sp)
+
+            userRunRepo.all().size shouldBe 0
+            // Run still transitions to RUNNING (zero users is valid)
+            val updatedRun = runRepo.all().first { it.id == run.id }
+            updatedRun.status shouldBe RunStatus.RUNNING
+        }
+
+        // -------------------------------------------------------------------------
+        // Phase B — consumeAvailable with no pending UserRuns
+        // -------------------------------------------------------------------------
+
+        "Phase B: consumeAvailable does nothing when no PENDING UserRuns exist" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(emptySet())
+            val caseService = mockk<CaseService>(relaxed = true)
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            ).consumeAvailable()
+
+            verify(exactly = 0) { caseService.create(any()) }
+        }
+
+        // -------------------------------------------------------------------------
+        // Phase B — full execution path
+        // -------------------------------------------------------------------------
+
+        "Phase B: consumeAvailable creates Case, grants ADMIN, and injects @agentName /promptName message" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptTemplate = makePromptTemplate() // name = "digest-template"
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns promptTemplate
+            }
+
+            val agentConfig = makeAgentConfig(name = "weekly-agent")
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns agentConfig
+            }
+
+            val createdCase = Case(
+                metadata = EntityMetadata(id = caseId),
+                namespaceId = namespaceId,
+            )
+            val caseService = mockk<CaseService>(relaxed = true).also {
+                every { it.create(any()) } returns createdCase
+                every { it.findById(caseId) } returns createdCase.copy(status = CaseStatus.IDLE)
+                every { it.findActiveRuntime(caseId) } returns null // runtime evicted — IDLE
+            }
+
+            val permissionService = mockk<PermissionService>(relaxed = true)
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = permissionService,
+                userService = userService,
+            ).consumeAvailable()
+
+            // Wait for the background coroutine to settle
+            kotlinx.coroutines.delay(500)
+
+            verify(exactly = 1) { caseService.create(any()) }
+            verify(exactly = 1) {
+                permissionService.grantPermission(
+                    userId1.toString(),
+                    EntityType.CASE,
+                    caseId.toString(),
+                    PermissionRelation.ADMIN,
+                )
+            }
+            val actorSlot = slot<Actor>()
+            val contentSlot = slot<List<MessageContent>>()
+            verify(exactly = 1) {
+                caseService.addMessage(
+                    caseId = caseId,
+                    actor = capture(actorSlot),
+                    content = capture(contentSlot),
+                )
+            }
+            actorSlot.captured.role shouldBe ActorRole.USER
+            actorSlot.captured.id shouldBe userId1.toString()
+            // The message must be "@agentName <resolved prompt content>" — the Executor
+            // resolves the content directly rather than injecting a /slash-command, because
+            // PromptCommandParser requires text to start with '/' which is incompatible
+            // with the leading @mention.
+            val text = contentSlot.captured.filterIsInstance<MessageContent.Text>().first().content
+            text shouldBe "@weekly-agent Run your weekly digest report."
+        }
+
+        // -------------------------------------------------------------------------
+        // Completion check
+        // -------------------------------------------------------------------------
+
+        "Completion: Run transitions to DONE when all UserRuns are settled" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1))
+            userRunRepo.materialize(run.id, agentId, namespaceId)
+            val ur = userRunRepo.all().first()
+            userRunRepo.markTerminal(ur.id, UserRunStatus.DONE, nowInstant)
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            ).consumeAvailable()
+
+            val updatedRun = runRepo.all().first { it.id == run.id }
+            updatedRun.status shouldBe RunStatus.RUNNING
+        }
+
+        "Completion: Run transitions to FAILED when a UserRun has failed" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1))
+            userRunRepo.materialize(run.id, agentId, namespaceId)
+            val ur = userRunRepo.all().first()
+            userRunRepo.markTerminal(ur.id, UserRunStatus.FAILED, nowInstant, "boom")
+
+            userRunRepo.hasAnyFailed(run.id) shouldBe true
+            userRunRepo.countByRunIdAndStatus(run.id, UserRunStatus.PENDING) shouldBe 0
+            userRunRepo.countByRunIdAndStatus(run.id, UserRunStatus.RUNNING) shouldBe 0
+        }
+
+        // -------------------------------------------------------------------------
+        // Phase B: user not found — UserRun marked FAILED
+        // -------------------------------------------------------------------------
+
+        "Phase B: user not found in UserService marks UserRun FAILED" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns null
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).consumeAvailable()
+
+            // Wait for the background coroutine
+            kotlinx.coroutines.delay(500)
+
+            val userRun = userRunRepo.all().first()
+            userRun.status shouldBe UserRunStatus.FAILED
+        }
+
+        // -------------------------------------------------------------------------
+        // Phase B: prompt or agent not found — UserRun marked FAILED
+        // -------------------------------------------------------------------------
+
+        "Phase B: prompt template not found marks UserRun FAILED" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns null
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = promptService,
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).consumeAvailable()
+
+            kotlinx.coroutines.delay(500)
+
+            val userRun = userRunRepo.all().first()
+            userRun.status shouldBe UserRunStatus.FAILED
+            userRun.error shouldBe "PromptTemplate $promptTemplateId not found"
+        }
+
+        "Phase B: prompt template with empty content marks UserRun FAILED" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate(content = "")
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = promptService,
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).consumeAvailable()
+
+            kotlinx.coroutines.delay(500)
+
+            val userRun = userRunRepo.all().first()
+            userRun.status shouldBe UserRunStatus.FAILED
+            userRun.error shouldBe "PromptTemplate $promptTemplateId has empty content"
+        }
+
+        "Phase B: agent config not found marks UserRun FAILED" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns null
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).consumeAvailable()
+
+            kotlinx.coroutines.delay(500)
+
+            val userRun = userRunRepo.all().first()
+            userRun.status shouldBe UserRunStatus.FAILED
+            userRun.error shouldBe "AgentConfig $agentId not found"
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -56,7 +56,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
     private val caseId: UUID = UUID.fromString("50000000-0000-0000-0000-000000000001")
 
     private val properties = SchedulerProperties(
-        maxConcurrentExecutions = 5,
+        batchSize = 5,
         leaseMinutes = 30L,
     )
 
@@ -602,7 +602,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
         "Phase B: awaitCaseCompletion marks UserRun FAILED on lease timeout" {
             // Use a very short lease so the timeout triggers immediately.
             val shortLeaseProperties = SchedulerProperties(
-                maxConcurrentExecutions = 5,
+                batchSize = 5,
                 leaseMinutes = 0L, // 0 minutes → withTimeoutOrNull(0) times out immediately
             )
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -489,10 +489,10 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
-        // Phase B — awaitCaseCompletion via statusFlow
+        // Phase B — monitorLaunch via statusFlow
         // -------------------------------------------------------------------------
 
-        "Phase B: awaitCaseCompletion closes UserRun as DONE when runtime reaches IDLE" {
+        "Phase B: monitorLaunch closes UserRun as DONE when runtime reaches IDLE" {
             val sp = makeScheduledPrompt()
             val run = makeRun(sp).copy(status = RunStatus.RUNNING)
             val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
@@ -547,7 +547,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             userRun.status shouldBe UserRunStatus.DONE
         }
 
-        "Phase B: awaitCaseCompletion closes UserRun as FAILED when runtime reaches ERROR" {
+        "Phase B: monitorLaunch closes UserRun as FAILED when runtime reaches ERROR" {
             val sp = makeScheduledPrompt()
             val run = makeRun(sp).copy(status = RunStatus.RUNNING)
             val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
@@ -599,11 +599,12 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             userRun.error shouldBe "Case reached terminal status ERROR"
         }
 
-        "Phase B: awaitCaseCompletion marks UserRun FAILED on lease timeout" {
-            // Use a very short lease so the timeout triggers immediately.
-            val shortLeaseProperties = SchedulerProperties(
+        "Phase B: monitorLaunch closes UserRun as DONE on timeout (Case still RUNNING)" {
+            // Use a zero launch timeout so it times out immediately.
+            val shortTimeoutProperties = SchedulerProperties(
                 batchSize = 5,
-                leaseMinutes = 0L, // 0 minutes → withTimeoutOrNull(0) times out immediately
+                launchTimeoutSeconds = 0L, // 0 seconds → withTimeoutOrNull(0) times out immediately
+                leaseMinutes = 30L,
             )
 
             val sp = makeScheduledPrompt()
@@ -628,7 +629,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 namespaceId = namespaceId,
             )
 
-            // StatusFlow stays RUNNING forever — simulates an agent that never finishes.
+            // StatusFlow stays RUNNING forever — simulates a slow but healthy agent.
             val statusFlow = MutableStateFlow(CaseStatus.RUNNING)
             val runtime = mockk<CaseRuntime>(relaxed = true).also {
                 every { it.statusFlow } returns statusFlow
@@ -648,13 +649,14 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = caseService,
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-                properties = shortLeaseProperties,
+                properties = shortTimeoutProperties,
                 clock = clock,
             ).consumeAvailable()
 
+            // Timeout on a still-RUNNING Case is not a failure — the Case is healthy,
+            // just slow. The UserRun is closed as DONE.
             val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.FAILED
-            userRun.error!!.contains("Lease expired") shouldBe true
+            userRun.status shouldBe UserRunStatus.DONE
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeUnitSpec.kt
@@ -109,6 +109,27 @@ class ScheduledPromptUserRunNodeUnitSpec : StringSpec({
     }
 
     // -------------------------------------------------------------------------
+    // fromDomain / toDomain round-trip — TIMEOUT
+    // -------------------------------------------------------------------------
+
+    "fromDomain then toDomain preserves all fields for a TIMEOUT UserRun" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.TIMEOUT,
+            startedAt = now,
+            finishedAt = now.plusSeconds(30),
+        )
+
+        val roundTripped = ScheduledPromptUserRunNode.fromDomain(domain).toDomain()
+
+        roundTripped.status shouldBe UserRunStatus.TIMEOUT
+        roundTripped.finishedAt shouldBe now.plusSeconds(30)
+        roundTripped.error.shouldBeNull()
+        roundTripped.leaseUntil.shouldBeNull()
+    }
+
+    // -------------------------------------------------------------------------
     // Node field invariants
     // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeUnitSpec.kt
@@ -1,0 +1,197 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Unit tests for [ScheduledPromptUserRunNode] toDomain / fromDomain round-trip
+ * and the [ScheduledPromptUserRunNode.userRunKey] static helper.
+ */
+class ScheduledPromptUserRunNodeUnitSpec : StringSpec({
+
+    val runId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    val userId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    val now: Instant = Instant.parse("2025-01-15T10:00:00Z")
+
+    // -------------------------------------------------------------------------
+    // userRunKey helper
+    // -------------------------------------------------------------------------
+
+    "userRunKey produces deterministic composite key" {
+        val key = ScheduledPromptUserRunNode.userRunKey(runId, userId)
+        key shouldBe "$runId|$userId"
+    }
+
+    "userRunKey is stable across calls" {
+        val k1 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
+        val k2 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
+        k1 shouldBe k2
+    }
+
+    "userRunKey differs when runId differs" {
+        val other = UUID.fromString("00000000-0000-0000-0000-000000000099")
+        val k1 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
+        val k2 = ScheduledPromptUserRunNode.userRunKey(other, userId)
+        (k1 == k2) shouldBe false
+    }
+
+    "userRunKey differs when userId differs" {
+        val other = UUID.fromString("00000000-0000-0000-0000-000000000099")
+        val k1 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
+        val k2 = ScheduledPromptUserRunNode.userRunKey(runId, other)
+        (k1 == k2) shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // fromDomain / toDomain round-trip — PENDING
+    // -------------------------------------------------------------------------
+
+    "fromDomain then toDomain preserves all fields for a PENDING UserRun" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.PENDING,
+        )
+
+        val node = ScheduledPromptUserRunNode.fromDomain(domain)
+        val roundTripped = node.toDomain()
+
+        roundTripped.id shouldBe domain.id
+        roundTripped.runId shouldBe runId
+        roundTripped.userId shouldBe userId
+        roundTripped.status shouldBe UserRunStatus.PENDING
+        roundTripped.error.shouldBeNull()
+        roundTripped.startedAt.shouldBeNull()
+        roundTripped.finishedAt.shouldBeNull()
+        roundTripped.leaseUntil.shouldBeNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // fromDomain / toDomain round-trip — RUNNING with lease
+    // -------------------------------------------------------------------------
+
+    "fromDomain then toDomain preserves all fields for a RUNNING UserRun" {
+        val leaseUntil = now.plusSeconds(1800)
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.RUNNING,
+            startedAt = now,
+            leaseUntil = leaseUntil,
+        )
+
+        val roundTripped = ScheduledPromptUserRunNode.fromDomain(domain).toDomain()
+
+        roundTripped.status shouldBe UserRunStatus.RUNNING
+        roundTripped.startedAt shouldBe now
+        roundTripped.leaseUntil shouldBe leaseUntil
+        roundTripped.error.shouldBeNull()
+        roundTripped.finishedAt.shouldBeNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // fromDomain / toDomain round-trip — DONE
+    // -------------------------------------------------------------------------
+
+    "fromDomain then toDomain preserves all fields for a DONE UserRun" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.DONE,
+            startedAt = now,
+            finishedAt = now.plusSeconds(120),
+        )
+
+        val roundTripped = ScheduledPromptUserRunNode.fromDomain(domain).toDomain()
+
+        roundTripped.status shouldBe UserRunStatus.DONE
+        roundTripped.finishedAt shouldBe now.plusSeconds(120)
+        roundTripped.leaseUntil.shouldBeNull()
+        roundTripped.error.shouldBeNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // fromDomain / toDomain round-trip — FAILED
+    // -------------------------------------------------------------------------
+
+    "fromDomain then toDomain preserves all fields for a FAILED UserRun" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.FAILED,
+            error = "Permission grant failed",
+            finishedAt = now,
+        )
+
+        val roundTripped = ScheduledPromptUserRunNode.fromDomain(domain).toDomain()
+
+        roundTripped.status shouldBe UserRunStatus.FAILED
+        roundTripped.error shouldBe "Permission grant failed"
+        roundTripped.finishedAt shouldBe now
+        roundTripped.leaseUntil.shouldBeNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // Node field invariants
+    // -------------------------------------------------------------------------
+
+    "fromDomain sets userRunKey to the composite runId|userId key" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.PENDING,
+        )
+        val node = ScheduledPromptUserRunNode.fromDomain(domain)
+        node.userRunKey shouldBe "$runId|$userId"
+    }
+
+    "fromDomain sets removed to null for active UserRun" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.PENDING,
+        )
+        val node = ScheduledPromptUserRunNode.fromDomain(domain)
+        node.removed.shouldBeNull()
+    }
+
+    "toDomain maps null removed to removed=false on EntityMetadata" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.PENDING,
+        )
+        val node = ScheduledPromptUserRunNode.fromDomain(domain)
+        val back = node.toDomain()
+        back.metadata.removed shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // Node id is preserved across round-trip
+    // -------------------------------------------------------------------------
+
+    "fromDomain preserves the domain entity id as the node id string" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.PENDING,
+        )
+        val node = ScheduledPromptUserRunNode.fromDomain(domain)
+        node.id shouldBe domain.id.toString()
+    }
+
+    "toDomain recovers the same UUID from the node id string" {
+        val domain = ScheduledPromptUserRun(
+            runId = runId,
+            userId = userId,
+            status = UserRunStatus.PENDING,
+        )
+        val back = ScheduledPromptUserRunNode.fromDomain(domain).toDomain()
+        back.id shouldBe domain.id
+    }
+
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeUnitSpec.kt
@@ -8,43 +8,16 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * Unit tests for [ScheduledPromptUserRunNode] toDomain / fromDomain round-trip
- * and the [ScheduledPromptUserRunNode.userRunKey] static helper.
+ * Unit tests for [ScheduledPromptUserRunNode] toDomain / fromDomain round-trip.
+ *
+ * Uniqueness is enforced by a composite Neo4j constraint on `(runId, userId)`;
+ * there is no synthetic key field.
  */
 class ScheduledPromptUserRunNodeUnitSpec : StringSpec({
 
     val runId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
     val userId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
     val now: Instant = Instant.parse("2025-01-15T10:00:00Z")
-
-    // -------------------------------------------------------------------------
-    // userRunKey helper
-    // -------------------------------------------------------------------------
-
-    "userRunKey produces deterministic composite key" {
-        val key = ScheduledPromptUserRunNode.userRunKey(runId, userId)
-        key shouldBe "$runId|$userId"
-    }
-
-    "userRunKey is stable across calls" {
-        val k1 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
-        val k2 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
-        k1 shouldBe k2
-    }
-
-    "userRunKey differs when runId differs" {
-        val other = UUID.fromString("00000000-0000-0000-0000-000000000099")
-        val k1 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
-        val k2 = ScheduledPromptUserRunNode.userRunKey(other, userId)
-        (k1 == k2) shouldBe false
-    }
-
-    "userRunKey differs when userId differs" {
-        val other = UUID.fromString("00000000-0000-0000-0000-000000000099")
-        val k1 = ScheduledPromptUserRunNode.userRunKey(runId, userId)
-        val k2 = ScheduledPromptUserRunNode.userRunKey(runId, other)
-        (k1 == k2) shouldBe false
-    }
 
     // -------------------------------------------------------------------------
     // fromDomain / toDomain round-trip — PENDING
@@ -138,16 +111,6 @@ class ScheduledPromptUserRunNodeUnitSpec : StringSpec({
     // -------------------------------------------------------------------------
     // Node field invariants
     // -------------------------------------------------------------------------
-
-    "fromDomain sets userRunKey to the composite runId|userId key" {
-        val domain = ScheduledPromptUserRun(
-            runId = runId,
-            userId = userId,
-            status = UserRunStatus.PENDING,
-        )
-        val node = ScheduledPromptUserRunNode.fromDomain(domain)
-        node.userRunKey shouldBe "$runId|$userId"
-    }
 
     "fromDomain sets removed to null for active UserRun" {
         val domain = ScheduledPromptUserRun(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -495,19 +495,21 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
         }
 
-        "tickClaim with ON_DATE: disables when next slot equals endDate at timeUtc" {
+        "tickClaim with ON_DATE: disables when next slot equals endDate at timeUtc (exclusive boundary)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
-            // endDate = 2026-01-08, next slot = 2026-01-08T08:00 — slot is NOT after endDate@timeUtc → still active
-            // Actually: endDate@timeUtc = 2026-01-08T08:00, nextSlot = 2026-01-08T08:00 → isAfter is false → NOT disabled
+            // slot = 2026-01-01T08:00 (Jan 1), endDate = 2026-01-08 (exclusive)
+            // current slot Jan 1 < endDate → runs; next slot Jan 8 == endInstant → !isBefore → disabled
             val sp = scheduledPromptRepo.insertScheduledPrompt(
                 nextRunAt = slot,
                 endType = SchedulerEndType.ON_DATE,
                 endDate = LocalDate.of(2026, 1, 8),
             )
             scanner(scheduledPromptRepo, runRepo).tickClaim()
-            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+            runRepo.all() shouldHaveSize 1
+            runRepo.all().first().status shouldBe RunStatus.DONE
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -29,8 +29,11 @@ import java.util.UUID
  *
  * Uses in-memory repositories and a fixed clock — no Spring context, no Neo4j.
  *
- * A real [ScheduledPromptExecutor] is used (not a mock) so that the RUNNING transition
+ * A real [ScheduledPromptExecutor] is used (not a mock) so that the RUNNING/DONE transition
  * happens inside [ScheduledPromptExecutor.materialize], exactly as it does in production.
+ * The [scanner] factory uses an empty user provider (0 UserRuns created), so materialize
+ * transitions Runs directly to DONE. Tests that need RUNNING Runs use [scannerWithUserRunRepo]
+ * with a non-empty target user set.
  * Services that are not exercised by Phase A
  * (Phase B: [PromptService], [CaseService], [PermissionService], [UserService]) are
  * relaxed mocks.
@@ -64,39 +67,29 @@ class SchedulerScannerUnitSpec : StringSpec() {
     private fun makeScheduledPromptRepo() = InMemoryScheduledPromptRepository()
     private fun makeRunRepo() = InMemoryScheduledPromptRunRepository()
 
-    /**
-     * Build a real [ScheduledPromptExecutor] backed by the supplied in-memory repositories.
-     *
-     * Phase B services ([PromptService], [CaseService], [PermissionService], [UserService])
-     * are relaxed mocks — they are never called by Phase A ([materialize]).
-     * [InMemoryScheduledPromptUserRunRepository] uses an empty target-user provider because
-     * the Scanner tests only verify Run-level behaviour, not UserRun creation.
-     */
-    private fun makeExecutor(
-        scheduledPromptRepo: InMemoryScheduledPromptRepository,
-        runRepo: InMemoryScheduledPromptRunRepository,
-    ): ScheduledPromptExecutor = ScheduledPromptExecutor(
-        scheduledPromptRepository = scheduledPromptRepo,
-        runRepository = runRepo,
-        userRunRepository = InMemoryScheduledPromptUserRunRepository(),
-        promptService = mockk(relaxed = true),
-        agentConfigService = mockk(relaxed = true),
-        caseService = mockk(relaxed = true),
-        permissionService = mockk(relaxed = true),
-        userService = mockk(relaxed = true),
-        properties = properties,
-        clock = clock,
-    )
-
     private fun scanner(
         scheduledPromptRepo: InMemoryScheduledPromptRepository,
         runRepo: InMemoryScheduledPromptRunRepository,
         agentConfigService: AgentConfigService = defaultAgentConfigService(),
     ): SchedulerScanner {
-        val executor = makeExecutor(scheduledPromptRepo, runRepo)
+        val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+        runRepo.userRunRepository = userRunRepo
+        val executor = ScheduledPromptExecutor(
+            scheduledPromptRepository = scheduledPromptRepo,
+            runRepository = runRepo,
+            userRunRepository = userRunRepo,
+            promptService = mockk(relaxed = true),
+            agentConfigService = mockk(relaxed = true),
+            caseService = mockk(relaxed = true),
+            permissionService = mockk(relaxed = true),
+            userService = mockk(relaxed = true),
+            properties = properties,
+            clock = clock,
+        )
         return SchedulerScanner(
             scheduledPromptRepository = scheduledPromptRepo,
             runRepository = runRepo,
+            userRunRepository = userRunRepo,
             agentConfigService = agentConfigService,
             properties = properties,
             clock = clock,
@@ -104,6 +97,46 @@ class SchedulerScannerUnitSpec : StringSpec() {
             executor = executor,
         )
     }
+
+    /**
+     * Builds a [SchedulerScanner] backed by an [InMemoryScheduledPromptUserRunRepository]
+     * that resolves target users via [targetUserIdsProvider]. Returns both so tests can
+     * seed UserRuns directly.
+     */
+    private fun scannerWithUserRunRepo(
+        scheduledPromptRepo: InMemoryScheduledPromptRepository,
+        runRepo: InMemoryScheduledPromptRunRepository,
+        targetUserIdsProvider: (agentConfigId: UUID, namespaceId: UUID) -> Set<UUID>,
+        agentConfigService: AgentConfigService = defaultAgentConfigService(),
+    ): Pair<SchedulerScanner, InMemoryScheduledPromptUserRunRepository> {
+        val userRunRepo = InMemoryScheduledPromptUserRunRepository(targetUserIdsProvider)
+        runRepo.userRunRepository = userRunRepo
+        val executor = ScheduledPromptExecutor(
+            scheduledPromptRepository = scheduledPromptRepo,
+            runRepository = runRepo,
+            userRunRepository = userRunRepo,
+            promptService = mockk(relaxed = true),
+            agentConfigService = mockk(relaxed = true),
+            caseService = mockk(relaxed = true),
+            permissionService = mockk(relaxed = true),
+            userService = mockk(relaxed = true),
+            properties = properties,
+            clock = clock,
+        )
+        val scanner = SchedulerScanner(
+            scheduledPromptRepository = scheduledPromptRepo,
+            runRepository = runRepo,
+            userRunRepository = userRunRepo,
+            agentConfigService = agentConfigService,
+            properties = properties,
+            clock = clock,
+            nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+            executor = executor,
+        )
+        return scanner to userRunRepo
+    }
+
+    private val defaultNamespaceId: UUID = UUID.randomUUID()
 
     private fun InMemoryScheduledPromptRepository.insertScheduledPrompt(
         nextRunAt: Instant,
@@ -113,9 +146,11 @@ class SchedulerScannerUnitSpec : StringSpec() {
         endType: SchedulerEndType = SchedulerEndType.NEVER,
         endDate: LocalDate? = null,
         maxOccurrenceCount: Int? = null,
+        namespaceId: UUID? = defaultNamespaceId,
     ): ScheduledPrompt {
         val scheduledPrompt = ScheduledPrompt(
             metadata = EntityMetadata(id = UUID.randomUUID()),
+            namespaceId = namespaceId,
             agentConfigId = agentId,
             promptTemplateId = promptId,
             name = "sp-${UUID.randomUUID().toString().take(6)}",
@@ -157,15 +192,16 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // Tick — one due prompt, happy path
         // -------------------------------------------------------------------------
 
-        "tickClaim with 1 due prompt: run inserted and transitioned to RUNNING" {
+        "tickClaim with 1 due prompt: run inserted and transitioned to DONE (no target users)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+            // scanner() uses an empty user provider — 0 UserRuns created — materialize transitions to DONE
             scanner(scheduledPromptRepo, runRepo).tickClaim()
             val runs = runRepo.all()
             runs shouldHaveSize 1
-            runs.first().status shouldBe RunStatus.RUNNING
+            runs.first().status shouldBe RunStatus.DONE
         }
 
         "tickClaim with 1 due prompt: nextRunAt advanced" {
@@ -218,7 +254,14 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             val scheduledPrompt = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-            runRepo.insert(
+            val targetUserId = UUID.randomUUID()
+            // Use scannerWithUserRunRepo so the RUNNING run has an active PENDING UserRun —
+            // the settled-running sweep must NOT close it, preserving the overlap guard.
+            val (scanner, userRunRepo) = scannerWithUserRunRepo(
+                scheduledPromptRepo, runRepo,
+                targetUserIdsProvider = { _, _ -> setOf(targetUserId) },
+            )
+            val existingRun = runRepo.insert(
                 ScheduledPromptRun(
                     scheduledPromptId = scheduledPrompt.id,
                     scheduledFor = slot.minusSeconds(3600),
@@ -226,11 +269,18 @@ class SchedulerScannerUnitSpec : StringSpec() {
                     correlationId = "running",
                 ),
             )
-            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            // Seed a PENDING UserRun so the sweep sees a non-terminal UserRun and skips it.
+            userRunRepo.materialize(existingRun.id, scheduledPrompt.agentConfigId, scheduledPrompt.namespaceId!!)
+
+            scanner.tickClaim()
+
+            // Existing run untouched — still has a PENDING UserRun, not settled.
+            runRepo.findById(existingRun.id)!!.status shouldBe RunStatus.RUNNING
+            // New run for the due slot is SKIPPED because hasActive() returned true.
             runRepo.all().filter { it.correlationId != "running" }.first().status shouldBe RunStatus.SKIPPED
         }
 
-        "tickClaim with DONE run: run inserted and transitioned to RUNNING (DONE is not active)" {
+        "tickClaim with DONE run: new run inserted and transitioned to DONE (DONE is not active)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -243,8 +293,9 @@ class SchedulerScannerUnitSpec : StringSpec() {
                     correlationId = "done-run",
                 ),
             )
+            // DONE is not active — hasActive() returns false — new run is CLAIMED then materialised to DONE
             scanner(scheduledPromptRepo, runRepo).tickClaim()
-            runRepo.all().filter { it.correlationId != "done-run" }.first().status shouldBe RunStatus.RUNNING
+            runRepo.all().filter { it.correlationId != "done-run" }.first().status shouldBe RunStatus.DONE
         }
 
         // -------------------------------------------------------------------------
@@ -335,14 +386,14 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scheduledPromptRepo.findById(scheduledPrompt.id)!!.enabled shouldBe false
         }
 
-        "tickClaim with valid AgentConfig: run inserted and transitioned to RUNNING" {
+        "tickClaim with valid AgentConfig: run inserted and transitioned to DONE (no target users)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
             scanner(scheduledPromptRepo, runRepo, defaultAgentConfigService()).tickClaim()
             runRepo.all() shouldHaveSize 1
-            runRepo.all().first().status shouldBe RunStatus.RUNNING
+            runRepo.all().first().status shouldBe RunStatus.DONE
         }
 
         // -------------------------------------------------------------------------
@@ -426,7 +477,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             )
             scanner(scheduledPromptRepo, runRepo).tickClaim()
             runRepo.all() shouldHaveSize 1
-            runRepo.all().first().status shouldBe RunStatus.RUNNING
+            runRepo.all().first().status shouldBe RunStatus.DONE
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
         }
 
@@ -587,7 +638,98 @@ class SchedulerScannerUnitSpec : StringSpec() {
             orphan.status shouldBe RunStatus.FAILED
 
             val newRun = runs.first { it.correlationId != "orphaned" }
-            newRun.status shouldBe RunStatus.RUNNING
+            newRun.status shouldBe RunStatus.DONE
+        }
+
+        // -------------------------------------------------------------------------
+        // Orphaned RUNNING sweep (crash recovery)
+        // -------------------------------------------------------------------------
+
+        "tickClaim closes orphaned RUNNING run as DONE when all UserRuns are settled" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            // ScheduledPrompt not due — the RUNNING sweep must fire independently of findDue
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T10:00:00Z"))
+            val targetUserId = UUID.randomUUID()
+            val (scanner, userRunRepo) = scannerWithUserRunRepo(
+                scheduledPromptRepo, runRepo,
+                targetUserIdsProvider = { _, _ -> setOf(targetUserId) },
+            )
+
+            // Insert a RUNNING run directly (simulates a run that was materialised but whose
+            // checkCompletion call was lost in a crash)
+            val run = ScheduledPromptRun(
+                metadata = EntityMetadata(id = UUID.randomUUID(), created = Instant.parse("2026-01-01T08:00:00Z")),
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2026-01-01T08:00:00Z"),
+                status = RunStatus.RUNNING,
+                correlationId = "orphaned-running",
+            )
+            runRepo.insert(run)
+
+            // Seed a terminal UserRun (DONE) — materialize then mark terminal
+            userRunRepo.materialize(run.id, sp.agentConfigId, sp.namespaceId!!)
+            val ur = userRunRepo.findByRunId(run.id).first()
+            userRunRepo.markTerminal(ur.id, UserRunStatus.DONE, nowInstant)
+
+            scanner.tickClaim()
+
+            runRepo.findById(run.id)!!.status shouldBe RunStatus.DONE
+        }
+
+        "tickClaim closes orphaned RUNNING run as FAILED when a UserRun has failed" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T10:00:00Z"))
+            val targetUserId = UUID.randomUUID()
+            val (scanner, userRunRepo) = scannerWithUserRunRepo(
+                scheduledPromptRepo, runRepo,
+                targetUserIdsProvider = { _, _ -> setOf(targetUserId) },
+            )
+
+            val run = ScheduledPromptRun(
+                metadata = EntityMetadata(id = UUID.randomUUID(), created = Instant.parse("2026-01-01T08:00:00Z")),
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2026-01-01T08:00:00Z"),
+                status = RunStatus.RUNNING,
+                correlationId = "orphaned-running-failed",
+            )
+            runRepo.insert(run)
+
+            userRunRepo.materialize(run.id, sp.agentConfigId, sp.namespaceId!!)
+            val ur = userRunRepo.findByRunId(run.id).first()
+            userRunRepo.markTerminal(ur.id, UserRunStatus.FAILED, nowInstant, "boom")
+
+            scanner.tickClaim()
+
+            runRepo.findById(run.id)!!.status shouldBe RunStatus.FAILED
+        }
+
+        "tickClaim does NOT close RUNNING run when UserRuns are still active" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T10:00:00Z"))
+            val targetUserId = UUID.randomUUID()
+            val (scanner, userRunRepo) = scannerWithUserRunRepo(
+                scheduledPromptRepo, runRepo,
+                targetUserIdsProvider = { _, _ -> setOf(targetUserId) },
+            )
+
+            val run = ScheduledPromptRun(
+                metadata = EntityMetadata(id = UUID.randomUUID(), created = Instant.parse("2026-01-01T08:00:00Z")),
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2026-01-01T08:00:00Z"),
+                status = RunStatus.RUNNING,
+                correlationId = "still-running",
+            )
+            runRepo.insert(run)
+
+            // Materialize but do NOT mark terminal — UserRun stays PENDING
+            userRunRepo.materialize(run.id, sp.agentConfigId, sp.namespaceId!!)
+
+            scanner.tickClaim()
+
+            runRepo.findById(run.id)!!.status shouldBe RunStatus.RUNNING
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -47,7 +47,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
     private val today = LocalDate.of(2026, 1, 1)
     private val defaultTime = LocalTime.of(8, 0)  // 08:00 UTC — before now
 
-    private val properties = SchedulerProperties(tickIntervalMs = 60_000)
+    private val properties = SchedulerProperties()
 
     private val agentId: UUID = UUID.randomUUID()
     private val promptId: UUID = UUID.randomUUID()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -10,10 +10,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
-import io.mockk.coEvery
+import io.whozoss.agentos.caseFlow.CaseService
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.prompt.PromptService
 import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerEndType
 import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerUnit
 import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.UserService
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -25,6 +28,12 @@ import java.util.UUID
  * Unit tests for [SchedulerScanner].
  *
  * Uses in-memory repositories and a fixed clock — no Spring context, no Neo4j.
+ *
+ * A real [ScheduledPromptExecutor] is used (not a mock) so that the RUNNING transition
+ * happens inside [ScheduledPromptExecutor.materialize], exactly as it does in production.
+ * Services that are not exercised by Phase A
+ * (Phase B: [PromptService], [CaseService], [PermissionService], [UserService]) are
+ * relaxed mocks.
  *
  * Fixed "now": 2026-01-01 09:00:00 UTC (Thursday).
  */
@@ -55,15 +64,36 @@ class SchedulerScannerUnitSpec : StringSpec() {
     private fun makeScheduledPromptRepo() = InMemoryScheduledPromptRepository()
     private fun makeRunRepo() = InMemoryScheduledPromptRunRepository()
 
+    /**
+     * Build a real [ScheduledPromptExecutor] backed by the supplied in-memory repositories.
+     *
+     * Phase B services ([PromptService], [CaseService], [PermissionService], [UserService])
+     * are relaxed mocks — they are never called by Phase A ([materialize]).
+     * [InMemoryScheduledPromptUserRunRepository] uses an empty target-user provider because
+     * the Scanner tests only verify Run-level behaviour, not UserRun creation.
+     */
+    private fun makeExecutor(
+        scheduledPromptRepo: InMemoryScheduledPromptRepository,
+        runRepo: InMemoryScheduledPromptRunRepository,
+    ): ScheduledPromptExecutor = ScheduledPromptExecutor(
+        scheduledPromptRepository = scheduledPromptRepo,
+        runRepository = runRepo,
+        userRunRepository = InMemoryScheduledPromptUserRunRepository(),
+        promptService = mockk(relaxed = true),
+        agentConfigService = mockk(relaxed = true),
+        caseService = mockk(relaxed = true),
+        permissionService = mockk(relaxed = true),
+        userService = mockk(relaxed = true),
+        properties = properties,
+        clock = clock,
+    )
+
     private fun scanner(
         scheduledPromptRepo: InMemoryScheduledPromptRepository,
         runRepo: InMemoryScheduledPromptRunRepository,
         agentConfigService: AgentConfigService = defaultAgentConfigService(),
     ): SchedulerScanner {
-        val executor = mockk<ScheduledPromptExecutor>(relaxed = true).also {
-            every { it.materialize(any(), any()) } returns Unit
-            coEvery { it.consumeAvailable() } returns Unit
-        }
+        val executor = makeExecutor(scheduledPromptRepo, runRepo)
         return SchedulerScanner(
             scheduledPromptRepository = scheduledPromptRepo,
             runRepository = runRepo,
@@ -127,7 +157,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // Tick — one due prompt, happy path
         // -------------------------------------------------------------------------
 
-        "tickClaim with 1 due prompt: run CLAIMED inserted" {
+        "tickClaim with 1 due prompt: run inserted and transitioned to RUNNING" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -135,7 +165,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scanner(scheduledPromptRepo, runRepo).tickClaim()
             val runs = runRepo.all()
             runs shouldHaveSize 1
-            runs.first().status shouldBe RunStatus.CLAIMED
+            runs.first().status shouldBe RunStatus.RUNNING
         }
 
         "tickClaim with 1 due prompt: nextRunAt advanced" {
@@ -200,7 +230,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             runRepo.all().filter { it.correlationId != "running" }.first().status shouldBe RunStatus.SKIPPED
         }
 
-        "tickClaim with DONE run: run CLAIMED (DONE is not active)" {
+        "tickClaim with DONE run: run inserted and transitioned to RUNNING (DONE is not active)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -214,7 +244,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 ),
             )
             scanner(scheduledPromptRepo, runRepo).tickClaim()
-            runRepo.all().filter { it.correlationId != "done-run" }.first().status shouldBe RunStatus.CLAIMED
+            runRepo.all().filter { it.correlationId != "done-run" }.first().status shouldBe RunStatus.RUNNING
         }
 
         // -------------------------------------------------------------------------
@@ -305,14 +335,14 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scheduledPromptRepo.findById(scheduledPrompt.id)!!.enabled shouldBe false
         }
 
-        "tickClaim with valid AgentConfig: run CLAIMED inserted normally" {
+        "tickClaim with valid AgentConfig: run inserted and transitioned to RUNNING" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
             scanner(scheduledPromptRepo, runRepo, defaultAgentConfigService()).tickClaim()
             runRepo.all() shouldHaveSize 1
-            runRepo.all().first().status shouldBe RunStatus.CLAIMED
+            runRepo.all().first().status shouldBe RunStatus.RUNNING
         }
 
         // -------------------------------------------------------------------------
@@ -396,7 +426,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             )
             scanner(scheduledPromptRepo, runRepo).tickClaim()
             runRepo.all() shouldHaveSize 1
-            runRepo.all().first().status shouldBe RunStatus.CLAIMED
+            runRepo.all().first().status shouldBe RunStatus.RUNNING
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
         }
 
@@ -486,6 +516,78 @@ class SchedulerScannerUnitSpec : StringSpec() {
             // tickClaim inserts run #1 (non-skipped) → total completed = 1 < maxOccurrenceCount = 2
             scanner(scheduledPromptRepo, runRepo).tickClaim()
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // Orphaned CLAIMED sweep (crash recovery)
+        // -------------------------------------------------------------------------
+
+        "tickClaim sweeps orphaned CLAIMED runs older than threshold — marks FAILED" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T10:00:00Z")) // not due
+            // Insert a CLAIMED run with creation time well in the past (orphaned)
+            val orphanedRun = ScheduledPromptRun(
+                metadata = EntityMetadata(id = UUID.randomUUID(), created = Instant.parse("2026-01-01T08:00:00Z")),
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2026-01-01T08:00:00Z"),
+                status = RunStatus.CLAIMED,
+                correlationId = "orphaned",
+            )
+            runRepo.insert(orphanedRun)
+
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+
+            val updated = runRepo.findById(orphanedRun.id)!!
+            updated.status shouldBe RunStatus.FAILED
+            updated.error shouldBe "Orphaned CLAIMED — materialize never completed (crash recovery)"
+        }
+
+        "tickClaim does NOT sweep recent CLAIMED runs (within threshold)" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T10:00:00Z")) // not due
+            // Insert a CLAIMED run with creation time = now (recent, not orphaned)
+            val recentRun = ScheduledPromptRun(
+                metadata = EntityMetadata(id = UUID.randomUUID(), created = nowInstant),
+                scheduledPromptId = sp.id,
+                scheduledFor = nowInstant,
+                status = RunStatus.CLAIMED,
+                correlationId = "recent",
+            )
+            runRepo.insert(recentRun)
+
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+
+            val updated = runRepo.findById(recentRun.id)!!
+            updated.status shouldBe RunStatus.CLAIMED // not touched
+        }
+
+        "tickClaim sweep unblocks hasActive guard — next slot is CLAIMED not SKIPPED" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+            // Insert an orphaned CLAIMED run for a previous slot
+            val orphanedRun = ScheduledPromptRun(
+                metadata = EntityMetadata(id = UUID.randomUUID(), created = Instant.parse("2025-12-31T08:00:00Z")),
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2025-12-31T08:00:00Z"),
+                status = RunStatus.CLAIMED,
+                correlationId = "orphaned",
+            )
+            runRepo.insert(orphanedRun)
+
+            // Without the sweep, hasActive() would return true → SKIPPED
+            // With the sweep, the orphan is marked FAILED first → hasActive() returns false → CLAIMED
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+
+            val runs = runRepo.all()
+            val orphan = runs.first { it.correlationId == "orphaned" }
+            orphan.status shouldBe RunStatus.FAILED
+
+            val newRun = runs.first { it.correlationId != "orphaned" }
+            newRun.status shouldBe RunStatus.RUNNING
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
+import io.mockk.coEvery
 import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerEndType
 import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerUnit
 import io.whozoss.agentos.sdk.entity.EntityMetadata
@@ -58,14 +59,21 @@ class SchedulerScannerUnitSpec : StringSpec() {
         scheduledPromptRepo: InMemoryScheduledPromptRepository,
         runRepo: InMemoryScheduledPromptRunRepository,
         agentConfigService: AgentConfigService = defaultAgentConfigService(),
-    ) = SchedulerScanner(
-        scheduledPromptRepository = scheduledPromptRepo,
-        runRepository = runRepo,
-        agentConfigService = agentConfigService,
-        properties = properties,
-        clock = clock,
-        nextRunCalculatorService = NextRunCalculatorService(clock = clock),
-    )
+    ): SchedulerScanner {
+        val executor = mockk<ScheduledPromptExecutor>(relaxed = true).also {
+            every { it.materialize(any(), any()) } returns Unit
+            coEvery { it.consumeAvailable() } returns Unit
+        }
+        return SchedulerScanner(
+            scheduledPromptRepository = scheduledPromptRepo,
+            runRepository = runRepo,
+            agentConfigService = agentConfigService,
+            properties = properties,
+            clock = clock,
+            nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+            executor = executor,
+        )
+    }
 
     private fun InMemoryScheduledPromptRepository.insertScheduledPrompt(
         nextRunAt: Instant,
@@ -91,19 +99,19 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // Tick — no due prompts
         // -------------------------------------------------------------------------
 
-        "tick with no due prompts: no runs created" {
+        "tickClaim with no due prompts: no runs created" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T10:00:00Z"))
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             runRepo.all().shouldBeEmpty()
         }
 
-        "tick with disabled prompt: no runs created" {
+        "tickClaim with disabled prompt: no runs created" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T08:00:00Z"), enabled = false)
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             runRepo.all().shouldBeEmpty()
         }
 
@@ -111,34 +119,34 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // Tick — one due prompt, happy path
         // -------------------------------------------------------------------------
 
-        "tick with 1 due prompt: run CLAIMED inserted" {
+        "tickClaim with 1 due prompt: run CLAIMED inserted" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             val runs = runRepo.all()
             runs shouldHaveSize 1
             runs.first().status shouldBe RunStatus.CLAIMED
         }
 
-        "tick with 1 due prompt: nextRunAt advanced" {
+        "tickClaim with 1 due prompt: nextRunAt advanced" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T09:00:00Z")
             // startDate=2026-01-01 (Thursday), WEEK no filter → next slot = next Thursday 2026-01-08
             val scheduledPrompt = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot, timeUtc = LocalTime.of(9, 0))
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             val updated = scheduledPromptRepo.findById(scheduledPrompt.id)!!
             updated.nextRunAt shouldBe Instant.parse("2026-01-08T09:00:00Z")
         }
 
-        "tick with 1 due prompt: run scheduled for the claimed slot" {
+        "tickClaim with 1 due prompt: run scheduled for the claimed slot" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             val scheduledPrompt = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             val run = runRepo.all().first()
             run.scheduledPromptId shouldBe scheduledPrompt.id
             run.scheduledFor shouldBe slot
@@ -148,7 +156,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // Tick — overlap (active run already exists)
         // -------------------------------------------------------------------------
 
-        "tick with active run already exists: run SKIPPED (overlap)" {
+        "tickClaim with active run already exists: run SKIPPED (overlap)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -161,13 +169,13 @@ class SchedulerScannerUnitSpec : StringSpec() {
                     correlationId = "pre-existing",
                 ),
             )
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             val runs = runRepo.all()
             runs shouldHaveSize 2
             runs.filter { it.correlationId != "pre-existing" }.first().status shouldBe RunStatus.SKIPPED
         }
 
-        "tick with RUNNING run already exists: run SKIPPED (overlap)" {
+        "tickClaim with RUNNING run already exists: run SKIPPED (overlap)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -180,11 +188,11 @@ class SchedulerScannerUnitSpec : StringSpec() {
                     correlationId = "running",
                 ),
             )
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             runRepo.all().filter { it.correlationId != "running" }.first().status shouldBe RunStatus.SKIPPED
         }
 
-        "tick with DONE run: run CLAIMED (DONE is not active)" {
+        "tickClaim with DONE run: run CLAIMED (DONE is not active)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -197,7 +205,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                     correlationId = "done-run",
                 ),
             )
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             runRepo.all().filter { it.correlationId != "done-run" }.first().status shouldBe RunStatus.CLAIMED
         }
 
@@ -205,7 +213,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // Tick — DuplicateRunException (concurrent tick wins the race)
         // -------------------------------------------------------------------------
 
-        "tick with DuplicateRunException: nextRunAt still advanced" {
+        "tickClaim with DuplicateRunException: nextRunAt still advanced" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -219,12 +227,12 @@ class SchedulerScannerUnitSpec : StringSpec() {
                     correlationId = "first-tick",
                 ),
             )
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             val updated = scheduledPromptRepo.findById(scheduledPrompt.id)!!
             updated.nextRunAt shouldBe Instant.parse("2026-01-08T08:00:00Z")
         }
 
-        "tick with DuplicateRunException: no extra run inserted" {
+        "tickClaim with DuplicateRunException: no extra run inserted" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -237,7 +245,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                     correlationId = "first-tick",
                 ),
             )
-            scanner(scheduledPromptRepo, runRepo).tick()
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
             runRepo.all() shouldHaveSize 1
         }
 
@@ -263,7 +271,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // AgentConfig guard
         // -------------------------------------------------------------------------
 
-        "tick with deleted AgentConfig: ScheduledPrompt disabled, no run inserted" {
+        "tickClaim with deleted AgentConfig: ScheduledPrompt disabled, no run inserted" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -271,12 +279,12 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val agentSvc = mockk<AgentConfigService>().also {
                 every { it.findById(agentId) } returns null
             }
-            scanner(scheduledPromptRepo, runRepo, agentSvc).tick()
+            scanner(scheduledPromptRepo, runRepo, agentSvc).tickClaim()
             runRepo.all().shouldBeEmpty()
             scheduledPromptRepo.findById(scheduledPrompt.id)!!.enabled shouldBe false
         }
 
-        "tick with disabled AgentConfig: ScheduledPrompt disabled, no run inserted" {
+        "tickClaim with disabled AgentConfig: ScheduledPrompt disabled, no run inserted" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -284,17 +292,17 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val agentSvc = mockk<AgentConfigService>().also {
                 every { it.findById(agentId) } returns activeAgent.copy(enabled = false)
             }
-            scanner(scheduledPromptRepo, runRepo, agentSvc).tick()
+            scanner(scheduledPromptRepo, runRepo, agentSvc).tickClaim()
             runRepo.all().shouldBeEmpty()
             scheduledPromptRepo.findById(scheduledPrompt.id)!!.enabled shouldBe false
         }
 
-        "tick with valid AgentConfig: run CLAIMED inserted normally" {
+        "tickClaim with valid AgentConfig: run CLAIMED inserted normally" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-            scanner(scheduledPromptRepo, runRepo, defaultAgentConfigService()).tick()
+            scanner(scheduledPromptRepo, runRepo, defaultAgentConfigService()).tickClaim()
             runRepo.all() shouldHaveSize 1
             runRepo.all().first().status shouldBe RunStatus.CLAIMED
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -80,6 +80,9 @@ class SchedulerScannerUnitSpec : StringSpec() {
         enabled: Boolean = true,
         startDate: LocalDate = today,
         timeUtc: LocalTime = defaultTime,
+        endType: SchedulerEndType = SchedulerEndType.NEVER,
+        endDate: LocalDate? = null,
+        maxOccurrenceCount: Int? = null,
     ): ScheduledPrompt {
         val scheduledPrompt = ScheduledPrompt(
             metadata = EntityMetadata(id = UUID.randomUUID()),
@@ -87,7 +90,12 @@ class SchedulerScannerUnitSpec : StringSpec() {
             promptTemplateId = promptId,
             name = "sp-${UUID.randomUUID().toString().take(6)}",
             recurrence = Recurrence(unit = SchedulerUnit.WEEK, timeUtc = timeUtc),
-            planning = Planning(startDate = startDate, endType = SchedulerEndType.NEVER),
+            planning = Planning(
+                startDate = startDate,
+                endType = endType,
+                endDate = endDate,
+                maxOccurrenceCount = maxOccurrenceCount,
+            ),
             enabled = enabled,
             nextRunAt = nextRunAt,
         )
@@ -330,6 +338,175 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T10:00:00Z"))
             scheduledPromptRepo.findDue(nowInstant).shouldBeEmpty()
+        }
+
+        // -------------------------------------------------------------------------
+        // End condition — pre-check (before execution)
+        // -------------------------------------------------------------------------
+
+        "tickClaim with ON_DATE already past: disables without executing (slot past endDate)" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            // endDate = 2025-12-25 (in the past), slot = 2026-01-01T08:00 (due, but past endDate)
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = Instant.parse("2026-01-01T08:00:00Z"),
+                endType = SchedulerEndType.ON_DATE,
+                endDate = LocalDate.of(2025, 12, 25),
+            )
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            runRepo.all().shouldBeEmpty()
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
+        }
+
+        "tickClaim with OCCURRENCES already reached: disables without inserting a run" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.OCCURRENCES,
+                maxOccurrenceCount = 1,
+            )
+            // Pre-insert 1 completed run → already at max
+            runRepo.insert(ScheduledPromptRun(
+                scheduledPromptId = sp.id,
+                scheduledFor = slot.minusSeconds(86400),
+                status = RunStatus.DONE,
+                correlationId = "prev-done",
+            ))
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            // Only the pre-existing run, no new one inserted
+            runRepo.all() shouldHaveSize 1
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
+        }
+
+        // -------------------------------------------------------------------------
+        // End condition — ON_DATE (post-advance)
+        // -------------------------------------------------------------------------
+
+        "tickClaim with ON_DATE: disables when next slot is after endDate" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            // endDate = 2026-01-05 → next slot after claim = 2026-01-08 > endDate
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.ON_DATE,
+                endDate = LocalDate.of(2026, 1, 5),
+            )
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            runRepo.all() shouldHaveSize 1
+            runRepo.all().first().status shouldBe RunStatus.CLAIMED
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
+        }
+
+        "tickClaim with ON_DATE: does NOT disable when next slot is before endDate" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            // endDate = 2026-01-15 → next slot = 2026-01-08 < endDate → still active
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.ON_DATE,
+                endDate = LocalDate.of(2026, 1, 15),
+            )
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+        }
+
+        "tickClaim with ON_DATE: disables when next slot equals endDate at timeUtc" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            // endDate = 2026-01-08, next slot = 2026-01-08T08:00 — slot is NOT after endDate@timeUtc → still active
+            // Actually: endDate@timeUtc = 2026-01-08T08:00, nextSlot = 2026-01-08T08:00 → isAfter is false → NOT disabled
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.ON_DATE,
+                endDate = LocalDate.of(2026, 1, 8),
+            )
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // End condition — OCCURRENCES
+        // -------------------------------------------------------------------------
+
+        "tickClaim with OCCURRENCES: disables when completed runs reach maxOccurrenceCount" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.OCCURRENCES,
+                maxOccurrenceCount = 2,
+            )
+            // Pre-insert 1 completed run
+            runRepo.insert(ScheduledPromptRun(
+                scheduledPromptId = sp.id,
+                scheduledFor = slot.minusSeconds(86400),
+                status = RunStatus.DONE,
+                correlationId = "prev-1",
+            ))
+            // tickClaim inserts run #2 → total completed = 2 (prev + this one) ≥ maxOccurrenceCount = 2
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
+        }
+
+        "tickClaim with OCCURRENCES: does NOT disable when completed runs are below maxOccurrenceCount" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.OCCURRENCES,
+                maxOccurrenceCount = 5,
+            )
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+        }
+
+        "tickClaim with OCCURRENCES: SKIPPED runs do not count toward maxOccurrenceCount" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.OCCURRENCES,
+                maxOccurrenceCount = 2,
+            )
+            // Pre-insert 1 SKIPPED run (should not count)
+            runRepo.insert(ScheduledPromptRun(
+                scheduledPromptId = sp.id,
+                scheduledFor = slot.minusSeconds(86400),
+                status = RunStatus.SKIPPED,
+                correlationId = "skipped",
+            ))
+            // tickClaim inserts run #1 (non-skipped) → total completed = 1 < maxOccurrenceCount = 2
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // End condition — NEVER
+        // -------------------------------------------------------------------------
+
+        "tickClaim with NEVER: does not disable regardless of run count" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+            repeat(10) { i ->
+                runRepo.insert(ScheduledPromptRun(
+                    scheduledPromptId = sp.id,
+                    scheduledFor = slot.minusSeconds((i + 1) * 86400L),
+                    status = RunStatus.DONE,
+                    correlationId = "done-$i",
+                ))
+            }
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -495,12 +495,13 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
         }
 
-        "tickClaim with ON_DATE: disables when next slot equals endDate at timeUtc (exclusive boundary)" {
+        "tickClaim with ON_DATE: last valid run is the day before endDate (exclusive at midnight)" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
-            // slot = 2026-01-01T08:00 (Jan 1), endDate = 2026-01-08 (exclusive)
-            // current slot Jan 1 < endDate → runs; next slot Jan 8 == endInstant → !isBefore → disabled
+            // endDate = 2026-01-08 (exclusive) → endInstant = 2026-01-08T00:00Z
+            // current slot Jan 1 08:00 < Jan 8 00:00 → runs
+            // next slot Jan 8 08:00 >= Jan 8 00:00 → !isBefore → disables after
             val sp = scheduledPromptRepo.insertScheduledPrompt(
                 nextRunAt = slot,
                 endType = SchedulerEndType.ON_DATE,

--- a/agentos/agentos-service/src/test/resources/application-test.yml
+++ b/agentos/agentos-service/src/test/resources/application-test.yml
@@ -48,9 +48,10 @@ agentos:
     # contaminate the embedded Neo4j DB.
     enabled: false
 
-scheduler:
-  # Disable the scheduler in tests to prevent background ticks from interfering.
-  enabled: false
+  prompt:
+    scheduler:
+      # Disable the scheduler in tests to prevent background ticks from interfering.
+      enabled: false
 
 logging:
   level:


### PR DESCRIPTION
Scheduled prompts needed two missing capabilities: creating one Case **per target user**, and **disabling themselves** when their end condition is reached (`ON_DATE` or `OCCURRENCES`). Without the latter, a scheduled prompt with an expired end date would keep firing indefinitely.

## Approach

The implementation extends the existing two-phase tick architecture rather than introducing new scheduling infrastructure:

- **Phase A** handles the fast path: insert a CLAIMED Run, then materialize all target UserRuns in a single Cypher MERGE and transition to RUNNING in one `@Transactional`. When no target users exist (e.g. platform-scope), the Run transitions directly to DONE. The insert is outside the transaction, if the instance crashes between the insert and materialize, a sweep at the start of each tick marks orphaned CLAIMED Runs as FAILED to unblock subsequent slots.
- **Phase B** handles the slow path: claim UserRuns in batches, execute each as an independent Case with structured concurrency, await each Case's completion reactively via CaseRuntime.statusFlow, and check Run completion once per batch.

End condition checks are placed at two strategic points: **before** execution (crash-recovery safety net — prevents zombie ticks when the server was down while the condition expired, or when a previous tick crashed between `advanceNextRunAt` and the disable) and **after** advancing `nextRunAt` (normal path, disable when the next slot would exceed the boundary).

## Compromises

- **At-least-once delivery, not exactly-once.** No idempotence key links a Case to its UserRun. If an instance crashes after `CaseService.create()` but before `markTerminal()`, the lease expires and another instance reclaims the UserRun, creating a second Case. Acceptable for the use case (duplicate conversation, no data corruption). Exactly-once would require a UNIQUE constraint on Case keyed by `(runId, userId)`.

- **No dedicated `ScheduledPromptTargetUserResolver`.** User resolution and UserRun materialization are fused in a single Cypher MERGE traversing the deployment graph.

- **Neither fire-and-forget nor a fully reliable messaging system.** The Executor creates Cases and waits for their completion, with lease-based crash recovery and optimistic locking, but there is no dead-letter queue, no retry policy, and no exactly-once guarantee. This is a pragmatic middle ground: significantly more robust than fire-and-forget (which would lose track of in-flight Cases on crash), without the complexity of a proper message broker. It covers the current use case, periodic automated conversations, where an occasional duplicate or missed run after a crash is acceptable, and where the operational priority is simplicity over exhaustive delivery guarantees.

## Domain model

Three entities form the execution hierarchy:

**`ScheduledPrompt`** (existing, extended):  the aggregate root declaring what to run, when, and for whom. Extended with `Planning` (startDate, endType, endDate, maxOccurrenceCount) and `Recurrence` (unit, days, timeUtc). `enabled` is toggled to `false` when the end condition is reached. `nextRunAt` is advanced by CAS Cypher after each tick.

**`ScheduledPromptRun`** (existing): one per scheduler tick per ScheduledPrompt. Represents a single firing of the schedule. (`scheduledPromptId`,`scheduledFor`) is UNIQUE in Neo4j, acts as the distributed lock preventing duplicate firings for the same slot. Status: CLAIMED-> RUNNING -> DONE/FAILED (or SKIPPED on overlap). The CLAIMED -> RUNNING transition serves as the completion guard: `checkCompletion` only inspects RUNNING Runs, so a Run still being materialized is never prematurely closed.

**`ScheduledPromptUserRun`** (new) : one per `(Run, User)` pair. Tracks the execution of a single Case for a single target user. Composite UNIQUE constraint on `(runId, userId)`, idempotent via MERGE, safe to replay on crash. `@Version` optimistic locking prevents double-claim across instances. `leaseUntil` enables crash recovery: a RUNNING UserRun whose lease has expired is reclaimed by the next `findClaimable`. Status: PENDING -> RUNNING -> DONE/FAILED.

## Implementation details

### Case creation per user

The Executor resolves the prompt content directly via `promptService.findById(promptTemplateId)` and creates a Case per user through the following sequence:

1. `CaseService.create()`: persists the Case with the scheduled prompt's name as title (e.g. "Weekly Digest")
2. `PermissionService.grantPermission()`: grants ADMIN on the Case to the target user
3. `CaseService.addMessage()`: injects `"@agentName <resolved prompt content>"` as the user's message, which internally launches `runtime.run()` in `CaseServiceImpl.scope`

The `@agentName` is resolved by `selectAgent()` in the Case runtime. This avoids the incompatibility between `@mention` prefix and `PromptCommandParser`'s `/command` requirement, and positions the Executor as the right resolution point for future placeholder support.

All values are configurable via `SchedulerProperties`:

| Property | Env var | Default | Description |
|---|---|---|---|
| `scheduler.enabled` | `SCHEDULER_ENABLED` | `false` | Enable/disable the scheduler |
| `scheduler.tick-interval-ms` | `SCHEDULER_TICK_INTERVAL_MS` | `30000` | Interval between claim ticks (ms) |
| `scheduler.consume-interval-ms` | `SCHEDULER_CONSUME_INTERVAL_MS` | `10000` | Interval between consume ticks (ms) |
| `scheduler.batch-size` | `SCHEDULER_BATCH_SIZE` | `20` | Max UserRuns claimed and executed in parallel per consume tick |
| `scheduler.launch-timeout-seconds` | `SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | `30` | Max seconds to wait for a Case to reach IDLE or terminal after launch |
| `scheduler.lease-minutes` | `SCHEDULER_LEASE_MINUTES` | `30` | Lease duration for RUNNING UserRuns (minutes) |

### End condition enforcement

- **Pre-check guard**: if `ON_DATE` endDate is already past or `OCCURRENCES` max is already reached, the ScheduledPrompt is disabled without inserting a Run. This is a crash-recovery safety net, prevents zombie ticks when the server was down or a previous disable failed.
- **Post-advance check**: after advancing nextRunAt, if the next slot exceeds endDate or the total number of non-SKIPPED runs (including the one just inserted) reaches maxOccurrenceCount, the ScheduledPrompt is disabled.

### Multi-instance safety

The scheduler runs safely across multiple AgentOS instances with no leader election:

| Mechanism | Where | Guarantee |
|---|---|---|
| UNIQUE constraint | `ScheduledPromptRun` insert | Only one instance claims a given slot, losers catch `DuplicateRunException` and skip |
| Compare-And-Set Cypher on `nextRunAt` | `advanceNextRunAt` | Auto-repairing: every instance advances the slot, even on duplicate, prevents stuck prompts |
| `@Transactional` on `materialize()` | MERGE UserRuns + CLAIMED→RUNNING | Atomic: crash cannot leave orphaned PENDING UserRuns or a RUNNING Run with no UserRuns |
| MERGE Cypher on composite key | `materialize()` | Idempotent UserRun creation, safe to replay, UNIQUE constraint deduplicates |
| Orphan sweep on CLAIMED | `recoverOrphanedClaimedRuns` in `tickClaim` | Crash between Run insert and `materialize()` leaves a CLAIMED orphan blocking the overlap guard, swept to FAILED after 5 min, unblocking subsequent slots |
| Orphan sweep on RUNNING | `recoverOrphanedRunningRuns` in `tickClaim` | Crash between last `markTerminal` and batch completion check leaves a RUNNING Run with all UserRuns terminal, swept to DONE or FAILED on next tick |
| `@Version` optimistic lock | `claimBatch()` on UserRun | `OptimisticLockingFailureException` → skip (another instance took it) |
| `leaseUntil` expiry | RUNNING UserRuns | Instance crash recovery: if the instance dies between Case creation and `closeUserRun`, the lease expires and another instance reclaims the UserRun (at-least-once — may create a duplicate Case) |

### Known limitations / follow-up

- **No purge of completed Runs and UserRuns.** `ScheduledPromptRun` and `ScheduledPromptUserRun` are append-only audit records that accumulate indefinitely. A scheduled prompt firing daily for 100 users produces ~36,500 UserRun nodes per year. A purge mechanism (retention policy, TTL-based cleanup, or archival) is needed in a future PR to prevent unbounded growth.

### Architectural note
The two-phase tick, UNIQUE-constraint locking, lease-based recovery, and completion sweeps are a hand-rolled workflow engine built on Neo4j.
As the volume grows, migrating to a dedicated workflow engine would replace most of this machinery with battle-tested infrastructure.