### PR TITLE
feat: display running delegation count in thinking loader

### DIFF
--- a/apps/client/src/app/components/chat-history/chat-history.component.html
+++ b/apps/client/src/app/components/chat-history/chat-history.component.html
@@ -23,7 +23,7 @@
 
   <!-- Thinking Loader -->
   @if (isThinking) {
-    <app-thinking-loader></app-thinking-loader>
+    <app-thinking-loader [runningDelegations]="delegationTracker.runningCount()"></app-thinking-loader>
   }
 
   <!-- Go to Bottom Button -->

--- a/apps/client/src/app/components/chat-history/chat-history.component.ts
+++ b/apps/client/src/app/components/chat-history/chat-history.component.ts
@@ -18,6 +18,7 @@ import { UnreadMessagesService } from '../../services/unread-messages.service'
 import { VoiceSynthesisService } from '../../services/voice-synthesis.service'
 import { PreferencesService } from '../../services/preferences.service'
 import { CodayService } from '../../core/services/coday.service'
+import { DelegationTrackerService } from '../../core/services/delegation-tracker.service'
 import { Subject } from 'rxjs'
 import { MatIcon } from '@angular/material/icon'
 import { ThinkingLoaderComponent } from '../thinking-loader/thinking-loader.component'
@@ -65,6 +66,7 @@ export class ChatHistoryComponent implements AfterViewChecked, OnInit, OnDestroy
   private voiceSynthesisService = inject(VoiceSynthesisService)
   private preferencesService = inject(PreferencesService)
   private codayService = inject(CodayService)
+  readonly delegationTracker = inject(DelegationTrackerService)
   private markdownService = inject(MarkdownService)
   private sanitizer = inject(DomSanitizer)
 

--- a/apps/client/src/app/components/thinking-loader/thinking-loader.component.html
+++ b/apps/client/src/app/components/thinking-loader/thinking-loader.component.html
@@ -5,7 +5,16 @@
         <div class="logo-container">
           <img src="CODAY-Logo.png" alt="Coday Logo" class="coday-logo" />
         </div>
-        <p class="thinking-text">{{ currentThinkingPhrase }}</p>
+        <p class="thinking-text">
+          {{ currentThinkingPhrase }}
+          @if (runningDelegations > 0) {
+            <span class="delegation-suffix">
+              &nbsp;&mdash;&nbsp;{{ runningDelegations }}&nbsp;{{
+                runningDelegations === 1 ? 'sub-task' : 'sub-tasks'
+              }}&nbsp;running
+            </span>
+          }
+        </p>
       </div>
     </div>
   </div>

--- a/apps/client/src/app/components/thinking-loader/thinking-loader.component.scss
+++ b/apps/client/src/app/components/thinking-loader/thinking-loader.component.scss
@@ -60,6 +60,11 @@
   animation: fadeInOut 2s ease-in-out infinite;
   letter-spacing: 0.01em;
   font-style: italic;
+
+  .delegation-suffix {
+    opacity: 0.7;
+    font-style: normal;
+  }
 }
 
 @keyframes pulse {

--- a/apps/client/src/app/components/thinking-loader/thinking-loader.component.spec.ts
+++ b/apps/client/src/app/components/thinking-loader/thinking-loader.component.spec.ts
@@ -66,4 +66,32 @@ describe('ThinkingLoaderComponent', () => {
     component.ngOnDestroy()
     expect(stopSpy).toHaveBeenCalled()
   })
+
+  describe('runningDelegations suffix', () => {
+    it('should NOT show the delegation suffix when runningDelegations is 0', () => {
+      component.runningDelegations = 0
+      fixture.detectChanges()
+      const suffix = fixture.nativeElement.querySelector('.delegation-suffix')
+      expect(suffix).toBeNull()
+    })
+
+    it('should show singular "sub-task" when runningDelegations is 1', () => {
+      component.runningDelegations = 1
+      fixture.detectChanges()
+      const suffix = fixture.nativeElement.querySelector('.delegation-suffix')
+      expect(suffix).toBeTruthy()
+      expect(suffix?.textContent).toContain('1')
+      expect(suffix?.textContent).toContain('sub-task')
+      expect(suffix?.textContent).not.toContain('sub-tasks')
+    })
+
+    it('should show plural "sub-tasks" when runningDelegations is 3', () => {
+      component.runningDelegations = 3
+      fixture.detectChanges()
+      const suffix = fixture.nativeElement.querySelector('.delegation-suffix')
+      expect(suffix).toBeTruthy()
+      expect(suffix?.textContent).toContain('3')
+      expect(suffix?.textContent).toContain('sub-tasks')
+    })
+  })
 })

