### PR TITLE
fix: wz-33620 restrict UserRun materialisation to UserGroup deployment only

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
@@ -13,18 +13,20 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
      * Traverses the deployment graph and materialises PENDING UserRuns in a single query.
      *
      * Resolves all non-removed Users that are **deployment targets** of [agentConfigId]
-     * in [namespaceId] via two paths:
+     * in [namespaceId] via UserGroup deployment only:
      *
-     * 1. **UserGroup deployment**: `AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User`,
-     *    where the UserGroup `[:BELONGS_TO]` the namespace.
-     * 2. **Namespace deployment**: `AgentConfig -[:DEPLOYED_TO]-> Namespace <-[:MEMBER|ADMIN]- User`.
+     * `AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User`,
+     * where the UserGroup `[:BELONGS_TO]` the namespace.
+     *
+     * Namespace-level deployment is intentionally excluded: being a member of the namespace
+     * does not mean the user is a target audience of this specific agent. Only users
+     * belonging to a UserGroup explicitly deployed to the agent are targeted.
      *
      * Super-admins are intentionally **excluded** unless they are also members of a
-     * deployed UserGroup or namespace. `isAdmin` grants the ability to *use* any agent
-     * (access control), but scheduled prompts target users who are *deployed to* the
-     * agent — being an admin is not the same as being a target audience.
+     * deployed UserGroup. `isAdmin` grants the ability to *use* any agent (access control),
+     * but scheduled prompts target users who are *deployed to* the agent — being an admin
+     * is not the same as being a target audience.
      *
-     * Both paths are resolved via OPTIONAL MATCH and collected into a single set.
      * Then MERGEs a PENDING [ScheduledPromptUserRunNode] for each distinct eligible user.
      *
      * Safe to replay on crash — MERGE is idempotent on the composite UNIQUE `(runId, userId)` constraint.
@@ -39,17 +41,11 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
           WHERE NOT COALESCE(ns.removed, false)
         MATCH (u:User)
           WHERE NOT COALESCE(u.removed, false)
-            AND (
-                EXISTS {
-                    MATCH (u)-[:MEMBER|ADMIN]->(g:UserGroup)-[:BELONGS_TO]->(ns)
-                    WHERE NOT COALESCE(g.removed, false)
-                    MATCH (a)-[:DEPLOYED_TO]->(g)
-                }
-                OR (
-                    EXISTS { MATCH (a)-[:DEPLOYED_TO]->(ns) }
-                    AND EXISTS { MATCH (u)-[:MEMBER|ADMIN]->(ns) }
-                )
-            )
+            AND EXISTS {
+                MATCH (u)-[:MEMBER|ADMIN]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+                WHERE NOT COALESCE(g.removed, false)
+                MATCH (a)-[:DEPLOYED_TO]->(g)
+            }
         WITH DISTINCT u.id AS userId
         MERGE (ur:ScheduledPromptUserRun {runId: $runId, userId: userId})
         ON CREATE SET

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunNodeNeo4jRepository.kt
@@ -39,13 +39,10 @@ interface ScheduledPromptUserRunNodeNeo4jRepository : Neo4jRepository<ScheduledP
           WHERE NOT COALESCE(a.removed, false) AND a.enabled = true
         MATCH (ns:Namespace {id: $namespaceId})
           WHERE NOT COALESCE(ns.removed, false)
-        MATCH (u:User)
+        MATCH (a)-[:DEPLOYED_TO]->(g:UserGroup)-[:BELONGS_TO]->(ns)
+          WHERE NOT COALESCE(g.removed, false)
+        MATCH (u:User)-[:MEMBER|ADMIN]->(g)
           WHERE NOT COALESCE(u.removed, false)
-            AND EXISTS {
-                MATCH (u)-[:MEMBER|ADMIN]->(g:UserGroup)-[:BELONGS_TO]->(ns)
-                WHERE NOT COALESCE(g.removed, false)
-                MATCH (a)-[:DEPLOYED_TO]->(g)
-            }
         WITH DISTINCT u.id AS userId
         MERGE (ur:ScheduledPromptUserRun {runId: $runId, userId: userId})
         ON CREATE SET

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptUserRunRepository.kt
@@ -39,11 +39,13 @@ interface ScheduledPromptUserRunRepository {
      * Traverses the deployment graph and materialises ALL PENDING UserRuns in one query.
      *
      * Resolves all non-removed Users that are deployment targets of [agentConfigId] in
-     * [namespaceId] via two paths:
-     * 1. UserGroup deployment (`AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User`)
-     * 2. Namespace deployment (`AgentConfig -[:DEPLOYED_TO]-> Namespace <-[:MEMBER|ADMIN]- User`)
+     * [namespaceId] via UserGroup deployment only:
+     * `AgentConfig -[:DEPLOYED_TO]-> UserGroup <-[:MEMBER|ADMIN]- User`
      *
-     * Super-admins are excluded unless they are also members of a deployed group/namespace.
+     * Namespace-level membership is intentionally excluded — only users belonging to a
+     * UserGroup explicitly deployed to the agent are targeted.
+     *
+     * Super-admins are excluded unless they are also members of a deployed UserGroup.
      *
      * Then MERGEs a PENDING [ScheduledPromptUserRun] for each distinct user.
      *

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
@@ -200,35 +200,16 @@ abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
             count shouldBe 0
         }
 
