### PR TITLE
fix: wz-33620 improve coroutine handling in scheduled prompt UserRun consumption + other fixes

### DIFF
--- a/.idea/runConfigurations/AgentOSApplication.xml
+++ b/.idea/runConfigurations/AgentOSApplication.xml
@@ -4,7 +4,7 @@
     <envs>
       <env name="AGENTOS_ENCRYPTION_KEY" value="NONE" />
       <env name="AGENTOS_ENCRYPTION_SALT" value="NONE" />
-      <env name="AGENTOS_PROMPT_SCHEDULER_ENABLED" value="false" />
+      <env name="AGENTOS_PROMPT_SCHEDULER_ENABLED" value="true" />
     </envs>
     <module name="agentos-service.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.whozoss.agentos.AgentOSApplication" />

--- a/.idea/runConfigurations/AgentOSApplication.xml
+++ b/.idea/runConfigurations/AgentOSApplication.xml
@@ -4,6 +4,7 @@
     <envs>
       <env name="AGENTOS_ENCRYPTION_KEY" value="NONE" />
       <env name="AGENTOS_ENCRYPTION_SALT" value="NONE" />
+      <env name="AGENTOS_PROMPT_SCHEDULER_ENABLED" value="false" />
     </envs>
     <module name="agentos-service.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.whozoss.agentos.AgentOSApplication" />

--- a/.idea/runConfigurations/AgentOSRegisteredOnWhoz.xml
+++ b/.idea/runConfigurations/AgentOSRegisteredOnWhoz.xml
@@ -4,6 +4,7 @@
     <envs>
       <env name="PLUGINS_DIR" value="./plugins" />
       <env name="SERVER_PORT" value="8125" />
+      <env name="AGENTOS_PROMPT_SCHEDULER_ENABLED" value="false" />
     </envs>
     <module name="agentos-service.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.whozoss.agentos.AgentOSApplication" />

