### PR TITLE
feat: memory learning loop with LEARNING level, reflect handler and prefetch

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,6 +1,9 @@
 import express from 'express'
 import path from 'path'
 import fs from 'fs'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 import { ThreadCodayManager } from './lib/thread-coday-manager'
 
 import { debugLog } from './lib/log'
@@ -76,17 +79,12 @@ let promptExecutionService: PromptExecutionService
 // Proxy /api/agentos/* → AgentOS Spring backend
 // Registered synchronously and BEFORE express.json() to avoid body-parser
 // consuming the request body before it can be forwarded.
-const AGENTOS_PORT = process.env.AGENTOS_PORT ? parseInt(process.env.AGENTOS_PORT) : 8124
-const AGENTOS_HOSTNAME = process.env.AGENTOS_HOSTNAME ?? 'localhost'
-const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
-const AGENTOS_URL = `http://${AGENTOS_HOSTNAME}:${AGENTOS_PORT}`
+const AGENTOS_PORT = process.env.AGENTOS_PORT ? parseInt(process.env.AGENTOS_PORT) : 8123
+const AGENTOS_URL = `http://localhost:${AGENTOS_PORT}`
 app.use(
   '/api/agentos',
   (req, _res, next) => {
     console.log(`[AGENTOS PROXY] ${req.method} ${req.path}`)
-    if (AGENTOS_EXTERNAL_USERID) {
-      req.headers['X-External-User-Id'] = AGENTOS_EXTERNAL_USERID
-    }
     next()
   },
   createProxyMiddleware({
@@ -339,7 +337,7 @@ registerThreadRoutes(
 )
 
 // Register message management routes
-registerMessageRoutes(app, threadCodayManager, getUsername, threadService)
+registerMessageRoutes(app, threadCodayManager, getUsername)
 
 // Register agent management routes
 const agentCrudService = new AgentCrudService(codayOptions.configDir, projectService)
@@ -490,26 +488,15 @@ PORT_PROMISE.catch((error) => {
 })
 
 // Graceful shutdown with proper cleanup
-// Counter-based guard: 1st signal starts shutdown, 2nd is tolerated (MCP child cascading),
-// 3rd force-exits. This prevents data loss from SIGINT propagating to child processes
-// in the same process group (e.g. MCP FETCH via uvx) which cascades back as a second signal.
-let shutdownSignalCount = 0
+let isShuttingDown = false
 
 async function gracefulShutdown(signal: string) {
-  shutdownSignalCount++
-
-  if (shutdownSignalCount === 2) {
-    console.log(
-      `Received ${signal} during shutdown (likely from child process cascade) — shutdown in progress, press Ctrl+C again to force exit`
-    )
-    return
-  }
-
-  if (shutdownSignalCount >= 3) {
-    console.log(`Received ${signal} — forcing exit`)
+  if (isShuttingDown) {
+    console.log(`Received ${signal} during shutdown, forcing exit...`)
     process.exit(1)
   }
 
+  isShuttingDown = true
   console.log(`Received ${signal}, shutting down gracefully...`)
 
   try {
@@ -552,7 +539,7 @@ process.on('uncaughtException', (error) => {
     return // Don't shutdown for this specific error
   }
 
-  if (shutdownSignalCount === 0) {
+  if (!isShuttingDown) {
     gracefulShutdown('uncaughtException')
   }
 })
@@ -583,7 +570,7 @@ process.on('unhandledRejection', (reason, promise) => {
 
   // Only shutdown for critical unhandled rejections
   console.error('Critical unhandled rejection detected')
-  if (shutdownSignalCount === 0) {
+  if (!isShuttingDown) {
     gracefulShutdown('unhandledRejection')
   }
 })

--- a/docs/05-working-effectively/learning-loop.md
+++ b/docs/05-working-effectively/learning-loop.md
@@ -1,0 +1,102 @@
+# Learning Loop
+
+Coday agents learn from conversations and retain knowledge across sessions. This learning is never autonomous — every memorization requires explicit user validation.
+
+## How It Works
+
+The learning system has three complementary mechanisms, each operating at a different timescale.
+
+### Continuous Learning (Real-Time)
+
+During any conversation, agents actively detect learning opportunities:
+
+- **Corrections**: when the user fixes an approach, output, or behavior
+- **Preferences**: recurring patterns in how the user wants things done
+- **Technical knowledge**: non-obvious discoveries — workarounds, config quirks, conventions
+- **Hard-won resolutions**: problems that required significant debugging effort
+- **Contradictions**: new information that invalidates an existing memory
+
+When the agent detects one of these, it proposes a concise rule and asks for confirmation before memorizing. It reads existing memories first to avoid duplicates and flags contradictions explicitly.
+
+This runs in every conversation with no setup required.
+
+### Reflect (Retrospective)
+
+The `memory reflect` command lets you select a past conversation thread and have the agent analyze it for missed learnings.
+
+The agent walks through the thread looking for corrections, preferences, technical insights, patterns, and contradictions with existing memories. For each finding, it asks for confirmation before memorizing.
+
+This is useful when a conversation was too intense to pause for learning, or when you suspect valuable knowledge was left uncaptured.
+
+```bash
+memory reflect
+# Prompts you to select a thread, then analyzes it
+```
+
+The reflect prompt can be customized by placing a `reflect-prompt.md` file in `~/.coday/`. The default prompt is bundled with Coday.
+
+### Curate (Maintenance)
+
+The `memory curate` command triggers a structured review of existing memories.
+
+The agent performs three passes:
+1. **Consolidation**: identifies overlapping or redundant memories and merges them
+2. **Cleanup**: detects outdated, incorrect, or inconsistent memories and proposes corrections or deletions
+3. **Verification**: reviews the final state for completeness and organization
+
+Curation can target a specific level and agent:
+
+```bash
+memory curate --user                        # curate user-level memories
+memory curate --project --agent=Sway        # curate project-level memories for Sway
+memory curate --user coding patterns        # curate user memories about a specific topic
+```
+
+## Challenging Existing Memories
+
+Memories are not sacred. The learning system treats them as living knowledge that can become wrong over time — a library upgrade, a refactored codebase, or a changed convention can invalidate a previously correct memory.
+
+Agents are instructed to:
+- Compare new learnings against existing memories
+- Flag contradictions explicitly: *"Memory [title] says X, but we just found Y. Should I update/delete it?"*
+- Never silently keep a known-wrong memory in place
+- Always defer the decision to the user
+
+This applies in all three mechanisms: during real-time learning, during reflect analysis, and during curation.
+
+## The User's Role
+
+The user is the sole authority on what gets memorized, updated, or deleted. The agent proposes — the user decides.
+
+This is a deliberate design choice. Fully autonomous learning loops tend to converge on local optima: the agent learns from itself, judges itself, and reinforces its own biases. Keeping the user in the loop provides the external perturbation that prevents drift.
+
+In practice, this means:
+- Every new memory requires a "yes" before being stored
+- Every update or deletion of an existing memory requires confirmation
+- The agent explains its reasoning but never acts unilaterally
+
+## Memory Levels
+
+Memories are stored at two levels:
+
+| Level | Scope | Injection | Examples |
+|-------|-------|-----------|----------|
+| USER | Follows the user across projects | Always in system prompt | Strong preferences, communication style |
+| LEARNING | Follows the user across projects | On-demand via prefetch | Technical knowledge, corrections, workarounds, patterns |
+| PROJECT | Specific to a project | On-demand via prefetch | Architectural decisions, conventions, project-specific constraints |
+
+Agents default to LEARNING level for technical knowledge and corrections. USER level is for strong personal preferences and communication style. PROJECT level is reserved for knowledge that only makes sense within a specific project's context.
+
+USER memories are always injected in the system prompt — keep them few and essential. LEARNING and PROJECT memories are retrieved on-demand: before each response, a cheap LLM call selects which memories are relevant to the current message. This means you can accumulate many learnings without polluting the context.
+
+## Tips
+
+- **Don't skip confirmations.** A wrong memory is worse than no memory — it actively misleads future conversations.
+- **Run `memory curate` periodically.** Memories accumulate. Consolidation keeps them useful.
+- **Use `memory reflect` after intense sessions.** The best learnings often come from the hardest conversations.
+- **Challenge old memories.** If an agent applies a memorized approach and it doesn't work, tell it. That's the signal to update.
+
+## Related
+
+- [Context and Memory](./context-and-memory.md): how context and memory work together
+- [Prompting Strategies](./prompting-strategies.md): effective communication with agents

--- a/docs/study/hermes-agent-memory-system.md
+++ b/docs/study/hermes-agent-memory-system.md
@@ -1,0 +1,408 @@
+# Hermes Agent — Memory & Self-Learning System Analysis
+
+> Study of https://github.com/NousResearch/hermes-agent memory architecture.
+> Sources: repo code (`agent/memory_manager.py`, `agent/memory_provider.py`, `agent/prompt_builder.py`, `agent/curator.py`, `tools/memory_tool.py`, `tools/skill_manager_tool.py`, `tools/session_search_tool.py`) + [official docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/overview).
+
+## Architecture Overview
+
+3 memory layers + 1 self-improvement loop:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    System Prompt                        │
+│  [MEMORY.md snapshot] [USER.md snapshot] [Skills index] │
+└─────────────────────────────────────────────────────────┘
+         ↑ injected once at session start
+
+┌─────────────────────────────────────────────────────────┐
+│              MemoryManager (orchestrator)                │
+│  BuiltinMemoryProvider + max 1 external provider        │
+│  → prefetch_all() → sync_all() per turn                 │
+└─────────────────────────────────────────────────────────┘
+
+┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐
+│  MEMORY.md   │  │   USER.md    │  │  session_search (FTS5)│
+│  2200 chars  │  │  1375 chars  │  │  SQLite ~/.hermes/    │
+│  ~800 tokens │  │  ~500 tokens │  │  state.db — unlimited │
+└──────────────┘  └──────────────┘  └──────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│            Self-learning loop                           │
+│  skill_manage (create/modify skills)                    │
+│  + Curator (background skill maintenance)               │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 1. Declarative Memory — MEMORY.md / USER.md
+
+### Storage
+- `~/.hermes/memories/MEMORY.md` — agent personal notes (env, conventions, learned errors)
+- `~/.hermes/memories/USER.md` — user profile (preferences, communication style)
+- Hard limits: 2200 chars for MEMORY, 1375 for USER
+
+### "Frozen snapshot" pattern
+At each session start, content is injected **once** into the system prompt (frozen snapshot). Never updated mid-session → preserves LLM prefix cache. Modifications via the `memory` tool are persisted to disk immediately but only visible at next session.
+
+### System prompt format
+```
+══════════════════════════════════════════════
+MEMORY (your personal notes) [67% — 1,474/2,200 chars]
+══════════════════════════════════════════════
+User's project is a Rust web service at ~/code/myapi using Axum + SQLx
+§
+This machine runs Ubuntu 22.04, has Docker and Podman installed
+§
+User prefers concise responses, dislikes verbose explanations
+```
+Entries separated by `§`.
+
+### Tool `memory`
+Actions: `add`, `replace`, `remove` via substring matching (`old_text` = unique substring).
+When memory is full (>80%), agent must consolidate before adding.
+
+### When the agent writes to memory
+Guided by `MEMORY_GUIDANCE` in `agent/prompt_builder.py` — proactive save of:
+- User preferences
+- Corrections received
+- Project conventions
+- Environment facts
+- Completed work
+
+## 2. MemoryManager — Multi-provider Abstraction
+
+`agent/memory_manager.py` — single integration point in `run_agent.py`.
+
+- **1 BuiltinMemoryProvider** always present
+- **Max 1 external provider** (Honcho, Mem0, OpenViking, Hindsight…) — intentional limit to avoid schema bloat
+
+`MemoryProvider` interface (`agent/memory_provider.py`):
+```python
+def system_prompt_block(self) -> str
+def prefetch(self, query, *, session_id) -> str       # recall before each turn
+def queue_prefetch(self, query, ...)                  # async prefetch next turn
+def sync_turn(self, user_content, assistant_content)  # post-turn persistence
+def get_tool_schemas(self) -> List[Dict]
+def on_turn_start(self, turn_number, message, **kwargs)
+def on_session_end(self, messages)                    # fact extraction at session end
+def on_delegation(self, task, result, child_session_id)
+def on_memory_write(self, action, target, content, metadata)  # cross-provider sync
+```
+
+Per-turn cycle in `run_agent.py`:
+```
+session start → initialize_all(session_id)
+  → build_system_prompt()  [frozen snapshot]
+
+per turn:
+  → prefetch_all(user_message)   [context recall injected via <memory-context>]
+  → [LLM call + tool loop]
+  → sync_all(user_msg, assistant_response)
+  → queue_prefetch_all(user_msg) [async prefetch for next turn]
+```
+
+`StreamingContextScrubber` strips `<memory-context>` tags from stream so they don't appear in UI.
+
+## 3. Session Search — Long-term Memory
+
+`tools/session_search_tool.py` — cross-session recall via SQLite FTS5:
+
+1. FTS5 on `~/.hermes/state.db` — all CLI and gateway sessions
+2. Top N relevant sessions (default 3)
+3. Each session truncated to ~100k chars centered on matches
+4. LLM summary (fast auxiliary model, e.g. Gemini Flash) per session
+5. Returns structured summaries with metadata
+
+| | Persistent memory | Session Search |
+|---|---|---|
+| Capacity | ~1300 tokens total | Unlimited |
+| Speed | Instant (system prompt) | Search + LLM |
+| Use case | Key facts always available | "Did we discuss X last week?" |
+| Management | Agent-curated | Automatic — everything stored |
+
+## 4. Procedural Memory — Skills System
+
+### Structure
+```
+~/.hermes/skills/
+├── my-skill/
+│   ├── SKILL.md          # instructions (required)
+│   ├── references/
+│   ├── templates/
+│   └── scripts/
+└── .usage.json           # telemetry (use_count, view_count, patch_count, state)
+```
+
+### Progressive disclosure (token-efficient)
+```
+Level 0: skills_list()          → [{name, description, category}]  (~3k tokens)
+Level 1: skill_view(name)       → full content
+Level 2: skill_view(name, path) → specific reference file
+```
+Level 0 index injected in every system prompt.
+
+### Tool `skill_manage` — autonomous writing
+Actions: `create`, `patch` (preferred, token-efficient), `edit`, `delete`, `write_file`, `remove_file`.
+
+**When the agent creates a skill**:
+- After a complex task (≥5 tool calls) resolved successfully
+- When it encountered errors and found the working path
+- When the user corrected its approach
+- When it discovered a non-trivial workflow
+
+## 5. Curator — Self-improvement Loop
+
+`agent/curator.py` — background maintenance of agent-created skills.
+
+### Trigger
+No cron daemon — triggered by inactivity:
+- At CLI session start
+- On recurring tick in gateway
+- Conditions: `interval_hours` (default 7 days) **AND** `min_idle_hours` (default 2h) elapsed
+
+### Two phases per pass
+1. **Automatic transitions** (deterministic, no LLM):
+   - `active → stale` after 30 days without usage
+   - `stale → archived` after 90 days → moved to `.archive/`
+
+2. **LLM review** (AIAgent fork, max 8 turns, configurable auxiliary model):
+   - Reads each skill with `skill_view`
+   - Decides: keep / patch / consolidate / archive
+   - Mutates via `skill_manage`
+
+### Telemetry `.usage.json`
+```json
+{
+  "my-skill": {
+    "use_count": 12,
+    "view_count": 34,
+    "last_used_at": "2026-04-24T18:12:03Z",
+    "patch_count": 3,
+    "state": "active",
+    "pinned": false
+  }
+}
+```
+
+### Protections
+- **Pinning**: absolute protection — blocks even `skill_manage` tool mid-conversation
+- **Automatic backup** before each pass → `.curator_backups/`
+- **Rollback**: `hermes curator rollback`
+- Never touches bundled or hub-installed skills
+
+## 6. External Providers — Detailed Comparison
+
+8 plugins via `hermes memory setup`. Max 1 active alongside builtin.
+
+Automatic behaviors when a provider is active:
+- Injects provider context into system prompt
+- Prefetch before each turn (non-blocking, background)
+- Sync turns after each response
+- Extract memories at session end (providers that support it)
+- Mirror builtin writes to external provider via `on_memory_write()`
+
+Isolation per profile: each provider isolates data via `$HERMES_HOME/` (differs per profile).
+
+### Comparison Table
+
+| Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
+|---|---|---|---|---|---|
+| Honcho | Cloud | Paid | 5 | honcho-ai | Dialectic user modeling + session context |
+| OpenViking | Self-hosted | Free | 5 | openviking + server | Filesystem hierarchy + tiered loading |
+| Mem0 | Cloud | Paid | 3 | mem0ai | Server-side LLM extraction |
+| Hindsight | Cloud/Local | Free/Paid | 3 | hindsight-client | Knowledge graph + reflect synthesis |
+| Holographic | Local | Free | 2 | None | HRR algebra + trust scoring |
+| RetainDB | Cloud | $20/mo | 5 | requests | Delta compression + hybrid search |
+| ByteRover | Local/Cloud | Free/Paid | 3 | brv CLI | Pre-compression extraction |
+| Supermemory | Cloud | Paid | 4 | supermemory | Context fencing + multi-container |
+
+### Honcho
+
+**Tools (5)**: `honcho_profile`, `honcho_search`, `honcho_context`, `honcho_reasoning`, `honcho_conclude`
+
+Two-layer architecture:
+- **Base**: session summary + representation + peer card, refreshed per `contextCadence`
+- **Dialectic**: LLM reasoning, per `dialecticCadence`, depth 1–3 via `dialecticDepth`
+
+Automatic cold-start vs warm prompt selection based on whether base context exists.
+
+Multi-profile: shared workspace, global user peer, one AI peer per Hermes profile (`hermes`, `hermes.coder`…). Each AI peer builds an independent representation.
+
+4 observation toggles per peer: `observeMe` / `observeOthers` for user and AI. Preset `directional` (all on) or `unified` (AI models user only).
+
+Config: `$HERMES_HOME/honcho.json` > `~/.hermes/honcho.json` > `~/.honcho/config.json`
+
+- ✅ Most sophisticated user modeling, cross-session, independent multi-profile
+- ❌ Paid cloud, config complexity, external dependency
+
+### OpenViking
+
+**Tools (5)**: `viking_search`, `viking_read`, `viking_browse`, `viking_remember`, `viking_add_resource`
+
+- Tiered loading: L0 (~100 tokens) → L1 (~2k) → L2 (full)
+- Auto extraction in 6 categories at session commit: profile, preferences, entities, events, cases, patterns
+- URI scheme `viking://` for hierarchical navigation
+
+- ✅ Free, self-hosted, structured extraction, browsable like a filesystem
+- ❌ Local server required, AGPL-3.0 license
+
+### Mem0
+
+**Tools (3)**: `mem0_profile`, `mem0_search`, `mem0_conclude`
+
+Automatic server-side LLM extraction, semantic search + reranking, automatic deduplication.
+
+- ✅ Zero friction, fully automatic extraction, semantic search
+- ❌ Cloud only, paid, no fine control over what gets extracted
+
+### Hindsight
+
+**Tools (3)**: `hindsight_retain`, `hindsight_recall`, `hindsight_reflect`
+
+`hindsight_reflect` = cross-memory synthesis — **unique among all providers**.
+
+- `auto_retain: true`: automatically stores complete turns (tool calls included)
+- `recall_budget`: `low` / `mid` / `high` (controls LLM cost)
+- Modes: `hybrid` / `context-only` / `tools-only`
+- Local mode available (embedded PostgreSQL), local UI via `hindsight-embed`
+
+- ✅ Knowledge graph + entity resolution, only provider with cross-memory reflect/synthesis, local mode
+- ❌ Dependency `hindsight-client >= 0.4.22` (auto-upgrade), paid cloud or local infra to manage
+
+### Holographic
+
+**Tools (2)**: `fact_store` (9 actions: add, search, probe, related, reason, contradict, update, remove, list), `fact_feedback`
+
+- Asymmetric trust scoring: +0.05 helpful / -0.10 unhelpful
+- `probe`: algebraic recall by entity
+- `reason`: AND-compositional multi-entity queries (HRR — Holographic Reduced Representations)
+- `contradict`: automatic detection of contradictory facts
+- `auto_extract: false` by default
+
+- ✅ 100% local, zero dependencies (SQLite always available), trust scoring, unique HRR algebra, free
+- ❌ FTS5 only (no semantic search), NumPy optional for HRR, non-automatic extraction by default
+
+### RetainDB
+
+**Tools (5)**: `retaindb_profile`, `retaindb_search`, `retaindb_context`, `retaindb_remember`, `retaindb_forget`
+
+Hybrid search: Vector + BM25 + Reranking. 7 memory types, delta compression.
+
+- ✅ Advanced hybrid search, delta compression, rich tooling (5 tools)
+- ❌ $20/month, cloud only, niche (mainly useful if already a RetainDB customer)
+
+### ByteRover
+
+**Tools (3)**: `brv_query`, `brv_curate`, `brv_status`
+
+**Pre-compression extraction**: extracts insights *before* context compression discards them — only provider that hooks into compression.
+
+- Knowledge tree stored in `$HERMES_HOME/byterover/` (profile-isolated)
+- Tiered retrieval: fuzzy text → LLM-driven search
+- Optional cloud sync (SOC2 Type II)
+
+- ✅ Local-first, portable (npm CLI), only provider with pre-compression hook, free locally
+- ❌ `brv` CLI required, limited tooling (3 tools), paid cloud sync
+
+### Supermemory
+
+**Tools (4)**: `supermemory_store`, `supermemory_search`, `supermemory_forget`, `supermemory_profile`
+
+- **Automatic context fencing**: recalled memories are stripped from captured turns → prevents recursive pollution
+- Session-end ingest for knowledge graph-level building
+- Profile facts injected at 1st turn and every N turns (`profile_frequency: 50`)
+- Trivial message filtering (skips "ok", "thanks"…)
+- Multi-container: `{identity}` template for profile isolation, `enable_custom_container_tags` for cross-container read/write
+
+- ✅ Unique context fencing, flexible multi-container, graph-level session ingest
+- ❌ Cloud only, paid, `api_timeout: 5.0s` can slow turns
+
+## 7. Prompt Assembly — Layer Order
+
+Exact system prompt construction order at each session:
+
+```
+1. SOUL.md (or hardcoded DEFAULT_AGENT_IDENTITY)
+2. Guidance blocks (MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE)
+3. Provider static block (e.g. Honcho base context)
+4. Frozen MEMORY.md snapshot
+5. Frozen USER.md snapshot
+6. Skills index (Level 0 — ~3k tokens)
+7. Context files (AGENTS.md, .cursorrules, CLAUDE.md, .hermes.md)
+8. Timestamp + session ID + platform hint
+```
+
+Kept **outside** the cached prefix (injected per API call):
+- Prefetch recall `<memory-context>` (scrubbed by `StreamingContextScrubber`)
+- Ephemeral gateway overlays
+- Honcho dialectic recall
+
+Context files — priority (first match wins):
+1. `.hermes.md` / `HERMES.md` → walks up to git root
+2. `AGENTS.md` → CWD only
+3. `CLAUDE.md` → CWD only
+4. `.cursorrules` / `.cursor/rules/*.mdc` → CWD only
+
+All scanned for injection attacks (invisible unicode, "ignore previous instructions", credential exfiltration), truncated to 20k chars.
+
+## Summary
+
+| Layer | Technology | Capacity | Persistence |
+|---|---|---|---|
+| MEMORY.md | Markdown file | 2200 chars | Cross-session |
+| USER.md | Markdown file | 1375 chars | Cross-session |
+| Session Search | SQLite FTS5 + LLM | Unlimited | Cross-session |
+| Skills | SKILL.md files | Unlimited | Cross-session |
+| External provider | Plugin (Honcho, Mem0…) | Variable | Cross-session |
+
+Full loop: agent **learns** (memory tool) → **generalizes** (skill_manage) → **consolidates** (curator in background) → **retrieves** (session_search on-demand).
+
+---
+
+## Architectural Review
+
+### Strengths
+
+- **Declarative / procedural / episodic separation.** MEMORY.md = semantic memory (facts), Skills = procedural memory (know-how), Session Search = episodic memory (events). Right taxonomy, each layer gets an adapted management mechanism.
+- **Frozen snapshot for prefix cache.** Accepting that memory writes are only visible next session is a good trade-off — modifying the system prompt mid-session invalidates provider-side cache.
+- **Progressive disclosure of skills.** Level 0 index (~3k tokens) in system prompt, drill-down on-demand. Lazy loading applied to prompting — scales well.
+- **Curator as skill GC.** Deterministic transitions (stale → archived) + LLM review pass for consolidation. Pinning and rollback show anticipation of drift.
+- **ByteRover's pre-compression hook.** Extracting insights before context compression destroys them is a rare architectural insight.
+- **Skill creation triggers.** ≥5 tool calls + success, user correction, or errors overcome — high-value moments for procedural knowledge capture, not arbitrary.
+- **Deterministic lifecycle decoupled from LLM review.** 30 days unused = stale, 90 days = archived. No LLM needed for that. LLM pass comes on top for intelligent consolidation.
+
+### Weaknesses
+
+- **2200/1375 char caps are too low.** ~1300 tokens total for persistent memory. A developer working on 3 projects saturates this in a day. Could be dynamic based on model context window.
+- **Agent self-manages its memory.** Quality depends entirely on MEMORY_GUIDANCE adherence. LLMs are inconsistent at memorization discipline — no automatic safety net (unless opting into an external provider).
+- **Max 1 external provider.** Presented as architectural choice, but it's an implementation simplification. Holographic (local, trust scoring) and Honcho (cloud user modeling) are complementary, not substitutable.
+- **No semantic search in builtin.** FTS5 = keyword matching only. "How to deploy the service" won't find a session about "mise en production de l'API". 90% of users use the default path — and it has no semantic recall.
+- **Curator is a cheap LLM judging a capable LLM's work.** Risk: archiving valid skills or introducing regressions via patches. Backup/rollback mitigates but detection is retroactive.
+- **No multi-user shared memory.** Everything in `~/.hermes/` — single user. No mechanism to share skills or memories across a team working on the same project.
+- **Substring matching for replace/remove is fragile.** Intrinsically brittle compared to ID-based or index-based systems.
+- **Context fencing only in Supermemory (paid plugin).** Builtin has no protection against recursive memory pollution in session_search recall.
+
+### Self-learning Loop — Specific Analysis
+
+The full cycle: complex task succeeded → `skill_manage create` → skill reused in future sessions → telemetry tracks usage → Curator reviews (max 8 turns, cheap model) → patch / consolidate / archive → refined skills available next session.
+
+**Architecturally coherent but epistemically closed.** The agent learns from itself, judges itself, corrects itself. Works as long as the underlying LLM has sufficient judgment capacity. But this is exactly the type of system that can converge to a local optimum without external perturbation.
+
+Key gaps in the loop:
+- **No human validation at skill creation.** If the agent solves a problem sub-optimally, it crystallizes a bad practice into a reusable skill.
+- **Curator has no feedback loop of its own.** Nobody curates the Curator. If a curation pass introduces a regression, the only detection is the user noticing degraded behavior after the fact.
+- **8 turns max for Curator is insufficient.** With 30 active skills, that's ~0.25 turns per skill. Consolidation (merging two overlapping skills) alone consumes 2-3 turns.
+- **No structured user feedback.** User can pin (protect) but cannot signal "this skill is bad" or "this skill helped". The only signal is passive usage (`use_count`). The learning loop is entirely self-referential.
+
+### Relevance for Coday
+
+Directly applicable:
+- Frozen snapshot pattern (already similar in Coday memories)
+- Progressive disclosure for skills/memories
+- Deterministic lifecycle management (stale → archive) for knowledge maintenance
+
+Not applicable:
+- Single-user local architecture (`~/.hermes/`) vs Coday's multi-tenant server-side model
+- Max 1 provider limit vs Coday's extensibility goals
+- No semantic search in builtin — non-starter for professional use
+
+Open question for Coday: if we implement procedural memory (skills), where do we inject human feedback into the loop? Not just rollback after the fact, but active signals — "this skill is good", "this skill misled me", "merge these two".

--- a/libs/agent/src/lib/agent.service.ts
+++ b/libs/agent/src/lib/agent.service.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs/promises'
+import * as os from 'os'
 import * as path from 'path'
+import { fileURLToPath } from 'url'
 import * as yaml from 'yaml'
 import { getFormattedDocs, findFilesByName } from '@coday/function'
 import {
@@ -351,6 +353,22 @@ export class AgentService implements Killable, AgentServiceModel {
     this.interactor.debug(`  📝 Parsed agent files: ${parseTime.toFixed(2)}ms`)
   }
 
+  private async readLearningPrompt(): Promise<string> {
+    const userFilePath = path.join(os.homedir(), '.coday', 'learning-prompt.md')
+    try {
+      return await fs.readFile(userFilePath, 'utf-8')
+    } catch {
+      // fall back to default
+    }
+    const currentDir = path.dirname(fileURLToPath(import.meta.url))
+    const defaultFilePath = path.join(currentDir, 'default-learning-prompt.md')
+    try {
+      return await fs.readFile(defaultFilePath, 'utf-8')
+    } catch {
+      return ''
+    }
+  }
+
   /**
    * Try to create and add an agent (lazy loading)
    * Logs error if dependencies are missing
@@ -388,16 +406,17 @@ export class AgentService implements Killable, AgentServiceModel {
       const agentDocs = await getFormattedDocs(def, this.interactor, basePath, def.name)
       const docsTime = performance.now() - docsStart
 
-      // overwrite agent instructions with the added project and user context
+      const learningPrompt = await this.readLearningPrompt()
+
       def.instructions = `${def.instructions}\n\n
 ## Project description
 ${context.project.description}
 
 ${this.services.memory.getFormattedMemories(MemoryLevel.USER, def.name)}
 
-${this.services.memory.getFormattedMemories(MemoryLevel.PROJECT, def.name)}
-
 ${agentDocs}
+
+${learningPrompt}
 
 `
 
@@ -427,7 +446,7 @@ ${agentDocs}
       )
 
       const toolset = new ToolSet([...syncTools])
-      const agent = new Agent(def, aiClient, toolset)
+      const agent = new Agent(def, aiClient, toolset, false, this.services.memory)
 
       const totalTime = performance.now() - agentStart
       this.interactor.debug(

--- a/libs/agent/src/lib/default-learning-prompt.md
+++ b/libs/agent/src/lib/default-learning-prompt.md
@@ -1,0 +1,76 @@
+## Continuous Learning
+
+You have the ability to learn from conversations and remember important insights
+across sessions using memory tools.
+
+### What to detect
+
+**Corrections**: When the user corrects your approach, output, or behavior:
+- Explicit: "no, do X instead", "I told you not to do that", "wrong, the right way is..."
+- Implicit: user redoes your work differently, user reformulates after your response,
+  user truncates and retries
+
+**Preferences**: When the user expresses how they like things done:
+- Code style, communication style, workflow habits
+- Things the user repeats or insists on
+
+**Positive validation**: When the user confirms a non-obvious approach works:
+- Only when the approach was non-trivial, surprising, or hard-won
+- Do NOT memorize obvious successes
+
+**Technical knowledge**: When you discover something non-obvious during the task:
+- A workaround, a project convention, a configuration quirk
+- Something that took multiple attempts to resolve
+
+**Hard-won resolutions**: When a problem required significant debugging effort:
+- Multiple failed attempts before finding the solution
+- Long diagnostic sequences (checking logs, trying different approaches)
+- Environment issues, configuration problems, tooling quirks
+- The moment the fix works, proactively propose to memorize the problem and solution
+- This is the highest-value learning — pain that should never be repeated
+
+**Contradictions with existing memories**: When new information contradicts a stored memory:
+- A correction from the user invalidates a previously memorized approach
+- A solution that worked before now fails (library upgrade, refactor, convention change)
+- A discovered fact contradicts what a memory states
+- Propose update or deletion to the user — never silently keep a wrong memory
+
+### How to learn
+
+1. **Detect**: Recognize corrections, preferences, validations, technical insights,
+   or hard-won resolutions as they happen
+2. **Be proactive**: Do not wait to be told to learn. When you see a learning
+   opportunity, act on it. Especially after debugging sessions that led to a fix.
+3. **Confirm**: Ask the user to validate your understanding. Keep it short:
+   "Should I remember that [lesson]?"
+4. **Check existing memories**: Read existing memories first — update rather than duplicate.
+   If a new learning **contradicts** an existing memory, flag it explicitly:
+   "Memory [title] says X, but we just found Y. Should I update/delete it?"
+5. **Memorize**: Once confirmed, create or update a memory with:
+   - A clear, specific title
+   - The problem or context
+   - The correct approach or preference
+   - LEARNING level for technical knowledge, corrections, workarounds, patterns
+   - USER level for strong personal preferences and communication style
+   - PROJECT level only for project-specific architectural decisions
+
+### Memory hygiene
+
+Before creating a new memory, read existing memories and assess their total volume.
+If you notice more than 20 memories at a given level, or the total content exceeds
+what feels like a large block of text, warn the user:
+"You have [N] memories at [LEVEL] level. Consider running `memory curate` to
+consolidate and clean up redundant or outdated entries."
+
+When adding a new memory, always prefer updating an existing one over creating a
+new entry. Merge related knowledge into a single well-structured memory rather
+than scattering it across many small ones.
+
+### Rules
+
+- Never memorize without user confirmation
+- Never memorize trivial or one-time information
+- Formulate as reusable rules: "When X, do Y — not Z"
+- If a correction or discovery contradicts an existing memory, explicitly flag it
+  and propose update or deletion — never leave a known-wrong memory in place
+- Do not interrupt complex tasks — wait for a natural pause, but do not forget

--- a/libs/agent/src/lib/default-reflect-prompt.md
+++ b/libs/agent/src/lib/default-reflect-prompt.md
@@ -1,0 +1,30 @@
+## Memory Reflection
+
+Analyze the conversation provided below and extract learnings worth memorizing.
+
+### What to look for
+
+- **Corrections**: user explicitly or implicitly corrected your approach, output, or behavior
+- **Preferences**: user expressed how they want things done (style, format, workflow)
+- **Technical knowledge**: non-obvious discoveries — workarounds, conventions, config quirks
+- **Patterns**: recurring behaviors or decisions that reveal a working style
+- **Contradictions**: findings in the conversation that contradict existing memories — propose correction or deletion
+
+### Process
+
+1. Read existing memories first to avoid duplicates — update rather than create when relevant
+2. Compare findings against existing memories. If a memory is contradicted, propose its update or deletion before creating new ones.
+3. For each finding, state it concisely and ask the user: "Should I remember that [rule]?"
+4. Wait for confirmation before memorizing anything
+5. Formulate as reusable rules: "When X, do Y — not Z"
+
+### Memory levels
+
+- USER level: preferences, technical knowledge, working patterns
+- PROJECT level: only project-specific architectural decisions
+
+### Rules
+
+- Never memorize without user confirmation
+- Skip trivial or one-time information
+- One confirmation per finding — keep it brief

--- a/libs/handlers/memory/src/lib/memory.handler.ts
+++ b/libs/handlers/memory/src/lib/memory.handler.ts
@@ -5,6 +5,7 @@ import { MemoryEditHandler } from './edit.handler'
 import { MemoryListHandler } from './list.handler'
 import { MemoryDeleteHandler } from './delete.handler'
 import { MemoryCurateHandler } from './curate.handler'
+import { MemoryReflectHandler } from './reflect.handler'
 
 export class MemoryHandler extends NestedHandler {
   constructor(interactor: Interactor, services: CodayServices) {
@@ -22,6 +23,7 @@ export class MemoryHandler extends NestedHandler {
       new MemoryEditHandler(interactor, services.memory),
       new MemoryDeleteHandler(interactor, services.memory),
       new MemoryCurateHandler(interactor),
+      new MemoryReflectHandler(interactor, services),
     ]
   }
 }

--- a/libs/handlers/memory/src/lib/reflect.handler.ts
+++ b/libs/handlers/memory/src/lib/reflect.handler.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import * as os from 'os'
+import { fileURLToPath } from 'url'
+import { CommandHandler } from '@coday/handler'
+import { CommandContext } from '@coday/model'
+import { Interactor } from '@coday/model'
+import { CodayServices } from '@coday/coday-services'
+import { MessageEvent } from '@coday/model'
+
+export class MemoryReflectHandler extends CommandHandler {
+  constructor(
+    private interactor: Interactor,
+    private services: CodayServices
+  ) {
+    super({
+      commandWord: 'reflect',
+      description: 'Select a past thread and have the AI analyze it to extract learnings.',
+    })
+  }
+
+  async handle(_command: string, context: CommandContext): Promise<CommandContext> {
+    const projectName = context.project.name
+    const username = context.username
+
+    const threads = await this.services.thread.listThreads(projectName, username)
+
+    if (!threads.length) {
+      this.interactor.displayText('No threads found for this project.')
+      return context
+    }
+
+    const sorted = [...threads].sort((a, b) => (a.modifiedDate > b.modifiedDate ? -1 : 1))
+    const options = sorted.map((t) => `[${t.modifiedDate}] ${t.name}`)
+
+    const chosen = await this.interactor.chooseOption(options, 'Select a thread to reflect on:')
+    if (!chosen) return context
+
+    const selectedIndex = options.indexOf(chosen)
+    const selectedThread = sorted[selectedIndex]
+    if (!selectedThread) return context
+
+    const thread = await this.services.thread.getThread(projectName, selectedThread.id)
+    if (!thread) {
+      this.interactor.displayText('Thread not found.')
+      return context
+    }
+
+    const messages = thread.getAllMessages()
+    const formattedMessages = messages
+      .filter((m): m is MessageEvent => m instanceof MessageEvent)
+      .map((m) => `${m.role} (${m.name}):\n${m.getTextContent()}`)
+      .join('\n\n')
+
+    const reflectPrompt = await this.readReflectPrompt()
+    const combined = reflectPrompt + '\n\n## Conversation to analyze\n\n' + formattedMessages
+
+    context.addCommands('ai ' + combined)
+    return context
+  }
+
+  private async readReflectPrompt(): Promise<string> {
+    const userFilePath = path.join(os.homedir(), '.coday', 'reflect-prompt.md')
+    try {
+      return await fs.readFile(userFilePath, 'utf-8')
+    } catch {
+      // fall back to default
+    }
+    const currentDir = path.dirname(fileURLToPath(import.meta.url))
+    const defaultFilePath = path.join(
+      currentDir,
+      '..',
+      '..',
+      '..',
+      '..',
+      'agent',
+      'src',
+      'lib',
+      'default-reflect-prompt.md'
+    )
+    try {
+      return await fs.readFile(defaultFilePath, 'utf-8')
+    } catch {
+      return 'Analyze the conversation below and extract learnings worth memorizing. Ask for confirmation before memorizing each one.'
+    }
+  }
+}

--- a/libs/integration/src/lib/memory.tools.ts
+++ b/libs/integration/src/lib/memory.tools.ts
@@ -27,7 +27,8 @@ export class MemoryTools extends AssistantToolFactory {
           // Return specific memory content
           const projectMemories = this.memoryService.listMemories(MemoryLevel.PROJECT, agentName)
           const userMemories = this.memoryService.listMemories(MemoryLevel.USER, agentName)
-          const allMemories = [...projectMemories, ...userMemories]
+          const learningMemories = this.memoryService.listMemories(MemoryLevel.LEARNING, agentName)
+          const allMemories = [...projectMemories, ...userMemories, ...learningMemories]
 
           const memory = allMemories.find((m) => m.title === title)
           if (!memory) {
@@ -39,8 +40,9 @@ export class MemoryTools extends AssistantToolFactory {
           // Return list of memories with titles and levels
           const projectMemories = this.memoryService.listMemories(MemoryLevel.PROJECT, agentName)
           const userMemories = this.memoryService.listMemories(MemoryLevel.USER, agentName)
+          const learningMemories = this.memoryService.listMemories(MemoryLevel.LEARNING, agentName)
 
-          if (projectMemories.length === 0 && userMemories.length === 0) {
+          if (projectMemories.length === 0 && userMemories.length === 0 && learningMemories.length === 0) {
             return 'No memories found.'
           }
 
@@ -57,6 +59,14 @@ export class MemoryTools extends AssistantToolFactory {
           if (userMemories.length > 0) {
             result += '## USER Level\n'
             userMemories.forEach((m) => {
+              result += `- ${m.title}\n`
+            })
+            result += '\n'
+          }
+
+          if (learningMemories.length > 0) {
+            result += '## LEARNING Level\n'
+            learningMemories.forEach((m) => {
               result += `- ${m.title}\n`
             })
           }
@@ -188,6 +198,57 @@ Do not memorize partial knowledge, single-use information, or minor implementati
     }
     result.push(memorizeUserTool)
 
+    // Tool to memorize at LEARNING level
+    const memorizeLearningFunction = async ({ title, content }: { title: string; content: string }) => {
+      try {
+        this.memoryService.upsertMemory({ title, content, level: MemoryLevel.LEARNING, agentName })
+        return `LEARNING memory added/updated with title: ${title}`
+      } catch (error) {
+        const errorMessage = `Failed to memorize at LEARNING level: ${error instanceof Error ? error.message : 'Unknown error'}`
+        this.interactor.error(errorMessage)
+        return errorMessage
+      }
+    }
+
+    const memorizeLearningTool: FunctionTool<{ title: string; content: string }> = {
+      type: 'function',
+      function: {
+        name: `${this.name}__memorizeLearning`,
+        description: `Upsert a LEARNING-level memory entry. LEARNING memories are for:
+- Technical knowledge discovered during conversations
+- Corrections and validated approaches
+- Hard-won resolutions and workarounds
+- Non-obvious patterns and conventions
+
+LEARNING memories are NOT injected in every conversation. They are searched and retrieved on-demand based on relevance to the current message. This means you can store many learnings without worrying about context pollution.
+
+Should be used selectively for significant knowledge that:
+1) was discovered through conversation or debugging
+2) will be valuable in future interactions
+3) is not redundant with existing memories (in that case, update the existing one)
+
+Do not memorize partial knowledge, single-use information, or minor implementation details.`,
+        parameters: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description:
+                'Title of the memory: should be precise, unique, and reflect the full scope of the content. Avoid generic titles unless the content is really generic.',
+            },
+            content: {
+              type: 'string',
+              description:
+                'Content of the memory: must be complete, validated knowledge with clear structure (sections, examples when relevant). Should include enough context to be self-contained but avoid redundancy with other memories. Length: preferably between a paragraph (for focused topics) and 3 pages (for complex patterns).',
+            },
+          },
+        },
+        parse: JSON.parse,
+        function: memorizeLearningFunction,
+      },
+    }
+    result.push(memorizeLearningTool)
+
     // Tool to delete memory
     const deleteMemoryFunction = async ({ title }: { title: string }) => {
       try {
@@ -204,7 +265,7 @@ Do not memorize partial knowledge, single-use information, or minor implementati
       type: 'function',
       function: {
         name: `${this.name}__delete`,
-        description: 'Delete a memory entry by its title. Works for both PROJECT and USER level memories.',
+        description: 'Delete a memory entry by its title. Works for PROJECT, USER, and LEARNING level memories.',
         parameters: {
           type: 'object',
           properties: {

--- a/libs/model/src/lib/agent.ts
+++ b/libs/model/src/lib/agent.ts
@@ -4,6 +4,12 @@ import { Observable, ReplaySubject } from 'rxjs'
 import { AnswerEvent, CodayEvent } from './coday-events'
 import { AgentDefinition } from './agent-definition'
 import { ToolSet } from './integration-tool-set'
+import { MemoryLevel } from './memory'
+
+export interface MemoryPrefetchProvider {
+  listTitles(levels: MemoryLevel[], agentName?: string): string[]
+  getMemoriesByTitles(titles: string[]): Array<{ title: string; content: string }>
+}
 
 /**
  * Simplified view of an agent for listing and selection purposes
@@ -22,16 +28,20 @@ export class Agent {
   readonly name: string
   readonly description: string
   definition: AgentDefinition
+  private readonly baseInstructions: string
+  private prefetchCumulativePrice: number = 0
 
   constructor(
     initialDefinition: AgentDefinition,
     private readonly aiClient: AiClient,
     readonly tools: ToolSet,
-    readonly internal: boolean = false
+    readonly internal: boolean = false,
+    private readonly memoryProvider?: MemoryPrefetchProvider
   ) {
     this.name = initialDefinition.name
     this.description = initialDefinition.description
     this.definition = { ...initialDefinition }
+    this.baseInstructions = initialDefinition.instructions ?? ''
   }
 
   get systemInstructions(): string {
@@ -65,7 +75,8 @@ export class Agent {
     const answerEvent = new AnswerEvent({ answer: trimmedCommand, name: username ?? thread.username })
     thread.addAnswerEvent(answerEvent)
 
-    // Run with AI client
+    await this.prefetchAndInjectMemories(trimmedCommand, thread)
+
     const events = await this.aiClient.run(this, thread)
 
     // Bridge through a ReplaySubject to prevent event loss when the AI client
@@ -73,5 +84,29 @@ export class Agent {
     const replay = new ReplaySubject<CodayEvent>()
     events.subscribe(replay)
     return replay.asObservable()
+  }
+
+  private async prefetchAndInjectMemories(userMessage: string, thread: AiThread): Promise<void> {
+    if (!this.memoryProvider) return
+
+    const titles = this.memoryProvider.listTitles([MemoryLevel.PROJECT, MemoryLevel.LEARNING], this.name)
+    if (!titles.length) return
+
+    const { titles: selectedTitles, price } = await this.aiClient.prefetchMemories(userMessage, titles)
+    if (price > 0) {
+      thread.addUsage({ price })
+      this.prefetchCumulativePrice += price
+      console.log(`🧠 Memory prefetch: ${price.toFixed(4)} (cumulative: ${this.prefetchCumulativePrice.toFixed(4)})`)
+    }
+    if (!selectedTitles.length) return
+
+    const memories = this.memoryProvider.getMemoriesByTitles(selectedTitles)
+    const memoriesBlock = memories.map((m) => `  - ${m.title}\n    ${m.content}`).join('\n')
+    const section = `\n\n## Relevant memories\n\n    Context retrieved from previous learnings:\n\n${memoriesBlock}`
+
+    this.definition = {
+      ...this.definition,
+      instructions: this.baseInstructions + section,
+    }
   }
 }

--- a/libs/model/src/lib/ai.client.ts
+++ b/libs/model/src/lib/ai.client.ts
@@ -548,6 +548,52 @@ It can be summarized as:
     return this.models.some((model) => model.name.toLowerCase() === name || model?.alias?.toLowerCase() === name)
   }
 
+  protected getCheapestModel(): AiModel | undefined {
+    if (!this.models.length) return undefined
+    const withPrice = this.models.filter((m) => m.price?.inputMTokens != null)
+    if (withPrice.length) {
+      return withPrice.reduce((cheapest, m) => (m.price!.inputMTokens! < cheapest.price!.inputMTokens! ? m : cheapest))
+    }
+    return this.models[this.models.length - 1]
+  }
+
+  async prefetchMemories(userMessage: string, titles: string[]): Promise<{ titles: string[]; price: number }> {
+    if (!titles.length) return { titles: [], price: 0 }
+
+    const model = this.getCheapestModel()
+    if (!model) return { titles: [], price: 0 }
+
+    const titlesBlock = titles.map((t) => `- ${t}`).join('\n')
+    const prompt = `Given the user message below, select which memories are relevant to help answer it.
+Return ONLY a JSON array of relevant titles. Return [] if none are relevant.
+
+## Available memories
+${titlesBlock}
+
+## User message
+${userMessage}`
+
+    try {
+      const response = await this.complete(prompt, {
+        model: model.name,
+        maxTokens: Math.min(1024, titles.length * 30),
+        temperature: 0,
+      })
+      const inputTokens = prompt.length / this.charsPerToken
+      const outputTokens = response.length / this.charsPerToken
+      const price = model.price
+        ? (inputTokens * (model.price.inputMTokens ?? 0) + outputTokens * (model.price.outputMTokens ?? 0)) / 1_000_000
+        : 0
+      const match = response.match(/\[([\s\S]*?)\]/)
+      if (!match) return { titles: [], price }
+      const selectedTitles = JSON.parse(`[${match[1]}]`).filter((t: string) => titles.includes(t))
+      return { titles: selectedTitles, price }
+    } catch (e) {
+      this.interactor.warn(`Memory prefetch failed: ${e instanceof Error ? e.message : 'Unknown error'}`)
+      return { titles: [], price: 0 }
+    }
+  }
+
   returnError(error: string): Observable<CodayEvent> {
     return of(new ErrorEvent({ error }))
   }

--- a/libs/model/src/lib/memory.ts
+++ b/libs/model/src/lib/memory.ts
@@ -31,5 +31,6 @@ export class Memory {
 
 export enum MemoryLevel {
   USER = 'USER',
+  LEARNING = 'LEARNING',
   PROJECT = 'PROJECT',
 }

--- a/libs/service/src/lib/memory.service.ts
+++ b/libs/service/src/lib/memory.service.ts
@@ -58,6 +58,18 @@ export class MemoryService {
     return this.memories.filter((m) => m.level === level && (!m.agentName || m.agentName === agentName))
   }
 
+  listTitles(levels: MemoryLevel[], agentName?: string): string[] {
+    this.checkInit()
+    return this.memories
+      .filter((m) => levels.includes(m.level) && (!m.agentName || m.agentName === agentName))
+      .map((m) => m.title)
+  }
+
+  getMemoriesByTitles(titles: string[]): Memory[] {
+    this.checkInit()
+    return this.memories.filter((m) => titles.includes(m.title))
+  }
+
   getFormattedMemories(level: MemoryLevel, agentName?: string): string {
     const levelMemories = this.listMemories(level, agentName).map((m: Memory) => `  - ${m.title}\n    ${m.content}`)
     if (!levelMemories.length) return ''
@@ -114,7 +126,7 @@ export class MemoryService {
 
   private saveMemories(): void {
     this.checkInit()
-    const userMemories = this.memories.filter((m) => m.level === MemoryLevel.USER)
+    const userMemories = this.memories.filter((m) => m.level === MemoryLevel.USER || m.level === MemoryLevel.LEARNING)
     const projectMemories = this.memories.filter((m) => m.level === MemoryLevel.PROJECT)
     writeYamlFile(this.userMemoriesPath!!, { memories: userMemories })
     writeYamlFile(this.projectMemoriesPath!!, { memories: projectMemories })


### PR DESCRIPTION
# Why
PROJECT and USER memories were injected wholesale into every agent's system instructions at creation time. Any memory added therefore polluted the context of every conversation, relevant or not — making it impossible to accumulate knowledge.

# What changes
New LEARNING level for technical knowledge discovered during conversations (corrections, workarounds, hard-won resolutions). Persisted at user level, so shared across projects.

On-demand retrieval. PROJECT and LEARNING are no longer injected systematically: on each message, Agent.prefetchAndInjectMemories() submits the titles only to the provider's cheapest model (temperature 0) and loads just the memories deemed relevant. The call cost is estimated and charged to the thread (thread.addUsage), so it stays visible. USER remains statically injected at agent creation.

reflect command: pick a past thread and have the agent analyse it to extract learnings after the fact.

Overridable prompts: default-learning-prompt.md and default-reflect-prompt.md, replaceable by ~/.coday/learning-prompt.md and ~/.coday/reflect-prompt.md.

New memorizeLearning tool, with read/delete extended to all three levels.

Prompt-level safeguards: no memorization without confirmation, mandatory flagging of contradictions with an existing memory, warning past 20 entries per level.

# Known limitations
Single-file, non-atomic storage. USER and LEARNING share ~/.coday/memories.yaml, rewritten in full on every upsertMemory/deleteMemory. An interrupted write or a malformed entry therefore puts every memory at that level at risk. readMemories() also swallows all exceptions and invalidates the path on a parsing failure, leaving the service unusable with no diagnostic. To be addressed separately: atomic writes, possibly one file per memory to isolate corruption.