--- a/apps/client/src/app/components/thinking-loader/thinking-loader.component.ts
+++ b/apps/client/src/app/components/thinking-loader/thinking-loader.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core'
+import { Component, Input, OnInit, OnDestroy } from '@angular/core'
 import { CommonModule } from '@angular/common'
 
 @Component({
@@ -9,6 +9,9 @@ import { CommonModule } from '@angular/common'
   styleUrl: './thinking-loader.component.scss',
 })
 export class ThinkingLoaderComponent implements OnInit, OnDestroy {
+  /** Number of sub-tasks (delegations) currently running. 0 means no suffix is shown. */
+  @Input() runningDelegations: number = 0
+
   // Same thinking phrases as in chat-textarea
   private thinkingPhrases: string[] = ['Processing request...', 'Thinking...', 'Working on it...']
   currentThinkingPhrase: string = 'Processing request...'

--- a/apps/client/src/app/components/thread/thread.component.ts
+++ b/apps/client/src/app/components/thread/thread.component.ts
@@ -30,6 +30,7 @@ import { MatBadgeModule } from '@angular/material/badge'
 
 import { toSignal } from '@angular/core/rxjs-interop'
 import { CodayService } from '../../core/services/coday.service'
+import { DelegationTrackerService } from '../../core/services/delegation-tracker.service'
 import { OAuthService } from '../../core/services/oauth.service'
 import { ConnectionStatus } from '../../core/services/event-stream.service'
 import { PreferencesService } from '../../services/preferences.service'
@@ -136,6 +137,7 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
 
   // Modern Angular dependency injection
   private readonly codayService = inject(CodayService)
+  private readonly delegationTracker = inject(DelegationTrackerService)
   private readonly oauthService = inject(OAuthService)
 
   /** Signal exposing the current pending OAuth request for the template. */
@@ -275,8 +277,9 @@ export class ThreadComponent implements OnInit, OnDestroy, OnChanges, AfterViewC
       this.threadDetails = thread
     })
 
-    // Reset messages when switching threads
+    // Reset messages and delegation tracker when switching threads
     this.codayService.resetMessages()
+    this.delegationTracker.reset()
 
     // Connect services (to avoid circular dependency)
     this.codayService.setTabTitleService(this.titleService)

--- a/apps/client/src/app/core/services/delegation-tracker.service.spec.ts
+++ b/apps/client/src/app/core/services/delegation-tracker.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing'
+import { Subject } from 'rxjs'
+import { DelegationTrackerService } from './delegation-tracker.service'
+import { CodayService } from './coday.service'
+import { CodayEvent, DelegationStatusEvent, TextEvent } from '@coday/model'
+
+/** Minimal CodayService mock exposing a controllable subThreadEvents$ subject. */
+function makeCodayServiceMock() {
+  const subject = new Subject<CodayEvent>()
+  return {
+    subThreadEvents$: subject.asObservable(),
+    _emit: (event: CodayEvent) => subject.next(event),
+  }
+}
+
+function makeStatusEvent(
+  threadId: string,
+  status: 'running' | 'completed' | 'failed' | 'interrupted'
+): DelegationStatusEvent {
+  return new DelegationStatusEvent({ status, threadId })
+}
+
+describe('DelegationTrackerService', () => {
+  let service: DelegationTrackerService
+  let mock: ReturnType<typeof makeCodayServiceMock>
+
+  beforeEach(() => {
+    mock = makeCodayServiceMock()
+    TestBed.configureTestingModule({
+      providers: [DelegationTrackerService, { provide: CodayService, useValue: mock }],
+    })
+    service = TestBed.inject(DelegationTrackerService)
+  })
+
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('should start with runningCount === 0', () => {
+    expect(service.runningCount()).toBe(0)
+  })
+
+  it('running event → runningCount === 1', () => {
+    mock._emit(makeStatusEvent('sub-1', 'running'))
+    expect(service.runningCount()).toBe(1)
+  })
+
+  it('two running events on different sub-threads → runningCount === 2', () => {
+    mock._emit(makeStatusEvent('sub-1', 'running'))
+    mock._emit(makeStatusEvent('sub-2', 'running'))
+    expect(service.runningCount()).toBe(2)
+  })
+
+  it('running then completed on the same threadId → runningCount === 0', () => {
+    mock._emit(makeStatusEvent('sub-1', 'running'))
+    mock._emit(makeStatusEvent('sub-1', 'completed'))
+    expect(service.runningCount()).toBe(0)
+  })
+
+  it('failed status decrements the count', () => {
+    mock._emit(makeStatusEvent('sub-1', 'running'))
+    mock._emit(makeStatusEvent('sub-1', 'failed'))
+    expect(service.runningCount()).toBe(0)
+  })
+
+  it('interrupted status decrements the count', () => {
+    mock._emit(makeStatusEvent('sub-1', 'running'))
+    mock._emit(makeStatusEvent('sub-1', 'interrupted'))
+    expect(service.runningCount()).toBe(0)
+  })
+
+  it('reset() clears the counter', () => {
+    mock._emit(makeStatusEvent('sub-1', 'running'))
+    mock._emit(makeStatusEvent('sub-2', 'running'))
+    service.reset()
+    expect(service.runningCount()).toBe(0)
+  })
+
+  it('non-DelegationStatusEvent events are ignored', () => {
+    mock._emit(new TextEvent({ text: 'hello', threadId: 'sub-1' }))
+    expect(service.runningCount()).toBe(0)
+  })
+})

