### PR TITLE
fix: git.yaml missing closing braces on NAMESPACE_CONFIG_PATH token

### DIFF
--- a/integrations/GIT.yaml
+++ b/integrations/GIT.yaml
@@ -15,7 +15,7 @@
 name: "GIT"
 integrationType: "BASH"
 parameters:
-  workingDirectory: "{{NAMESPACE_CONFIG_PATH"
+  workingDirectory: "{{NAMESPACE_CONFIG_PATH}}"
   defaultTimeoutSeconds: 30
   tools:
   - name: "git"


### PR DESCRIPTION
Le token `{{NAMESPACE_CONFIG_PATH}}` dans `integrations/GIT.yaml` avait une accolade fermante manquante (`{{NAMESPACE_CONFIG_PATH`), ce qui empêchait la substitution de fonctionner à l'exécution.