### PR TITLE
feat: #1174 AgentOS managed mode — full provisioning and lifecycle

### DIFF
--- a/agentos/.env.example
+++ b/agentos/.env.example
@@ -13,6 +13,10 @@ MCP_ENABLED=false
 # Server Configuration
 SERVER_PORT=8080
 
+# Express proxy target for the AgentOS backend.
+# Must be a complete URL including scheme. Defaults to http://localhost:<AGENTOS_PORT> when unset.
+# AGENTOS_URL=http://localhost:8124
+
 # Plugin Configuration
 PLUGINS_DIR=plugins
 PLUGINS_AUTO_LOAD=true

--- a/agentos/docs/running.md
+++ b/agentos/docs/running.md
@@ -16,7 +16,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 nx bootRun agentos-service
 ```
 
-The service starts on **port 8080**. Ready signal in logs: `Started AgentOSApplication`.
+The service starts on **port 8124** by default (see `server.port` in `application.yml`). Ready signal in logs: `Started AgentOSApplication`.
 
 ## Filesystem Plugin Directories
 

--- a/apps/server/src/lib/agentos-download.ts
+++ b/apps/server/src/lib/agentos-download.ts
@@ -1,96 +1,64 @@
 /**
  * agentos-download.ts
  *
- * Attempt to download a single AgentOS JAR from the GitHub Release assets.
+ * Download all 5 AgentOS JARs from GitHub Release assets, verify their
+ * SHA-256 checksums, write them atomically to disk, and clean up stale JARs.
  *
- * SCOPE: one artefact only — agentos-bash-plugin — to validate the download
- * chain end-to-end (URL reachability, public access without auth, checksum
- * verification, atomic write to disk). Extending to other artefacts is
- * intentionally left for a later iteration once the chain is validated.
+ * Layout (mode managé only):
+ *   <configDir>/agentos/agentos-service-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-bash-plugin-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-file-plugin-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-mcp-plugin-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-tmux-plugin-<version>.jar
  *
- * NAMING CONTRACT NOTE:
- *   The release 0.239.0 (and earlier) published assets with version-less names:
- *   "agentos-bash-plugin.jar", "checksums.sha256", etc.
- *   Starting from the NEXT release, assets will use versioned names:
- *   "agentos-bash-plugin-<version>.jar", etc.
- *   The code below builds URLs with versioned names (the target contract).
- *   On the current release this will produce 404s — that is EXPECTED and logged
- *   as a known transition artefact, NOT a bug. The 404s will disappear once the
- *   first release with the new naming lands.
- *
- * INVARIANTS (same as the rest of this module family):
+ * INVARIANTS:
  *   - Never throws. Every error is caught, logged, and returned as a structured result.
  *   - No side effects at import time.
  *   - No new npm dependencies (uses Node 24 built-in fetch + node:crypto + node:fs).
- *   - No process spawn.
- *   - No network access unless the JAR is absent or at the wrong version.
+ *   - No network access unless JARs are absent or at the wrong version.
  */
 
 import * as crypto from 'crypto'
 import * as fs from 'fs'
-import * as os from 'os'
 import * as path from 'path'
 import { debugLog } from './log'
+import { AGENTOS_ARTIFACT_IDS, AgentosArtifactId, expectedJarPath } from './agentos-lifecycle'
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-/**
- * The only artefact we attempt to download in this initial probe.
- * Deliberately limited to the smallest JAR (~35 KB) to validate the chain
- * without risking a 227 MB download (agentos-service.jar) at server startup.
- */
-const PROBE_ARTIFACT_ID = 'agentos-bash-plugin'
-
-/**
- * Timeout for each individual HTTP request (JAR download + manifest download).
- * 10 s is generous for a ~35 KB file on a normal connection; it avoids hanging
- * the server startup indefinitely on a slow or unreachable network.
- */
-const FETCH_TIMEOUT_MS = 10_000
+/** Timeout for each individual HTTP request. */
+const FETCH_TIMEOUT_MS = 60_000
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
 export type DownloadOutcome =
-  | 'skipped:already-present' // JAR already at the expected version — no network access
+  | 'skipped:all-present' // All JARs already at the expected version
   | 'skipped:dev-version' // getCodayVersion() returned 'dev' — no release to download from
   | 'error:manifest-unavailable' // checksums.sha256 returned non-2xx
   | 'error:manifest-parse' // checksums.sha256 could not be parsed
-  | 'error:jar-unavailable' // JAR URL returned non-2xx (e.g. 404 during naming transition)
-  | 'error:checksum-mismatch' // Downloaded JAR hash does not match manifest
-  | 'error:write' // Filesystem error during atomic write
-  | 'error:network' // fetch threw (DNS failure, timeout, AbortError, etc.)
-  | 'success' // JAR downloaded, checksum verified, written to disk
+  | 'error:download-failed' // One or more JARs failed to download/verify/write
+  | 'success' // All needed JARs downloaded, verified, written; stale JARs cleaned
 
 export interface DownloadResult {
   outcome: DownloadOutcome
-  /** Absolute path of the JAR (set even on failure if destination was determined). */
-  destPath?: string
-  /** HTTP status received for the JAR URL, if a request was made. */
-  jarHttpStatus?: number
-  /** HTTP status received for the manifest URL, if a request was made. */
-  manifestHttpStatus?: number
-  /** SHA-256 hash of the downloaded bytes, if computed. */
-  downloadedHash?: string
-  /** SHA-256 hash expected from the manifest, if found. */
-  expectedHash?: string
-  /** Size of the downloaded JAR in bytes, if received. */
-  downloadedBytes?: number
   /** Human-readable description of the outcome. */
   message: string
+  /** Number of JARs successfully downloaded. */
+  downloaded?: number
+  /** Number of stale JARs removed. */
+  cleaned?: number
 }
 
 // ---------------------------------------------------------------------------
-// Implementation
+// URL builders
 // ---------------------------------------------------------------------------
 
 /**
  * Build the GitHub Release download URL for a versioned JAR asset.
- *
- * URL pattern: https://github.com/whoz-oss/coday/releases/download/release/<version>/<artifactId>-<version>.jar
  * Tag pattern confirmed in .github/workflows/release.yml: TAG="release/${VERSION}"
  */
 function buildJarUrl(artifactId: string, version: string): string {
@@ -99,15 +67,14 @@ function buildJarUrl(artifactId: string, version: string): string {
 
 /**
  * Build the GitHub Release download URL for the checksums manifest.
- *
- * NOTE: The manifest filename follows the same naming convention as the JARs.
- * For releases <= 0.239.0: "checksums.sha256" (version-less, old contract).
- * For releases after the naming change: "checksums.sha256" (unchanged — the
- * manifest filename itself has no version).
  */
 function buildManifestUrl(version: string): string {
   return `https://github.com/whoz-oss/coday/releases/download/release/${version}/checksums.sha256`
 }
+
+// ---------------------------------------------------------------------------
+// Manifest parsing
+// ---------------------------------------------------------------------------
 
 /**
  * Parse the checksums.sha256 manifest and extract the hash for a given filename.
@@ -116,16 +83,12 @@ function buildManifestUrl(version: string): string {
  *   <64-hex-chars>  <filename>\n
  * (two spaces between hash and filename)
  *
- * The filename in the manifest matches the asset name as uploaded — which may
- * be versioned ("agentos-bash-plugin-0.240.0.jar") or version-less
- * ("agentos-bash-plugin.jar") depending on the release.
- * We search for a line whose filename component matches `targetFilename` exactly.
+ * Filenames in the manifest are VERSIONED (e.g. "agentos-bash-plugin-0.244.0.jar").
  */
 function extractHashFromManifest(manifestText: string, targetFilename: string): string | null {
   for (const line of manifestText.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed) continue
-    // sha256sum format: "<hash>  <filename>" (two spaces)
     const spaceIdx = trimmed.indexOf('  ')
     if (spaceIdx === -1) continue
     const hash = trimmed.slice(0, spaceIdx).trim()
@@ -137,58 +100,94 @@ function extractHashFromManifest(manifestText: string, targetFilename: string): 
   return null
 }
 
-/**
- * Compute the SHA-256 hash of a Buffer and return the hex digest.
- */
+// ---------------------------------------------------------------------------
+// Checksum
+// ---------------------------------------------------------------------------
+
 function sha256hex(data: Buffer): string {
   return crypto.createHash('sha256').update(data).digest('hex')
 }
 