-        "materialize creates UserRuns for users in multiple groups deployed to the same agent" {
+        "materialize deduplicates users belonging to multiple deployed groups" {
             val runId = UUID.randomUUID()
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id))
             val group1 = userGroupRepo.save(userGroup(ns.id, "group-1"))
             val group2 = userGroupRepo.save(userGroup(ns.id, "group-2"))
-            userRepo.save(user("alice@example.com"))
-            userRepo.save(user("bob@example.com"))
             userGroupRepo.addAgents(group1.id, listOf(agent.id))
             userGroupRepo.addAgents(group2.id, listOf(agent.id))
-            userGroupRepo.addUsers(group1.id, listOf("alice@example.com"))
-            userGroupRepo.addUsers(group2.id, listOf("bob@example.com"))
-
-            val count = userRunRepo.materialize(runId, agent.id, ns.id)
-
-            count shouldBe 2
-            userRunRepo.findByRunId(runId).size shouldBe 2
-        }
-
-        "materialize deduplicates users in multiple groups deployed to the same agent" {
-            val runId = UUID.randomUUID()
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id))
-            val group1 = userGroupRepo.save(userGroup(ns.id, "group-1"))
-            val group2 = userGroupRepo.save(userGroup(ns.id, "group-2"))
+            // alice is in both deployed groups — must produce only one UserRun
             userRepo.save(user("alice@example.com"))
-            userGroupRepo.addAgents(group1.id, listOf(agent.id))
-            userGroupRepo.addAgents(group2.id, listOf(agent.id))
-            // alice is in BOTH groups — should produce only one UserRun
             userGroupRepo.addUsers(group1.id, listOf("alice@example.com"))
             userGroupRepo.addUsers(group2.id, listOf("alice@example.com"))
 
@@ -238,18 +219,47 @@ abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
             userRunRepo.findByRunId(runId).size shouldBe 1
         }
 
