### PR TITLE
feat: collapse long error messages in chat

### DIFF
--- a/apps/client/src/app/components/chat-message/chat-message.component.html
+++ b/apps/client/src/app/components/chat-message/chat-message.component.html
@@ -29,12 +29,29 @@
 
     <!-- Simplified layout for other message types -->
     @if (isSimplified) {
-      <div class="simple-content markdown-content">
-        <span [innerHTML]="renderedContent"></span>
-        @if (eventLink) {
-          <a [href]="eventLink" target="_blank" class="event-link">view</a>
-        }
-      </div>
+      @if (message.type === 'error' && isLongError) {
+        <div class="simple-content error-collapsible">
+          @if (isErrorExpanded()) {
+            <span [innerHTML]="renderedContent"></span>
+          } @else {
+            <span class="error-collapsed-text">{{ collapsedErrorText }}</span>
+          }
+          <button class="error-toggle" (click)="toggleErrorExpanded()" type="button">
+            @if (isErrorExpanded()) {
+              Show less ▲
+            } @else {
+              Show more ▼
+            }
+          </button>
+        </div>
+      } @else {
+        <div class="simple-content markdown-content">
+          <span [innerHTML]="renderedContent"></span>
+          @if (eventLink) {
+            <a [href]="eventLink" target="_blank" class="event-link">view</a>
+          }
+        </div>
+      }
     }
   </div>
 

--- a/apps/client/src/app/components/chat-message/chat-message.component.scss
+++ b/apps/client/src/app/components/chat-message/chat-message.component.scss
@@ -177,6 +177,36 @@
   opacity: 1;
 }
 
+.error-collapsible {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .error-collapsed-text {
+    white-space: pre-wrap;
+    font-family: 'SF Mono', Monaco, Menlo, monospace;
+    font-size: 0.85rem;
+    word-break: break-all;
+  }
+
+  .error-toggle {
+    align-self: flex-start;
+    background: none;
+    border: 1px solid currentColor;
+    border-radius: 4px;
+    color: var(--color-error);
+    cursor: pointer;
+    font-size: 0.75rem;
+    opacity: 0.75;
+    padding: 0.15rem 0.5rem;
+    transition: opacity 0.15s ease;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}
+
 // Simplified layout (system/technical/error/warning)
 .simple-content {
   display: flex;

--- a/apps/client/src/app/components/chat-message/chat-message.component.ts
+++ b/apps/client/src/app/components/chat-message/chat-message.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, inject } from '@angular/core'
+import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, inject, signal } from '@angular/core'
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
 import { MessageContent } from '@coday/model'
 import { MessageContextMenuComponent, MenuAction } from '../message-context-menu/message-context-menu.component'
@@ -45,6 +45,10 @@ export class ChatMessageComponent implements OnInit, OnDestroy {
   renderedContent: SafeHtml = ''
   shouldHideTechnical = false
   shouldHideWarning = false
+
+  protected readonly isErrorExpanded = signal(false)
+
+  private static readonly ERROR_COLLAPSE_LINE_THRESHOLD = 5
 
   // Modern Angular dependency injection
   private sanitizer = inject(DomSanitizer)
@@ -114,6 +118,24 @@ export class ChatMessageComponent implements OnInit, OnDestroy {
     if (this.message.role !== 'user' || !this.message.timestamp) return null
     const isToday = new Date().toDateString() === this.message.timestamp.toDateString()
     return this.datePipe.transform(this.message.timestamp, isToday ? 'HH:mm' : 'dd/MM HH:mm')
+  }
+
+  get isLongError(): boolean {
+    if (this.message.type !== 'error') return false
+    const textContent = this.extractTextContent()
+    // Support both real newlines and escaped \n (from JSON.stringify of error objects)
+    const lines = textContent.split(/\n|\\n/)
+    return lines.length > ChatMessageComponent.ERROR_COLLAPSE_LINE_THRESHOLD
+  }
+
+  get collapsedErrorText(): string {
+    const textContent = this.extractTextContent()
+    const lines = textContent.split(/\n|\\n/)
+    return lines.slice(0, ChatMessageComponent.ERROR_COLLAPSE_LINE_THRESHOLD).join('\n') + '\u2026'
+  }
+
+  toggleErrorExpanded(): void {
+    this.isErrorExpanded.update((v) => !v)
   }
 
   get isLongMessage(): boolean {


### PR DESCRIPTION
<img width="807" height="268" alt="Capture d’écran 2026-08-05 à 12 38 12" src="https://github.com/user-attachments/assets/56335948-7151-4586-b7f8-881766def44b" />
