### PR TITLE
feat: delegation status event and inline status icon

### DIFF
--- a/apps/client/src/app/components/delegation-inline/delegation-inline.component.html
+++ b/apps/client/src/app/components/delegation-inline/delegation-inline.component.html
@@ -8,6 +8,15 @@
     (keydown.space)="toggle()"
   >
     <mat-icon class="expand-icon">{{ isExpanded ? 'expand_more' : 'chevron_right' }}</mat-icon>
+    @if (status === 'running') {
+      <mat-spinner class="status-icon" [diameter]="14"></mat-spinner>
+    } @else if (status === 'completed') {
+      <mat-icon class="status-icon status-completed">check_circle</mat-icon>
+    } @else if (status === 'failed') {
+      <mat-icon class="status-icon status-failed">error</mat-icon>
+    } @else if (status === 'interrupted') {
+      <mat-icon class="status-icon status-interrupted">cancel</mat-icon>
+    }
     <span class="agent-name">{{ agentName }}</span>
     @if (taskSummary) {
       <span class="task-summary">{{ taskSummary }}</span>

--- a/apps/client/src/app/components/delegation-inline/delegation-inline.component.scss
+++ b/apps/client/src/app/components/delegation-inline/delegation-inline.component.scss
@@ -25,6 +25,25 @@
     color: var(--color-text-secondary, #94a3b8);
   }
 
+  .status-icon {
+    flex-shrink: 0;
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  .status-completed {
+    color: var(--color-success, #22c55e);
+  }
+
+  .status-failed {
+    color: var(--color-error, #ef4444);
+  }
+
+  .status-interrupted {
+    color: var(--color-warning, #f59e0b);
+  }
+
   .agent-name {
     font-weight: 600;
     color: var(--color-primary, #6366f1);

--- a/apps/client/src/app/components/delegation-inline/delegation-inline.component.ts
+++ b/apps/client/src/app/components/delegation-inline/delegation-inline.component.ts
@@ -12,13 +12,15 @@ import {
   AnswerEvent,
   buildCodayEvent,
   CodayEvent,
+  DelegationEvent,
+  DelegationStatus,
+  DelegationStatusEvent,
   ErrorEvent,
   MessageEvent,
   TextEvent,
   ToolRequestEvent,
   ToolResponseEvent,
   TextChunkEvent,
-  DelegationEvent,
 } from '@coday/model'
 
 @Component({
@@ -36,6 +38,7 @@ export class DelegationInlineComponent implements OnInit, OnDestroy {
   isLoading = false
   subMessages: ChatMessage[] = []
   streamingText = ''
+  status: DelegationStatus = 'completed'
 
   private restLoaded = false
   private messageIds = new Set<string>()
@@ -153,6 +156,8 @@ export class DelegationInlineComponent implements OnInit, OnDestroy {
         type: 'technical',
         eventId: event.timestamp,
       })
+    } else if (event instanceof DelegationStatusEvent) {
+      this.status = event.status
     } else if (event instanceof DelegationEvent) {
       this.addMessage({
         id: event.timestamp,

--- a/libs/integrations/ai/src/lib/delegate.function.ts
+++ b/libs/integrations/ai/src/lib/delegate.function.ts
@@ -4,6 +4,8 @@ import {
   AnswerEvent,
   CommandContext,
   DelegationEvent,
+  DelegationStatus,
+  DelegationStatusEvent,
   Interactor,
   MessageEvent,
   RunStatus,
@@ -183,9 +185,11 @@ async function setupAndRunAsync(
   const agent: Agent | undefined = await agentFind(agentName, context)
   if (!agent) {
     interactor.error(`Async delegation: agent '${agentName}' not found.`)
+    interactor.sendEvent(new DelegationStatusEvent({ status: 'failed', threadId: subThread.id }))
     return
   }
 
+  interactor.sendEvent(new DelegationStatusEvent({ status: 'running', threadId: subThread.id }))
   interactor.sendEvent(new AnswerEvent({ answer: task, threadId: subThread.id }))
 
   // Stop propagation still runs in background
@@ -196,11 +200,17 @@ async function setupAndRunAsync(
     }
   }, 1000)
 
+  let terminalStatus: DelegationStatus = 'completed'
+
   try {
     const agentEvents: Observable<MessageEvent> = (await agent.run(task, subThread)).pipe(
       filter((e: unknown) => e instanceof MessageEvent)
     )
     const lastMessage: MessageEvent | undefined = await lastValueFrom(agentEvents, { defaultValue: undefined })
+
+    if (subThread.runStatus === RunStatus.STOPPED) {
+      terminalStatus = 'interrupted'
+    }
 
     const wrappedResult =
       emitResultAsUserMessage && lastMessage && subThread.runStatus !== RunStatus.STOPPED
@@ -249,9 +259,11 @@ ${lastMessage.getTextContent()}
       interactor.debug(`Could not persist price merge for parent thread ${parentThread.id}: ${mergeErr}`)
     }
   } catch (error: any) {
+    terminalStatus = 'failed'
     interactor.error(`Async delegation to '${agentName}' failed: ${error?.message ?? error}`)
   } finally {
     clearInterval(stopPropagationInterval)
+    interactor.sendEvent(new DelegationStatusEvent({ status: terminalStatus, threadId: subThread.id }))
   }
 }
 
@@ -316,8 +328,11 @@ async function runSingleDelegation(
 
   const agent: Agent | undefined = await agentFind(agentName, context)
   if (!agent) {
+    interactor.sendEvent(new DelegationStatusEvent({ status: 'failed', threadId: subThread.id }))
     return { result: `Agent ${agentName} not found.`, threadId: subThread.id }
   }
+
+  interactor.sendEvent(new DelegationStatusEvent({ status: 'running', threadId: subThread.id }))
 
   // Propagate stop signal from parent thread to sub-thread
   const stopPropagationInterval = setInterval(() => {
@@ -328,6 +343,7 @@ async function runSingleDelegation(
   }, 1000)
 
   let result: string = 'Delegation did not produce a result.'
+  let terminalStatus: DelegationStatus = 'completed'
 
   try {
     // Emit the task as an AnswerEvent tagged with the sub-thread ID so the
@@ -350,6 +366,7 @@ async function runSingleDelegation(
     const lastMessage: MessageEvent | undefined = await lastValueFrom(agentEvents, { defaultValue: undefined })
 
     if (subThread.runStatus === RunStatus.STOPPED) {
+      terminalStatus = 'interrupted'
       result = 'Delegation was interrupted before completion. No result available.'
     } else if (!lastMessage) {
       result = 'Delegation completed but produced no message.'
@@ -401,11 +418,13 @@ ${result}
       interactor.debug(`Could not persist price merge for parent thread ${parentThread.id}: ${mergeErr}`)
     }
   } catch (error: any) {
+    terminalStatus = 'failed'
     result = `Error during delegation: ${error.message}`
     console.error(`Error in delegation for agent ${agentName}:`, error)
     interactor.error(result)
   } finally {
     clearInterval(stopPropagationInterval)
+    interactor.sendEvent(new DelegationStatusEvent({ status: terminalStatus, threadId: subThread.id }))
   }
 
   return { result, threadId: subThread.id }

--- a/libs/model/src/lib/coday-events.ts
+++ b/libs/model/src/lib/coday-events.ts
@@ -446,6 +446,32 @@ export class DelegationEvent extends CodayEvent {
   }
 }
 
+/**
+ * Union of possible execution statuses for a delegation sub-thread.
+ */
+export type DelegationStatus = 'running' | 'completed' | 'failed' | 'interrupted'
+
+/**
+ * Transient event reporting the execution status of a delegation sub-thread.
+ *
+ * **Never persisted** in thread history — this event must never be added to
+ * `THREAD_MESSAGE_TYPES` nor to the `ThreadMessage` union, as it would be forwarded
+ * to AI providers and trigger unknown-message-type errors.
+ *
+ * Tagged with `threadId: subThread.id` so the frontend routes it via the existing
+ * `subThreadEvents$` channel directly to the matching `DelegationInlineComponent`,
+ * including for nested delegations.
+ */
+export class DelegationStatusEvent extends CodayEvent {
+  status: DelegationStatus
+  static override type = 'delegation_status'
+
+  constructor(event: Partial<DelegationStatusEvent>) {
+    super(event, DelegationStatusEvent.type)
+    this.status = event.status!
+  }
+}
+
 export class UsageEvent extends CodayEvent {
   static override type = 'usage'
 
@@ -491,6 +517,7 @@ const eventTypeToClassMap: { [key: string]: typeof CodayEvent } = {
   [AnswerEvent.type]: AnswerEvent,
   [ChoiceEvent.type]: ChoiceEvent,
   [DelegationEvent.type]: DelegationEvent,
+  [DelegationStatusEvent.type]: DelegationStatusEvent,
   [ErrorEvent.type]: ErrorEvent,
   [HeartBeatEvent.type]: HeartBeatEvent,
   [InviteEvent.type]: InviteEvent,


### PR DESCRIPTION

<img width="829" height="79" alt="Capture d’écran 2026-08-07 à 10 31 13" src="https://github.com/user-attachments/assets/432da18c-c3ca-4e4a-9325-0d6d7268fba6" />


## Contexte

Les délégations vers des sous-threads n'exposaient aucun signal d'exécution : une fois lancée, impossible de savoir depuis l'UI si une sous-tâche tournait encore, avait abouti ou avait échoué.

## Changements

Introduit `DelegationStatusEvent` dans `libs/model/src/lib/coday-events.ts`, avec le type associé `DelegationStatus` (`running` | `completed` | `failed` | `interrupted`).

L'événement est émis par `libs/integrations/ai/src/lib/delegate.function.ts` pour **chaque** délégation, synchrone comme asynchrone :
- `running` au démarrage,
- statut terminal dans un bloc `finally`, ce qui garantit l'émission même en cas d'erreur ou d'interruption.

Il est tagué avec `threadId = subThread.id`, ce qui le fait transiter par le canal `subThreadEvents$` existant côté client et le route directement vers le `DelegationInlineComponent` correspondant — y compris pour les délégations imbriquées.

Côté UI, `DelegationInlineComponent` affiche désormais une icône reflétant ce statut.

## Note de conception

`DelegationStatusEvent` est **transient** : il ne doit jamais être ajouté à `THREAD_MESSAGE_TYPES` ni à l'union `ThreadMessage`, sous peine d'être transmis aux providers d'IA et de déclencher des erreurs de type de message inconnu. Un commentaire explicite le rappelle dans le code.

## Stack

Première PR d'une pile de deux. La suivante (compteur de délégations en cours dans l'indicateur de travail) cible cette branche et doit être mergée après.