+// ---------------------------------------------------------------------------
+// Strict cleanup
+// ---------------------------------------------------------------------------
+
 /**
- * Attempt to download agentos-bash-plugin from the GitHub Release assets,
- * verify its SHA-256 checksum, and write it atomically to ~/.coday/agentos/.
+ * Remove any JAR in the given directory that is NOT in the allowedFilenames set.
+ * Logs each deletion. Never throws.
+ */
+function cleanDirectory(dir: string, allowedFilenames: Set<string>): number {
+  let removed = 0
+  try {
+    const entries = fs.readdirSync(dir).filter((f) => f.endsWith('.jar') || f.endsWith('.tmp'))
+    for (const filename of entries) {
+      if (!allowedFilenames.has(filename)) {
+        const fullPath = path.join(dir, filename)
+        try {
+          fs.unlinkSync(fullPath)
+          debugLog('AGENTOS', `  [CLEAN] Removed stale file: ${fullPath}`)
+          removed++
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          debugLog('AGENTOS', `  [CLEAN] Failed to remove ${fullPath}: ${msg}`)
+        }
+      }
+    }
+  } catch {
+    // Directory doesn't exist — nothing to clean
+  }
+  return removed
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Download all missing AgentOS JARs from GitHub Release assets, verify their
+ * SHA-256 checksums, write them atomically to disk, then clean up stale JARs.
  *
  * Conditions under which NO network access is attempted:
- *   - The JAR is already present at `destDir/<artifactId>-<version>.jar`
+ *   - All JARs are already present at the expected version
  *   - The resolved version is the sentinel 'dev'
  *
- * @param expectedVersion  Version string from getCodayVersion().
- * @param jarAlreadyPresent  True when checkAgentosJars() found the JAR at the expected version.
+ * If any download fails, the function returns an error outcome immediately
+ * (no retry, no partial recovery — next startup will retry).
+ *
+ * @param configDir       Root config directory (from codayOptions.configDir).
+ * @param expectedVersion Version string from getCodayVersion().
+ * @param missingArtifacts Artifact IDs that are absent or at the wrong version.
  * @returns A structured DownloadResult describing every step taken.
  */
-export async function downloadProbeJar(expectedVersion: string, jarAlreadyPresent: boolean): Promise<DownloadResult> {
-  const destDir = path.join(os.homedir(), '.coday', 'agentos')
-  const jarFilename = `${PROBE_ARTIFACT_ID}-${expectedVersion}.jar`
-  const destPath = path.join(destDir, jarFilename)
-
-  // --- Guard: skip if already present at the correct version ---
-  if (jarAlreadyPresent) {
-    debugLog(
-      'AGENTOS',
-      `[DOWNLOAD] ${PROBE_ARTIFACT_ID}: already present at version ${expectedVersion} — skipping download`
-    )
-    return { outcome: 'skipped:already-present', destPath, message: `Already present at ${destPath}` }
+export async function downloadAgentosJars(
+  configDir: string,
+  expectedVersion: string,
+  missingArtifacts: AgentosArtifactId[]
+): Promise<DownloadResult> {
+  // --- Guard: skip if all present ---
+  if (missingArtifacts.length === 0) {
+    debugLog('AGENTOS', '[DOWNLOAD] All JARs already present at the expected version — skipping download')
+    return { outcome: 'skipped:all-present', message: 'All JARs already present at the expected version' }
   }
 
   // --- Guard: skip if version is the 'dev' sentinel ---
   if (expectedVersion === 'dev') {
-    debugLog('AGENTOS', `[DOWNLOAD] ${PROBE_ARTIFACT_ID}: version is 'dev' sentinel — no release to download from`)
+    debugLog('AGENTOS', "[DOWNLOAD] Version is 'dev' sentinel — no release to download from")
     return { outcome: 'skipped:dev-version', message: "Version is 'dev' sentinel — no release URL available" }
   }
 
-  const jarUrl = buildJarUrl(PROBE_ARTIFACT_ID, expectedVersion)
+  const agentosDir = path.join(configDir, 'agentos')
+  const pluginsDir = path.join(agentosDir, 'plugins')
   const manifestUrl = buildManifestUrl(expectedVersion)
 
-  debugLog('AGENTOS', `[DOWNLOAD] ${PROBE_ARTIFACT_ID}: initiating probe download`)
-  debugLog('AGENTOS', `[DOWNLOAD]   JAR URL:      ${jarUrl}`)
-  debugLog('AGENTOS', `[DOWNLOAD]   Manifest URL: ${manifestUrl}`)
   debugLog(
     'AGENTOS',
-    `[DOWNLOAD]   NOTE: on releases <= 0.239.0 the JAR URL will return 404 (old naming contract).
-` + `[DOWNLOAD]         This is expected during the naming transition and will resolve on the next release.`
+    `[DOWNLOAD] Starting download of ${missingArtifacts.length} artifact(s) for version ${expectedVersion}`
   )
+  debugLog('AGENTOS', `[DOWNLOAD] Missing: ${missingArtifacts.join(', ')}`)
+  debugLog('AGENTOS', `[DOWNLOAD] Manifest URL: ${manifestUrl}`)
 
-  // --- Step 1: Fetch the checksums manifest ---
+  // --- Step 1: Fetch the checksums manifest ONCE for all artifacts ---
   let manifestText: string
   try {
     const controller = new AbortController()
@@ -200,141 +199,148 @@ export async function downloadProbeJar(expectedVersion: string, jarAlreadyPresen
       clearTimeout(timer)
     }
 
-    debugLog('AGENTOS', `[DOWNLOAD]   manifest HTTP ${manifestRes.status}`)
+    debugLog('AGENTOS', `[DOWNLOAD] Manifest HTTP ${manifestRes.status}`)
 
     if (!manifestRes.ok) {
       return {
         outcome: 'error:manifest-unavailable',
-        manifestHttpStatus: manifestRes.status,
         message: `Manifest request failed with HTTP ${manifestRes.status} — cannot verify JAR integrity, aborting download`,
       }
     }
     manifestText = await manifestRes.text()
+    debugLog('AGENTOS', `[DOWNLOAD] Manifest fetched (${manifestText.length} chars)`)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    debugLog('AGENTOS', `[DOWNLOAD]   manifest fetch error: ${msg}`)
+    debugLog('AGENTOS', `[DOWNLOAD] Manifest fetch error: ${msg}`)
     return {
-      outcome: 'error:network',
+      outcome: 'error:manifest-unavailable',
       message: `Network error fetching manifest: ${msg}`,
     }
   }
 
-  // --- Step 2: Extract the expected hash from the manifest ---
-  // The manifest may list the JAR under its versioned name (new releases) or
-  // version-less name (releases <= 0.239.0). Try both.
-  const versionedFilename = jarFilename // e.g. "agentos-bash-plugin-0.239.0.jar"
-  const versionlessFilename = `${PROBE_ARTIFACT_ID}.jar` // e.g. "agentos-bash-plugin.jar"
-
-  let expectedHash = extractHashFromManifest(manifestText, versionedFilename)
-  let hashSource = versionedFilename
-  if (!expectedHash) {
-    expectedHash = extractHashFromManifest(manifestText, versionlessFilename)
-    hashSource = versionlessFilename
-  }
-
-  if (!expectedHash) {
-    debugLog(
-      'AGENTOS',
-      `[DOWNLOAD]   manifest does not contain an entry for '${versionedFilename}' or '${versionlessFilename}'`
-    )
-    return {
-      outcome: 'error:manifest-parse',
-      message: `Could not find hash for ${versionedFilename} (or ${versionlessFilename}) in manifest`,
-    }
-  }
-  debugLog('AGENTOS', `[DOWNLOAD]   expected SHA-256 (from manifest entry '${hashSource}'): ${expectedHash}`)
-
-  // --- Step 3: Fetch the JAR ---
-  let jarBuffer: Buffer
-  let jarHttpStatus: number
+  // --- Step 2: Ensure directories exist ---
   try {
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-    let jarRes: Response
-    try {
-      jarRes = await fetch(jarUrl, { signal: controller.signal })
-    } finally {
-      clearTimeout(timer)
-    }
+    fs.mkdirSync(agentosDir, { recursive: true })
+    fs.mkdirSync(pluginsDir, { recursive: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    debugLog('AGENTOS', `[DOWNLOAD] Failed to create directories: ${msg}`)
+    return { outcome: 'error:download-failed', message: `Failed to create directories: ${msg}` }
+  }
 
-    jarHttpStatus = jarRes.status
-    debugLog('AGENTOS', `[DOWNLOAD]   JAR HTTP ${jarHttpStatus}`)
+  // --- Step 3: Download each missing artifact ---
+  let downloadedCount = 0
 
-    if (!jarRes.ok) {
+  for (const artifactId of missingArtifacts) {
+    const jarFilename = `${artifactId}-${expectedVersion}.jar`
+    const destPath = expectedJarPath(configDir, artifactId, expectedVersion)
+    const jarUrl = buildJarUrl(artifactId, expectedVersion)
+
+    debugLog('AGENTOS', `[DOWNLOAD] Downloading ${jarFilename}...`)
+    debugLog('AGENTOS', `[DOWNLOAD]   URL: ${jarUrl}`)
+
+    // Extract expected hash from manifest
+    const expectedHash = extractHashFromManifest(manifestText, jarFilename)
+    if (!expectedHash) {
+      debugLog('AGENTOS', `[DOWNLOAD]   ERROR: No entry for '${jarFilename}' in manifest`)
       return {
-        outcome: 'error:jar-unavailable',
-        jarHttpStatus,
-        message: `JAR request failed with HTTP ${jarHttpStatus} — likely naming transition (expected on releases <= 0.239.0)`,
+        outcome: 'error:manifest-parse',
+        message: `Could not find hash for '${jarFilename}' in manifest — aborting`,
+      }
+    }
+    debugLog('AGENTOS', `[DOWNLOAD]   Expected SHA-256: ${expectedHash}`)
+
+    // Fetch the JAR
+    let jarBuffer: Buffer
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+      let jarRes: Response
+      try {
+        jarRes = await fetch(jarUrl, { signal: controller.signal })
+      } finally {
+        clearTimeout(timer)
+      }
+
+      debugLog('AGENTOS', `[DOWNLOAD]   JAR HTTP ${jarRes.status}`)
+
+      if (!jarRes.ok) {
+        return {
+          outcome: 'error:download-failed',
+          message: `JAR request for '${jarFilename}' failed with HTTP ${jarRes.status} — aborting`,
+        }
+      }
+
+      const arrayBuffer = await jarRes.arrayBuffer()
+      jarBuffer = Buffer.from(arrayBuffer)
+      debugLog('AGENTOS', `[DOWNLOAD]   Received ${jarBuffer.length} bytes`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      debugLog('AGENTOS', `[DOWNLOAD]   Network error fetching ${jarFilename}: ${msg}`)
+      return {
+        outcome: 'error:download-failed',
+        message: `Network error fetching '${jarFilename}': ${msg} — aborting`,
       }
     }
 
-    const arrayBuffer = await jarRes.arrayBuffer()
-    jarBuffer = Buffer.from(arrayBuffer)
-    debugLog('AGENTOS', `[DOWNLOAD]   received ${jarBuffer.length} bytes`)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    debugLog('AGENTOS', `[DOWNLOAD]   JAR fetch error: ${msg}`)
-    return {
-      outcome: 'error:network',
-      message: `Network error fetching JAR: ${msg}`,
+    // Verify checksum
+    const downloadedHash = sha256hex(jarBuffer)
+    debugLog('AGENTOS', `[DOWNLOAD]   Computed  SHA-256: ${downloadedHash}`)
+    if (downloadedHash !== expectedHash) {
+      debugLog('AGENTOS', `[DOWNLOAD]   CHECKSUM MISMATCH — discarding downloaded bytes`)
+      return {
+        outcome: 'error:download-failed',
+        message: `Checksum mismatch for '${jarFilename}' — downloaded bytes discarded, aborting`,
+      }
     }
-  }
+    debugLog('AGENTOS', `[DOWNLOAD]   Checksum OK`)
 
-  // --- Step 4: Verify checksum ---
-  const downloadedHash = sha256hex(jarBuffer)
-  debugLog('AGENTOS', `[DOWNLOAD]   computed  SHA-256: ${downloadedHash}`)
-  debugLog('AGENTOS', `[DOWNLOAD]   expected  SHA-256: ${expectedHash}`)
-
-  if (downloadedHash !== expectedHash) {
-    debugLog('AGENTOS', `[DOWNLOAD]   CHECKSUM MISMATCH — discarding downloaded bytes`)
-    return {
-      outcome: 'error:checksum-mismatch',
-      jarHttpStatus,
-      downloadedHash,
-      expectedHash,
-      downloadedBytes: jarBuffer.length,
-      destPath,
-      message: `Checksum mismatch for ${jarFilename} — downloaded bytes discarded`,
-    }
-  }
-  debugLog('AGENTOS', `[DOWNLOAD]   checksum OK`)
-
-  // --- Step 5: Atomic write to disk ---
-  // Write to a temp file first, then rename, so an interrupted download
-  // never leaves a truncated JAR that would be mistaken for valid on next startup.
-  const tmpPath = `${destPath}.tmp`
-  try {
-    fs.mkdirSync(destDir, { recursive: true })
-    fs.writeFileSync(tmpPath, jarBuffer)
-    fs.renameSync(tmpPath, destPath)
-    debugLog('AGENTOS', `[DOWNLOAD]   written to ${destPath} (${jarBuffer.length} bytes)`)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    debugLog('AGENTOS', `[DOWNLOAD]   write error: ${msg}`)
-    // Best-effort cleanup of the temp file
+    // Atomic write: temp file then rename
+    const tmpPath = `${destPath}.tmp`
     try {
-      fs.unlinkSync(tmpPath)
-    } catch {
-      /* ignore */
+      fs.writeFileSync(tmpPath, jarBuffer)
+      fs.renameSync(tmpPath, destPath)
+      debugLog('AGENTOS', `[DOWNLOAD]   Written to ${destPath} (${jarBuffer.length} bytes)`)
+      downloadedCount++
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      debugLog('AGENTOS', `[DOWNLOAD]   Write error for ${jarFilename}: ${msg}`)
+      // Best-effort cleanup of the temp file
+      try {
+        fs.unlinkSync(tmpPath)
+      } catch {
+        /* ignore */
+      }
+      return {
+        outcome: 'error:download-failed',
+        message: `Failed to write '${jarFilename}' to disk: ${msg} — aborting`,
+      }
     }
-    return {
-      outcome: 'error:write',
-      jarHttpStatus,
-      downloadedHash,
-      expectedHash,
-      downloadedBytes: jarBuffer.length,
-      destPath,
-      message: `Failed to write JAR to disk: ${msg}`,
-    }
+  }
+
+  // --- Step 4: Strict cleanup — remove any JAR that should not be there ---
+  // Root dir: only agentos-service-<version>.jar is allowed
+  const allowedRoot = new Set([`agentos-service-${expectedVersion}.jar`])
+  // Plugins dir: only the 4 plugin JARs at the expected version are allowed
+  const allowedPlugins = new Set(
+    AGENTOS_ARTIFACT_IDS.filter((id) => id !== 'agentos-service').map((id) => `${id}-${expectedVersion}.jar`)
+  )
+
+  debugLog('AGENTOS', '[DOWNLOAD] Running strict cleanup...')
+  const cleanedRoot = cleanDirectory(agentosDir, allowedRoot)
+  const cleanedPlugins = cleanDirectory(pluginsDir, allowedPlugins)
+  const totalCleaned = cleanedRoot + cleanedPlugins
+
+  if (totalCleaned > 0) {
+    debugLog('AGENTOS', `[DOWNLOAD] Cleanup complete: removed ${totalCleaned} stale file(s)`)
+  } else {
+    debugLog('AGENTOS', '[DOWNLOAD] Cleanup complete: no stale files found')
   }
 
   return {
     outcome: 'success',
-    jarHttpStatus,
-    downloadedHash,
-    expectedHash,
-    downloadedBytes: jarBuffer.length,
-    destPath,
-    message: `Successfully downloaded and verified ${jarFilename} (${jarBuffer.length} bytes)`,
+    message: `Downloaded ${downloadedCount} JAR(s), cleaned ${totalCleaned} stale file(s)`,
+    downloaded: downloadedCount,
+    cleaned: totalCleaned,
   }
 }

--- a/apps/server/src/lib/agentos-lifecycle.ts
+++ b/apps/server/src/lib/agentos-lifecycle.ts
@@ -1,20 +1,21 @@
 /**
  * agentos-lifecycle.ts
  *
- * JAR presence and version check for AgentOS.
+ * JAR presence and version check for AgentOS — single-directory edition.
+ *
+ * There is exactly one location for AgentOS JARs: <configDir>/agentos/.
+ * The layout is:
+ *   <configDir>/agentos/agentos-service-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-bash-plugin-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-file-plugin-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-mcp-plugin-<version>.jar
+ *   <configDir>/agentos/plugins/agentos-tmux-plugin-<version>.jar
  *
  * THIS MODULE HAS NO SIDE EFFECTS AT IMPORT TIME.
- * All filesystem access is strictly inside the exported functions.
- *
- * Current scope: scan candidate directories, identify AgentOS JARs by their
- * versioned filename, compare found versions against the expected version, and
- * log the result. No download, no Java detection, no process spawn, no network.
  */
 
 import * as fs from 'fs'
-import * as os from 'os'
 import * as path from 'path'
-import { fileURLToPath } from 'url'
 import { debugLog } from './log'
 
 // ---------------------------------------------------------------------------
@@ -24,23 +25,13 @@ import { debugLog } from './log'
 /**
  * Canonical artifact IDs for the AgentOS JARs we own.
  *
- * NAMING CONTRACT — versioned filenames, same convention as `deployPlugins` in
- * agentos/build.gradle.kts:
- *
+ * NAMING CONTRACT — versioned filenames:
  *   "<artifactId>-<version>.jar"
  *
  * The artifactId NEVER contains a digit immediately after a hyphen, which makes
  * the split unambiguous: cut at the first "-<digit>" boundary.
- * Example: "agentos-bash-plugin-0.239.0.jar"
- *          └── artifactId: "agentos-bash-plugin"   version: "0.239.0"
- *
- * WHY version-prefix matching is now the expected approach (and why it must
- * be done correctly):
- *   The historical bug was NOT in using prefixes per se — it was an inconsistency
- *   between the producer (CI renamed to version-less names) and the consumer
- *   (code expected version-less names). Now both sides agree: versioned names,
- *   split on "-<digit>". Use `parseJarFilename()` to derive artifactId and version;
- *   NEVER use a raw `startsWith('agentos-bash-plugin-')` without the digit check.
+ * Example: "agentos-bash-plugin-0.244.0.jar"
+ *          └── artifactId: "agentos-bash-plugin"   version: "0.244.0"
  */
 export const AGENTOS_ARTIFACT_IDS = [
   'agentos-service',
@@ -51,6 +42,9 @@ export const AGENTOS_ARTIFACT_IDS = [
 ] as const
 
 export type AgentosArtifactId = (typeof AGENTOS_ARTIFACT_IDS)[number]
+
+/** Artifacts stored at the root of <configDir>/agentos/ */
+const ROOT_ARTIFACTS: readonly AgentosArtifactId[] = ['agentos-service']
 
 // ---------------------------------------------------------------------------
 // Filename parsing — pure function, exported for unit testing
@@ -96,26 +90,19 @@ export function parseJarFilename(filename: string): ParsedJarFilename {
 }
 
 // ---------------------------------------------------------------------------
-// Candidate directories
+// Layout helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Ordered list of directories to scan for AgentOS JARs.
- *
- * Easy to extend: add new entries here and the check loop picks them up.
- *
- * - `moduleDir/agentos`  : historical location when JARs were bundled inside
- *   the npm tarball (dist/agentos/). No longer populated; kept as a sentinel
- *   so logs confirm the old path is absent.
- * - `~/.coday/agentos`   : user-level cache aligned with Coday's persistence
- *   model (~/.coday/). Intended home for on-demand downloaded JARs.
+ * Return the expected absolute path for a given artifact at the given version.
+ * Encodes the layout: service at root, plugins in plugins/.
  */
-function getCandidateDirectories(): string[] {
-  // Portable ESM-compatible path resolution — works with tsx (no __dirname)
-  // and with the esbuild bundle (which injects a __dirname shim via `banner`).
-  const moduleDir = path.dirname(fileURLToPath(import.meta.url))
-
-  return [path.resolve(moduleDir, 'agentos'), path.join(os.homedir(), '.coday', 'agentos')]
+export function expectedJarPath(configDir: string, artifactId: AgentosArtifactId, version: string): string {
+  const agentosDir = path.join(configDir, 'agentos')
+  if ((ROOT_ARTIFACTS as readonly string[]).includes(artifactId)) {
+    return path.join(agentosDir, `${artifactId}-${version}.jar`)
+  }
+  return path.join(agentosDir, 'plugins', `${artifactId}-${version}.jar`)
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +118,8 @@ export interface ArtifactCheckResult {
   foundVersion: string | null
   /** True when the found version matches the expected version. */
   versionMatch: boolean
+  /** Expected absolute path for this artifact at the expected version. */
+  expectedPath: string
 }
 
 export interface AgentosJarStatus {
@@ -140,10 +129,8 @@ export interface AgentosJarStatus {
   expectedVersion: string
   /** Per-artifact detail. */
   artifacts: ArtifactCheckResult[]
-  /** JARs present in scanned directories that are NOT one of our artifact IDs. */
-  unknownJars: string[]
-  /** Candidate directories that were inspected. */
-  inspectedDirectories: string[]
+  /** Artifacts that are missing or at the wrong version. */
+  missing: AgentosArtifactId[]
 }
 
 // ---------------------------------------------------------------------------
@@ -151,94 +138,80 @@ export interface AgentosJarStatus {
 // ---------------------------------------------------------------------------
 
 /**
- * Scan candidate directories for AgentOS JARs, compare versions, and log.
+ * Check <configDir>/agentos for the 5 expected AgentOS JARs at the expected version.
  *
  * - Never throws: all I/O errors are caught and logged.
  * - No network access, no process spawn.
  * - Safe to call at any point during server startup.
  *
+ * @param configDir        Root config directory (from codayOptions.configDir).
  * @param expectedVersion  Version string to compare against found JARs.
  * @returns A structured status describing what was found and where.
  */
-export async function checkAgentosJars(expectedVersion: string): Promise<AgentosJarStatus> {
-  const candidates = getCandidateDirectories()
+export function checkAgentosJars(configDir: string, expectedVersion: string): AgentosJarStatus {
+  const agentosDir = path.join(configDir, 'agentos')
   debugLog('AGENTOS', `Checking JAR availability (expected version: ${expectedVersion})`)
-  debugLog('AGENTOS', `Scanning ${candidates.length} candidate director${candidates.length === 1 ? 'y' : 'ies'}:`)
-  for (const dir of candidates) {
-    debugLog('AGENTOS', `  * ${dir}`)
-  }
+  debugLog('AGENTOS', `AgentOS directory: ${agentosDir}`)
 
-  // Build a map: artifactId → { path, version } for the first match found
-  const found = new Map<string, { filePath: string; version: string | null }>()
-  const unknownJars: string[] = []
-
-  for (const dir of candidates) {
-    let entries: string[]
-    try {
-      entries = fs.readdirSync(dir).filter((f) => f.endsWith('.jar'))
-    } catch {
-      // Directory does not exist or is not readable — expected for absent candidates
-      continue
-    }
-
-    for (const filename of entries) {
-      const { artifactId, version } = parseJarFilename(filename)
-      const isOurs = (AGENTOS_ARTIFACT_IDS as readonly string[]).includes(artifactId)
-
-      if (!isOurs) {
-        const fullPath = path.join(dir, filename)
-        unknownJars.push(fullPath)
-        debugLog('AGENTOS', `  [UNKNOWN] ${filename} — not one of our artifacts (${fullPath})`)
-        continue
-      }
-
-      // First match per artifactId wins (candidates are ordered by priority)
-      if (!found.has(artifactId)) {
-        found.set(artifactId, { filePath: path.join(dir, filename), version })
-      }
-    }
-  }
-
-  // Build per-artifact results
   const artifacts: ArtifactCheckResult[] = AGENTOS_ARTIFACT_IDS.map((artifactId) => {
-    const entry = found.get(artifactId) ?? null
-    const foundVersion = entry?.version ?? null
+    const expPath = expectedJarPath(configDir, artifactId, expectedVersion)
+
+    let foundAt: string | null = null
+    let foundVersion: string | null = null
+
+    try {
+      if (fs.existsSync(expPath)) {
+        foundAt = expPath
+        foundVersion = expectedVersion
+      } else {
+        // Check if any other version of this artifact exists (for MISMATCH logging)
+        const dir = (ROOT_ARTIFACTS as readonly string[]).includes(artifactId)
+          ? agentosDir
+          : path.join(agentosDir, 'plugins')
+        try {
+          const entries = fs.readdirSync(dir).filter((f) => f.endsWith('.jar'))
+          for (const filename of entries) {
+            const parsed = parseJarFilename(filename)
+            if (parsed.artifactId === artifactId) {
+              foundAt = path.join(dir, filename)
+              foundVersion = parsed.version
+              break
+            }
+          }
+        } catch {
+          // Directory doesn't exist yet — fine
+        }
+      }
+    } catch {
+      // existsSync threw — treat as absent
+    }
+
     const versionMatch = foundVersion === expectedVersion
 
-    if (!entry) {
-      debugLog('AGENTOS', `  [MISSING]  ${artifactId} — not found in any candidate directory`)
+    if (!foundAt) {
+      debugLog('AGENTOS', `  [MISSING]  ${artifactId} — expected at ${expPath}`)
     } else if (!versionMatch) {
       debugLog(
         'AGENTOS',
-        `  [MISMATCH] ${artifactId} — found ${foundVersion} at ${entry.filePath} (expected ${expectedVersion})`
+        `  [MISMATCH] ${artifactId} — found version ${foundVersion} at ${foundAt} (expected ${expectedVersion})`
       )
     } else {
-      debugLog('AGENTOS', `  [OK]       ${artifactId}-${foundVersion}.jar — ${entry.filePath}`)
+      debugLog('AGENTOS', `  [OK]       ${artifactId}-${foundVersion}.jar`)
     }
 
-    return {
-      artifactId,
-      foundAt: entry?.filePath ?? null,
-      foundVersion,
-      versionMatch,
-    }
+    return { artifactId, foundAt, foundVersion, versionMatch, expectedPath: expPath }
   })
 
-  const allPresent = artifacts.every((a) => a.versionMatch)
-  const presentCount = artifacts.filter((a) => a.versionMatch).length
+  const missing = artifacts.filter((a) => !a.versionMatch).map((a) => a.artifactId)
+  const allPresent = missing.length === 0
+  const presentCount = artifacts.length - missing.length
 
   debugLog(
     'AGENTOS',
     allPresent
       ? `JAR check complete: all ${AGENTOS_ARTIFACT_IDS.length} JARs present at version ${expectedVersion}.`
-      : `JAR check complete: ${presentCount}/${AGENTOS_ARTIFACT_IDS.length} JARs match version ${expectedVersion} — AgentOS will not start until all JARs are available at the expected version.`
+      : `JAR check complete: ${presentCount}/${AGENTOS_ARTIFACT_IDS.length} JARs match version ${expectedVersion} — missing: ${missing.join(', ')}`
   )
 
-  return {
-    allPresent,
-    expectedVersion,
-    artifacts,
-    unknownJars,
-    inspectedDirectories: candidates,
-  }
+  return { allPresent, expectedVersion, artifacts, missing }
 }

--- a/apps/server/src/lib/agentos-runtime.ts
+++ b/apps/server/src/lib/agentos-runtime.ts
@@ -4,11 +4,10 @@
  * Launch the AgentOS Spring Boot JAR as a managed child process.
  *
  * Design decisions:
- *   - Port FIXE 8124. AgentOS est un singleton de fait (Neo4j embedded locke
- *     data/neo4j/ et le port Bolt 7688). Faire tourner deux instances en
- *     parallèle est proscrit.
- *   - Avant de spawner, on sonde /management/health. Si un AgentOS répond
- *     déjà, on l'ADOPTE sans le tuer — et on ne le tue PAS au shutdown.
+ *   - Port dynamique : findAvailablePort(expressPort + 1) — AgentOS ne prend
+ *     jamais le port du serveur Express, et s'adapte si le suivant est pris.
+ *   - Avant de spawner, on sonde /management/health sur le port choisi. Si un
+ *     AgentOS répond déjà, on l'ADOPTE sans le tuer — et on ne le tue PAS au shutdown.
  *   - cwd = <configDir>/agentos : les chemins relatifs de Spring (plugins/,
  *     data/, data/exchange/) tombent exactement sur le layout voulu sans
  *     aucune env var supplémentaire.
@@ -25,13 +24,11 @@
 import { spawn, execFileSync, ChildProcess } from 'child_process'
 import * as path from 'path'
 import { debugLog } from './log'
+import { findAvailablePort } from './find-available-port'
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/** Fixed port for AgentOS. See module JSDoc for rationale. */
-const AGENTOS_PORT = 8124
 
 /** Minimum Java major version required. AgentOS toolchain targets Java 25. */
 const JAVA_MIN_VERSION = 25
@@ -133,9 +130,9 @@ function detectJava(): { available: boolean; version?: string } {
  * Check if an AgentOS instance is already healthy at the fixed port.
  * Single probe, no retry. Used for adoption detection before spawn.
  */
-async function isAlreadyRunning(): Promise<boolean> {
+async function isAlreadyRunning(port: number): Promise<boolean> {
   try {
-    const url = `http://localhost:${AGENTOS_PORT}/management/health`
+    const url = `http://localhost:${port}/management/health`
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), 3_000)
     let res: Response
@@ -154,25 +151,28 @@ async function isAlreadyRunning(): Promise<boolean> {
  * Poll /management/health until Spring Boot reports 2xx or timeout.
  * Spring Boot with Neo4j embedded can take up to ~60 s on first start.
  */
-async function waitForHealthy(): Promise<boolean> {
-  const url = `http://localhost:${AGENTOS_PORT}/management/health`
+async function waitForHealthy(port: number): Promise<boolean> {
+  const url = `http://localhost:${port}/management/health`
   const deadline = Date.now() + HEALTH_TIMEOUT_MS
 
   while (Date.now() < deadline) {
     try {
       const res = await fetch(url)
       if (res.ok) {
-        debugLog('AGENTOS', `[RUNTIME] Health check passed on port ${AGENTOS_PORT}`)
+        debugLog('AGENTOS', `[RUNTIME] Health check passed on port ${port}`)
         return true
       }
-      debugLog('AGENTOS', `[RUNTIME] Health check returned ${res.status}, retrying in ${HEALTH_POLL_INTERVAL_MS}ms...`)
+      debugLog(
+        'AGENTOS',
+        `[RUNTIME] Health check on port ${port} returned ${res.status}, retrying in ${HEALTH_POLL_INTERVAL_MS}ms...`
+      )
     } catch {
       // Connection refused or network error — process still starting
     }
     await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS))
   }
 
-  debugLog('AGENTOS', `[RUNTIME] Health check timed out after ${HEALTH_TIMEOUT_MS / 1000} s`)
+  debugLog('AGENTOS', `[RUNTIME] Health check on port ${port} timed out after ${HEALTH_TIMEOUT_MS / 1000} s`)
   return false
 }
 
@@ -205,18 +205,24 @@ export async function startAgentos(
   expressPort: number
 ): Promise<AgentosProcess | null> {
   // ------------------------------------------------------------------
-  // 1. Check if an AgentOS instance is already running (adoption)
+  // 1. Find available port (expressPort + 1 as starting point)
   // ------------------------------------------------------------------
-  const alreadyRunning = await isAlreadyRunning()
+  const agentosPort = await findAvailablePort(expressPort + 1, 10)
+  debugLog('AGENTOS', `[RUNTIME] Selected port ${agentosPort} for AgentOS (Express is on ${expressPort})`)
+
+  // ------------------------------------------------------------------
+  // 2. Check if an AgentOS instance is already running on that port (adoption)
+  // ------------------------------------------------------------------
+  const alreadyRunning = await isAlreadyRunning(agentosPort)
   if (alreadyRunning) {
     debugLog(
       'AGENTOS',
-      `[RUNTIME] An AgentOS instance is already responding at http://localhost:${AGENTOS_PORT}.` +
+      `[RUNTIME] An AgentOS instance is already responding at http://localhost:${agentosPort}.` +
         ` ADOPTING it — Coday did NOT start this process and will NOT stop it at shutdown.` +
         ` NOTE: it may be running an older version. If you observe unexpected behaviour, kill it manually and restart Coday.`
     )
     return {
-      port: AGENTOS_PORT,
+      port: agentosPort,
       spawned: false,
       shutdown: async () => {
         debugLog('AGENTOS', '[RUNTIME] Adopted process — skipping shutdown')
@@ -225,7 +231,7 @@ export async function startAgentos(
   }
 
   // ------------------------------------------------------------------
-  // 2. Detect Java >= 25
+  // 3. Detect Java >= 25
   // ------------------------------------------------------------------
   const java = detectJava()
   if (!java.available) {
@@ -234,7 +240,7 @@ export async function startAgentos(
   }
 
   // ------------------------------------------------------------------
-  // 3. Verify JAR exists
+  // 4. Verify JAR exists
   // ------------------------------------------------------------------
   const agentosDir = path.join(configDir, 'agentos')
   const jarPath = path.join(agentosDir, `agentos-service-${version}.jar`)
@@ -247,16 +253,20 @@ export async function startAgentos(
   }
 
   // ------------------------------------------------------------------
-  // 4. Spawn the process
+  // 5. Spawn the process
   // ------------------------------------------------------------------
-  debugLog('AGENTOS', `[RUNTIME] Spawning AgentOS on port ${AGENTOS_PORT}`)
-  debugLog('AGENTOS', `[RUNTIME]   JAR:  ${jarPath}`)
-  debugLog('AGENTOS', `[RUNTIME]   CWD:  ${agentosDir}`)
+  debugLog('AGENTOS', `[RUNTIME] Spawning AgentOS — config:`)
+  debugLog('AGENTOS', `[RUNTIME]   port:     ${agentosPort}`)
+  debugLog('AGENTOS', `[RUNTIME]   JAR:      ${jarPath}`)
+  debugLog('AGENTOS', `[RUNTIME]   CWD:      ${agentosDir}`)
+  debugLog('AGENTOS', `[RUNTIME]   JAVA_HOME: ${process.env.JAVA_HOME ?? '(not set, using PATH)'}`)
+  debugLog('AGENTOS', `[RUNTIME]   encryption: NONE (plaintext — temporary)`)
+  debugLog('AGENTOS', `[RUNTIME]   OAuth redirect: http://localhost:${expressPort}/agentos/oauth/callback`)
 
   const javaHome = process.env.JAVA_HOME
   const javaBin = javaHome ? path.join(javaHome, 'bin', 'java') : 'java'
 
-  const child: ChildProcess = spawn(javaBin, ['-jar', jarPath, `--server.port=${AGENTOS_PORT}`], {
+  const child: ChildProcess = spawn(javaBin, ['-jar', jarPath, `--server.port=${agentosPort}`], {
     cwd: agentosDir,
     // Inherit env from parent process, then add our overrides.
     // AGENTOS_ENCRYPTION_KEY/SALT=NONE: explicitly disables field encryption
@@ -300,10 +310,13 @@ export async function startAgentos(
   })
 
   // ------------------------------------------------------------------
-  // 5. Wait for healthy
+  // 6. Wait for healthy
   // ------------------------------------------------------------------
-  debugLog('AGENTOS', `[RUNTIME] Waiting for AgentOS to become healthy (up to ${HEALTH_TIMEOUT_MS / 1000} s)...`)
-  const healthy = await waitForHealthy()
+  debugLog(
+    'AGENTOS',
+    `[RUNTIME] Waiting for AgentOS to become healthy on port ${agentosPort} (up to ${HEALTH_TIMEOUT_MS / 1000} s)...`
+  )
+  const healthy = await waitForHealthy(agentosPort)
 
   const spawnErrorMsg = spawnError ? (spawnError as { message: string }).message : null
   if (!healthy || exited || spawnError) {
@@ -319,10 +332,10 @@ export async function startAgentos(
     return null
   }
 
-  debugLog('AGENTOS', `[RUNTIME] AgentOS is up and healthy on port ${AGENTOS_PORT}`)
+  debugLog('AGENTOS', `[RUNTIME] AgentOS is up and healthy on port ${agentosPort}`)
 
   // ------------------------------------------------------------------
-  // 6. Build and return the handle
+  // 7. Build and return the handle
   // ------------------------------------------------------------------
   const shutdown = (): Promise<void> =>
     new Promise((resolve) => {
@@ -356,5 +369,5 @@ export async function startAgentos(
       }
     })
 
-  return { port: AGENTOS_PORT, spawned: true, shutdown }
+  return { port: agentosPort, spawned: true, shutdown }
 }

--- a/apps/server/src/lib/agentos-runtime.ts
+++ b/apps/server/src/lib/agentos-runtime.ts
@@ -1,0 +1,350 @@
+/**
+ * agentos-runtime.ts
+ *
+ * Launch the AgentOS Spring Boot JAR as a managed child process.
+ *
+ * Design decisions:
+ *   - Port FIXE 8124. AgentOS est un singleton de fait (Neo4j embedded locke
+ *     data/neo4j/ et le port Bolt 7688). Faire tourner deux instances en
+ *     parallèle est proscrit.
+ *   - Avant de spawner, on sonde /management/health. Si un AgentOS répond
+ *     déjà, on l'ADOPTE sans le tuer — et on ne le tue PAS au shutdown.
+ *   - cwd = <configDir>/agentos : les chemins relatifs de Spring (plugins/,
+ *     data/, data/exchange/) tombent exactement sur le layout voulu sans
+ *     aucune env var supplémentaire.
+ *   - AGENTOS_ENCRYPTION_KEY=NONE + AGENTOS_ENCRYPTION_SALT=NONE : désactive
+ *     explicitement le chiffrement (temporaire — credentials en clair sur
+ *     disque, AgentOS logue un WARN). À remplacer par de vraies valeurs quand
+ *     la gestion des secrets sera en place.
+ *   - AGENTOS_OAUTH_REDIRECT_URI : dérivé du port du serveur Express pour que
+ *     le callback OAuth pointe sur la bonne URL.
+ *
+ * THIS MODULE HAS NO SIDE EFFECTS AT IMPORT TIME.
+ */
+
+import { spawn, execFileSync, ChildProcess } from 'child_process'
+import * as path from 'path'
+import { debugLog } from './log'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Fixed port for AgentOS. See module JSDoc for rationale. */
+const AGENTOS_PORT = 8124
+
+/** Minimum Java major version required. AgentOS toolchain targets Java 25. */
+const JAVA_MIN_VERSION = 25
+
+/** How often (ms) to poll the Spring Boot health endpoint while waiting for startup. */
+const HEALTH_POLL_INTERVAL_MS = 2_000
+
+/** Maximum time (ms) to wait for Spring Boot to become healthy. */
+const HEALTH_TIMEOUT_MS = 60_000
+
+/** Time (ms) to wait for graceful SIGTERM before escalating to SIGKILL. */
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10_000
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Handle returned by startAgentos() once AgentOS is running and healthy. */
+export interface AgentosProcess {
+  /** The TCP port AgentOS is listening on (always AGENTOS_PORT = 8124). */
+  port: number
+  /**
+   * Whether this process was spawned by us (true) or adopted (false).
+   * Only spawned processes are stopped at shutdown.
+   */
+  spawned: boolean
+  /**
+   * Gracefully stop AgentOS.
+   * No-op if the process was adopted (not spawned by us).
+   * Sends SIGTERM first; escalates to SIGKILL after 10 s.
+   */
+  shutdown: () => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Java detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Probe the local JVM installation.
+ *
+ * `java -version` writes its output to stderr (JVM convention).
+ * We require Java >= 25 (AgentOS toolchain, see agentos/gradle/libs.versions.toml).
+ *
+ * @returns { available: true, version } when a suitable JVM is found, otherwise { available: false }.
+ */
+function detectJava(): { available: boolean; version?: string } {
+  try {
+    const stderr = execFileSync('java', ['-version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    // First line: `openjdk version "25.0.1" ...` or `java version "1.8.0_382"`
+    const versionMatch = stderr.match(/"(\d+)(?:\.(\d+))?/)
+    if (!versionMatch) {
+      debugLog('AGENTOS', `[RUNTIME] java -version output could not be parsed: ${stderr.slice(0, 200)}`)
+      return { available: false }
+    }
+
+    const rawMajor = parseInt(versionMatch[1] ?? '0', 10)
+    // Java 8 and earlier use "1.x" notation; 9+ use single-component major.
+    const major = rawMajor === 1 ? parseInt(versionMatch[2] ?? '0', 10) : rawMajor
+    const versionString = stderr.split('\n')[0]?.trim() ?? `Java ${major}`
+
+    if (major < JAVA_MIN_VERSION) {
+      debugLog(
+        'AGENTOS',
+        `[RUNTIME] WARN: Java ${major} detected but >= ${JAVA_MIN_VERSION} is required by AgentOS toolchain.` +
+          ` AgentOS will NOT be started. The proxy will return errors until a suitable JVM is installed.`
+      )
+      return { available: false, version: versionString }
+    }
+
+    debugLog('AGENTOS', `[RUNTIME] Java ${major} detected — OK (${versionString})`)
+    return { available: true, version: versionString }
+  } catch {
+    debugLog(
+      'AGENTOS',
+      `[RUNTIME] WARN: 'java' not found in PATH. AgentOS will NOT be started.` +
+        ` The proxy will return errors until Java >= ${JAVA_MIN_VERSION} is installed and on PATH.`
+    )
+    return { available: false }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Health polling
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if an AgentOS instance is already healthy at the fixed port.
+ * Single probe, no retry. Used for adoption detection before spawn.
+ */
+async function isAlreadyRunning(): Promise<boolean> {
+  try {
+    const url = `http://localhost:${AGENTOS_PORT}/management/health`
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 3_000)
+    let res: Response
+    try {
+      res = await fetch(url, { signal: controller.signal })
+    } finally {
+      clearTimeout(timer)
+    }
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Poll /management/health until Spring Boot reports 2xx or timeout.
+ * Spring Boot with Neo4j embedded can take up to ~60 s on first start.
+ */
+async function waitForHealthy(): Promise<boolean> {
+  const url = `http://localhost:${AGENTOS_PORT}/management/health`
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) {
+        debugLog('AGENTOS', `[RUNTIME] Health check passed on port ${AGENTOS_PORT}`)
+        return true
+      }
+      debugLog('AGENTOS', `[RUNTIME] Health check returned ${res.status}, retrying in ${HEALTH_POLL_INTERVAL_MS}ms...`)
+    } catch {
+      // Connection refused or network error — process still starting
+    }
+    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS))
+  }
+
+  debugLog('AGENTOS', `[RUNTIME] Health check timed out after ${HEALTH_TIMEOUT_MS / 1000} s`)
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to start the AgentOS Spring Boot JAR as a child process.
+ *
+ * If an AgentOS instance is already responding at port 8124, it is ADOPTED
+ * (not spawned, not killed at shutdown). This handles orphaned processes from
+ * a previous Coday killed with SIGKILL, or a developer's own bootRun instance.
+ *
+ * Returns null (without throwing) if:
+ *   - Java >= 25 is not available
+ *   - The JAR file does not exist at the expected path
+ *   - The process fails to become healthy within 60 s
+ *
+ * A null return means the proxy will return errors — the Express server still starts normally.
+ *
+ * @param configDir   Root config directory (from codayOptions.configDir).
+ * @param version     Expected version string (from getCodayVersion()).
+ * @param expressPort Port the Express server is listening on (for OAuth redirect URI).
+ * @returns An AgentosProcess handle when AgentOS is running and healthy, or null.
+ */
+export async function startAgentos(
+  configDir: string,
+  version: string,
+  expressPort: number
+): Promise<AgentosProcess | null> {
+  // ------------------------------------------------------------------
+  // 1. Check if an AgentOS instance is already running (adoption)
+  // ------------------------------------------------------------------
+  const alreadyRunning = await isAlreadyRunning()
+  if (alreadyRunning) {
+    debugLog(
+      'AGENTOS',
+      `[RUNTIME] An AgentOS instance is already responding at http://localhost:${AGENTOS_PORT}.` +
+        ` ADOPTING it — Coday did NOT start this process and will NOT stop it at shutdown.` +
+        ` NOTE: it may be running an older version. If you observe unexpected behaviour, kill it manually and restart Coday.`
+    )
+    return {
+      port: AGENTOS_PORT,
+      spawned: false,
+      shutdown: async () => {
+        debugLog('AGENTOS', '[RUNTIME] Adopted process — skipping shutdown')
+      },
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Detect Java >= 25
+  // ------------------------------------------------------------------
+  const java = detectJava()
+  if (!java.available) {
+    // Warning already logged inside detectJava()
+    return null
+  }
+
+  // ------------------------------------------------------------------
+  // 3. Verify JAR exists
+  // ------------------------------------------------------------------
+  const agentosDir = path.join(configDir, 'agentos')
+  const jarPath = path.join(agentosDir, `agentos-service-${version}.jar`)
+
+  // We import fs lazily here to avoid any import-time side effects
+  const { existsSync } = await import('fs')
+  if (!existsSync(jarPath)) {
+    debugLog('AGENTOS', `[RUNTIME] JAR not found at ${jarPath} — skipping AgentOS startup`)
+    return null
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Spawn the process
+  // ------------------------------------------------------------------
+  debugLog('AGENTOS', `[RUNTIME] Spawning AgentOS on port ${AGENTOS_PORT}`)
+  debugLog('AGENTOS', `[RUNTIME]   JAR:  ${jarPath}`)
+  debugLog('AGENTOS', `[RUNTIME]   CWD:  ${agentosDir}`)
+
+  const child: ChildProcess = spawn('java', ['-jar', jarPath, `--server.port=${AGENTOS_PORT}`], {
+    cwd: agentosDir,
+    // Inherit env from parent process, then add our overrides.
+    // AGENTOS_ENCRYPTION_KEY/SALT=NONE: explicitly disables field encryption
+    // (temporary — credentials stored in plaintext on disk; AgentOS logs a WARN).
+    // Replace with real cryptographic values when secret management is in place.
+    env: {
+      ...process.env,
+      AGENTOS_ENCRYPTION_KEY: 'NONE',
+      AGENTOS_ENCRYPTION_SALT: 'NONE',
+      // Derive the OAuth redirect URI from the actual Express port so the
+      // browser callback URL is correct regardless of which port was assigned.
+      AGENTOS_OAUTH_REDIRECT_URI: `http://localhost:${expressPort}/agentos/oauth/callback`,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  })
+
+  child.stdout?.on('data', (data: Buffer) => {
+    for (const line of data.toString().split('\n')) {
+      if (line.trim()) debugLog('AGENTOS', line.trim())
+    }
+  })
+
+  child.stderr?.on('data', (data: Buffer) => {
+    for (const line of data.toString().split('\n')) {
+      if (line.trim()) debugLog('AGENTOS', line.trim())
+    }
+  })
+
+  let spawnError: { message: string } | null = null
+  let exited = false
+
+  child.on('error', (err) => {
+    spawnError = err
+    debugLog('AGENTOS', `[RUNTIME] Spawn error: ${err.message}`)
+  })
+
+  child.on('exit', (code, signal) => {
+    exited = true
+    debugLog('AGENTOS', `[RUNTIME] Process exited — code=${code} signal=${signal}`)
+  })
+
+  // ------------------------------------------------------------------
+  // 5. Wait for healthy
+  // ------------------------------------------------------------------
+  debugLog('AGENTOS', `[RUNTIME] Waiting for AgentOS to become healthy (up to ${HEALTH_TIMEOUT_MS / 1000} s)...`)
+  const healthy = await waitForHealthy()
+
+  const spawnErrorMsg = spawnError ? (spawnError as { message: string }).message : null
+  if (!healthy || exited || spawnError) {
+    debugLog(
+      'AGENTOS',
+      `[RUNTIME] AgentOS did not become healthy (healthy=${healthy}, exited=${exited}, spawnError=${spawnErrorMsg}) — killing process`
+    )
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // already dead
+    }
+    return null
+  }
+
+  debugLog('AGENTOS', `[RUNTIME] AgentOS is up and healthy on port ${AGENTOS_PORT}`)
+
+  // ------------------------------------------------------------------
+  // 6. Build and return the handle
+  // ------------------------------------------------------------------
+  const shutdown = (): Promise<void> =>
+    new Promise((resolve) => {
+      if (child.exitCode !== null || child.killed) {
+        resolve()
+        return
+      }
+
+      const timer = setTimeout(() => {
+        debugLog('AGENTOS', '[RUNTIME] Graceful shutdown timed out — sending SIGKILL')
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          /* ignore */
+        }
+      }, GRACEFUL_SHUTDOWN_TIMEOUT_MS)
+
+      child.once('exit', () => {
+        clearTimeout(timer)
+        debugLog('AGENTOS', '[RUNTIME] AgentOS process exited')
+        resolve()
+      })
+
+      debugLog('AGENTOS', '[RUNTIME] Sending SIGTERM to AgentOS')
+      try {
+        child.kill('SIGTERM')
+      } catch (err) {
+        clearTimeout(timer)
+        debugLog('AGENTOS', `[RUNTIME] Error sending SIGTERM: ${err}`)
+        resolve()
+      }
+    })
+
+  return { port: AGENTOS_PORT, spawned: true, shutdown }
+}

--- a/apps/server/src/lib/agentos-runtime.ts
+++ b/apps/server/src/lib/agentos-runtime.ts
@@ -79,8 +79,15 @@ export interface AgentosProcess {
  * @returns { available: true, version } when a suitable JVM is found, otherwise { available: false }.
  */
 function detectJava(): { available: boolean; version?: string } {
+  // JAVA_HOME may not be set in non-interactive shells (e.g. SDKMAN, Homebrew).
+  // Resolve the java binary path: prefer JAVA_HOME/bin/java, fall back to 'java' on PATH.
+  const javaHome = process.env.JAVA_HOME
+  const javaBin = javaHome ? path.join(javaHome, 'bin', 'java') : 'java'
+  if (javaHome) {
+    debugLog('AGENTOS', `[RUNTIME] Using JAVA_HOME: ${javaHome}`)
+  }
   try {
-    const stderr = execFileSync('java', ['-version'], {
+    const stderr = execFileSync(javaBin, ['-version'], {
       encoding: 'utf8',
       stdio: ['ignore', 'ignore', 'pipe'],
     })
@@ -111,8 +118,8 @@ function detectJava(): { available: boolean; version?: string } {
   } catch {
     debugLog(
       'AGENTOS',
-      `[RUNTIME] WARN: 'java' not found in PATH. AgentOS will NOT be started.` +
-        ` The proxy will return errors until Java >= ${JAVA_MIN_VERSION} is installed and on PATH.`
+      `[RUNTIME] WARN: java binary not found (tried: ${javaHome ? path.join(javaHome, 'bin', 'java') : 'java in PATH'}).` +
+        ` AgentOS will NOT be started. Set JAVA_HOME or ensure java >= ${JAVA_MIN_VERSION} is on PATH.`
     )
     return { available: false }
   }
@@ -246,7 +253,10 @@ export async function startAgentos(
   debugLog('AGENTOS', `[RUNTIME]   JAR:  ${jarPath}`)
   debugLog('AGENTOS', `[RUNTIME]   CWD:  ${agentosDir}`)
 
-  const child: ChildProcess = spawn('java', ['-jar', jarPath, `--server.port=${AGENTOS_PORT}`], {
+  const javaHome = process.env.JAVA_HOME
+  const javaBin = javaHome ? path.join(javaHome, 'bin', 'java') : 'java'
+
+  const child: ChildProcess = spawn(javaBin, ['-jar', jarPath, `--server.port=${AGENTOS_PORT}`], {
     cwd: agentosDir,
     // Inherit env from parent process, then add our overrides.
     // AGENTOS_ENCRYPTION_KEY/SALT=NONE: explicitly disables field encryption

--- a/apps/server/src/lib/agentos-runtime.ts
+++ b/apps/server/src/lib/agentos-runtime.ts
@@ -87,22 +87,22 @@ function detectJava(): { available: boolean; version?: string } {
     debugLog('AGENTOS', `[RUNTIME] Using JAVA_HOME: ${javaHome}`)
   }
   try {
-    const stderr = execFileSync(javaBin, ['-version'], {
+    // --version writes to stdout and exits 0 on Java 9+.
+    // -version writes to stderr — unreliable with execFileSync.
+    const stdout = execFileSync(javaBin, ['--version'], {
       encoding: 'utf8',
-      stdio: ['ignore', 'ignore', 'pipe'],
+      stdio: ['ignore', 'pipe', 'ignore'],
     })
 
-    // First line: `openjdk version "25.0.1" ...` or `java version "1.8.0_382"`
-    const versionMatch = stderr.match(/"(\d+)(?:\.(\d+))?/)
+    // First line: `openjdk 25 2025-09-16` or `openjdk 21.0.3 2024-04-16`
+    const versionMatch = stdout.match(/^\S+\s+(\d+)/)
     if (!versionMatch) {
-      debugLog('AGENTOS', `[RUNTIME] java -version output could not be parsed: ${stderr.slice(0, 200)}`)
+      debugLog('AGENTOS', `[RUNTIME] java --version output could not be parsed: ${stdout.slice(0, 200)}`)
       return { available: false }
     }
 
-    const rawMajor = parseInt(versionMatch[1] ?? '0', 10)
-    // Java 8 and earlier use "1.x" notation; 9+ use single-component major.
-    const major = rawMajor === 1 ? parseInt(versionMatch[2] ?? '0', 10) : rawMajor
-    const versionString = stderr.split('\n')[0]?.trim() ?? `Java ${major}`
+    const major = parseInt(versionMatch[1] ?? '0', 10)
+    const versionString = stdout.split('\n')[0]?.trim() ?? `Java ${major}`
 
     if (major < JAVA_MIN_VERSION) {
       debugLog(

--- a/apps/server/src/lib/validate-agentos-url.spec.ts
+++ b/apps/server/src/lib/validate-agentos-url.spec.ts
@@ -1,0 +1,45 @@
+import { validateAgentOsUrl } from './validate-agentos-url'
+
+describe('validateAgentOsUrl', () => {
+  describe('valid URLs', () => {
+    it('accepts http with localhost and port', () => {
+      expect(() => validateAgentOsUrl('http://localhost:8124')).not.toThrow()
+    })
+
+    it('accepts https with a named host', () => {
+      expect(() => validateAgentOsUrl('https://agentos.internal')).not.toThrow()
+    })
+
+    it('accepts a URL carrying a base path', () => {
+      expect(() => validateAgentOsUrl('https://example.com/agentos')).not.toThrow()
+    })
+  })
+
+  describe('invalid URLs', () => {
+    it('rejects a bare hostname without scheme', () => {
+      expect(() => validateAgentOsUrl('my-host')).toThrow('Invalid AGENTOS_URL: "my-host"')
+    })
+
+    it('rejects localhost:port without scheme (parsed as scheme=localhost:)', () => {
+      expect(() => validateAgentOsUrl('localhost:8124')).toThrow('Invalid AGENTOS_URL: "localhost:8124"')
+    })
+
+    it('rejects a doubled scheme (http://http://...)', () => {
+      expect(() => validateAgentOsUrl('http://http://localhost:8124')).toThrow(
+        'Invalid AGENTOS_URL: "http://http://localhost:8124"'
+      )
+    })
+
+    it('rejects a non-http scheme such as ftp://', () => {
+      expect(() => validateAgentOsUrl('ftp://localhost:8124')).toThrow('Invalid AGENTOS_URL: "ftp://localhost:8124"')
+    })
+
+    it('error message names the offending value', () => {
+      expect(() => validateAgentOsUrl('bad-value')).toThrow('"bad-value"')
+    })
+
+    it('error message shows a valid example', () => {
+      expect(() => validateAgentOsUrl('bad-value')).toThrow('http://localhost:8124')
+    })
+  })
+})

--- a/apps/server/src/lib/validate-agentos-url.ts
+++ b/apps/server/src/lib/validate-agentos-url.ts
@@ -1,0 +1,29 @@
+/**
+ * Validates that a string is a well-formed http(s) URL suitable for use as
+ * the AgentOS proxy target.
+ *
+ * `new URL()` alone is too permissive: `new URL('localhost:8124')` succeeds
+ * by treating `localhost:` as the scheme, which is the most likely migration
+ * mistake when a user copies a bare hostname from the old AGENTOS_HOSTNAME var.
+ * This helper adds an explicit protocol and hostname assertion.
+ *
+ * A pathname starting with '//' signals a doubled scheme
+ * (e.g. 'http://http://localhost' parses as hostname='http', pathname='//localhost').
+ *
+ * Throws an Error with a descriptive message if the URL is invalid.
+ */
+export function validateAgentOsUrl(url: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(
+      `Invalid AGENTOS_URL: "${url}". Must be a complete URL including scheme, e.g. "http://localhost:8124".`
+    )
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname || parsed.pathname.startsWith('//')) {
+    throw new Error(
+      `Invalid AGENTOS_URL: "${url}". Expected an http(s) URL with a hostname, e.g. "http://localhost:8124".`
+    )
+  }
+}

--- a/apps/server/src/lib/version.ts
+++ b/apps/server/src/lib/version.ts
@@ -87,3 +87,23 @@ export function getCodayVersion(): string {
   debugLog('VERSION', `Could not resolve version from any candidate — using sentinel 'dev'`)
   return _resolved
 }
+
+/**
+ * Hardcoded AgentOS version — updated only when AgentOS itself changes,
+ * NOT on every Coday release. This decouples the ~230 MB JAR download
+ * from the Coday release cadence.
+ *
+ * Override with AGENTOS_VERSION env var for local dev or testing:
+ *   AGENTOS_VERSION=0.244.1 pnpm web
+ */
+const AGENTOS_BUNDLED_VERSION = '0.244.1'
+
+export function getAgentosVersion(): string {
+  const override = process.env.AGENTOS_VERSION
+  if (override) {
+    debugLog('VERSION', `AgentOS version from AGENTOS_VERSION env var: ${override}`)
+    return override
+  }
+  debugLog('VERSION', `AgentOS version (bundled): ${AGENTOS_BUNDLED_VERSION}`)
+  return AGENTOS_BUNDLED_VERSION
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -539,10 +539,10 @@ PORT_PROMISE.then(async (PORT) => {
     console.log(`Server is running on http://localhost:${PORT}`)
   })
 
-  // AgentOS provisioning — non-fatal: a failure here must never prevent the
-  // Express server from starting. The proxy will return errors until AgentOS is
-  // available, which is acceptable.
-  await provisionAgentos(PORT)
+  // AgentOS provisioning — fire-and-forget: runs in background so downloads
+  // (up to ~230 MB) never block server startup or other services.
+  // The proxy will return errors until AgentOS is ready, which is acceptable.
+  provisionAgentos(PORT).catch((err) => debugLog('AGENTOS', '[PROVISION] Unhandled error:', err))
 
   // Start thread cleanup service after server is running
   try {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -37,7 +37,8 @@ import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
 import { checkAgentosJars } from './lib/agentos-lifecycle'
 import { getCodayVersion } from './lib/version'
-import { downloadProbeJar } from './lib/agentos-download'
+import { downloadAgentosJars } from './lib/agentos-download'
+import { startAgentos, AgentosProcess } from './lib/agentos-runtime'
 import { validateAgentOsUrl } from './lib/validate-agentos-url'
 
 const app = express()
@@ -74,33 +75,56 @@ debugLog('INIT', 'Webhook service initialized (will be initialized with prompt e
 // Note: projectPath will be set after projectService is initialized
 let promptService: PromptService
 let promptExecutionService: PromptExecutionService
-// Proxy /api/agentos/* → AgentOS Spring backend
-// Registered synchronously and BEFORE express.json() to avoid body-parser
-// consuming the request body before it can be forwarded.
-const AGENTOS_PORT = process.env.AGENTOS_PORT ? parseInt(process.env.AGENTOS_PORT) : 8124
-const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
-const AGENTOS_URL = process.env.AGENTOS_URL ?? `http://localhost:${AGENTOS_PORT}`
+// ---------------------------------------------------------------------------
+// AgentOS proxy — two mutually exclusive modes, discriminated by AGENTOS_URL
+//
+// EXTERNAL mode (AGENTOS_URL defined): Coday proxies to that URL unchanged.
+//   Use this when running your own AgentOS (./gradlew bootRun) or in server
+//   deployments where AgentOS is managed externally.
+//
+// MANAGED mode (AGENTOS_URL absent): Coday downloads JARs from GitHub
+//   Releases, launches the process itself, and stops it at shutdown.
+//   Target is always http://localhost:8124 (fixed port).
+//
+// The proxy middleware is registered synchronously and BEFORE express.json()
+// to avoid body-parser consuming the request body before forwarding.
+// ---------------------------------------------------------------------------
 
-// Fail fast on malformed configuration rather than surfacing it as a 504 later.
-// Note: `new URL` alone is too permissive — it accepts 'localhost:8124' by reading
-// 'localhost:' as the scheme, which is the most likely migration mistake here.
-validateAgentOsUrl(AGENTOS_URL)
+const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
+const AGENTOS_URL_ENV = process.env.AGENTOS_URL
+
+// Validate the env var if provided (fail fast on misconfiguration)
+if (AGENTOS_URL_ENV) {
+  validateAgentOsUrl(AGENTOS_URL_ENV)
+}
+
+// Mutable proxy target — updated to the managed URL once AgentOS is running.
+// In external mode this is set once and never changes.
+let currentAgentosUrl = AGENTOS_URL_ENV ?? `http://localhost:8124`
+
+// Track the managed AgentOS process handle (null in external mode or before startup)
+let agentosProcess: AgentosProcess | null = null
+
 app.use(
   '/api/agentos',
   (req, _res, next) => {
-    console.log(`[AGENTOS PROXY] ${req.method} ${req.path}`)
+    debugLog('AGENTOS', `[PROXY] ${req.method} ${req.path}`)
     if (AGENTOS_EXTERNAL_USERID) {
       req.headers['X-External-User-Id'] = AGENTOS_EXTERNAL_USERID
     }
     next()
   },
   createProxyMiddleware({
-    target: AGENTOS_URL,
+    // router callback reads currentAgentosUrl at request time, not at setup time
+    router: () => currentAgentosUrl,
     changeOrigin: true,
     pathRewrite: { '^/api/agentos': '' },
   })
 )
-debugLog('INIT', `AgentOS proxy configured: /api/agentos → ${AGENTOS_URL}`)
+debugLog(
+  'INIT',
+  `AgentOS proxy configured: /api/agentos → ${currentAgentosUrl} (${AGENTOS_URL_ENV ? 'external mode' : 'managed mode'})`
+)
 
 // Middleware to parse JSON bodies with increased limit for image uploads
 app.use(express.json({ limit: '20mb' }))
@@ -406,6 +430,73 @@ if (process.env.BUILD_ENV !== 'development') {
 // Initialize thread cleanup service (server-only)
 let cleanupService: ThreadCleanupService | null = null
 
+// ---------------------------------------------------------------------------
+// AgentOS provisioning entry point (managed mode only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Single entry point called after app.listen() to provision and start AgentOS.
+ *
+ * In EXTERNAL mode (AGENTOS_URL defined): logs and returns immediately.
+ * In MANAGED mode: checks JAR inventory → downloads missing → starts the process.
+ *
+ * Never throws — any error is logged and the function returns gracefully.
+ * The Express server stays up regardless of AgentOS provisioning outcome.
+ *
+ * @param expressPort The port the Express server is listening on.
+ */
+async function provisionAgentos(expressPort: number): Promise<void> {
+  if (AGENTOS_URL_ENV) {
+    debugLog('AGENTOS', `[PROVISION] External mode — target: ${AGENTOS_URL_ENV}. No provisioning performed.`)
+    return
+  }
+
+  debugLog('AGENTOS', '[PROVISION] Managed mode — starting AgentOS provisioning...')
+
+  try {
+    const codayVersion = getCodayVersion()
+
+    // --- 1. Check JAR inventory ---
+    const jarStatus = checkAgentosJars(codayOptions.configDir, codayVersion)
+
+    // --- 2. Download missing JARs + strict cleanup ---
+    // downloadAgentosJars always performs strict cleanup after downloads.
+    // If missing is empty it returns 'skipped:all-present' immediately (no cleanup),
+    // which is correct: if all JARs are at the right version, there is nothing stale.
+    const downloadResult = await downloadAgentosJars(codayOptions.configDir, codayVersion, jarStatus.missing)
+    debugLog('AGENTOS', `[PROVISION] Download outcome: ${downloadResult.outcome} — ${downloadResult.message}`)
+
+    if (
+      downloadResult.outcome !== 'success' &&
+      downloadResult.outcome !== 'skipped:all-present' &&
+      downloadResult.outcome !== 'skipped:dev-version'
+    ) {
+      debugLog('AGENTOS', '[PROVISION] Download failed — AgentOS will not be started. The proxy will return errors.')
+      return
+    }
+
+    // --- 3. Start the process ---
+    debugLog('AGENTOS', '[PROVISION] Starting AgentOS process...')
+    agentosProcess = await startAgentos(codayOptions.configDir, codayVersion, expressPort)
+
+    if (!agentosProcess) {
+      debugLog('AGENTOS', '[PROVISION] AgentOS did not start. The proxy will return errors until AgentOS is available.')
+      return
+    }
+
+    // Update the proxy target (always localhost:8124 in managed mode, but kept
+    // explicit so future flexibility (e.g. dynamic port) requires no refactor)
+    currentAgentosUrl = `http://localhost:${agentosProcess.port}`
+    debugLog(
+      'AGENTOS',
+      `[PROVISION] AgentOS is ready. Proxy target: ${currentAgentosUrl}` +
+        ` (${agentosProcess.spawned ? 'spawned by Coday' : 'adopted existing process'})`
+    )
+  } catch (error) {
+    debugLog('AGENTOS', '[PROVISION] Unexpected error during provisioning (non-fatal):', error)
+  }
+}
+
 // Error handling middleware
 app.use((err: any, req: express.Request, res: express.Response, _: express.NextFunction) => {
   debugLog('ERROR', `Request error on ${req.method} ${req.path}:`, err.message)
@@ -437,23 +528,10 @@ PORT_PROMISE.then(async (PORT) => {
     console.log(`Server is running on http://localhost:${PORT}`)
   })
 
-  // Check AgentOS JAR availability at startup (log only — no side effects).
-  // A failure here must never prevent the server from starting.
-  try {
-    const codayVersion = getCodayVersion()
-    const jarStatus = await checkAgentosJars(codayVersion)
-
-    // Attempt to download agentos-bash-plugin if absent or at the wrong version.
-    // This is a probe to validate the GitHub Release download chain end-to-end.
-    // Only agentos-bash-plugin is attempted (smallest JAR, ~35 KB).
-    // No download occurs if the JAR is already present at the expected version.
-    const bashPluginResult = jarStatus.artifacts.find((a) => a.artifactId === 'agentos-bash-plugin')
-    const bashPluginPresent = bashPluginResult?.versionMatch === true
-    const downloadResult = await downloadProbeJar(codayVersion, bashPluginPresent)
-    debugLog('AGENTOS', `[DOWNLOAD] outcome: ${downloadResult.outcome} — ${downloadResult.message}`)
-  } catch (error) {
-    debugLog('AGENTOS', 'Unexpected error during JAR check/download (non-fatal):', error)
-  }
+  // AgentOS provisioning — non-fatal: a failure here must never prevent the
+  // Express server from starting. The proxy will return errors until AgentOS is
+  // available, which is acceptable.
+  await provisionAgentos(PORT)
 
   // Start thread cleanup service after server is running
   try {
@@ -518,6 +596,12 @@ async function gracefulShutdown(signal: string) {
   console.log(`Received ${signal}, shutting down gracefully...`)
 
   try {
+    // Stop AgentOS first (only if we spawned it — not if adopted or external mode)
+    if (agentosProcess?.spawned) {
+      console.log('Stopping AgentOS...')
+      await agentosProcess.shutdown()
+    }
+
     // Stop scheduler service
     console.log('Stopping scheduler service...')
     schedulerService.stop()

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -36,7 +36,7 @@ import { McpInstancePool } from '@coday/mcp'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
 import { checkAgentosJars } from './lib/agentos-lifecycle'
-import { getCodayVersion } from './lib/version'
+import { getAgentosVersion } from './lib/version'
 import { downloadAgentosJars } from './lib/agentos-download'
 import { startAgentos, AgentosProcess } from './lib/agentos-runtime'
 import { validateAgentOsUrl } from './lib/validate-agentos-url'
@@ -454,27 +454,16 @@ async function provisionAgentos(expressPort: number): Promise<void> {
   debugLog('AGENTOS', '[PROVISION] Managed mode — starting AgentOS provisioning...')
 
   try {
-    const codayVersion = getCodayVersion()
-
-    // Dev sentinel: getCodayVersion() returns 'dev' when no package.json version
-    // can be resolved (e.g. tsx watch from monorepo root without a build).
-    // No release exists to download from, and no JAR will be found — skip cleanly.
-    if (codayVersion === 'dev') {
-      debugLog(
-        'AGENTOS',
-        '[PROVISION] Dev version detected — skipping managed provisioning. Set AGENTOS_URL to point to your AgentOS instance.'
-      )
-      return
-    }
+    const agentosVersion = getAgentosVersion()
 
     // --- 1. Check JAR inventory ---
-    const jarStatus = checkAgentosJars(codayOptions.configDir, codayVersion)
+    const jarStatus = checkAgentosJars(codayOptions.configDir, agentosVersion)
 
     // --- 2. Download missing JARs + strict cleanup ---
     // downloadAgentosJars always performs strict cleanup after downloads.
     // If missing is empty it returns 'skipped:all-present' immediately (no cleanup),
     // which is correct: if all JARs are at the right version, there is nothing stale.
-    const downloadResult = await downloadAgentosJars(codayOptions.configDir, codayVersion, jarStatus.missing)
+    const downloadResult = await downloadAgentosJars(codayOptions.configDir, agentosVersion, jarStatus.missing)
     debugLog('AGENTOS', `[PROVISION] Download outcome: ${downloadResult.outcome} — ${downloadResult.message}`)
 
     if (
@@ -488,7 +477,7 @@ async function provisionAgentos(expressPort: number): Promise<void> {
 
     // --- 3. Start the process ---
     debugLog('AGENTOS', '[PROVISION] Starting AgentOS process...')
-    agentosProcess = await startAgentos(codayOptions.configDir, codayVersion, expressPort)
+    agentosProcess = await startAgentos(codayOptions.configDir, agentosVersion, expressPort)
 
     if (!agentosProcess) {
       debugLog('AGENTOS', '[PROVISION] AgentOS did not start. The proxy will return errors until AgentOS is available.')

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -74,9 +74,17 @@ let promptExecutionService: PromptExecutionService
 // Registered synchronously and BEFORE express.json() to avoid body-parser
 // consuming the request body before it can be forwarded.
 const AGENTOS_PORT = process.env.AGENTOS_PORT ? parseInt(process.env.AGENTOS_PORT) : 8124
-const AGENTOS_HOSTNAME = process.env.AGENTOS_HOSTNAME ?? 'localhost'
 const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
-const AGENTOS_URL = `http://${AGENTOS_HOSTNAME}:${AGENTOS_PORT}`
+const AGENTOS_URL = process.env.AGENTOS_URL ?? `http://localhost:${AGENTOS_PORT}`
+
+// Fail fast on malformed configuration rather than surfacing it as a 504 later.
+try {
+  new URL(AGENTOS_URL)
+} catch {
+  throw new Error(
+    `Invalid AGENTOS_URL: "${AGENTOS_URL}". Must be a complete URL including scheme, e.g. "http://localhost:8124".`
+  )
+}
 app.use(
   '/api/agentos',
   (req, _res, next) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -35,6 +35,7 @@ import { ProjectFileRepository } from '@coday/repository'
 import { McpInstancePool } from '@coday/mcp'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { resolveUsername } from './lib/resolve-username'
+import { validateAgentOsUrl } from './lib/validate-agentos-url'
 
 const app = express()
 const DEFAULT_PORT = process.env.PORT
@@ -78,13 +79,9 @@ const AGENTOS_EXTERNAL_USERID = process.env.AGENTOS_EXTERNAL_USERID
 const AGENTOS_URL = process.env.AGENTOS_URL ?? `http://localhost:${AGENTOS_PORT}`
 
 // Fail fast on malformed configuration rather than surfacing it as a 504 later.
-try {
-  new URL(AGENTOS_URL)
-} catch {
-  throw new Error(
-    `Invalid AGENTOS_URL: "${AGENTOS_URL}". Must be a complete URL including scheme, e.g. "http://localhost:8124".`
-  )
-}
+// Note: `new URL` alone is too permissive — it accepts 'localhost:8124' by reading
+// 'localhost:' as the scheme, which is the most likely migration mistake here.
+validateAgentOsUrl(AGENTOS_URL)
 app.use(
   '/api/agentos',
   (req, _res, next) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -456,6 +456,17 @@ async function provisionAgentos(expressPort: number): Promise<void> {
   try {
     const codayVersion = getCodayVersion()
 
+    // Dev sentinel: getCodayVersion() returns 'dev' when no package.json version
+    // can be resolved (e.g. tsx watch from monorepo root without a build).
+    // No release exists to download from, and no JAR will be found — skip cleanly.
+    if (codayVersion === 'dev') {
+      debugLog(
+        'AGENTOS',
+        '[PROVISION] Dev version detected — skipping managed provisioning. Set AGENTOS_URL to point to your AgentOS instance.'
+      )
+      return
+    }
+
     // --- 1. Check JAR inventory ---
     const jarStatus = checkAgentosJars(codayOptions.configDir, codayVersion)
 


### PR DESCRIPTION
Implements full AgentOS bundling in managed mode (when `AGENTOS_URL` is not set).

Two mutually exclusive modes via `AGENTOS_URL`: external (proxy only, no provisioning) vs managed (Coday owns the process and config entirely).

Managed mode sequence after `app.listen()`: inventory check → download missing JARs (manifest once, SHA-256, atomic write) → strict cleanup → spawn JVM with correct `cwd` → adopt if already running → health check → graceful shutdown.

Guards: Java < 25 warns and skips, `dev` version skips explicitly, all errors non-fatal.