--- a/.idea/runConfigurations/AgentOSSprint-rcDB.xml
+++ b/.idea/runConfigurations/AgentOSSprint-rcDB.xml
@@ -1,6 +1,9 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AgentOSApplication - sprint-rc" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <option name="ACTIVE_PROFILES" value="priv,development,transient,neo4j-sprint-rc,neo4j-sprint-rc_transient" />
+    <envs>
+      <env name="AGENTOS_PROMPT_SCHEDULER_ENABLED" value="false" />
+    </envs>
     <module name="agentos-service.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.whozoss.agentos.AgentOSApplication" />
     <option name="WORKING_DIRECTORY" value="file://agentos" />

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRepository.kt
@@ -97,6 +97,9 @@ open class Neo4jScheduledPromptRepository(
     override fun advanceNextRunAt(id: UUID, currentSlot: Instant, nextSlot: Instant): Boolean =
         neo4jRepository.advanceNextRunAt(id.toString(), currentSlot, nextSlot)
 
+    override fun updateEnabled(id: UUID, enabled: Boolean) =
+        neo4jRepository.updateEnabled(id.toString(), enabled)
+
     @Transactional
     open override fun deleteByParent(parentId: UUID): Int {
         val active = neo4jRepository.findActiveByNamespaceId(parentId.toString())

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Neo4jScheduledPromptRunRepository.kt
@@ -48,8 +48,8 @@ open class Neo4jScheduledPromptRunRepository(
     override fun findById(id: UUID): ScheduledPromptRun? =
         neo4jRepository.findById(id.toString()).orElse(null)?.toDomain()
 
-    override fun countCompletedRuns(scheduledPromptId: UUID): Int =
-        neo4jRepository.countCompletedRuns(scheduledPromptId.toString())
+    override fun countCompletedRuns(scheduledPromptId: UUID, startInstant: Instant): Int =
+        neo4jRepository.countCompletedRuns(scheduledPromptId.toString(), startInstant)
 
     override fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun> =
         neo4jRepository.findByStatusAndCreatedBefore(RunStatus.CLAIMED.name, olderThan)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -298,7 +298,6 @@ class ScheduledPromptExecutor(
         }
         return UserRunContext(
             namespaceId = namespaceId,
-            caseTitle = scheduledPrompt.name,
             actor = Actor(id = userRun.userId.toString(), displayName = user.displayName(), role = ActorRole.USER),
             // Inject resolved content with @mention — selectAgent resolves the agent,
             // PromptCommandParser sees no /command and passes text through unchanged.
@@ -316,7 +315,7 @@ class ScheduledPromptExecutor(
      * a UNIQUE constraint on Case keyed by (runId, userId).
      */
     private fun createAndInjectCase(userRun: ScheduledPromptUserRun, context: UserRunContext): UUID {
-        val case = caseService.create(Case(namespaceId = context.namespaceId, title = context.caseTitle))
+        val case = caseService.create(Case(namespaceId = context.namespaceId))
         permissionService.grantPermission(
             userRun.userId.toString(),
             EntityType.CASE,
@@ -350,7 +349,6 @@ class ScheduledPromptExecutor(
     /** Resolved execution context for a single [ScheduledPromptUserRun]. */
     private data class UserRunContext(
         val namespaceId: UUID,
-        val caseTitle: String,
         val actor: Actor,
         val message: String,
     )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -55,17 +55,18 @@ import java.util.UUID
  *    [CaseService.addMessage]. The Executor resolves content itself rather than using
  *    a `/slash-command` because PromptCommandParser requires the text to start with `/`,
  *    which is incompatible with the leading `@mention`.
- * 5. Await the Case launch: collect the runtime's [CaseRuntime.statusFlow] for up to
- *    [SchedulerProperties.launchTimeoutSeconds] seconds to detect immediate failures.
- *    If the Case reaches IDLE or is still RUNNING after the timeout, the UserRun is
- *    closed as DONE (the Case continues independently). Only an immediate terminal
- *    status (ERROR/KILLED) marks the UserRun as FAILED.
+ * 5. Await the Case launch: inspect the runtime's [CaseRuntime.statusFlow] current value,
+ *    then observe future transitions for up to [SchedulerProperties.launchTimeoutSeconds]
+ *    seconds to detect immediate failures. If the Case is IDLE (turn finished) it is closed
+ *    as DONE. If still RUNNING after the timeout, monitoring is released (Case continues
+ *    independently) and the UserRun is closed as TIMEOUT. An immediate terminal status
+ *    (ERROR/KILLED) marks the UserRun as FAILED.
  *
- * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
- * UserRuns are grouped by their parent Run and each group is processed concurrently
- * under a [supervisorScope] so a failure in one group does not affect the others.
- * Further burst control is delegated to Spring AI's `RetryTemplate` on each `ChatModel`
- * (exponential backoff on 429 rate-limit responses).
+ * Concurrency is bounded by [SchedulerProperties.batchSize]: at most that many UserRuns
+ * are claimed per batch. Within a batch, UserRuns are grouped by their parent Run and each
+ * group is processed concurrently under a [supervisorScope] so a failure in one group does
+ * not cancel the others. Further burst control is delegated to Spring AI's `RetryTemplate`
+ * on each `ChatModel` (exponential backoff on 429 rate-limit responses).
  *
  * ### Completion check
  *
@@ -113,8 +114,12 @@ class ScheduledPromptExecutor(
      * consumed) nor a RUNNING Run with no UserRuns can result.
      *
      * Note: the Run insert happens in [SchedulerScanner.claim], **outside** this transaction.
-     * A crash between the insert and this call leaves an orphaned CLAIMED Run, which
-     * [SchedulerScanner.recoverOrphanedClaimedRuns] detects and marks FAILED on the next tick.
+     * A crash between the insert and this call, or an exception thrown by
+     * [ScheduledPromptUserRunRepository.materialize], leaves an orphaned CLAIMED Run —
+     * Spring rolls back the transaction so no partial UserRuns are written.
+     * [SchedulerScanner.recoverOrphanedClaimedRuns] detects such orphans and marks them
+     * FAILED on the next tick. The caller ([SchedulerScanner.claim]) is protected by
+     * `runCatching` so one failure does not block other prompts in the same tick.
      */
     @Transactional
     fun materialize(run: ScheduledPromptRun, scheduledPrompt: ScheduledPrompt) {
@@ -123,22 +128,6 @@ class ScheduledPromptExecutor(
         }
 
         val namespaceId = scheduledPrompt.namespaceId
-        val count = when {
-            namespaceId == null -> {
-                logger.debug {
-                    "[Executor] Platform-scope sp=${scheduledPrompt.id} — no users to materialise"
-                }
-                0
-            }
-            else -> runCatching {
-                userRunRepository.materialize(run.id, scheduledPrompt.agentConfigId, namespaceId)
-            }.onFailure { e ->
-                logger.error(e) {
-                    "[Executor] materialize failed for run=${run.id} sp=${scheduledPrompt.id}"
-                }
-            }.getOrDefault(0)
-        }
-
         // Transition based on whether any UserRuns were created:
         // - RUNNING when count > 0 — Phase B will consume the UserRuns and checkCompletion
         //   will close the Run once all are terminal.
@@ -146,6 +135,21 @@ class ScheduledPromptExecutor(
         //   with no target users, or namespace with no deployed users). Transitioning to
         //   RUNNING would leave the Run stuck forever since checkCompletion requires at
         //   least one UserRun closure to trigger.
+        // - On exception from userRunRepository.materialize: the exception propagates,
+        //   Spring rolls back the transaction, and the Run stays CLAIMED. The sweep
+        //   recoverOrphanedClaimedRuns marks it FAILED on the next tick. The caller
+        //   (SchedulerScanner.claim) is protected by runCatching so one failure does
+        //   not block the other prompts in the same tick.
+        val count = when {
+            namespaceId == null -> {
+                logger.debug {
+                    "[Executor] Platform-scope sp=${scheduledPrompt.id} — no users to materialise"
+                }
+                0
+            }
+            else -> userRunRepository.materialize(run.id, scheduledPrompt.agentConfigId, namespaceId)
+        }
+
         val finalStatus = if (count > 0) RunStatus.RUNNING else RunStatus.DONE
         runRepository.updateStatus(run.id, finalStatus, if (count == 0) Instant.now(clock) else null)
 
@@ -174,16 +178,16 @@ class ScheduledPromptExecutor(
      * [coroutineScope] ensures that a failure in one UserRun coroutine does not cancel
      * the sibling coroutines processing other UserRuns in the same batch.
      *
-     * Runs on [Dispatchers.IO] so the coroutines launched inside [coroutineScope] execute on
+     * Runs on [Dispatchers.IO] so the coroutines launched inside [supervisorScope] execute on
      * the IO thread pool (default 64 threads) rather than being serialised on the caller's
      * single thread. This is required because [processUserRun] calls blocking Spring services
      * (Neo4j, CaseService, PermissionService) that would otherwise starve the coroutine dispatcher.
      *
-     * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
-     * UserRuns are grouped by their parent Run and each group is processed concurrently
-     * under a [supervisorScope] so a failure in one group does not cancel the others.
-     * Further burst control is delegated to Spring AI's `RetryTemplate`
-     * (exponential backoff on 429 responses).
+     * Concurrency is bounded by [SchedulerProperties.batchSize]: at most that many UserRuns
+     * are claimed per batch. Within a batch, UserRuns are grouped by their parent Run and
+     * each group is processed concurrently under a [supervisorScope] so a failure in one
+     * group does not cancel the others. Further burst control is delegated to Spring AI's
+     * `RetryTemplate` (exponential backoff on 429 responses).
      *
      * ### Delivery guarantee: at-least-once
      *
@@ -193,16 +197,25 @@ class ScheduledPromptExecutor(
      * This is acceptable for the scheduled-prompt use case (duplicate conversation,
      * no data corruption). Exactly-once would require an idempotence key on Case
      * creation (e.g. a UNIQUE constraint on `runId|userId` carried by the Case).
+     *
+     * ### Completion sweep
+     *
+     * UserRuns are grouped by their parent Run so the completion check fires once per Run
+     * at the end of each group. [SchedulerScanner.recoverOrphanedRunningRuns] covers the
+     * crash window between the last [markTerminal] and the completion check.
      */
     suspend fun consumeAvailable() = withContext(Dispatchers.IO) {
         val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
 
-        // Group UserRuns by their parent Run so each Run's UserRuns and completion
-        // check are handled together in one coroutine — no need for a separate sweep.
+        // Group by parent Run so the completion check fires once per Run rather than
+        // once per UserRun. Each group runs concurrently under supervisorScope.
         var batch: List<ScheduledPromptUserRun>
         do {
             batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)
             supervisorScope {
+                // Group by parent Run so the completion check fires once per Run rather than
+                // once per UserRun. Each group runs concurrently; a failure in one group does
+                // not cancel the others (supervisorScope semantics).
                 batch.groupBy { it.runId }.forEach { (runId, userRuns) ->
                     launch { processUserRunGroup(runId, userRuns) }
                 }
@@ -256,7 +269,7 @@ class ScheduledPromptExecutor(
     /**
      * Resolve all data required to execute a [ScheduledPromptUserRun].
      * Throws [IllegalStateException] on any missing entity — propagates to the
-     * [runCatchingNonCancelling] in [processUserRunGroup] which marks the UserRun FAILED.
+     * try/catch in [processUserRunGroup] which marks the UserRun FAILED.
      */
     private fun resolveContext(userRun: ScheduledPromptUserRun): UserRunContext {
         val run = checkNotNull(runRepository.findById(userRun.runId)) {
@@ -362,6 +375,24 @@ class ScheduledPromptExecutor(
      * The Case continues running independently after this method returns.
      * The lease on the UserRun is only relevant for crash recovery (instance down
      * between Case creation and this point).
+     *
+     * ### StateFlow current-value guard
+     *
+     * [CaseRuntime.statusFlow] is a [kotlinx.coroutines.flow.StateFlow]. Calling `.first { predicate }`
+     * on a StateFlow always evaluates the **current value** first: if it satisfies the predicate,
+     * it is returned immediately without suspending.
+     *
+     * The status lifecycle in [CaseRuntime.run] is: `PENDING → RUNNING → IDLE/ERROR/KILLED`.
+     * `statusFlow` is initialised to `PENDING` at construction. The only status that can cause
+     * a false early return is **IDLE**: if a very fast turn completes before `monitorLaunch` is
+     * called, `statusFlow.value` is already `IDLE`, and `.first { it == IDLE || it.isTerminal() }`
+     * returns it immediately — which is actually the correct behaviour (the turn did finish).
+     *
+     * The guard below makes the intent explicit and handles the `IDLE` case without relying on
+     * the implicit StateFlow current-value semantics:
+     * - Already IDLE or terminal → the turn finished before we arrived; act on it directly.
+     * - PENDING or RUNNING → neither satisfies the predicate, so `.first { … }` suspends and
+     *   waits for the next emission, bounded by the timeout.
      */
     private suspend fun monitorLaunch(
         userRunId: UUID,
@@ -369,18 +400,26 @@ class ScheduledPromptExecutor(
         runtime: CaseRuntime,
     ) {
         val timeoutMs = Duration.ofSeconds(properties.launchTimeoutSeconds).toMillis()
+        val currentStatus = runtime.statusFlow.value
 
-        val finalStatus = withTimeoutOrNull(timeoutMs) {
-            runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
+        val observedStatus = when {
+            currentStatus == CaseStatus.IDLE || currentStatus.isTerminal() -> {
+                // The turn already completed before we started monitoring — act on it directly.
+                currentStatus
+            }
+            else -> {
+                // Status is RUNNING: drop the current value and wait for the next transition.
+                // withTimeoutOrNull returns null on timeout (Case still in flight).
+                withTimeoutOrNull(timeoutMs) {
+                    runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
+                }
+            }
         }
 
         when {
-            finalStatus != null && finalStatus.isTerminal() ->
-                // Immediate terminal status (ERROR/KILLED) — execution failed.
-                closeUserRun(userRunId, finalStatus, caseId)
-            finalStatus == CaseStatus.IDLE ->
-                // Agent finished its turn before the timeout — clean completion.
-                closeUserRun(userRunId, CaseStatus.IDLE, caseId)
+            observedStatus != null ->
+                // Either finished quickly (IDLE) or crashed immediately (ERROR/KILLED).
+                closeUserRun(userRunId, observedStatus, caseId)
             else -> {
                 // Timeout — Case is still RUNNING; monitoring released, Case continues independently.
                 userRunRepository.markTerminal(userRunId, UserRunStatus.TIMEOUT, Instant.now(clock))
@@ -436,7 +475,7 @@ class ScheduledPromptExecutor(
      */
     private fun checkCompletion(runId: UUID) {
         val run = runRepository.findById(runId) ?: return
-        if (run.status != RunStatus.RUNNING && run.status != RunStatus.CLAIMED) return
+        if (run.status != RunStatus.RUNNING) return
 
         if (userRunRepository.hasAnyActive(runId)) return
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -62,11 +62,10 @@ import java.util.UUID
  *    status (ERROR/KILLED) marks the UserRun as FAILED.
  *
  * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
- * each batch contains at most that many UserRuns, and all are launched as structured
- * coroutines within a single [coroutineScope]. A short stagger delay
- * ([SchedulerProperties.launchStaggerMs]) between each `launch` spreads the initial
- * burst to reduce memory pressure. Further burst control is delegated to Spring AI's `RetryTemplate`
- * on each `ChatModel` (exponential backoff on 429 rate-limit responses).
+ * UserRuns are grouped by their parent Run and each group is processed concurrently
+ * under a [supervisorScope] so a failure in one group does not affect the others.
+ * Further burst control is delegated to Spring AI's `RetryTemplate` on each `ChatModel`
+ * (exponential backoff on 429 rate-limit responses).
  *
  * ### Completion check
  *
@@ -181,10 +180,9 @@ class ScheduledPromptExecutor(
      * (Neo4j, CaseService, PermissionService) that would otherwise starve the coroutine dispatcher.
      *
      * Concurrency is bounded by the batch size ([SchedulerProperties.batchSize]):
-     * each batch contains at most that many UserRuns, all launched as structured coroutines
-     * within a single [coroutineScope]. A short [SchedulerProperties.launchStaggerMs] delay
-     * between each `launch` spreads the initial burst to reduce memory pressure (OOM observed
-     * on CI without stagger). Further burst control is delegated to Spring AI's `RetryTemplate`
+     * UserRuns are grouped by their parent Run and each group is processed concurrently
+     * under a [supervisorScope] so a failure in one group does not cancel the others.
+     * Further burst control is delegated to Spring AI's `RetryTemplate`
      * (exponential backoff on 429 responses).
      *
      * ### Delivery guarantee: at-least-once
@@ -221,10 +219,10 @@ class ScheduledPromptExecutor(
      * completion of the parent Run.
      *
      * Each UserRun is launched under a [supervisorScope] so an individual failure does
-     * not cancel its siblings. Exceptions from [processUserRun] are caught via
-     * [runCatching]: [CancellationException] is re-thrown (cooperative cancellation),
-     * all other exceptions mark the UserRun as FAILED. Once all UserRuns have settled,
-     * [checkCompletion] transitions the parent Run to DONE or FAILED.
+     * not cancel its siblings. Exceptions are caught at the launch site: [CancellationException]
+     * is re-thrown to preserve cooperative cancellation, all other exceptions mark the
+     * UserRun as FAILED. Once all UserRuns have settled, [checkCompletion] transitions
+     * the parent Run to DONE or FAILED.
      */
     private suspend fun processUserRunGroup(runId: UUID, userRuns: List<ScheduledPromptUserRun>) {
         supervisorScope {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -259,7 +259,9 @@ class ScheduledPromptExecutor(
         }
         // All UserRuns for this Run have finished — check completion immediately.
         // The sweep recoverOrphanedRunningRuns covers crashes between markTerminal and this point.
-        checkCompletion(runId)
+        runCatching { checkCompletion(runId) }.onFailure { e ->
+            logger.error(e) { "[Executor] checkCompletion failed for run=$runId" }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -202,7 +202,8 @@ class ScheduledPromptExecutor(
      *
      * UserRuns are grouped by their parent Run so the completion check fires once per Run
      * at the end of each group. [SchedulerScanner.recoverOrphanedRunningRuns] covers the
-     * crash window between the last [markTerminal] and the completion check.
+     * crash window between the last [markTerminal] and the completion check, as well as
+     * any failure thrown by [checkCompletion] itself.
      */
     suspend fun consumeAvailable() = withContext(Dispatchers.IO) {
         val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
@@ -235,7 +236,8 @@ class ScheduledPromptExecutor(
      * not cancel its siblings. Exceptions are caught at the launch site: [CancellationException]
      * is re-thrown to preserve cooperative cancellation, all other exceptions mark the
      * UserRun as FAILED. Once all UserRuns have settled, [checkCompletion] transitions
-     * the parent Run to DONE or FAILED.
+     * the parent Run to DONE or FAILED. A failure in [checkCompletion] is caught and logged;
+     * the Run is recovered by [SchedulerScanner.recoverOrphanedRunningRuns] on the next tick.
      */
     private suspend fun processUserRunGroup(runId: UUID, userRuns: List<ScheduledPromptUserRun>) {
         supervisorScope {
@@ -478,9 +480,10 @@ class ScheduledPromptExecutor(
      * ### Crash window
      *
      * If the instance crashes after the last [ScheduledPromptUserRunRepository.markTerminal]
-     * but before this method runs, the Run stays RUNNING forever — no subsequent UserRun
-     * closure will re-trigger this check. [SchedulerScanner.recoverOrphanedRunningRuns]
-     * handles this by re-evaluating the completion condition on every tick.
+     * but before this method runs, or if this method throws, the Run stays RUNNING forever —
+     * no subsequent UserRun closure will re-trigger this check.
+     * [SchedulerScanner.recoverOrphanedRunningRuns] handles both cases by re-evaluating
+     * the completion condition on every tick.
      */
     private fun checkCompletion(runId: UUID) {
         val run = runRepository.findById(runId) ?: return

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -298,6 +298,7 @@ class ScheduledPromptExecutor(
         }
         return UserRunContext(
             namespaceId = namespaceId,
+            caseTitle = "${scheduledPrompt.name} ${run.scheduledFor}",
             actor = Actor(id = userRun.userId.toString(), displayName = user.displayName(), role = ActorRole.USER),
             // Inject resolved content with @mention — selectAgent resolves the agent,
             // PromptCommandParser sees no /command and passes text through unchanged.
@@ -315,7 +316,7 @@ class ScheduledPromptExecutor(
      * a UNIQUE constraint on Case keyed by (runId, userId).
      */
     private fun createAndInjectCase(userRun: ScheduledPromptUserRun, context: UserRunContext): UUID {
-        val case = caseService.create(Case(namespaceId = context.namespaceId))
+        val case = caseService.create(Case(namespaceId = context.namespaceId, title = context.caseTitle))
         permissionService.grantPermission(
             userRun.userId.toString(),
             EntityType.CASE,
@@ -349,6 +350,7 @@ class ScheduledPromptExecutor(
     /** Resolved execution context for a single [ScheduledPromptUserRun]. */
     private data class UserRunContext(
         val namespaceId: UUID,
+        val caseTitle: String,
         val actor: Actor,
         val message: String,
     )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -13,11 +13,11 @@ import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.user.UserService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
@@ -170,8 +170,10 @@ class ScheduledPromptExecutor(
      * Each batch is claimed via [ScheduledPromptUserRunRepository.claimBatch], which
      * uses SDN `@Version` optimistic locking so concurrent instances cannot double-claim
      * the same UserRun. Within a batch, each UserRun is launched as a structured
-     * coroutine inside [coroutineScope]; the scope suspends until all launched children
-     * finish before the next batch is claimed.
+     * coroutine inside [supervisorScope]; the scope suspends until all launched children
+     * finish before the next batch is claimed. Using [supervisorScope] instead of
+     * [coroutineScope] ensures that a failure in one UserRun coroutine does not cancel
+     * the sibling coroutines processing other UserRuns in the same batch.
      *
      * Runs on [Dispatchers.IO] so the coroutines launched inside [coroutineScope] execute on
      * the IO thread pool (default 64 threads) rather than being serialised on the caller's
@@ -197,150 +199,150 @@ class ScheduledPromptExecutor(
     suspend fun consumeAvailable() = withContext(Dispatchers.IO) {
         val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
 
+        // Group UserRuns by their parent Run so each Run's UserRuns and completion
+        // check are handled together in one coroutine — no need for a separate sweep.
         var batch: List<ScheduledPromptUserRun>
         do {
             batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)
-            val runIds = batch.map { it.runId }.toSet()
-
-            coroutineScope {
-                for (userRun in batch) {
-                    logger.info {
-                        "[Executor] Phase B: claimed UserRun=${userRun.id} runId=${userRun.runId} userId=${userRun.userId}"
-                    }
-
-                    launch {
-                        processUserRun(userRun)
-                    }
-
-                    // Stagger launches to spread the initial burst and reduce memory pressure.
-                    // Without this delay, simultaneous Case+Runtime creation for a full batch
-                    // causes OOM on CI. Once launched, coroutines run concurrently.
-                    delay(properties.launchStaggerMs)
+            supervisorScope {
+                batch.groupBy { it.runId }.forEach { (runId, userRuns) ->
+                    launch { processUserRunGroup(runId, userRuns) }
                 }
             }
-
-            // All UserRuns in this batch have finished — check completion once per Run.
-            // The sweep recoverOrphanedRunningRuns covers crashes between markTerminal
-            // and this point.
-            runIds.forEach { checkCompletion(it) }
         } while (batch.isNotEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-Run processing
+    // -------------------------------------------------------------------------
+
+    /**
+     * Process all [userRuns] belonging to the same [runId] concurrently, then check
+     * completion of the parent Run.
+     *
+     * Each UserRun is launched under a [supervisorScope] so an individual failure does
+     * not cancel its siblings. Exceptions from [processUserRun] are caught via
+     * [runCatching]: [CancellationException] is re-thrown (cooperative cancellation),
+     * all other exceptions mark the UserRun as FAILED. Once all UserRuns have settled,
+     * [checkCompletion] transitions the parent Run to DONE or FAILED.
+     */
+    private suspend fun processUserRunGroup(runId: UUID, userRuns: List<ScheduledPromptUserRun>) {
+        supervisorScope {
+            userRuns.forEach { userRun ->
+                logger.info {
+                    "[Executor] Phase B: claimed UserRun=${userRun.id} runId=${userRun.runId} userId=${userRun.userId}"
+                }
+                launch {
+                    try {
+                        val context = resolveContext(userRun)
+                        val caseId = createAndInjectCase(userRun, context)
+                        awaitLaunch(userRun.id, caseId)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.error(e) { "[Executor] UserRun=${userRun.id} failed for user=${userRun.userId}" }
+                        markFailed(userRun.id, Instant.now(clock), e.message ?: "Unknown error")
+                    }
+                }
+            }
+        }
+        // All UserRuns for this Run have finished — check completion immediately.
+        // The sweep recoverOrphanedRunningRuns covers crashes between markTerminal and this point.
+        checkCompletion(runId)
     }
 
     // -------------------------------------------------------------------------
     // Single UserRun processing
     // -------------------------------------------------------------------------
 
-    private suspend fun processUserRun(userRun: ScheduledPromptUserRun) {
-        val now = Instant.now(clock)
-        val runId = userRun.runId
-        val userId = userRun.userId
-
-        try {
-            // --- Resolve context ---
-            // Each check is required: the resolved value is consumed below to create the Case,
-            // build the Actor, or compose the message. IllegalStateException on missing data
-            // is caught by the outer try/catch and marks the UserRun FAILED with a diagnostic.
-
-            val run = checkNotNull(runRepository.findById(runId)) {
-                "Parent Run $runId not found"
-            }
-
-            val scheduledPrompt = scheduledPromptRepository.findByIds(listOf(run.scheduledPromptId))
-                .firstOrNull()
-                ?: error("ScheduledPrompt ${run.scheduledPromptId} not found")
-
-            val namespaceId = checkNotNull(scheduledPrompt.namespaceId) {
-                "Platform-scope ScheduledPrompt cannot be executed per-user"
-            }
-
-            val user = checkNotNull(userService.findById(userId)) {
-                "User $userId not found"
-            }
-
-            // Resolve the prompt content directly — the Executor is the consumer of the prompt
-            // and has the full context (userId, namespaceId, scheduling metadata) needed to
-            // resolve it. Injecting a /slash-command would fail because addMessage's
-            // PromptCommandParser requires text to start with '/' but the @mention prefix
-            // prevents that.
-            val prompt = checkNotNull(promptService.findById(scheduledPrompt.promptTemplateId)) {
-                "PromptTemplate ${scheduledPrompt.promptTemplateId} not found"
-            }
-
-            // Mono-line content (enforced by ScheduledPromptService validation).
-            // Future: resolve {{placeholders}} here with execution context (user name, date, etc.)
-            val promptContent = prompt.content.firstOrNull()?.takeIf { it.isNotBlank() }
-                ?: error("PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content")
-
-            // Resolve the agent name — prepended as @mention so selectAgent picks it up
-            // via the normal @mention resolution path (no special-casing in the runtime).
-            val agentName = checkNotNull(agentConfigService.findById(scheduledPrompt.agentConfigId)?.name) {
-                "AgentConfig ${scheduledPrompt.agentConfigId} not found"
-            }
-
+    /**
+     * Resolve all data required to execute a [ScheduledPromptUserRun].
+     * Throws [IllegalStateException] on any missing entity — propagates to the
+     * [runCatchingNonCancelling] in [processUserRunGroup] which marks the UserRun FAILED.
+     */
+    private fun resolveContext(userRun: ScheduledPromptUserRun): UserRunContext {
+        val run = checkNotNull(runRepository.findById(userRun.runId)) {
+            "Parent Run ${userRun.runId} not found"
+        }
+        val scheduledPrompt = scheduledPromptRepository.findByIds(listOf(run.scheduledPromptId))
+            .firstOrNull()
+            ?: error("ScheduledPrompt ${run.scheduledPromptId} not found")
+        val namespaceId = checkNotNull(scheduledPrompt.namespaceId) {
+            "Platform-scope ScheduledPrompt cannot be executed per-user"
+        }
+        val user = checkNotNull(userService.findById(userRun.userId)) {
+            "User ${userRun.userId} not found"
+        }
+        val prompt = checkNotNull(promptService.findById(scheduledPrompt.promptTemplateId)) {
+            "PromptTemplate ${scheduledPrompt.promptTemplateId} not found"
+        }
+        // Mono-line content (enforced by ScheduledPromptService validation).
+        // Future: resolve {{placeholders}} here with execution context (user name, date, etc.)
+        val promptContent = prompt.content.firstOrNull()?.takeIf { it.isNotBlank() }
+            ?: error("PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content")
+        // Resolve the agent name — prepended as @mention so selectAgent picks it up
+        // via the normal @mention resolution path (no special-casing in the runtime).
+        val agentName = checkNotNull(agentConfigService.findById(scheduledPrompt.agentConfigId)?.name) {
+            "AgentConfig ${scheduledPrompt.agentConfigId} not found"
+        }
+        return UserRunContext(
+            namespaceId = namespaceId,
+            caseTitle = scheduledPrompt.name,
+            actor = Actor(id = userRun.userId.toString(), displayName = user.displayName(), role = ActorRole.USER),
             // Inject resolved content with @mention — selectAgent resolves the agent,
             // PromptCommandParser sees no /command and passes text through unchanged.
-            val message = "@$agentName $promptContent"
+            message = "@$agentName $promptContent",
+        )
+    }
 
-            // --- Execute ---
+    /**
+     * Create a [Case], grant ADMIN to the target user, and inject the prompt message.
+     * Returns the created [Case] id.
+     *
+     * No idempotence key links the Case to the UserRun — if the instance crashes after
+     * this point but before markTerminal(), the lease expires and another instance will
+     * create a second Case for the same user (at-least-once). Exactly-once would require
+     * a UNIQUE constraint on Case keyed by (runId, userId).
+     */
+    private fun createAndInjectCase(userRun: ScheduledPromptUserRun, context: UserRunContext): UUID {
+        val case = caseService.create(Case(namespaceId = context.namespaceId, title = context.caseTitle))
+        permissionService.grantPermission(
+            userRun.userId.toString(),
+            EntityType.CASE,
+            case.id.toString(),
+            PermissionRelation.ADMIN,
+        )
+        caseService.addMessage(
+            caseId = case.id,
+            actor = context.actor,
+            content = listOf(MessageContent.Text(context.message)),
+        )
+        logger.info {
+            "[Executor] UserRun=${userRun.id} — Case ${case.id} created and message injected for user=${userRun.userId}"
+        }
+        return case.id
+    }
 
-            // Step 1: Create the Case.
-            // No idempotence key links this Case to the UserRun — if the instance crashes
-            // after this point but before markTerminal(), the lease expires and another
-            // instance will create a second Case for the same user (at-least-once).
-            // Exactly-once would require a UNIQUE constraint on Case keyed by (runId, userId).
-            val case = caseService.create(
-                Case(
-                    namespaceId = namespaceId,
-                    title = scheduledPrompt.name,
-                ),
-            )
-            val caseId = case.id
-
-            // Step 2: Grant ADMIN to the target user.
-            permissionService.grantPermission(
-                userId.toString(),
-                EntityType.CASE,
-                caseId.toString(),
-                PermissionRelation.ADMIN,
-            )
-
-            // Step 3: Build Actor.
-            val actor = Actor(
-                id = userId.toString(),
-                displayName = user.displayName(),
-                role = ActorRole.USER,
-            )
-
-            // Step 4: Inject the prompt message.
-            // addMessage internally launches runtime.run() in CaseServiceImpl.scope.
-            caseService.addMessage(
-                caseId = caseId,
-                actor = actor,
-                content = listOf(MessageContent.Text(message)),
-            )
-
-            logger.info {
-                "[Executor] UserRun=${userRun.id} — Case $caseId created and message injected for user=$userId"
-            }
-
-            // Step 5: Await launch — detect immediate failures.
-            // The runtime is guaranteed to exist in activeRuntimes right after create().
-            // If the Case is still RUNNING after the timeout, it's healthy — close as DONE.
-            // Only an immediate terminal status (ERROR/KILLED) means the launch failed.
-            val runtime = caseService.findActiveRuntime(caseId)
-            if (runtime == null) {
-                // Runtime already evicted (terminal status reached before we got here)
-                closeUserRun(userRun.id, caseService.findById(caseId)?.status, caseId)
-            } else {
-                monitorLaunch(userRun.id, caseId, runtime)
-            }
-        } catch (e: Exception) {
-            logger.error(e) {
-                "[Executor] UserRun=${userRun.id} failed for user=$userId"
-            }
-            markFailed(userRun.id, now, e.message ?: "Unknown error")
+    /**
+     * Await the Case launch and close the UserRun based on the observed [CaseStatus].
+     * If no active runtime is found, the Case already reached a terminal status.
+     */
+    private suspend fun awaitLaunch(userRunId: UUID, caseId: UUID) {
+        val runtime = caseService.findActiveRuntime(caseId)
+        if (runtime == null) {
+            closeUserRun(userRunId, caseService.findById(caseId)?.status, caseId)
+        } else {
+            monitorLaunch(userRunId, caseId, runtime)
         }
     }
+
+    /** Resolved execution context for a single [ScheduledPromptUserRun]. */
+    private data class UserRunContext(
+        val namespaceId: UUID,
+        val caseTitle: String,
+        val actor: Actor,
+        val message: String,
+    )
 
     // -------------------------------------------------------------------------
     // Case completion
@@ -374,17 +376,19 @@ class ScheduledPromptExecutor(
             runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
         }
 
-        if (finalStatus != null && finalStatus.isTerminal()) {
-            // Immediate terminal status (ERROR/KILLED) — execution failed.
-            closeUserRun(userRunId, finalStatus, caseId)
-        } else if (finalStatus == CaseStatus.IDLE) {
-            // Agent finished its turn before the timeout — clean completion.
-            closeUserRun(userRunId, CaseStatus.IDLE, caseId)
-        } else {
-            // Timeout — Case is still RUNNING; monitoring released, Case continues independently.
-            userRunRepository.markTerminal(userRunId, UserRunStatus.TIMEOUT, Instant.now(clock))
-            logger.info {
-                "[Executor] UserRun=$userRunId timed out (caseId=$caseId still running) — monitoring released"
+        when {
+            finalStatus != null && finalStatus.isTerminal() ->
+                // Immediate terminal status (ERROR/KILLED) — execution failed.
+                closeUserRun(userRunId, finalStatus, caseId)
+            finalStatus == CaseStatus.IDLE ->
+                // Agent finished its turn before the timeout — clean completion.
+                closeUserRun(userRunId, CaseStatus.IDLE, caseId)
+            else -> {
+                // Timeout — Case is still RUNNING; monitoring released, Case continues independently.
+                userRunRepository.markTerminal(userRunId, UserRunStatus.TIMEOUT, Instant.now(clock))
+                logger.info {
+                    "[Executor] UserRun=$userRunId timed out (caseId=$caseId still running) — monitoring released"
+                }
             }
         }
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -393,6 +393,11 @@ class ScheduledPromptExecutor(
      * - Already IDLE or terminal → the turn finished before we arrived; act on it directly.
      * - PENDING or RUNNING → neither satisfies the predicate, so `.first { … }` suspends and
      *   waits for the next emission, bounded by the timeout.
+     *
+     * Contract: [CaseRuntime.statusFlow] is initialised to [CaseStatus.PENDING] at construction
+     * and transitions PENDING → RUNNING at the top of [CaseRuntime.run]. It never starts at IDLE.
+     * This invariant is asserted by `CaseRuntimeSpec: "statusFlow reflects RUNNING during run()
+     * and IDLE after normal completion"`. If that test is changed, revisit this guard.
      */
     private suspend fun monitorLaunch(
         userRunId: UUID,
@@ -408,8 +413,10 @@ class ScheduledPromptExecutor(
                 currentStatus
             }
             else -> {
-                // Status is RUNNING: drop the current value and wait for the next transition.
-                // withTimeoutOrNull returns null on timeout (Case still in flight).
+                // Status is PENDING or RUNNING — neither satisfies the predicate.
+                // .first {} evaluates the current value first (StateFlow semantics), finds it
+                // unsatisfying, then suspends until the next emission that does satisfy it.
+                // withTimeoutOrNull returns null if no satisfying emission arrives in time.
                 withTimeoutOrNull(timeoutMs) {
                     runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
                 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptNodeNeo4jRepository.kt
@@ -134,4 +134,18 @@ interface ScheduledPromptNodeNeo4jRepository : Neo4jRepository<ScheduledPromptNo
             """,
     )
     fun advanceNextRunAt(id: String, currentSlot: Instant, nextSlot: Instant): Boolean
+
+    /**
+     * Targeted update of the enabled flag — does NOT touch any other field.
+     * Safe to call concurrently: only touches `enabled`, leaves `nextRunAt` and all
+     * other properties untouched, so it cannot overwrite a concurrent CAS advance.
+     */
+    @Query(
+        $$"""
+            MATCH (sp:ScheduledPrompt)
+            WHERE sp.id = $id AND NOT COALESCE(sp.removed, false)
+            SET sp.enabled = $enabled
+            """,
+    )
+    fun updateEnabled(id: String, enabled: Boolean)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptNodeNeo4jRepository.kt
@@ -120,10 +120,10 @@ interface ScheduledPromptNodeNeo4jRepository : Neo4jRepository<ScheduledPromptNo
     fun findDue(now: Instant): List<ScheduledPromptNode>
 
     /**
-     * Optimistic-CAS update of nextRunAt.
+     * Optimistic update of nextRunAt.
      * Sets nextRunAt = :nextSlot only when the current stored value equals :currentSlot.
      *
-     * Returns true if the update was applied (exactly one node matched the CAS condition).
+     * Returns true if the update was applied (exactly one node matched the condition).
      */
     @Query(
         $$"""
@@ -138,7 +138,7 @@ interface ScheduledPromptNodeNeo4jRepository : Neo4jRepository<ScheduledPromptNo
     /**
      * Targeted update of the enabled flag — does NOT touch any other field.
      * Safe to call concurrently: only touches `enabled`, leaves `nextRunAt` and all
-     * other properties untouched, so it cannot overwrite a concurrent CAS advance.
+     * other properties untouched, so it cannot overwrite a concurrent advance of nextRunAt.
      */
     @Query(
         $$"""

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRepository.kt
@@ -61,7 +61,7 @@ interface ScheduledPromptRepository : EntityRepository<ScheduledPrompt, UUID> {
      *
      * Prefer this over [save] when the only intent is to disable a prompt, to avoid
      * overwriting fields (e.g. [ScheduledPrompt.nextRunAt]) that may have been advanced
-     * by a concurrent CAS since the caller loaded the aggregate.
+     * by the scheduler between the time the caller loaded the aggregate and the time it saves it.
      */
     fun updateEnabled(id: UUID, enabled: Boolean)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRepository.kt
@@ -55,4 +55,13 @@ interface ScheduledPromptRepository : EntityRepository<ScheduledPrompt, UUID> {
      * @return true if the update was applied (the CAS matched), false if another tick beat us
      */
     fun advanceNextRunAt(id: UUID, currentSlot: Instant, nextSlot: Instant): Boolean
+
+    /**
+     * Targeted update of the [ScheduledPrompt.enabled] flag — does NOT touch any other field.
+     *
+     * Prefer this over [save] when the only intent is to disable a prompt, to avoid
+     * overwriting fields (e.g. [ScheduledPrompt.nextRunAt]) that may have been advanced
+     * by a concurrent CAS since the caller loaded the aggregate.
+     */
+    fun updateEnabled(id: UUID, enabled: Boolean)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -63,9 +63,13 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     /**
      * Find RUNNING Runs whose UserRuns are all terminal (none in PENDING or RUNNING).
      *
-     * A Run qualifies when it is in RUNNING status, not removed, and has no UserRun
-     * in PENDING or RUNNING status. Runs with zero UserRuns never reach RUNNING status
-     * (they are transitioned directly to DONE in [ScheduledPromptExecutor.materialize]).
+     * Terminal UserRun statuses: DONE, TIMEOUT, FAILED. TIMEOUT is terminal — monitoring
+     * was released, the Case continues independently, and the UserRun will not transition
+     * further. A Run settled with only TIMEOUT/DONE UserRuns closes as DONE; one with at
+     * least one FAILED closes as FAILED.
+     *
+     * Runs with zero UserRuns never reach RUNNING status (they are transitioned directly
+     * to DONE in [ScheduledPromptExecutor.materialize]).
      */
     @Query(
         """

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -41,7 +41,11 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     fun updateStatus(id: String, status: String, finishedAt: Instant?, error: String?, now: Instant): Int
 
     /**
-     * Count all non-removed runs for a given ScheduledPrompt, including SKIPPED.
+     * Count all non-removed runs for a given ScheduledPrompt within the current planning window,
+     * including SKIPPED. Only runs with [scheduledFor] >= [startInstant] are counted so that
+     * runs from a previous planning window (before the user moved [startDate] forward) do not
+     * consume quota in the new window.
+     *
      * SKIPPED runs represent slots that fired but overlapped with an active run —
      * the slot still occurred and counts toward the occurrence quota.
      */
@@ -49,10 +53,11 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
         $$"""
         MATCH (r:ScheduledPromptRun)
         WHERE r.scheduledPromptId = $scheduledPromptId
+        AND r.scheduledFor >= $startInstant
         RETURN count(r)
         """,
     )
-    fun countCompletedRuns(scheduledPromptId: String): Int
+    fun countCompletedRuns(scheduledPromptId: String, startInstant: Instant): Int
 
     /**
      * Find all runs in [status] created before [before], ordered by creation time.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -33,7 +33,7 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     @Query(
         $$"""
         MATCH (r:ScheduledPromptRun {id: $id})
-        WHERE r.status NOT IN ['DONE', 'FAILED']
+        WHERE NOT r.status IN ['DONE', 'FAILED']
         SET r.status = $status,
             r.finishedAt = $finishedAt,
             r.error = $error,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -26,11 +26,14 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
 
     /**
      * Update status (and optionally finishedAt + error) of a Run by id.
-     * Returns the count of updated nodes (0 if not found).
+     * Only updates if the Run is not already in a terminal status (DONE or FAILED) —
+     * prevents the orphan sweep from overwriting finishedAt already set by checkCompletion.
+     * Returns the count of updated nodes (0 if not found or already terminal).
      */
     @Query(
         $$"""
         MATCH (r:ScheduledPromptRun {id: $id})
+        WHERE r.status NOT IN ['DONE', 'FAILED']
         SET r.status = $status,
             r.finishedAt = $finishedAt,
             r.error = $error,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -41,14 +41,14 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     fun updateStatus(id: String, status: String, finishedAt: Instant?, error: String?, now: Instant): Int
 
     /**
-     * Count non-SKIPPED runs for a given ScheduledPrompt.
+     * Count all non-removed runs for a given ScheduledPrompt, including SKIPPED.
+     * SKIPPED runs represent slots that fired but overlapped with an active run —
+     * the slot still occurred and counts toward the occurrence quota.
      */
     @Query(
         $$"""
         MATCH (r:ScheduledPromptRun)
         WHERE r.scheduledPromptId = $scheduledPromptId
-          AND r.status <> 'SKIPPED'
-          AND NOT COALESCE(r.removed, false)
         RETURN count(r)
         """,
     )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -43,7 +43,12 @@ interface ScheduledPromptRunRepository {
     fun findById(id: UUID): ScheduledPromptRun?
 
     /**
-     * Count all runs for a given ScheduledPrompt, for use against [Planning.maxOccurrenceCount].
+     * Count all runs for a given ScheduledPrompt within the current planning window,
+     * for use against [Planning.maxOccurrenceCount].
+     *
+     * Only runs whose [ScheduledPromptRun.scheduledFor] is >= [startInstant] are counted.
+     * This ensures that runs from a previous planning window (before the user moved
+     * [Planning.startDate] forward) do not consume quota in the new window.
      *
      * Counts every status including SKIPPED: the quota tracks **slots**, not executions.
      * A SKIPPED slot means a créneau fired but overlapped with an active run — the slot
@@ -52,7 +57,7 @@ interface ScheduledPromptRunRepository {
      * FAILED runs also count: the quota tracks "how many times the slot fired",
      * not "how many times it succeeded".
      */
-    fun countCompletedRuns(scheduledPromptId: UUID): Int
+    fun countCompletedRuns(scheduledPromptId: UUID, startInstant: Instant): Int
 
     /**
      * Find all Runs in CLAIMED status created before [olderThan].

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -43,9 +43,13 @@ interface ScheduledPromptRunRepository {
     fun findById(id: UUID): ScheduledPromptRun?
 
     /**
-     * Count completed (non-SKIPPED) runs for a given ScheduledPrompt.
-     * Counts DONE, FAILED, CLAIMED, and RUNNING — everything except SKIPPED,
-     * since SKIPPED runs are overlap-guards that never actually executed.
+     * Count attempted runs for a given ScheduledPrompt, for use against [Planning.maxOccurrenceCount].
+     *
+     * Counts every status except SKIPPED: DONE, FAILED, CLAIMED, and RUNNING.
+     * SKIPPED runs are overlap-guards that never executed — they do not consume an occurrence.
+     * FAILED runs **do** consume an occurrence: the slot was attempted (a Case was created or
+     * materialize was called), regardless of outcome. This is intentional — the quota tracks
+     * "how many times the prompt fired", not "how many times it succeeded".
      */
     fun countCompletedRuns(scheduledPromptId: UUID): Int
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -43,13 +43,14 @@ interface ScheduledPromptRunRepository {
     fun findById(id: UUID): ScheduledPromptRun?
 
     /**
-     * Count attempted runs for a given ScheduledPrompt, for use against [Planning.maxOccurrenceCount].
+     * Count all runs for a given ScheduledPrompt, for use against [Planning.maxOccurrenceCount].
      *
-     * Counts every status except SKIPPED: DONE, FAILED, CLAIMED, and RUNNING.
-     * SKIPPED runs are overlap-guards that never executed — they do not consume an occurrence.
-     * FAILED runs **do** consume an occurrence: the slot was attempted (a Case was created or
-     * materialize was called), regardless of outcome. This is intentional — the quota tracks
-     * "how many times the prompt fired", not "how many times it succeeded".
+     * Counts every status including SKIPPED: the quota tracks **slots**, not executions.
+     * A SKIPPED slot means a créneau fired but overlapped with an active run — the slot
+     * still occurred and must count toward the stop condition. Without this, overlapping
+     * slots would allow the prompt to execute beyond its intended temporal window.
+     * FAILED runs also count: the quota tracks "how many times the slot fired",
+     * not "how many times it succeeded".
      */
     fun countCompletedRuns(scheduledPromptId: UUID): Int
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -63,9 +63,11 @@ interface ScheduledPromptRunRepository {
     fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun>
 
     /**
-     * Find RUNNING Runs whose UserRuns are ALL in a terminal status (DONE or FAILED).
+     * Find RUNNING Runs whose UserRuns are ALL in a terminal status (DONE, TIMEOUT, or FAILED).
      *
      * A Run is "settled" when none of its UserRuns are in PENDING or RUNNING status.
+     * TIMEOUT is terminal: monitoring was released, the Case continues independently,
+     * and the UserRun will not transition further.
      * Runs with zero UserRuns (platform-scope or no target users) are directly transitioned
      * to DONE in [ScheduledPromptExecutor.materialize] and never reach RUNNING status.
      *

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
@@ -24,8 +24,9 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
      * (access control), but scheduled prompts target users who are *deployed to* the
      * agent — being an admin is not the same as being a target audience.
      *
-     * Both paths are resolved via OPTIONAL MATCH and collected into a single set.
-     * Then MERGEs a PENDING [ScheduledPromptUserRunNode] for each distinct eligible user.
+     * Both paths are resolved via a `CALL { UNION }` subquery that traverses the graph
+     * starting from the agent — no full User scan. `UNION` deduplicates users found via
+     * both paths. Then MERGEs a PENDING [ScheduledPromptUserRunNode] for each distinct eligible user.
      *
      * Safe to replay on crash — MERGE is idempotent on the composite UNIQUE `(runId, userId)` constraint.
      *
@@ -37,20 +38,21 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
           WHERE NOT COALESCE(a.removed, false) AND a.enabled = true
         MATCH (ns:Namespace {id: $namespaceId})
           WHERE NOT COALESCE(ns.removed, false)
-        MATCH (u:User)
-          WHERE NOT COALESCE(u.removed, false)
-            AND (
-                EXISTS {
-                    MATCH (u)-[:MEMBER|ADMIN]->(g:UserGroup)-[:BELONGS_TO]->(ns)
-                    WHERE NOT COALESCE(g.removed, false)
-                    MATCH (a)-[:DEPLOYED_TO]->(g)
-                }
-                OR (
-                    EXISTS { MATCH (a)-[:DEPLOYED_TO]->(ns) }
-                    AND EXISTS { MATCH (u)-[:MEMBER|ADMIN]->(ns) }
-                )
-            )
-        WITH DISTINCT u.id AS userId
+        CALL {
+            WITH a, ns
+            MATCH (a)-[:DEPLOYED_TO]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+              WHERE NOT COALESCE(g.removed, false)
+            MATCH (u:User)-[:MEMBER|ADMIN]->(g)
+              WHERE NOT COALESCE(u.removed, false)
+            RETURN u.id AS userId
+            UNION
+            WITH a, ns
+            MATCH (a)-[:DEPLOYED_TO]->(ns)
+            MATCH (u:User)-[:MEMBER|ADMIN]->(ns)
+              WHERE NOT COALESCE(u.removed, false)
+            RETURN u.id AS userId
+        }
+        WITH DISTINCT userId
         MERGE (ur:ScheduledPromptUserRun {runId: $runId, userId: userId})
         ON CREATE SET
             ur.id       = randomUUID(),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -13,7 +13,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | `agentos.prompt.scheduler.tick-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS` | 30000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class |
  * | `agentos.prompt.scheduler.consume-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) — read directly by `@Scheduled`, not via this class |
  * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
- * | `agentos.prompt.scheduler.launch-stagger-ms` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_STAGGER_MS` | 50 | Delay (ms) between consecutive Case launches within a batch |
  * | `agentos.prompt.scheduler.launch-timeout-seconds` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `agentos.prompt.scheduler.lease-minutes` | `AGENTOS_PROMPT_SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
@@ -23,8 +22,6 @@ data class SchedulerProperties(
     val enabled: Boolean = false,
     /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
     val batchSize: Int = 20,
-    /** Delay (ms) between consecutive Case launches within a batch. Spreads the initial burst to reduce peak memory pressure. */
-    val launchStaggerMs: Long = 50L,
     /** Max seconds to wait for a Case to reach IDLE or terminal after launch. Beyond this the UserRun is closed as DONE (Case continues running independently). */
     val launchTimeoutSeconds: Long = 30L,
     /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -22,8 +22,16 @@ data class SchedulerProperties(
     val enabled: Boolean = false,
     /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
     val batchSize: Int = 20,
-    /** Max seconds to wait for a Case to reach IDLE or terminal after launch. Beyond this the UserRun is closed as DONE (Case continues running independently). */
+    /**
+     * Max seconds to wait for a Case to reach IDLE or terminal after launch.
+     * Beyond this the UserRun is closed as TIMEOUT (Case continues running independently).
+     * Must be strictly less than [leaseMinutes] × 60 — enforced at startup by [SchedulerScanner].
+     */
     val launchTimeoutSeconds: Long = 30L,
-    /** Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next tick. */
+    /**
+     * Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next
+     * consume tick, creating a second Case for the same user (at-least-once delivery).
+     * Must be strictly greater than [launchTimeoutSeconds] ÷ 60 — enforced at startup by [SchedulerScanner].
+     */
     val leaseMinutes: Long = 30L,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -12,7 +12,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | `agentos.prompt.scheduler.enabled` | `AGENTOS_PROMPT_SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
  * | `agentos.prompt.scheduler.tick-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS` | 30000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class |
  * | `agentos.prompt.scheduler.consume-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) — read directly by `@Scheduled`, not via this class |
- * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 20 | Max UserRuns claimed and executed in parallel per consume tick |
+ * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 5 | Max UserRuns claimed and executed in parallel per consume tick |
  * | `agentos.prompt.scheduler.launch-timeout-seconds` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `agentos.prompt.scheduler.lease-minutes` | `AGENTOS_PROMPT_SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
@@ -21,7 +21,7 @@ data class SchedulerProperties(
     /** Disabled by default; enable in production via env var AGENTOS_PROMPT_SCHEDULER_ENABLED=true. */
     val enabled: Boolean = false,
     /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
-    val batchSize: Int = 20,
+    val batchSize: Int = 5,
     /**
      * Max seconds to wait for a Case to reach IDLE or terminal after launch.
      * Beyond this the UserRun is closed as TIMEOUT (Case continues running independently).

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -265,7 +265,24 @@ class SchedulerScanner(
         checkEndConditionAfterAdvance(scheduledPrompt, nextSlot)
 
         if (status == RunStatus.CLAIMED && insertedRun != null) {
-            executor.materialize(insertedRun, scheduledPrompt)
+            runCatching { executor.materialize(insertedRun, scheduledPrompt) }
+                .onFailure { e ->
+                    logger.error(e) {
+                        "[SchedulerScanner] materialize failed for run=${insertedRun.id} sp=${scheduledPrompt.id} — marking FAILED"
+                    }
+                    runCatching {
+                        runRepository.updateStatus(
+                            id = insertedRun.id,
+                            status = RunStatus.FAILED,
+                            finishedAt = Instant.now(clock),
+                            error = e.message?.takeIf { it.isNotBlank() } ?: "materialize failed: ${e::class.simpleName}",
+                        )
+                    }.onFailure { updateError ->
+                        logger.error(updateError) {
+                            "[SchedulerScanner] Could not mark run=${insertedRun.id} as FAILED — will be swept by recoverOrphanedClaimedRuns"
+                        }
+                    }
+                }
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -56,6 +56,8 @@ import java.time.ZoneOffset
  * and [ScheduledPromptExecutor.checkCompletion].
  *
  * The [clock] is injected so tests can freeze time.
+ *
+ * See `docs/scheduled-prompt.md` for the full crash recovery matrix.
  */
 
 @Component

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -306,7 +306,8 @@ class SchedulerScanner(
             }
             SchedulerEndType.OCCURRENCES -> {
                 val max = planning.maxOccurrenceCount ?: return false
-                val completed = runRepository.countCompletedRuns(scheduledPrompt.id)
+                val startInstant = planning.startDate.atStartOfDay(ZoneOffset.UTC).toInstant()
+                val completed = runRepository.countCompletedRuns(scheduledPrompt.id, startInstant)
                 completed >= max
             }
         }
@@ -334,7 +335,8 @@ class SchedulerScanner(
             }
             SchedulerEndType.OCCURRENCES -> {
                 val max = planning.maxOccurrenceCount ?: return
-                val completed = runRepository.countCompletedRuns(scheduledPrompt.id)
+                val startInstant = planning.startDate.atStartOfDay(ZoneOffset.UTC).toInstant()
+                val completed = runRepository.countCompletedRuns(scheduledPrompt.id, startInstant)
                 completed >= max
             }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -73,6 +73,13 @@ class SchedulerScanner(
     @PostConstruct
     fun logStartup() {
         logger.info { "[SchedulerScanner] Scheduler enabled" }
+        val leaseSeconds = properties.leaseMinutes * 60
+        require(leaseSeconds > properties.launchTimeoutSeconds) {
+            "[SchedulerScanner] agentos.prompt.scheduler.lease-minutes (${properties.leaseMinutes}m = ${leaseSeconds}s) " +
+                "must be greater than launch-timeout-seconds (${properties.launchTimeoutSeconds}s). " +
+                "A shorter lease causes UserRuns to be reclaimed before monitorLaunch completes, " +
+                "leading to double execution."
+        }
     }
 
     /**
@@ -86,22 +93,30 @@ class SchedulerScanner(
 
         // Sweep: abandon orphaned CLAIMED runs that were never materialised.
         // This handles the crash window between Run insert and materialize() in claim().
-        // A CLAIMED Run older than the tick interval is presumed orphaned — materialize()
+        // A CLAIMED Run older than ORPHAN_THRESHOLD is presumed orphaned — materialize()
         // normally completes in seconds. Marking it FAILED unblocks the hasActive() overlap
         // guard so subsequent slots are not stuck in SKIPPED.
-        recoverOrphanedClaimedRuns(now)
+        runCatching { recoverOrphanedClaimedRuns(now) }.onFailure { e ->
+            logger.error(e) { "[SchedulerScanner] recoverOrphanedClaimedRuns failed — continuing tick" }
+        }
 
         // Sweep: close RUNNING runs whose UserRuns are all settled but whose completion
         // check was missed. This handles the crash window between markTerminal() and
         // checkCompletion() in ScheduledPromptExecutor.
-        recoverOrphanedRunningRuns(now)
+        runCatching { recoverOrphanedRunningRuns(now) }.onFailure { e ->
+            logger.error(e) { "[SchedulerScanner] recoverOrphanedRunningRuns failed — continuing tick" }
+        }
 
         scheduledPromptRepository.findDue(now)
             .also { due ->
                 if (due.isEmpty()) logger.debug { "[SchedulerScanner] tickClaim: no due prompts" }
                 else logger.info { "[SchedulerScanner] tickClaim: ${due.size} due prompt(s)" }
             }
-            .forEach { sp -> claim(sp) }
+            .forEach { sp ->
+                runCatching { claim(sp) }.onFailure { e ->
+                    logger.error(e) { "[SchedulerScanner] claim failed for sp=${sp.id} — skipping this prompt in this tick" }
+                }
+            }
     }
 
     /**
@@ -192,7 +207,7 @@ class SchedulerScanner(
                 "[SchedulerScanner] AgentConfig ${scheduledPrompt.agentConfigId} is ${if (agentConfig == null) "deleted" else "disabled"} " +
                     "— disabling sp=${scheduledPrompt.id} to prevent further zombie ticks"
             }
-            scheduledPromptRepository.save(scheduledPrompt.copy(enabled = false))
+            scheduledPromptRepository.updateEnabled(scheduledPrompt.id, false)
             return
         }
 
@@ -209,7 +224,7 @@ class SchedulerScanner(
                 "[SchedulerScanner] End condition already reached for sp=${scheduledPrompt.id} " +
                     "(${scheduledPrompt.planning.endType}) \u2014 disabling without execution"
             }
-            scheduledPromptRepository.save(scheduledPrompt.copy(enabled = false))
+            scheduledPromptRepository.updateEnabled(scheduledPrompt.id, false)
             return
         }
 
@@ -238,7 +253,6 @@ class SchedulerScanner(
 
         // Always advance nextRunAt — auto-repairing even on duplicate or skip.
         val nextSlot = nextRunCalculatorService.nextAfter(recurrence = scheduledPrompt.recurrence, planning = scheduledPrompt.planning, after = slot)
-        logger.info { "[DEBUG] slot=$slot nextSlot=$nextSlot" }
         val advanced = scheduledPromptRepository.advanceNextRunAt(scheduledPrompt.id, slot, nextSlot)
         if (advanced) {
             logger.debug { "[SchedulerScanner] Advanced sp=${scheduledPrompt.id} nextRunAt=$nextSlot" }
@@ -313,7 +327,9 @@ class SchedulerScanner(
                 "[SchedulerScanner] End condition reached after advance for sp=${scheduledPrompt.id} " +
                     "(${planning.endType}) \u2014 disabling"
             }
-            scheduledPromptRepository.save(scheduledPrompt.copy(enabled = false))
+            // Use targeted updateEnabled rather than save(copy(enabled=false)) to avoid
+            // overwriting the nextRunAt that was just advanced by CAS above.
+            scheduledPromptRepository.updateEnabled(scheduledPrompt.id, false)
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -42,7 +42,7 @@ import java.time.ZoneOffset
  * - Otherwise → insert a CLAIMED Run, then call [ScheduledPromptExecutor.materialize]
  *   (MERGE + RUNNING transition in a single `@Transactional` boundary).
  * - Catch [DuplicateRunException] for both SKIPPED and CLAIMED (concurrent tick won the race).
- * - After the insert (or on duplicate), advance `nextRunAt` via CAS.
+ * - After the insert (or on duplicate), advance `nextRunAt` optimistically.
  *
  * ### Orphan recovery
  *
@@ -257,7 +257,7 @@ class SchedulerScanner(
         if (advanced) {
             logger.debug { "[SchedulerScanner] Advanced sp=${scheduledPrompt.id} nextRunAt=$nextSlot" }
         } else {
-            logger.debug { "[SchedulerScanner] CAS miss for sp=${scheduledPrompt.id} (another tick advanced first)" }
+            logger.debug { "[SchedulerScanner] Optimistic advance miss for sp=${scheduledPrompt.id} (another tick advanced first)" }
         }
 
         // Check if the end condition will be reached after this run.
@@ -347,7 +347,7 @@ class SchedulerScanner(
                     "(${planning.endType}) \u2014 disabling"
             }
             // Use targeted updateEnabled rather than save(copy(enabled=false)) to avoid
-            // overwriting the nextRunAt that was just advanced by CAS above.
+            // overwriting the nextRunAt that was just advanced above.
             scheduledPromptRepository.updateEnabled(scheduledPrompt.id, false)
         }
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptRunPersistenceSpec.kt
@@ -1,0 +1,302 @@
+package io.whozoss.agentos.persistence.neo4j
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.scheduledPrompt.RunStatus
+import io.whozoss.agentos.scheduledPrompt.ScheduledPromptRunRepository
+import org.neo4j.driver.Driver
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Persistence contract tests for all custom Cypher queries in
+ * [io.whozoss.agentos.scheduledPrompt.ScheduledPromptRunNodeNeo4jRepository].
+ *
+ * Covers:
+ * - [ScheduledPromptRunRepository.updateStatus] — terminal-status guard, field persistence
+ * - [ScheduledPromptRunRepository.hasActive] — CLAIMED/RUNNING detection, removed filter
+ * - [ScheduledPromptRunRepository.countCompletedRuns] — temporal filter on scheduledFor
+ * - [ScheduledPromptRunRepository.findOrphanedClaimed] — status + age filter, ordering
+ * - [ScheduledPromptRunRepository.findSettledRunning] — NOT EXISTS sub-query against UserRuns
+ *
+ * This spec was introduced after a production bug where `r.status NOT IN [...]` (invalid Cypher)
+ * was used instead of `NOT r.status IN [...]` in `updateStatus`. Any Cypher syntax error in any
+ * query causes the Spring context to fail at startup, so the test acts as an early-detection guard
+ * for query regressions across the entire repository.
+ */
+abstract class AbstractScheduledPromptRunPersistenceSpec : StringSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired lateinit var runRepo: ScheduledPromptRunRepository
+
+    @Autowired lateinit var driver: Driver
+
+    // ---------------------------------------------------------------------------
+    // Builders
+    // ---------------------------------------------------------------------------
+
+    private fun run(
+        status: RunStatus = RunStatus.CLAIMED,
+        scheduledPromptId: UUID = UUID.randomUUID(),
+        scheduledFor: Instant = Instant.now(),
+    ) = io.whozoss.agentos.scheduledPrompt.ScheduledPromptRun(
+        scheduledPromptId = scheduledPromptId,
+        scheduledFor = scheduledFor,
+        status = status,
+        correlationId = "test-${UUID.randomUUID()}",
+    )
+
+    /**
+     * Insert a minimal ScheduledPromptUserRun node directly via Cypher.
+     * Uses $$""" raw strings so $param tokens are literal Cypher parameters,
+     * not Kotlin string interpolation.
+     */
+    private fun insertUserRun(runId: UUID, status: String) {
+        driver.session().use { session ->
+            session.run(
+                $$"""
+                CREATE (ur:ScheduledPromptUserRun {
+                    id:       randomUUID(),
+                    runId:    $runId,
+                    userId:   randomUUID(),
+                    status:   $status,
+                    version:  0,
+                    created:  datetime(),
+                    modified: datetime()
+                })
+                """,
+                mapOf("runId" to runId.toString(), "status" to status),
+            )
+        }
+    }
+
+    init {
+        beforeEach { Neo4jContainerSupport.clearDatabase(driver) }
+
+        // -------------------------------------------------------------------------
+        // updateStatus — non-terminal source status
+        // -------------------------------------------------------------------------
+
+        "updateStatus returns true and updates status when Run is CLAIMED" {
+            val saved = runRepo.insert(run(RunStatus.CLAIMED))
+
+            val updated = runRepo.updateStatus(saved.id, RunStatus.RUNNING)
+
+            updated shouldBe true
+            runRepo.findById(saved.id)!!.status shouldBe RunStatus.RUNNING
+        }
+
+        "updateStatus returns true and updates status when Run is RUNNING" {
+            val saved = runRepo.insert(run(RunStatus.RUNNING))
+
+            val updated = runRepo.updateStatus(saved.id, RunStatus.DONE, finishedAt = Instant.now())
+
+            updated shouldBe true
+            runRepo.findById(saved.id)!!.status shouldBe RunStatus.DONE
+        }
+
+        "updateStatus sets finishedAt and error when provided" {
+            val saved = runRepo.insert(run(RunStatus.RUNNING))
+
+            runRepo.updateStatus(saved.id, RunStatus.FAILED, finishedAt = Instant.now(), error = "boom")
+
+            val result = runRepo.findById(saved.id)!!
+            result.status shouldBe RunStatus.FAILED
+            result.error shouldBe "boom"
+        }
+
+        // -------------------------------------------------------------------------
+        // updateStatus — terminal-status guard
+        // -------------------------------------------------------------------------
+
+        "updateStatus returns false and does not overwrite a DONE Run" {
+            val saved = runRepo.insert(run(RunStatus.DONE))
+
+            val updated = runRepo.updateStatus(saved.id, RunStatus.FAILED, error = "late")
+
+            updated shouldBe false
+            runRepo.findById(saved.id)!!.status shouldBe RunStatus.DONE
+        }
+
+        "updateStatus returns false and does not overwrite a FAILED Run" {
+            val saved = runRepo.insert(run(RunStatus.FAILED))
+
+            val updated = runRepo.updateStatus(saved.id, RunStatus.DONE)
+
+            updated shouldBe false
+            runRepo.findById(saved.id)!!.status shouldBe RunStatus.FAILED
+        }
+
+        "updateStatus returns false when Run does not exist" {
+            val updated = runRepo.updateStatus(UUID.randomUUID(), RunStatus.DONE)
+
+            updated shouldBe false
+        }
+
+        // -------------------------------------------------------------------------
+        // hasActive
+        // -------------------------------------------------------------------------
+
+        "hasActive returns true when a CLAIMED Run exists" {
+            val spId = UUID.randomUUID()
+            runRepo.insert(run(RunStatus.CLAIMED, scheduledPromptId = spId))
+
+            runRepo.hasActive(spId) shouldBe true
+        }
+
+        "hasActive returns true when a RUNNING Run exists" {
+            val spId = UUID.randomUUID()
+            runRepo.insert(run(RunStatus.RUNNING, scheduledPromptId = spId))
+
+            runRepo.hasActive(spId) shouldBe true
+        }
+
+        "hasActive returns false when only terminal Runs exist" {
+            val spId = UUID.randomUUID()
+            runRepo.insert(run(RunStatus.DONE, scheduledPromptId = spId))
+            runRepo.insert(run(RunStatus.FAILED, scheduledPromptId = spId, scheduledFor = Instant.now().plusSeconds(1)))
+
+            runRepo.hasActive(spId) shouldBe false
+        }
+
+        "hasActive returns false when no Runs exist for the scheduledPromptId" {
+            runRepo.hasActive(UUID.randomUUID()) shouldBe false
+        }
+
+        // -------------------------------------------------------------------------
+        // countCompletedRuns
+        // -------------------------------------------------------------------------
+
+        "countCompletedRuns counts all runs on or after startInstant" {
+            val spId = UUID.randomUUID()
+            val base = Instant.parse("2026-01-01T00:00:00Z")
+            runRepo.insert(run(RunStatus.DONE, scheduledPromptId = spId, scheduledFor = base))
+            runRepo.insert(run(RunStatus.DONE, scheduledPromptId = spId, scheduledFor = base.plusSeconds(1)))
+            runRepo.insert(run(RunStatus.DONE, scheduledPromptId = spId, scheduledFor = base.minusSeconds(1)))
+
+            // startInstant = base: the run at base-1s is excluded
+            runRepo.countCompletedRuns(spId, base) shouldBe 2
+        }
+
+        "countCompletedRuns includes SKIPPED and FAILED runs" {
+            val spId = UUID.randomUUID()
+            val base = Instant.parse("2026-01-01T00:00:00Z")
+            runRepo.insert(run(RunStatus.DONE,    scheduledPromptId = spId, scheduledFor = base))
+            runRepo.insert(run(RunStatus.SKIPPED, scheduledPromptId = spId, scheduledFor = base.plusSeconds(1)))
+            runRepo.insert(run(RunStatus.FAILED,  scheduledPromptId = spId, scheduledFor = base.plusSeconds(2)))
+
+            runRepo.countCompletedRuns(spId, base) shouldBe 3
+        }
+
+        "countCompletedRuns returns 0 when all runs are before startInstant" {
+            val spId = UUID.randomUUID()
+            val base = Instant.parse("2026-01-01T00:00:00Z")
+            runRepo.insert(run(RunStatus.DONE, scheduledPromptId = spId, scheduledFor = base.minusSeconds(1)))
+
+            runRepo.countCompletedRuns(spId, base) shouldBe 0
+        }
+
+        "countCompletedRuns does not count runs for other scheduledPromptIds" {
+            val spId = UUID.randomUUID()
+            val otherId = UUID.randomUUID()
+            val base = Instant.parse("2026-01-01T00:00:00Z")
+            runRepo.insert(run(RunStatus.DONE, scheduledPromptId = spId,    scheduledFor = base))
+            runRepo.insert(run(RunStatus.DONE, scheduledPromptId = otherId, scheduledFor = base))
+
+            runRepo.countCompletedRuns(spId, base) shouldBe 1
+        }
+
+        // -------------------------------------------------------------------------
+        // findOrphanedClaimed
+        // -------------------------------------------------------------------------
+
+        "findOrphanedClaimed returns CLAIMED runs created before the threshold" {
+            val old = runRepo.insert(run(RunStatus.CLAIMED))
+            // Force created timestamp to the past via Cypher
+            driver.session().use { session ->
+                session.run(
+                    $$"""MATCH (r:ScheduledPromptRun {id: $id}) SET r.created = datetime('2020-01-01T00:00:00Z')""",
+                    mapOf("id" to old.id.toString()),
+                )
+            }
+
+            val orphans = runRepo.findOrphanedClaimed(Instant.now())
+
+            orphans shouldHaveSize 1
+            orphans.first().id shouldBe old.id
+        }
+
+        "findOrphanedClaimed does not return CLAIMED runs created after the threshold" {
+            runRepo.insert(run(RunStatus.CLAIMED))
+
+            // threshold in the past — the freshly inserted run is NOT older than it
+            val orphans = runRepo.findOrphanedClaimed(Instant.now().minusSeconds(60))
+
+            orphans.shouldBeEmpty()
+        }
+
+        "findOrphanedClaimed does not return non-CLAIMED runs" {
+            listOf(RunStatus.RUNNING, RunStatus.DONE, RunStatus.FAILED, RunStatus.SKIPPED).forEachIndexed { i, status ->
+                runRepo.insert(run(status, scheduledFor = Instant.now().plusSeconds(i.toLong())))
+            }
+            // Push all created timestamps to the past
+            driver.session().use { session ->
+                session.run("MATCH (r:ScheduledPromptRun) SET r.created = datetime('2020-01-01T00:00:00Z')")
+            }
+
+            val orphans = runRepo.findOrphanedClaimed(Instant.now())
+
+            orphans.shouldBeEmpty()
+        }
+
+        // -------------------------------------------------------------------------
+        // findSettledRunning
+        // -------------------------------------------------------------------------
+
+        "findSettledRunning returns RUNNING Run with no UserRuns" {
+            val saved = runRepo.insert(run(RunStatus.RUNNING))
+
+            val settled = runRepo.findSettledRunning()
+
+            settled shouldHaveSize 1
+            settled.first().id shouldBe saved.id
+        }
+
+        "findSettledRunning returns RUNNING Run whose UserRuns are all terminal" {
+            val saved = runRepo.insert(run(RunStatus.RUNNING))
+            insertUserRun(saved.id, "DONE")
+            insertUserRun(saved.id, "FAILED")
+
+            val settled = runRepo.findSettledRunning()
+
+            settled shouldHaveSize 1
+            settled.first().id shouldBe saved.id
+        }
+
+        "findSettledRunning does not return RUNNING Run with a PENDING UserRun" {
+            val saved = runRepo.insert(run(RunStatus.RUNNING))
+            insertUserRun(saved.id, "PENDING")
+
+            runRepo.findSettledRunning().shouldBeEmpty()
+        }
+
+        "findSettledRunning does not return RUNNING Run with a RUNNING UserRun" {
+            val saved = runRepo.insert(run(RunStatus.RUNNING))
+            insertUserRun(saved.id, "RUNNING")
+
+            runRepo.findSettledRunning().shouldBeEmpty()
+        }
+
+        "findSettledRunning does not return non-RUNNING Runs" {
+            listOf(RunStatus.CLAIMED, RunStatus.DONE, RunStatus.FAILED, RunStatus.SKIPPED).forEachIndexed { i, status ->
+                runRepo.insert(run(status, scheduledFor = Instant.now().plusSeconds(i.toLong())))
+            }
+
+            runRepo.findSettledRunning().shouldBeEmpty()
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/EmbeddedNeo4jScheduledPromptRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/EmbeddedNeo4jScheduledPromptRunPersistenceSpec.kt
@@ -1,0 +1,19 @@
+package io.whozoss.agentos.persistence.neo4j
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Runs the [AbstractScheduledPromptRunPersistenceSpec] contract against the embedded Neo4j
+ * engine using the Neo4j test harness (`embedded-neo4j` persistence mode).
+ *
+ * Introduced after a production bug where `r.status NOT IN [...]` (invalid Cypher)
+ * was used instead of `NOT r.status IN [...]` in [io.whozoss.agentos.scheduledPrompt.ScheduledPromptRunNodeNeo4jRepository.updateStatus].
+ * Any Cypher syntax error in the query causes the Spring context to fail at startup, so
+ * this test acts as an early-detection guard for query regressions.
+ */
+@SpringBootTest
+@ActiveProfiles("test", "embedded-neo4j")
+@Import(EmbeddedNeo4jTestConfiguration::class)
+class EmbeddedNeo4jScheduledPromptRunPersistenceSpec : AbstractScheduledPromptRunPersistenceSpec()

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRepository.kt
@@ -77,6 +77,12 @@ class InMemoryScheduledPromptRepository : ScheduledPromptRepository {
         return true
     }
 
+    /** Targeted update of the enabled flag — does NOT touch any other field. */
+    override fun updateEnabled(id: UUID, enabled: Boolean) {
+        val existing = delegate.findAll().firstOrNull { it.metadata.id == id } ?: return
+        delegate.save(existing.copy(enabled = enabled))
+    }
+
     companion object {
         private const val ALL_KEY = "all"
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -50,7 +50,7 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
 
     override fun countCompletedRuns(scheduledPromptId: UUID): Int =
         store.values.count {
-            it.scheduledPromptId == scheduledPromptId && it.status != RunStatus.SKIPPED
+            it.scheduledPromptId == scheduledPromptId
         }
 
     override fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun> =

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -48,9 +48,10 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
     override fun findById(id: UUID): ScheduledPromptRun? =
         store.values.firstOrNull { it.id == id }
 
-    override fun countCompletedRuns(scheduledPromptId: UUID): Int =
+    override fun countCompletedRuns(scheduledPromptId: UUID, startInstant: Instant): Int =
         store.values.count {
-            it.scheduledPromptId == scheduledPromptId
+            it.scheduledPromptId == scheduledPromptId &&
+                !it.scheduledFor.isBefore(startInstant)
         }
 
     override fun findOrphanedClaimed(olderThan: Instant): List<ScheduledPromptRun> =

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/InMemoryScheduledPromptRunRepository.kt
@@ -41,6 +41,8 @@ class InMemoryScheduledPromptRunRepository : ScheduledPromptRunRepository {
         error: String?,
     ): Boolean {
         val entry = store.entries.firstOrNull { it.value.id == id } ?: return false
+        // Mirror the Cypher guard: do not overwrite a terminal status
+        if (entry.value.status == RunStatus.DONE || entry.value.status == RunStatus.FAILED) return false
         store[entry.key] = entry.value.copy(status = status, finishedAt = finishedAt, error = error)
         return true
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
@@ -1,0 +1,364 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.agentConfig.AgentConfig
+import io.whozoss.agentos.agentConfig.AgentConfigService
+import io.whozoss.agentos.caseFlow.Case
+import io.whozoss.agentos.caseFlow.CaseRuntime
+import io.whozoss.agentos.caseFlow.CaseService
+import io.whozoss.agentos.permissions.PermissionService
+import io.whozoss.agentos.prompt.Prompt
+import io.whozoss.agentos.prompt.PromptService
+import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerEndType
+import io.whozoss.agentos.sdk.api.scheduledPrompt.SchedulerUnit
+import io.whozoss.agentos.sdk.caseFlow.CaseStatus
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import io.whozoss.agentos.user.User
+import io.whozoss.agentos.user.UserService
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * End-to-end scenario tests for the scheduled prompt batch pipeline.
+ *
+ * Each test drives the full sequence tickClaim() → tickConsume() and verifies the
+ * cumulative state transitions across both phases, including crash-recovery sweeps.
+ *
+ * Uses in-memory repositories and MockK stubs — no Spring context, no Neo4j.
+ * Fixed clock: 2026-01-01 09:00:00 UTC (Thursday).
+ *
+ * Complements [SchedulerScannerUnitSpec] and [ScheduledPromptExecutorUnitSpec] which
+ * test each phase in isolation. These scenarios validate the cross-phase orchestration.
+ */
+class ScheduledPromptBatchScenarioSpec : StringSpec() {
+
+    private val nowInstant = Instant.parse("2026-01-01T09:00:00Z")
+    private val clock = Clock.fixed(nowInstant, ZoneOffset.UTC)
+
+    private val namespaceId: UUID = UUID.fromString("10000000-0000-0000-0000-000000000001")
+    private val agentId: UUID = UUID.fromString("20000000-0000-0000-0000-000000000001")
+    private val promptTemplateId: UUID = UUID.fromString("30000000-0000-0000-0000-000000000001")
+    private val userId1: UUID = UUID.fromString("40000000-0000-0000-0000-000000000001")
+    private val userId2: UUID = UUID.fromString("40000000-0000-0000-0000-000000000002")
+
+    private val properties = SchedulerProperties(batchSize = 10, leaseMinutes = 30L)
+
+    private val activeAgent = AgentConfig(
+        metadata = EntityMetadata(id = agentId, version = 0L),
+        namespaceId = namespaceId,
+        name = "weekly-agent",
+        enabled = true,
+    )
+    private val promptTemplate = Prompt(
+        metadata = EntityMetadata(id = promptTemplateId),
+        name = "digest-template",
+        content = listOf("Run your weekly digest."),
+    )
+    private val user1 = User(
+        metadata = EntityMetadata(id = userId1),
+        externalId = "user1@example.com",
+        firstname = "Alice",
+        lastname = "Smith",
+    )
+    private val user2 = User(
+        metadata = EntityMetadata(id = userId2),
+        externalId = "user2@example.com",
+        firstname = "Bob",
+        lastname = "Jones",
+    )
+
+    // ---------------------------------------------------------------------------
+    // Fixture builders
+    // ---------------------------------------------------------------------------
+
+    private fun makeScheduledPrompt(
+        spRepo: InMemoryScheduledPromptRepository,
+        slot: Instant = Instant.parse("2026-01-01T08:00:00Z"),
+    ): ScheduledPrompt = spRepo.save(
+        ScheduledPrompt(
+            metadata = EntityMetadata(id = UUID.randomUUID()),
+            namespaceId = namespaceId,
+            agentConfigId = agentId,
+            promptTemplateId = promptTemplateId,
+            name = "weekly-digest",
+            recurrence = Recurrence(unit = SchedulerUnit.WEEK, timeUtc = LocalTime.of(8, 0)),
+            planning = Planning(startDate = LocalDate.of(2026, 1, 1), endType = SchedulerEndType.NEVER),
+            enabled = true,
+            nextRunAt = slot,
+        ),
+    )
+
+    private fun makeScanner(
+        spRepo: InMemoryScheduledPromptRepository,
+        runRepo: InMemoryScheduledPromptRunRepository,
+        userRunRepo: InMemoryScheduledPromptUserRunRepository,
+        caseService: CaseService,
+        agentConfigService: AgentConfigService = mockk<AgentConfigService>().also {
+            every { it.findById(agentId) } returns activeAgent
+        },
+        userService: UserService = mockk<UserService>().also {
+            every { it.findById(userId1) } returns user1
+            every { it.findById(userId2) } returns user2
+        },
+    ): SchedulerScanner {
+        runRepo.userRunRepository = userRunRepo
+        val promptService = mockk<PromptService>().also {
+            every { it.findById(promptTemplateId) } returns promptTemplate
+        }
+        val executor = ScheduledPromptExecutor(
+            scheduledPromptRepository = spRepo,
+            runRepository = runRepo,
+            userRunRepository = userRunRepo,
+            promptService = promptService,
+            agentConfigService = agentConfigService,
+            caseService = caseService,
+            permissionService = mockk<PermissionService>(relaxed = true),
+            userService = userService,
+            properties = properties,
+            clock = clock,
+        )
+        return SchedulerScanner(
+            scheduledPromptRepository = spRepo,
+            runRepository = runRepo,
+            userRunRepository = userRunRepo,
+            agentConfigService = agentConfigService,
+            properties = properties,
+            clock = clock,
+            nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+            executor = executor,
+        )
+    }
+
+    /**
+     * CaseService where each Case's runtime transitions to IDLE after addMessage is called,
+     * simulating a fast agent turn completing synchronously from the test's perspective.
+     *
+     * The runtime map is keyed by caseId and populated in `create` so that `findActiveRuntime`
+     * and `addMessage` can look up the correct flow. All state is local to the returned mock.
+     */
+    private fun eventuallyIdleCaseService(): CaseService {
+        val runtimeMap = mutableMapOf<UUID, Pair<CaseRuntime, MutableStateFlow<CaseStatus>>>()
+        return mockk<CaseService>(relaxed = true).also { svc ->
+            every { svc.create(any()) } answers {
+                val id = UUID.randomUUID()
+                val flow = MutableStateFlow(CaseStatus.RUNNING)
+                val rt = mockk<CaseRuntime>(relaxed = true).also { every { it.statusFlow } returns flow }
+                runtimeMap[id] = rt to flow
+                Case(metadata = EntityMetadata(id = id), namespaceId = namespaceId)
+            }
+            every { svc.findActiveRuntime(any()) } answers { runtimeMap[firstArg<UUID>()]?.first }
+            every { svc.addMessage(caseId = any(), actor = any(), content = any()) } answers {
+                runtimeMap[firstArg<UUID>()]?.second?.value = CaseStatus.IDLE
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenarios
+    // ---------------------------------------------------------------------------
+
+    init {
+
+        "happy path: tickClaim then tickConsume closes Run as DONE" {
+            val spRepo = InMemoryScheduledPromptRepository()
+            val runRepo = InMemoryScheduledPromptRunRepository()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> setOf(userId1, userId2) }
+            makeScheduledPrompt(spRepo)
+
+            val scanner = makeScanner(
+                spRepo, runRepo, userRunRepo,
+                caseService = eventuallyIdleCaseService(),
+            )
+
+            // Phase A: claim the due slot, materialise UserRuns
+            scanner.tickClaim()
+
+            val runAfterClaim = runRepo.all().single()
+            runAfterClaim.status shouldBe RunStatus.RUNNING
+            userRunRepo.all() shouldHaveSize 2
+            userRunRepo.all().all { it.status == UserRunStatus.PENDING } shouldBe true
+
+            // Phase B: claim and execute UserRuns; Cases reach IDLE → UserRuns DONE → Run DONE
+            scanner.tickConsume()
+
+            val runAfterConsume = runRepo.findById(runAfterClaim.id)!!
+            runAfterConsume.status shouldBe RunStatus.DONE
+            userRunRepo.all().all { it.status == UserRunStatus.DONE } shouldBe true
+        }
+
+        "crash Phase A: orphaned CLAIMED Run is swept to FAILED, next tick creates new Run" {
+            val spRepo = InMemoryScheduledPromptRepository()
+            val runRepo = InMemoryScheduledPromptRunRepository()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> setOf(userId1) }
+            val sp = makeScheduledPrompt(spRepo, slot = Instant.parse("2026-01-01T08:00:00Z"))
+
+            // Simulate crash: insert a CLAIMED Run older than the orphan threshold (5 min)
+            // as if materialize never completed.
+            val orphanedRun = ScheduledPromptRun(
+                metadata = EntityMetadata(
+                    id = UUID.randomUUID(),
+                    created = Instant.parse("2025-12-31T08:00:00Z"),
+                ),
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2025-12-31T08:00:00Z"),
+                status = RunStatus.CLAIMED,
+                correlationId = "orphaned-claimed",
+            )
+            runRepo.insert(orphanedRun)
+
+            val scanner = makeScanner(
+                spRepo, runRepo, userRunRepo,
+                caseService = eventuallyIdleCaseService(),
+            )
+
+            // tickClaim: sweep marks orphan FAILED (unblocking hasActive guard),
+            // then claims the due slot → materialises → RUNNING.
+            scanner.tickClaim()
+
+            runRepo.findById(orphanedRun.id)!!.status shouldBe RunStatus.FAILED
+            val newRun = runRepo.all().first { it.id != orphanedRun.id }
+            newRun.status shouldBe RunStatus.RUNNING
+            userRunRepo.findByRunId(newRun.id) shouldHaveSize 1
+        }
+
+        "crash Phase B: orphaned RUNNING Run is swept to DONE on next tickClaim" {
+            val spRepo = InMemoryScheduledPromptRepository()
+            val runRepo = InMemoryScheduledPromptRunRepository()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> setOf(userId1) }
+            val sp = makeScheduledPrompt(spRepo, slot = Instant.parse("2026-01-01T10:00:00Z")) // not due
+
+            // Simulate crash: Run is RUNNING but checkCompletion was never called.
+            val orphanedRun = runRepo.insert(
+                ScheduledPromptRun(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    scheduledPromptId = sp.id,
+                    scheduledFor = Instant.parse("2026-01-01T08:00:00Z"),
+                    status = RunStatus.RUNNING,
+                    correlationId = "orphaned-running",
+                ),
+            )
+            // Seed a terminal UserRun — all settled, but the Run was never closed.
+            userRunRepo.materialize(orphanedRun.id, agentId, namespaceId)
+            userRunRepo.markTerminal(
+                userRunRepo.findByRunId(orphanedRun.id).first().id,
+                UserRunStatus.DONE,
+                nowInstant,
+            )
+
+            val scanner = makeScanner(
+                spRepo, runRepo, userRunRepo,
+                caseService = mockk(relaxed = true), // no due prompt — consume not invoked
+            )
+
+            // tickClaim sweeps the orphaned RUNNING run → DONE (no due prompts to claim)
+            scanner.tickClaim()
+
+            runRepo.findById(orphanedRun.id)!!.status shouldBe RunStatus.DONE
+        }
+
+        "multi-batch: all UserRuns processed when count exceeds batchSize" {
+            val userIds = (1..5).map { UUID.randomUUID() }.toSet()
+            val spRepo = InMemoryScheduledPromptRepository()
+            val runRepo = InMemoryScheduledPromptRunRepository()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> userIds }
+            makeScheduledPrompt(spRepo)
+
+            // batchSize = 2 → 3 batches needed for 5 UserRuns
+            val smallBatchProperties = SchedulerProperties(batchSize = 2, leaseMinutes = 30L)
+            val userService = mockk<UserService>().also { svc ->
+                userIds.forEach { id ->
+                    every { svc.findById(id) } returns User(
+                        metadata = EntityMetadata(id = id),
+                        externalId = "$id@example.com",
+                        firstname = "User",
+                        lastname = id.toString().take(6),
+                    )
+                }
+            }
+
+            val caseService = eventuallyIdleCaseService()
+
+            runRepo.userRunRepository = userRunRepo
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns promptTemplate
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns activeAgent
+            }
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = spRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+                properties = smallBatchProperties,
+                clock = clock,
+            )
+            val scanner = SchedulerScanner(
+                scheduledPromptRepository = spRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = agentConfigService,
+                properties = smallBatchProperties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+
+            // Phase A
+            scanner.tickClaim()
+            userRunRepo.all() shouldHaveSize 5
+
+            // Phase B: 3 batches of 2, 2, 1 — all 5 UserRuns must be processed
+            scanner.tickConsume()
+
+            userRunRepo.all().all { it.status == UserRunStatus.DONE } shouldBe true
+            runRepo.findById(runRepo.all().single().id)!!.status shouldBe RunStatus.DONE
+        }
+
+        "crash Phase B: orphaned RUNNING Run with failed UserRun is swept to FAILED" {
+            val spRepo = InMemoryScheduledPromptRepository()
+            val runRepo = InMemoryScheduledPromptRunRepository()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> setOf(userId1) }
+            val sp = makeScheduledPrompt(spRepo, slot = Instant.parse("2026-01-01T10:00:00Z")) // not due
+
+            val orphanedRun = runRepo.insert(
+                ScheduledPromptRun(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    scheduledPromptId = sp.id,
+                    scheduledFor = Instant.parse("2026-01-01T08:00:00Z"),
+                    status = RunStatus.RUNNING,
+                    correlationId = "orphaned-running-failed",
+                ),
+            )
+            userRunRepo.materialize(orphanedRun.id, agentId, namespaceId)
+            userRunRepo.markTerminal(
+                userRunRepo.findByRunId(orphanedRun.id).first().id,
+                UserRunStatus.FAILED,
+                nowInstant,
+                "Case creation failed",
+            )
+
+            val scanner = makeScanner(
+                spRepo, runRepo, userRunRepo,
+                caseService = mockk(relaxed = true),
+            )
+
+            scanner.tickClaim()
+
+            runRepo.findById(orphanedRun.id)!!.status shouldBe RunStatus.FAILED
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -346,7 +346,8 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
 
             val caseSlot = slot<Case>()
             verify(exactly = 1) { caseService.create(capture(caseSlot)) }
-            caseSlot.captured.title shouldBe "Weekly Digest"
+            // Title is left as the default "Case <uuid>" so CaseNamingService can auto-name it via LLM
+            caseSlot.captured.title shouldBe "Case ${caseSlot.captured.id}"
             verify(exactly = 1) {
                 permissionService.grantPermission(
                     userId1.toString(),

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -215,6 +215,37 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             userRunRepo.all().size shouldBe 1
         }
 
+        "Phase A: materialise propagates exception from userRunRepository — Run stays CLAIMED" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+
+            // Mock a userRunRepository whose materialize throws
+            val throwingUserRunRepo = mockk<ScheduledPromptUserRunRepository>().also {
+                every { it.materialize(run.id, agentId, namespaceId) } throws RuntimeException("Simulated Neo4j failure")
+            }
+
+            val exec = executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = throwingUserRunRepo,
+                promptService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            )
+
+            io.kotest.assertions.throwables.shouldThrow<RuntimeException> {
+                exec.materialize(run, sp)
+            }
+
+            // Run remains CLAIMED because updateStatus is never reached (exception thrown before it).
+            // In production the @Transactional boundary also rolls back any partial writes,
+            // but that cannot be verified in a unit test without a Spring context.
+            val updatedRun = runRepo.all().first { it.id == run.id }
+            updatedRun.status shouldBe RunStatus.CLAIMED
+        }
+
         "Phase A: platform-scope ScheduledPrompt materialises zero UserRuns and transitions to DONE" {
             val sp = makeScheduledPrompt(nsId = null)
             val run = makeRun(sp)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -346,8 +346,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
 
             val caseSlot = slot<Case>()
             verify(exactly = 1) { caseService.create(capture(caseSlot)) }
-            // Title is left as the default "Case <uuid>" so CaseNamingService can auto-name it via LLM
-            caseSlot.captured.title shouldBe "Case ${caseSlot.captured.id}"
+            caseSlot.captured.title shouldBe "Weekly Digest ${nowInstant}"
             verify(exactly = 1) {
                 permissionService.grantPermission(
                     userId1.toString(),

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -551,7 +551,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
         }
 
-        "tickClaim with OCCURRENCES: SKIPPED runs do not count toward maxOccurrenceCount" {
+        "tickClaim with OCCURRENCES: SKIPPED runs count toward maxOccurrenceCount" {
             val scheduledPromptRepo = makeScheduledPromptRepo()
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
@@ -560,16 +560,16 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 endType = SchedulerEndType.OCCURRENCES,
                 maxOccurrenceCount = 2,
             )
-            // Pre-insert 1 SKIPPED run (should not count)
+            // Pre-insert 1 SKIPPED run — slots count, not just executions
             runRepo.insert(ScheduledPromptRun(
                 scheduledPromptId = sp.id,
                 scheduledFor = slot.minusSeconds(86400),
                 status = RunStatus.SKIPPED,
                 correlationId = "skipped",
             ))
-            // tickClaim inserts run #1 (non-skipped) → total completed = 1 < maxOccurrenceCount = 2
+            // tickClaim inserts run #2 (SKIPPED + this one) → total = 2 ≥ maxOccurrenceCount = 2 → disables
             scanner(scheduledPromptRepo, runRepo).tickClaim()
-            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -736,6 +736,178 @@ class SchedulerScannerUnitSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
+        // Tick isolation — one failing prompt must not block others
+        // -------------------------------------------------------------------------
+
+        "tickClaim: exception in claim() for one prompt does not block subsequent prompts" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp1 = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+            val sp2 = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+
+            // Real repo for sp2's run tracking; mock that throws on insert for sp1 only.
+            val realRunRepo = makeRunRepo()
+            val throwingRunRepo = mockk<ScheduledPromptRunRepository>(relaxed = true).also {
+                every { it.insert(match { run -> run.scheduledPromptId == sp1.id }) } throws
+                    RuntimeException("Simulated Neo4j failure for sp1")
+                every { it.insert(match { run -> run.scheduledPromptId == sp2.id }) } answers {
+                    realRunRepo.insert(firstArg())
+                }
+                every { it.hasActive(any()) } returns false
+                every { it.findOrphanedClaimed(any()) } returns emptyList()
+                every { it.findSettledRunning() } returns emptyList()
+                every { it.findById(any()) } answers { realRunRepo.findById(firstArg()) }
+                every { it.updateStatus(any(), any(), any(), any()) } answers {
+                    realRunRepo.updateStatus(firstArg(), secondArg(), thirdArg(), arg(3))
+                }
+                every { it.countCompletedRuns(any()) } returns 0
+            }
+
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = throwingRunRepo,
+                userRunRepository = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = properties,
+                clock = clock,
+            )
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = throwingRunRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = properties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+
+            // Must not throw — sp1 fails, sp2 must still be processed
+            sc.tickClaim()
+
+            // sp2 produced a run, sp1 did not (exception on insert)
+            realRunRepo.all().any { it.scheduledPromptId == sp2.id } shouldBe true
+            realRunRepo.all().none { it.scheduledPromptId == sp1.id } shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // updateEnabled does not overwrite nextRunAt
+        // -------------------------------------------------------------------------
+
+        "tickClaim with deleted AgentConfig: nextRunAt is preserved after disable" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+
+            val agentSvc = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns null
+            }
+            scanner(scheduledPromptRepo, runRepo, agentSvc).tickClaim()
+
+            val updated = scheduledPromptRepo.findById(sp.id)!!
+            updated.enabled shouldBe false
+            // nextRunAt must be untouched — updateEnabled only writes enabled
+            updated.nextRunAt shouldBe slot
+        }
+
+        "tickClaim with ON_DATE end condition: nextRunAt is preserved after post-advance disable" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            // endDate = 2026-01-05 → next slot Jan 8 > endDate → disables after advance
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.ON_DATE,
+                endDate = LocalDate.of(2026, 1, 5),
+            )
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+
+            val updated = scheduledPromptRepo.findById(sp.id)!!
+            updated.enabled shouldBe false
+            // nextRunAt must have been advanced to Jan 8, not reverted to the original slot
+            updated.nextRunAt shouldBe Instant.parse("2026-01-08T08:00:00Z")
+        }
+
+        // -------------------------------------------------------------------------
+        // Startup invariant: leaseMinutes > launchTimeoutSeconds
+        // -------------------------------------------------------------------------
+
+        "SchedulerScanner startup: throws when leaseMinutes * 60 <= launchTimeoutSeconds" {
+            val badProperties = SchedulerProperties(
+                leaseMinutes = 1L,          // 60 seconds
+                launchTimeoutSeconds = 60L, // equal → not strictly greater
+            )
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = badProperties,
+                clock = clock,
+            )
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = badProperties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+            io.kotest.assertions.throwables.shouldThrow<IllegalArgumentException> {
+                sc.logStartup()
+            }
+        }
+
+        "SchedulerScanner startup: does not throw when leaseMinutes * 60 > launchTimeoutSeconds" {
+            val goodProperties = SchedulerProperties(
+                leaseMinutes = 2L,          // 120 seconds
+                launchTimeoutSeconds = 60L, // strictly less → valid
+            )
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = goodProperties,
+                clock = clock,
+            )
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = goodProperties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+            // Must not throw
+            sc.logStartup()
+        }
+
+        // -------------------------------------------------------------------------
         // End condition — NEVER
         // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -448,10 +448,11 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 endType = SchedulerEndType.OCCURRENCES,
                 maxOccurrenceCount = 1,
             )
-            // Pre-insert 1 completed run → already at max
+            // Pre-insert 1 completed run within the planning window (startDate = 2026-01-01)
+            // → already at max
             runRepo.insert(ScheduledPromptRun(
                 scheduledPromptId = sp.id,
-                scheduledFor = slot.minusSeconds(86400),
+                scheduledFor = Instant.parse("2026-01-01T07:00:00Z"),
                 status = RunStatus.DONE,
                 correlationId = "prev-done",
             ))
@@ -526,16 +527,72 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 endType = SchedulerEndType.OCCURRENCES,
                 maxOccurrenceCount = 2,
             )
-            // Pre-insert 1 completed run
+            // Pre-insert 1 completed run within the planning window (startDate = 2026-01-01)
             runRepo.insert(ScheduledPromptRun(
                 scheduledPromptId = sp.id,
-                scheduledFor = slot.minusSeconds(86400),
+                scheduledFor = Instant.parse("2026-01-01T07:00:00Z"),
                 status = RunStatus.DONE,
                 correlationId = "prev-1",
             ))
             // tickClaim inserts run #2 → total completed = 2 (prev + this one) ≥ maxOccurrenceCount = 2
             scanner(scheduledPromptRepo, runRepo).tickClaim()
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
+        }
+
+        "tickClaim with OCCURRENCES: runs before startDate do NOT count toward maxOccurrenceCount" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            // startDate = today (2026-01-01), maxOccurrenceCount = 1
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.OCCURRENCES,
+                maxOccurrenceCount = 1,
+            )
+            // Pre-insert 1 completed run BEFORE startDate (from the old planning window)
+            // This run must NOT count toward the quota
+            runRepo.insert(ScheduledPromptRun(
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2025-12-31T08:00:00Z"), // before 2026-01-01
+                status = RunStatus.DONE,
+                correlationId = "old-window-run",
+            ))
+            // tickClaim runs the due slot → quota count = 1 (only the new run counts)
+            // → disables after (count reaches maxOccurrenceCount = 1)
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            // The new run was inserted (old-window run does not block it)
+            runRepo.all().filter { it.correlationId != "old-window-run" } shouldHaveSize 1
+            // After inserting run #1 in the window, count = 1 >= max = 1 → disabled
+            scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe false
+        }
+
+        "tickClaim with OCCURRENCES: runs before startDate do NOT block pre-check (quota not consumed)" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            // startDate = today (2026-01-01), maxOccurrenceCount = 1
+            val sp = scheduledPromptRepo.insertScheduledPrompt(
+                nextRunAt = slot,
+                endType = SchedulerEndType.OCCURRENCES,
+                maxOccurrenceCount = 1,
+            )
+            // Pre-insert 2 completed runs BEFORE startDate
+            // Neither should count — the pre-check must NOT disable the prompt
+            runRepo.insert(ScheduledPromptRun(
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2025-12-30T08:00:00Z"),
+                status = RunStatus.DONE,
+                correlationId = "old-1",
+            ))
+            runRepo.insert(ScheduledPromptRun(
+                scheduledPromptId = sp.id,
+                scheduledFor = Instant.parse("2025-12-31T08:00:00Z"),
+                status = RunStatus.DONE,
+                correlationId = "old-2",
+            ))
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            // The due slot must have been executed (old-window runs did not consume the quota)
+            runRepo.all().filter { it.correlationId !in listOf("old-1", "old-2") } shouldHaveSize 1
         }
 
         "tickClaim with OCCURRENCES: does NOT disable when completed runs are below maxOccurrenceCount" {
@@ -560,10 +617,11 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 endType = SchedulerEndType.OCCURRENCES,
                 maxOccurrenceCount = 2,
             )
-            // Pre-insert 1 SKIPPED run — slots count, not just executions
+            // Pre-insert 1 SKIPPED run within the planning window (startDate = 2026-01-01)
+            // Slots count, not just successful executions
             runRepo.insert(ScheduledPromptRun(
                 scheduledPromptId = sp.id,
-                scheduledFor = slot.minusSeconds(86400),
+                scheduledFor = Instant.parse("2026-01-01T07:00:00Z"),
                 status = RunStatus.SKIPPED,
                 correlationId = "skipped",
             ))
@@ -760,7 +818,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 every { it.updateStatus(any(), any(), any(), any()) } answers {
                     realRunRepo.updateStatus(firstArg(), secondArg(), thirdArg(), arg(3))
                 }
-                every { it.countCompletedRuns(any()) } returns 0
+                every { it.countCompletedRuns(any(), any()) } returns 0
             }
 
             val userRunRepo = InMemoryScheduledPromptUserRunRepository()

--- a/agentos/docs/scheduled-prompt.md
+++ b/agentos/docs/scheduled-prompt.md
@@ -1,0 +1,65 @@
+# Scheduled Prompt
+
+## Overview
+
+A `ScheduledPrompt` fires a prompt against an agent on a recurring schedule, creating one
+`ScheduledPromptRun` per slot and one `ScheduledPromptUserRun` per target user.
+
+Execution is split into two phases handled by `SchedulerScanner` and `ScheduledPromptExecutor`:
+
+- **Phase A — Claim** (`tickClaim`): discovers due prompts, inserts a Run, and materialises
+  UserRuns via a single Cypher INSERT-SELECT.
+- **Phase B — Consume** (`tickConsume`): claims PENDING UserRuns, creates a Case per user,
+  injects the prompt, and monitors the launch.
+
+## UserRun lifecycle
+
+```
+PENDING → RUNNING → DONE
+                  → TIMEOUT   (Case still running after launchTimeoutSeconds — monitoring released)
+                  → FAILED    (Case ERROR/KILLED, or exception during Case creation)
+```
+
+TIMEOUT is terminal. A Run whose UserRuns are all DONE/TIMEOUT closes as DONE.
+A Run with at least one FAILED UserRun closes as FAILED.
+
+## Occurrence quota
+
+`maxOccurrenceCount` counts **slots**, not executions. SKIPPED runs (overlap with an active
+run) consume an occurrence — without this, overlapping slots would allow the prompt to
+execute beyond its intended temporal window.
+
+The count is scoped to `scheduledFor >= planning.startDate` so that changing the start date
+resets the quota for the new planning window.
+
+## Crash recovery
+
+All recovery is passive — no dedicated recovery process, no manual intervention.
+Each mechanism fires automatically on the next tick.
+
+| Crash window | Stuck state | Recovery mechanism | Delay |
+|---|---|---|---|
+| Between `runRepository.insert()` and `runCatching { executor.materialize() }` | Run CLAIMED, no UserRuns created | `recoverOrphanedClaimedRuns` marks FAILED after `ORPHAN_THRESHOLD` (5 min) | ~5 min |
+| Inside `materialize()` (transactional) | Run CLAIMED (transaction rolled back), no UserRuns | Inline `runCatching` marks FAILED immediately if instance alive; otherwise same as above | Immediate or ~5 min |
+| Between `materialize()` and `markTerminal()` | UserRun RUNNING with expired lease | `claimBatch` reclaims on lease expiry — new Case created (at-least-once) | `leaseMinutes` |
+| Between last `markTerminal()` and `checkCompletion()` | Run RUNNING, all UserRuns terminal | `recoverOrphanedRunningRuns` closes Run as DONE or FAILED on next tick | Next claim tick |
+
+### Delivery guarantee
+
+UserRun execution is **at-least-once**: if an instance crashes after creating a Case but
+before `markTerminal`, the lease expires and a subsequent `claimBatch` creates a second
+Case for the same user. This is acceptable for the scheduled-prompt use case (duplicate
+conversation, no data corruption). Exactly-once would require a UNIQUE constraint on Case
+keyed by `(runId, userId)`.
+
+### Invariant: `leaseMinutes * 60 > launchTimeoutSeconds`
+
+The lease must outlive the launch timeout. A shorter lease allows UserRuns to be reclaimed
+before `monitorLaunch` completes, causing double execution within the same slot.
+Enforced at startup via `require()` in `SchedulerScanner.logStartup()`.
+
+## `updateStatus` guard
+
+`ScheduledPromptRunNodeNeo4jRepository.updateStatus` only writes when the Run is not already
+in a terminal status (`DONE` or `FAILED`). This prevents `recoverOrphanedRunningRuns` from
+overwriting `finishedAt` already set by `checkCompletion` when both race on the same Run.


### PR DESCRIPTION
This is a follow-up to https://github.com/whoz-oss/coday/pull/1214

Move the `try`/`catch` from inside processUserRun up to the launch site in the caller, so exceptions propagate correctly through the `supervisorScope` boundary.
Replace `coroutineScope` with `supervisorScope` so a failing UserRun does not cancel its siblings in the same batch.
Re-throw `CancellationException` explicitly to avoid silently swallowing coroutine cancellation from the parent scope.

Group UserRuns by runId so each group's completion check runs immediately after its UserRuns settle, removing the need for a separate post-batch sweep.

Extract resolveContext, createAndInjectCase and awaitLaunch to give each step a clear single responsibility.

## Follow-up fixes identified:

Fix materialize swallowing Neo4j failures: remove runCatching { }.getOrDefault(0) so exceptions propagate out of the `@Transactional` boundary. claim() catches the exception, marks the Run FAILED immediately with the error message, and logs the cause. Previously a transient Neo4j error silently produced count = 0 → DONE, losing the slot with no trace.

Isolate `claim()` failures per prompt: wrap each `claim(sp)` call and each orphan sweep in `runCatching` inside `tickClaim`. A single failing prompt no longer aborts the entire tick — subsequent prompts in the same tick are unaffected.

Fix checkEndConditionAfterAdvance overwriting the scheduler advance: replace `save(scheduledPrompt.copy(enabled = false))` with a targeted `updateEnabled(id, false)` Cypher query that touches only the `enabled` field. The full-aggregate save was writing the stale `nextRunAt` captured at the start of `claim()`, silently undoing the optimistic advance performed just above.

Add startup invariant for `leaseMinutes > launchTimeoutSeconds`: enforce via `require()` in `SchedulerScanner.logStartup()`. A lease shorter than the launch timeout allows UserRuns to be reclaimed and double-executed before `monitorLaunch` completes.

Collapse duplicate `when` branches in `monitorLaunch`: the two non-null branches both called `closeUserRun` — unified into a single `observedStatus != null` arm.

Remove forgotten `logger.info { "[DEBUG] slot=…" }` left in `claim()`.

Document `countCompletedRuns` intent: FAILED runs intentionally consume an occurrence of `maxOccurrenceCount` — the quota tracks "how many times the prompt fired", not "how many times it succeeded".

Fix KDoc divergences: `supervisorScope` vs `coroutineScope` in `consumeAvailable`, `batchSize` bounds concurrency (not `groupBy`), correct `monitorLaunch` StateFlow semantics, correct completion sweep description.

## Late additions

- **Occurrence counting on reschedule**: when a scheduled prompt is modified, only runs whose `scheduledFor` falls within the new planning window (`>= planning.startDate`) count toward the `maxOccurrenceCount` quota. Past executions outside the window are ignored.
- **LLM-generated conversation title**: conversation name is left `null` on creation, allowing the LLM to generate it lazily on first interaction.