--- a/apps/client/src/app/core/services/delegation-tracker.service.ts
+++ b/apps/client/src/app/core/services/delegation-tracker.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, OnDestroy, signal, inject } from '@angular/core'
+import { Subject } from 'rxjs'
+import { takeUntil, filter } from 'rxjs/operators'
+import { DelegationStatusEvent, DelegationStatus } from '@coday/model'
+import { CodayService } from './coday.service'
+
+/**
+ * Tracks the number of delegations (sub-threads) currently running.
+ *
+ * Subscribes to {@link CodayService#subThreadEvents$} and filters for
+ * {@link DelegationStatusEvent} instances. Maintains a flat map of sub-thread ID
+ * to last known status, and exposes the count of entries whose status is 'running'.
+ *
+ * Known limitation: {@link DelegationStatusEvent} is transient and never persisted
+ * in thread history. A page reload while delegations are in flight resets the counter
+ * to zero — this is an accepted trade-off; do not attempt to reconstruct this state.
+ */
+@Injectable({ providedIn: 'root' })
+export class DelegationTrackerService implements OnDestroy {
+  private readonly codayService = inject(CodayService)
+  private readonly destroy$ = new Subject<void>()
+
+  /** Last known status keyed by sub-thread ID. */
+  private readonly statusMap = new Map<string, DelegationStatus>()
+
+  private readonly _runningCount = signal<number>(0)
+
+  /** Number of delegations whose last known status is 'running'. */
+  readonly runningCount = this._runningCount.asReadonly()
+
+  constructor() {
+    this.codayService.subThreadEvents$
+      .pipe(
+        filter((event): event is DelegationStatusEvent => event instanceof DelegationStatusEvent),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((event) => {
+        this.statusMap.set(event.threadId!, event.status)
+        this.recount()
+      })
+  }
+
+  /**
+   * Clears the tracker. Call this whenever the active thread changes so that
+   * counts from a previous thread do not bleed into the new one.
+   */
+  reset(): void {
+    this.statusMap.clear()
+    this._runningCount.set(0)
+  }
+
+  private recount(): void {
+    let count = 0
+    for (const status of this.statusMap.values()) {
+      if (status === 'running') count++
+    }
+    this._runningCount.set(count)
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+}


### PR DESCRIPTION

<img width="428" height="65" alt="Capture d’écran 2026-08-07 à 10 31 16" src="https://github.com/user-attachments/assets/e6b0c678-1ffe-4a31-a5f7-e505b5e7de41" />

## Contexte

Pendant qu'un agent travaille, l'indicateur affiche une phrase tournante codée en dur (`Processing request... / Thinking... / Working on it...`) qui ne porte aucune information. Lorsque l'agent délègue — en particulier en mode synchrone, où il reste bloqué plusieurs minutes sur `Promise.allSettled` — rien ne permet de savoir si des sous-tâches sont en cours ni combien.

## Changements

Ajoute `DelegationTrackerService` (`apps/client/src/app/core/services/delegation-tracker.service.ts`) : un service d'état **purement dérivé**, qui s'abonne à `subThreadEvents$`, filtre les `DelegationStatusEvent`, maintient une `Map<subThreadId, DelegationStatus>` et expose un signal `runningCount`.

`ThinkingLoaderComponent` reçoit ce compte et suffixe sa phrase : `Working on it... — 2 sub-tasks running`. Le suffixe n'apparaît que si le compte est strictement positif — pas de `(0 sub-tasks)`, l'indicateur reste silencieux quand il n'a rien à dire.

Le compteur est remis à zéro au changement de thread, aux côtés du `resetMessages()` existant dans `ThreadComponent`.

## Choix d'architecture

Aucune modification du runtime ni du contrat d'événements : toute l'information nécessaire transite déjà par `subThreadEvents$`, le client ne la matérialisait simplement pas.

L'alternative consistant à enrichir `ThinkingEvent` d'un compteur et à créer un registre côté serveur a été écartée : elle aurait couplé un signal de vivacité à un état métier et dupliqué un état que le flux d'événements exprime déjà.

Le service est délibérément tenu hors de `CodayService`, déjà très chargé (connexion, messages, invites, choices, streaming).

## Limitation assumée

`DelegationStatusEvent` étant transient, un rechargement de page en pleine délégation remet le compteur à zéro alors que les sous-threads tournent encore. C'est un indicateur de confort pendant une session active, pas une source de vérité. Le combler demanderait un registre côté runtime rejoué à la connexion SSE — le pattern existe déjà avec `replayLastQuestion()` — et pourra s'ajouter par-dessus sans rien remettre en cause. La limitation est documentée en JSDoc dans le service.

## Validation

- `pnpm nx build client` : OK
- `pnpm nx run-many -t lint test -p client` : OK (26/26 tests, 0 erreur lint)

Tests unitaires ajoutés pour le service (comptage, statuts terminaux, reset, événements ignorés) et pour l'affichage conditionnel du suffixe (zéro / singulier / pluriel).

## Stack

Seconde PR d'une pile de deux. Cible `feature/romain-petit-whoz/delegation-status-icon` et non `master`, car elle dépend du `DelegationStatusEvent` introduit par la PR précédente. À merger après celle-ci.