-        "materialize does not create UserRuns for users in groups not deployed to the agent" {
+        "materialize only targets users in deployed groups, not all users of the same namespace" {
             val runId = UUID.randomUUID()
             val ns = namespaceRepo.save(namespace())
             val agent = agentConfigRepo.save(agentConfig(ns.id))
-            val undeployedGroup = userGroupRepo.save(userGroup(ns.id, "undeployed-group"))
+
+            // Group deployed to the agent — alice should be targeted
+            val deployedGroup = userGroupRepo.save(userGroup(ns.id, "deployed-group"))
+            userGroupRepo.addAgents(deployedGroup.id, listOf(agent.id))
             userRepo.save(user("alice@example.com"))
-            // alice is in a group, but the group has no DEPLOYED_TO edge to agent
-            userGroupRepo.addUsers(undeployedGroup.id, listOf("alice@example.com"))
+            userGroupRepo.addUsers(deployedGroup.id, listOf("alice@example.com"))
+
+            // Group in the same namespace but NOT deployed to the agent — bob must be excluded
+            val otherGroup = userGroupRepo.save(userGroup(ns.id, "other-group"))
+            userRepo.save(user("bob@example.com"))
+            userGroupRepo.addUsers(otherGroup.id, listOf("bob@example.com"))
+
+            val count = userRunRepo.materialize(runId, agent.id, ns.id)
+
+            count shouldBe 1
+            val userRuns = userRunRepo.findByRunId(runId)
+            userRuns.size shouldBe 1
+            userRuns.first().userId shouldBe userRepo.findByExternalId("alice@example.com")!!.id
+        }
+
+        "materialize does not create UserRuns for users who are namespace members but not in any deployed group" {
+            val runId = UUID.randomUUID()
+            val ns = namespaceRepo.save(namespace())
+            val agent = agentConfigRepo.save(agentConfig(ns.id))
+            val bob = userRepo.save(user("bob@example.com"))
+            // bob is a direct member of the namespace, but not in any UserGroup deployed to the agent
+            driver.session().use { session ->
+                session.run(
+                    "MATCH (u:User {id: \$userId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (u)-[:MEMBER]->(ns)",
+                    mapOf("userId" to bob.id.toString(), "nsId" to ns.id.toString()),
+                )
+            }
 
             val count = userRunRepo.materialize(runId, agent.id, ns.id)
 
             count shouldBe 0
+            userRunRepo.findByRunId(runId).shouldBeEmpty()
         }
 
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
@@ -27,8 +27,10 @@ import java.util.UUID
  * Persistence contract tests for [ScheduledPromptUserRunRepository] Cypher queries.
  *
  * Covers:
- * - [ScheduledPromptUserRunRepository.materialize] — deployment graph traversal,
- *   idempotency, soft-delete filtering, ADMIN relation, multi-group deduplication
+ * - [ScheduledPromptUserRunRepository.materialize] — UserGroup deployment graph traversal only,
+ *   idempotency, soft-delete filtering, ADMIN relation, multi-group deduplication.
+ *   Namespace-level deployment is intentionally excluded — only users in UserGroups
+ *   explicitly deployed to the agent are targeted.
  * - [ScheduledPromptUserRunRepository.claimBatch] — PENDING→RUNNING transition,
  *   limit enforcement, lease-based crash recovery, terminal status exclusion
  * - [ScheduledPromptUserRunRepository.markTerminal] — DONE/FAILED transitions
@@ -248,79 +250,6 @@ abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
             val count = userRunRepo.materialize(runId, agent.id, ns.id)
 
             count shouldBe 0
-        }
-
-        // -------------------------------------------------------------------------
-        // materialize — Namespace deployment path
-        // -------------------------------------------------------------------------
-
-        "materialize creates UserRuns for users when agent is deployed directly to namespace" {
-            val runId = UUID.randomUUID()
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id))
-            val alice = userRepo.save(user("alice@example.com"))
-            // Deploy agent directly to namespace (no UserGroup)
-            driver.session().use { session ->
-                session.run(
-                    "MATCH (a:AgentConfig {id: \$agentId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (a)-[:DEPLOYED_TO]->(ns)",
-                    mapOf("agentId" to agent.id.toString(), "nsId" to ns.id.toString()),
-                )
-                // User is MEMBER of namespace
-                session.run(
-                    "MATCH (u:User {id: \$userId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (u)-[:MEMBER]->(ns)",
-                    mapOf("userId" to alice.id.toString(), "nsId" to ns.id.toString()),
-                )
-            }
-
-            val count = userRunRepo.materialize(runId, agent.id, ns.id)
-
-            count shouldBe 1
-            val userRuns = userRunRepo.findByRunId(runId)
-            userRuns.size shouldBe 1
-            userRuns.first().userId shouldBe alice.id
-        }
-
-        "materialize via namespace deployment excludes users not member/admin of namespace" {
-            val runId = UUID.randomUUID()
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id))
-            userRepo.save(user("alice@example.com"))
-            // Deploy agent to namespace, but alice has NO membership edge to namespace
-            driver.session().use { session ->
-                session.run(
-                    "MATCH (a:AgentConfig {id: \$agentId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (a)-[:DEPLOYED_TO]->(ns)",
-                    mapOf("agentId" to agent.id.toString(), "nsId" to ns.id.toString()),
-                )
-            }
-
-            val count = userRunRepo.materialize(runId, agent.id, ns.id)
-
-            count shouldBe 0
-        }
-
-        "materialize deduplicates users found via both UserGroup and Namespace deployment" {
-            val runId = UUID.randomUUID()
-            val ns = namespaceRepo.save(namespace())
-            val agent = agentConfigRepo.save(agentConfig(ns.id))
-            val group = userGroupRepo.save(userGroup(ns.id))
-            val alice = userRepo.save(user("alice@example.com"))
-            userGroupRepo.addAgents(group.id, listOf(agent.id))
-            userGroupRepo.addUsers(group.id, listOf("alice@example.com"))
-            // Also deploy agent directly to namespace, and alice is MEMBER of namespace
-            driver.session().use { session ->
-                session.run(
-                    "MATCH (a:AgentConfig {id: \$agentId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (a)-[:DEPLOYED_TO]->(ns)",
-                    mapOf("agentId" to agent.id.toString(), "nsId" to ns.id.toString()),
-                )
-                session.run(
-                    "MATCH (u:User {id: \$userId}) MATCH (ns:Namespace {id: \$nsId}) MERGE (u)-[:MEMBER]->(ns)",
-                    mapOf("userId" to alice.id.toString(), "nsId" to ns.id.toString()),
-                )
-            }
-
-            val count = userRunRepo.materialize(runId, agent.id, ns.id)
-
-            count shouldBe 1
         }
 
         // -------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow-up to https://github.com/whoz-oss/coday/pull/1214

---

The Cypher query was targeting all namespace members when the agent was deployed to the namespace, too broad. Now only users who are members of a UserGroup explicitly deployed on the agent are targeted.