### PR TITLE
feat(agentos): add star endpoints and list my cases by parent on SDK #33653

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseApi.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseApi.kt
@@ -21,6 +21,14 @@ interface CaseApi : EntityCrudApi<CaseDto> {
     @Operation(summary = "List cases by namespace", description = "GET /api/cases/by-parentId/{parentId} — list all cases belonging to a namespace.")
     fun listByParent(parentId: UUID): List<CaseDto>
 
+    @Operation(
+        summary = "List my cases by namespace",
+        description = "GET /api/cases/by-parentId/{parentId}/mine — list only the cases in the namespace the " +
+            "current user has a direct relation with. Unlike listByParent, admin transitivity is excluded: " +
+            "every returned case is one the caller can star.",
+    )
+    fun listMineByParent(parentId: UUID): List<CaseDto>
+
     @Operation(summary = "List cases by user", description = "GET /api/cases/by-user/{userId} — list all cases concerning a specific user.")
     fun listByUser(userId: UUID): List<CaseDto>
 
@@ -41,4 +49,18 @@ interface CaseApi : EntityCrudApi<CaseDto> {
 
     @Operation(summary = "Kill a case", description = "POST /api/cases/{caseId}/kill — permanently terminate a case.")
     fun killCase(caseId: UUID)
+
+    @Operation(
+        summary = "Star a case",
+        description = "PUT /api/cases/{id}/star — mark the case as favorite for the current user. " +
+            "Requires a direct user↔case relation, otherwise the call is rejected.",
+    )
+    fun starCase(id: UUID)
+
+    @Operation(
+        summary = "Unstar a case",
+        description = "DELETE /api/cases/{id}/star — remove the case from the current user's favorites. " +
+            "Requires a direct user↔case relation, otherwise the call is rejected.",
+    )
+    fun unstarCase(id: UUID)
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -123,7 +123,7 @@ class CaseController(
      */
     @GetMapping("/by-parentId/{parentId}/mine")
     @PreAuthorize("hasPermission(#parentId, 'Namespace', 'READ')")
-    fun listMineByParent(
+    override fun listMineByParent(
         @PathVariable parentId: UUID,
     ): List<CaseDto> {
         val user = userService.getCurrentUser()
@@ -316,7 +316,7 @@ class CaseController(
     @PutMapping("/{id}/star")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("hasPermission(#id, 'Case', 'READ')")
-    fun starCase(
+    override fun starCase(
         @PathVariable id: UUID,
     ) {
         val userId = userService.getCurrentUser().id.toString()
@@ -328,7 +328,7 @@ class CaseController(
     @DeleteMapping("/{id}/star")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasPermission(#id, 'Case', 'READ')")
-    fun unstarCase(
+    override fun unstarCase(
         @PathVariable id: UUID,
     ) {
         val userId = userService.getCurrentUser().id.toString()

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -939,6 +939,10 @@ paths:
       - case-controller
   /api/cases/by-parentId/{parentId}/mine:
     get:
+      description: "GET /api/cases/by-parentId/{parentId}/mine — list only the cases\
+        \ in the namespace the current user has a direct relation with. Unlike listByParent,\
+        \ admin transitivity is excluded: every returned case is one the caller can\
+        \ star."
       operationId: listMineByParentCase
       parameters:
       - in: path
@@ -956,6 +960,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Case"
           description: OK
+      summary: List my cases by namespace
       tags:
       - case-controller
   /api/cases/by-user/external/{externalId}:
@@ -1359,6 +1364,9 @@ paths:
       - case-controller
   /api/cases/{id}/star:
     delete:
+      description: "DELETE /api/cases/{id}/star — remove the case from the current\
+        \ user's favorites. Requires a direct user↔case relation, otherwise the call\
+        \ is rejected."
       operationId: unstarCase
       parameters:
       - in: path
@@ -1370,9 +1378,12 @@ paths:
       responses:
         "204":
           description: No Content
+      summary: Unstar a case
       tags:
       - case-controller
     put:
+      description: "PUT /api/cases/{id}/star — mark the case as favorite for the current\
+        \ user. Requires a direct user↔case relation, otherwise the call is rejected."
       operationId: starCase
       parameters:
       - in: path
@@ -1384,6 +1395,7 @@ paths:
       responses:
         "200":
           description: OK
+      summary: Star a case
       tags:
       - case-controller
   /api/feedbacks:

--- a/libs/agentos-api-client/src/lib/api/case-controller.service.ts
+++ b/libs/agentos-api-client/src/lib/api/case-controller.service.ts
@@ -855,6 +855,8 @@ export class CaseControllerService extends BaseService {
   }
 
   /**
+   * List my cases by namespace
+   * GET /api/cases/by-parentId/{parentId}/mine — list only the cases in the namespace the current user has a direct relation with. Unlike listByParent, admin transitivity is excluded: every returned case is one the caller can star.
    * @param parentId
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
@@ -924,6 +926,8 @@ export class CaseControllerService extends BaseService {
   }
 
   /**
+   * Star a case
+   * PUT /api/cases/{id}/star — mark the case as favorite for the current user. Requires a direct user↔case relation, otherwise the call is rejected.
    * @param id
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
@@ -993,6 +997,8 @@ export class CaseControllerService extends BaseService {
   }
 
   /**
+   * Unstar a case
+   * DELETE /api/cases/{id}/star — remove the case from the current user\&#39;s favorites. Requires a direct user↔case relation, otherwise the call is rejected.
    * @param id
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.


### PR DESCRIPTION
## Context

`CaseApi` (`agentos/agentos-sdk/.../api/case/CaseApi.kt`) is the SDK's hand-written HTTP contract: it is implemented server-side by `CaseController`, and by external consumers — notably the whoz Copilot module — as a Feign client. It is therefore the only API surface an external consumer sees.

Three endpoints existed in `CaseController` but had never been declared in the interface:

- `PUT /api/cases/{id}/star`
- `DELETE /api/cases/{id}/star`
- `GET /api/cases/by-parentId/{parentId}/mine`

As a result, these routes were unreachable for any Feign consumer, and nothing guaranteed parity between the controller and the contract — the gap could grow silently.

## Changes

Declare the three missing operations on `CaseApi`, with `@Operation` describing their semantics:

- `starCase(id: UUID)` / `unstarCase(id: UUID)` — the description states that the call requires a direct user↔case relation, otherwise it is rejected (409).
- `listMineByParent(parentId: UUID): List<CaseDto>` — placed right after `listByParent` to keep both listing variants together; the description spells out the difference, namely that namespace-admin transitivity is excluded, which is what makes every returned case starrable by the caller.

The three matching `CaseController` methods become `override`.

## Design notes

The `override` is the real point of this PR: any future divergence between the controller and the SDK contract now breaks compilation instead of going unnoticed.

Existing `CaseApi` conventions are preserved: no Spring annotations, no `@PreAuthorize` and no `@Valid` on the interface — these are service-layer concerns, as documented in the interface KDoc. Parameter naming follows the controller (`id` for star/unstar, `parentId` for listings), which is a prerequisite for the `override` to compile.

## Side effect on the spec and the TS client

`agentos-openapi.yaml` and `case-controller.service.ts` are regenerated (`nx run agentos-service:regenerate`), since the spec is derived from the controller and verified in CI. The diff is **documentation only**: the `summary`/`description` inherited from the `@Operation` annotations. No signature, no `operationId` and no TS method changes — the TypeScript client already exposed `starCase`, `unstarCase` and `listMineByParentCase`, because it is generated from the controller and not from the interface. That very gap between the two layers is what hid the problem.

## Verification

- `agentos-sdk` + `agentos-service` compile
- `CaseControllerSpec` and `CaseControllerMvcIntegrationSpec` green (tests for all three endpoints, including the 409 cases, already existed)
- Spec regenerated and committed, consistent with the `check-openapi-spec` CI check