### PR TITLE
feat: #1235 Add queryUser tool and resume agents after answers

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
@@ -5,6 +5,7 @@ import io.whozoss.agentos.caseFlow.CaseConfigProperties
 import io.whozoss.agentos.config.PersistenceConfigProperties
 import io.whozoss.agentos.exchange.ExchangeStorageConfigProperties
 import io.whozoss.agentos.exchange.ExchangeToolsConfigProperties
+import io.whozoss.agentos.queryUser.QueryUserConfigProperties
 import io.whozoss.agentos.scheduledPrompt.SchedulerProperties
 import io.whozoss.agentos.service.config.AgentOsPluginsConfigProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -28,6 +29,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
     PersistenceConfigProperties::class,
     ExchangeStorageConfigProperties::class,
     ExchangeToolsConfigProperties::class,
+    QueryUserConfigProperties::class,
     SchedulerProperties::class,
 )
 class AgentOSApplication

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -426,6 +426,7 @@ class AgentAdvanced(
                                     MessageContent.Text(
                                         when (e) {
                                             is AgentInterrupt.Redirect -> "Redirecting to agent '${e.targetAgentName}'."
+                                            is AgentInterrupt.AwaitAnswer -> "Waiting for the user's answer."
                                         },
                                     ),
                                 success = true,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -1,10 +1,12 @@
 package io.whozoss.agentos.agent
 
 import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.IntentionGeneratedEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
 import io.whozoss.agentos.sdk.tool.StandardTool
@@ -105,6 +107,30 @@ data class AgentAdvancedContext(
 
                 is IntentionGeneratedEvent -> {
                     toIntentionMessage(event)
+                }
+
+                // QuestionEvent: the agent asked the user a question and terminated its run.
+                // Rendered as AssistantMessage (the agent's own voice) so the LLM sees its
+                // own question in the history when it resumes after the answer.
+                // No XML balisage is applied — the question is plain agent speech, not a
+                // "foreign" message, so the same convention as other AssistantMessages holds.
+                is QuestionEvent -> {
+                    val text = buildString {
+                        append(event.question)
+                        val opts = event.options
+                        if (!opts.isNullOrEmpty()) {
+                            append("\nOptions: ")
+                            append(opts.joinToString(", ") { "\"$it\"" })
+                        }
+                    }
+                    listOf(AssistantMessage(text))
+                }
+
+                // AnswerEvent: the user's reply to a QuestionEvent.
+                // Rendered as UserMessage so the LLM sees it as the user speaking,
+                // consistent with MessageEvent USER rendering in toSpringAiMessage.
+                is AnswerEvent -> {
+                    listOf(UserMessage(event.answer))
                 }
 
                 else -> {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -115,15 +115,7 @@ data class AgentAdvancedContext(
                 // No XML balisage is applied — the question is plain agent speech, not a
                 // "foreign" message, so the same convention as other AssistantMessages holds.
                 is QuestionEvent -> {
-                    val text = buildString {
-                        append(event.question)
-                        val opts = event.options
-                        if (!opts.isNullOrEmpty()) {
-                            append("\nOptions: ")
-                            append(opts.joinToString(", ") { "\"$it\"" })
-                        }
-                    }
-                    listOf(AssistantMessage(text))
+                    listOf(AssistantMessage(event.toPromptText()))
                 }
 
                 // AnswerEvent: the user's reply to a QuestionEvent.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterrupt.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterrupt.kt
@@ -1,5 +1,8 @@
 package io.whozoss.agentos.agent
 
+import io.whozoss.agentos.sdk.caseEvent.QuestionType
+import java.util.UUID
+
 /**
  * Sealed exception hierarchy used as a control-flow signal to interrupt the current
  * agent run from inside a [io.whozoss.agentos.sdk.tool.StandardTool] execution.
@@ -23,11 +26,12 @@ package io.whozoss.agentos.agent
  * ## Current members
  *
  * - [Redirect]: hand off the current case to another agent.
+ * - [AwaitAnswer]: terminate the current run and wait for the user to answer a question.
+ *   The run resumes automatically once the answer is received (pre-flight in [CaseRuntime]).
  *
  * ## Planned members
  *
  * - `SyncDelegation`: suspend the current agent and wait for a sub-case to finish.
- * - `AwaitAnswer`: suspend and wait for a human answer to a QuestionEvent.
  */
 sealed class AgentInterrupt(
     message: String,
@@ -46,4 +50,41 @@ sealed class AgentInterrupt(
     class Redirect(
         val targetAgentName: String,
     ) : AgentInterrupt("Redirect to '\$targetAgentName'")
+
+    /**
+     * Terminate the current agent run and emit a [io.whozoss.agentos.sdk.caseEvent.QuestionEvent]
+     * so the user can answer asynchronously.
+     *
+     * Thrown by [io.whozoss.agentos.queryUser.QueryUserTool] on the happy path.
+     * [AgentInterruptHandler.emitInterruptAndFinishEvents] catches this, emits
+     * [io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent] to close the turn, then
+     * emits a [io.whozoss.agentos.sdk.caseEvent.QuestionEvent] addressed to the user
+     * identified by [userId] (or any user when [userId] is null).
+     *
+     * The run resumes automatically: [io.whozoss.agentos.caseFlow.CaseRuntime.run]
+     * performs a pre-flight check ([CaseRuntime.findUnresolvedQuestion]) at the start
+     * of each turn. When it finds a [io.whozoss.agentos.sdk.caseEvent.QuestionEvent]
+     * that has been answered but whose agent has not yet restarted, it emits an
+     * [io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent] targeting the original
+     * agent so the normal loop picks up from there.
+     *
+     * @param question The question text to display to the user.
+     * @param options Optional list of choices. Null or empty → [QuestionType.FREE_TEXT].
+     *   Non-empty + [allowCustomAnswer]=false → [QuestionType.SINGLE_CHOICE].
+     *   Non-empty + [allowCustomAnswer]=true → [QuestionType.OPEN_CHOICE].
+     * @param questionType The resolved [QuestionType], derived by [QueryUserTool] from
+     *   [options] and [allowCustomAnswer] before throwing.
+     * @param userId The user for whom the agent is running — the one whose answer is
+     *   awaited. Null means the question is addressed to any user of the case (e.g. when
+     *   the executing context has no resolved user, such as a webhook or system call).
+     *   No artificial fallback is applied: if the upstream context has no userId, this
+     *   stays null and the [io.whozoss.agentos.sdk.caseEvent.QuestionEvent] remains
+     *   unaddressed.
+     */
+    class AwaitAnswer(
+        val question: String,
+        val options: List<String>? = null,
+        val questionType: QuestionType = QuestionType.FREE_TEXT,
+        val userId: UUID? = null,
+    ) : AgentInterrupt("Awaiting user answer")
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
@@ -5,6 +5,7 @@ import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
 import kotlinx.coroutines.flow.FlowCollector
 import mu.KLogger
 import org.springframework.ai.retry.NonTransientAiException
@@ -75,6 +76,27 @@ suspend fun FlowCollector<CaseEvent>.emitInterruptAndFinishEvents(
                     caseId = caseId,
                     agentId = UUID.nameUUIDFromBytes(e.targetAgentName.toByteArray()),
                     agentName = e.targetAgentName,
+                ),
+            )
+        }
+
+        is AgentInterrupt.AwaitAnswer -> {
+            logger.info { "[${agent.name}] awaiting user answer: ${e.question}" }
+            emit(
+                QuestionEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agent.id,
+                    agentName = agent.name,
+                    question = e.question,
+                    options = e.options,
+                    questionType = e.questionType,
+                    // userId is the user for whom the agent is running — the one whose answer
+                    // is awaited. Null means the question is addressed to any user of the case.
+                    // The value comes from AgentInterrupt.AwaitAnswer, which receives it from
+                    // ToolContext.userId (set by AgentSimple/AgentAdvanced from their own userId
+                    // constructor parameter). No fallback: null in → null out.
+                    userId = e.userId,
                 ),
             )
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -18,6 +18,7 @@ import io.whozoss.agentos.exchange.ExchangeCapabilityService
 import io.whozoss.agentos.exchange.ExchangeIntegrationTypes
 import io.whozoss.agentos.exchange.ExchangeStorageService
 import io.whozoss.agentos.exchange.ExchangeToolGrantService
+import io.whozoss.agentos.queryUser.QueryUserToolGrantService
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.metrics.ToolMetricsService
@@ -71,6 +72,7 @@ class AgentServiceImpl(
     private val exchangeToolGrantService: ExchangeToolGrantService,
     private val agentDocumentResolver: AgentDocumentResolver,
     private val agentConfigProperties: AgentConfigProperties,
+    private val queryUserToolGrantService: QueryUserToolGrantService,
 ) : AgentService {
     /**
      * Resolves an agent by name for a given [context].
@@ -331,6 +333,12 @@ class AgentServiceImpl(
         // Delegation and exchange tools are appended after resolveToolsForRun's own de-dup, so
         // de-dup the combined set by tool name (shared with the resolver) to avoid a duplicate-name
         // collision (e.g. a user FILE_ACCESS integration named "case-exchange") crashing downstream.
+        val queryUserTools =
+            if (queryUserToolGrantService.isGranted(agentConfig.integrations)) {
+                queryUserToolGrantService.grantTools(toolContext)
+            } else {
+                emptyList()
+            }
         val tools =
             toolResolverService.dedupToolsByName(
                 baseTools +
@@ -343,7 +351,8 @@ class AgentServiceImpl(
                             )
                         },
                     ) +
-                    buildExchangeTools(agentConfig, context, toolContext),
+                    buildExchangeTools(agentConfig, context, toolContext) +
+                    queryUserTools,
             )
 
         return ResolvedAgentDefinition(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -18,12 +18,12 @@ import io.whozoss.agentos.exchange.ExchangeCapabilityService
 import io.whozoss.agentos.exchange.ExchangeIntegrationTypes
 import io.whozoss.agentos.exchange.ExchangeStorageService
 import io.whozoss.agentos.exchange.ExchangeToolGrantService
-import io.whozoss.agentos.queryUser.QueryUserToolGrantService
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.metrics.ToolMetricsService
 import io.whozoss.agentos.namespace.NamespaceService
 import io.whozoss.agentos.permissions.EntityType
+import io.whozoss.agentos.queryUser.QueryUserToolGrantService
 import io.whozoss.agentos.redirect.globToRegex
 import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.aiProvider.AiModel

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -330,15 +330,7 @@ class AgentSimple(
                 // AssistantMessage with tool_calls must be followed by a ToolResponseMessage).
                 is QuestionEvent -> {
                     flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
-                    val text = buildString {
-                        append(event.question)
-                        val opts = event.options
-                        if (!opts.isNullOrEmpty()) {
-                            append("\nOptions: ")
-                            append(opts.joinToString(", ") { "\"$it\"" })
-                        }
-                    }
-                    messages.add(AssistantMessage(text))
+                    messages.add(AssistantMessage(event.toPromptText()))
                 }
 
                 // AnswerEvent: the user's reply to a QuestionEvent.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -5,9 +5,11 @@ import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
 import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
@@ -302,31 +304,7 @@ class AgentSimple(
                     if (index == lastUserMessageIndex) {
                         event.sessionContextPromptText()?.let { messages.add(UserMessage(it)) }
                     }
-                    // If we have accumulated tool calls, create AssistantMessage with them
-                    if (toolCallsForCurrentMessage.isNotEmpty()) {
-                        messages.add(
-                            AssistantMessage
-                                .builder()
-                                .toolCalls(
-                                    toolCallsForCurrentMessage.toList(),
-                                ).build(),
-                        )
-
-                        // Every AssistantMessage with tool_calls MUST be followed by a
-                        // ToolResponseMessage for each tool_call_id — OpenAI returns 400
-                        // otherwise. Use the real response when available, or a placeholder.
-                        val toolResponseMessages =
-                            toolCallsForCurrentMessage.map { toolCall ->
-                                val response = toolResponses[toolCall.id()]
-                                val output = response?.let { toolResponseText(it) } ?: "[No response recorded]"
-                                ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
-                            }
-
-                        messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
-
-                        toolCallsForCurrentMessage.clear()
-                    }
-
+                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
                     messages.add(event.toSpringAiMessage(id.toString()))
                 }
 
@@ -346,37 +324,87 @@ class AgentSimple(
                     )
                 }
 
+                // QuestionEvent: the agent asked the user a question and terminated its run.
+                // Rendered as AssistantMessage (the agent's own voice). Any accumulated tool
+                // calls are flushed first so the message list stays well-formed (every
+                // AssistantMessage with tool_calls must be followed by a ToolResponseMessage).
+                is QuestionEvent -> {
+                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
+                    val text = buildString {
+                        append(event.question)
+                        val opts = event.options
+                        if (!opts.isNullOrEmpty()) {
+                            append("\nOptions: ")
+                            append(opts.joinToString(", ") { "\"$it\"" })
+                        }
+                    }
+                    messages.add(AssistantMessage(text))
+                }
+
+                // AnswerEvent: the user's reply to a QuestionEvent.
+                // Rendered as UserMessage, consistent with MessageEvent USER rendering.
+                // Tool calls are flushed first for the same well-formedness reason.
+                is AnswerEvent -> {
+                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
+                    messages.add(UserMessage(event.answer))
+                }
+
                 else -> {
                     // Ignore other event types for message conversion
                 }
             }
         }
 
-        // Handle any remaining tool calls at the end.
-        // Note: args are already normalised to "{}" in the accumulation loop above.
-        if (toolCallsForCurrentMessage.isNotEmpty()) {
-            messages.add(
-                AssistantMessage
-                    .builder()
-                    .toolCalls(
-                        toolCallsForCurrentMessage.toList(),
-                    ).build(),
-            )
-
-            // Every AssistantMessage with tool_calls MUST be followed by a
-            // ToolResponseMessage for each tool_call_id — OpenAI returns 400
-            // otherwise. Use the real response when available, or a placeholder.
-            val toolResponseMessages =
-                toolCallsForCurrentMessage.map { toolCall ->
-                    val response = toolResponses[toolCall.id()]
-                    val output = response?.let { toolResponseText(it) } ?: "[No response recorded]"
-                    ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
-                }
-
-            messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
-        }
+        // Flush any tool calls that trail the end of the event list without a following
+        // conversational message (e.g. the last thing the agent did was call a tool, then
+        // the run was interrupted). Args are already normalised in the accumulation loop above.
+        flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
 
         return messages
+    }
+
+    /**
+     * Flush accumulated tool calls into [messages] as a well-formed
+     * `AssistantMessage(tool_calls) + ToolResponseMessage` pair, then clear the accumulator.
+     *
+     * ## Why this invariant exists
+     *
+     * OpenAI (and Anthropic) require that every `AssistantMessage` carrying `tool_calls`
+     * is immediately followed by a `ToolResponseMessage` that covers **each** `tool_call_id`
+     * referenced in that assistant turn. Violating this constraint causes a hard HTTP 400
+     * from the provider. Because `convertEventsToMessages` accumulates tool calls across
+     * `ToolRequestEvent` entries and only materialises the `AssistantMessage` when a
+     * conversational boundary is reached (a `MessageEvent`, `QuestionEvent`, `AnswerEvent`,
+     * or the end of the list), this flush must be called at every such boundary — and only
+     * at those boundaries.
+     *
+     * When a response is missing (e.g. the run was interrupted mid-tool), a
+     * `[No response recorded]` placeholder is inserted so the message list remains
+     * syntactically valid even for incomplete histories.
+     *
+     * This function is a no-op when [pendingToolCalls] is empty.
+     */
+    private fun flushPendingToolCalls(
+        messages: MutableList<Message>,
+        pendingToolCalls: MutableList<AssistantMessage.ToolCall>,
+        toolResponses: Map<String, ToolResponseEvent>,
+    ) {
+        if (pendingToolCalls.isEmpty()) return
+
+        messages.add(
+            AssistantMessage
+                .builder()
+                .toolCalls(pendingToolCalls.toList())
+                .build(),
+        )
+        val toolResponseMessages =
+            pendingToolCalls.map { toolCall ->
+                val response = toolResponses[toolCall.id()]
+                val output = response?.let { toolResponseText(it) } ?: "[No response recorded]"
+                ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
+            }
+        messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
+        pendingToolCalls.clear()
     }
 
     /**
@@ -506,6 +534,7 @@ class AgentSimple(
                                 val message =
                                     when (e) {
                                         is AgentInterrupt.Redirect -> "Redirecting to agent '${e.targetAgentName}'."
+                                        is AgentInterrupt.AwaitAnswer -> "Waiting for the user's answer."
                                     }
                                 sendEvent(
                                     ToolResponseEvent(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
@@ -3,6 +3,7 @@ package io.whozoss.agentos.agent
 import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
 import org.springframework.web.util.HtmlUtils
 import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
@@ -92,6 +93,26 @@ internal fun toolImagesUserMessage(
         .text("[Attached: ${images.size} image(s) produced by tool $toolName, see tool result above]")
         .media(images.map { it.toSpringAiMedia() })
         .build()
+
+/**
+ * Render a [QuestionEvent] as the text of the [AssistantMessage] replayed to the LLM.
+ *
+ * The question is the agent's own voice, so it is rendered plain — no XML tagging, unlike
+ * the `<user>` / `<agent>` wrapping applied by [toSpringAiMessage] to foreign messages.
+ * Closed-choice options are appended so the resuming agent sees the exact set it offered.
+ *
+ * Shared by both runtimes ([AgentSimple.convertEventsToMessages] and
+ * [AgentAdvancedContext.convertEventsToMessages]) so the two cannot drift apart.
+ */
+internal fun QuestionEvent.toPromptText(): String =
+    buildString {
+        append(question)
+        val opts = options
+        if (!opts.isNullOrEmpty()) {
+            append("\nOptions: ")
+            append(opts.joinToString(", ") { "\"$it\"" })
+        }
+    }
 
 internal fun MessageEvent.toSpringAiMessage(currentAgentId: String): Message {
     val textContent =

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -516,6 +516,22 @@ class CaseRuntime(
      * For [io.whozoss.agentos.agent.AgentInterrupt.AwaitAnswer], the run terminated
      * BEFORE the answer arrived, so no [AgentFinishedEvent] follows the legitimate answer.
      * The guard therefore lets exactly the right cases through.
+     *
+     * ## Known limitation — only the LAST question is considered
+     *
+     * Only the most recent [QuestionEvent] in the history is examined. An earlier question
+     * left unanswered is invisible to this pre-flight and its agent will never be woken up.
+     *
+     * This holds today because a case can only ever have one question outstanding: a
+     * [io.whozoss.agentos.agent.AgentInterrupt.AwaitAnswer] terminates the run that raised
+     * it, and [run] admits a single turn at a time via [runInFlight] — so no second agent
+     * can ask anything while the first is waiting.
+     *
+     * The assumption breaks as soon as two agents can be in flight on the same case (e.g.
+     * concurrent delegation). At that point the search must iterate over all unanswered
+     * questions rather than only the last one, and the wake-up must emit one
+     * [AgentSelectedEvent] per resolved question. Revisit this method — and the recipient
+     * check below, whose `indexOfFirst` anchoring assumes a single candidate question.
      */
     private fun findUnresolvedQuestion(events: List<CaseEvent>): QuestionEvent? {
         val lastQuestion = events.filterIsInstance<QuestionEvent>().lastOrNull() ?: return null

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseRuntime.kt
@@ -8,6 +8,7 @@ import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
@@ -279,6 +280,23 @@ class CaseRuntime(
         iterationCount = 0
 
         try {
+            // Pre-flight: resume an agent whose run was terminated by AwaitAnswer and
+            // whose question has since been answered. Must come AFTER the runInFlight
+            // guard (above) to avoid double execution on concurrent callers, and BEFORE
+            // runTurns() so the AgentSelectedEvent is in the history before the loop
+            // starts scanning backward.
+            findUnresolvedQuestion(eventList.getAll())?.let { question ->
+                logger.info { "[CaseRuntime $id] Resuming agent '${question.agentName}' after user answer" }
+                storeAndEmitEvent(
+                    AgentSelectedEvent(
+                        namespaceId = namespaceId,
+                        caseId = id,
+                        agentId = question.agentId,
+                        agentName = question.agentName,
+                    ),
+                )
+            }
+
             val finalStatus = runTurns()
             logger.info { "[CaseRuntime $id] Exited loop → $finalStatus, iterations: $iterationCount" }
             if (finalStatus != CaseStatus.IDLE) commandQueue.clear()
@@ -453,6 +471,80 @@ class CaseRuntime(
         // selectAgent stored only a WarnEvent — stop cleanly, return to IDLE.
         logger.warn { "[CaseRuntime $id] No agent selection found in history, stopping" }
         return StepResult.AGENT_FINISHED
+    }
+
+    /**
+     * Returns the [QuestionEvent] that should trigger an agent wake-up, or null when
+     * no wake-up is warranted.
+     *
+     * A wake-up is warranted when ALL of the following hold:
+     * 1. There is at least one [QuestionEvent] in the history.
+     * 2. A **legitimate** [AnswerEvent] exists for that question (see below).
+     * 3. No [AgentFinishedEvent] appears STRICTLY AFTER that legitimate answer.
+     *
+     * ## Legitimate answer — recipient check
+     *
+     * When [QuestionEvent.userId] is **null** the question is unaddressed: any
+     * [AnswerEvent] paired by [AnswerEvent.questionId] qualifies.
+     *
+     * When [QuestionEvent.userId] is **non-null** the question is directed at a specific
+     * user: the [AnswerEvent] qualifies only when `actor.id` parses as a [UUID] that
+     * equals `question.userId`. If the actor id cannot be parsed (system actor, external
+     * identifier), the answer does **not** qualify and the agent is not woken up; a debug
+     * log is emitted for diagnosability.
+     *
+     * ## Why the recipient check is inside indexOfFirst — DO NOT move it out
+     *
+     * Using `indexOfFirst { pairedById }` and then testing the recipient afterward
+     * introduces a permanent-deadlock bug on shared cases:
+     *   1. Bob answers a question directed at Alice.
+     *   2. `indexOfFirst` finds Bob's answer (first paired by questionId).
+     *   3. The recipient check fails → return null.
+     *   4. Alice answers later.
+     *   5. `indexOfFirst` STILL finds Bob's answer first → stuck forever.
+     *
+     * The recipient predicate must therefore be part of the `indexOfFirst` call so that
+     * only a legitimate answer can anchor the search.
+     *
+     * ## OAuth guard — condition 3, do not remove
+     *
+     * During an OAuth flow the agent is blocked INSIDE its run when the answer arrives.
+     * The agent finishes its turn normally, emitting an [AgentFinishedEvent] AFTER the
+     * [AnswerEvent]. Waking up again would plant a spurious [AgentSelectedEvent] in the
+     * middle of a completed turn, potentially triggering a phantom agent run.
+     *
+     * For [io.whozoss.agentos.agent.AgentInterrupt.AwaitAnswer], the run terminated
+     * BEFORE the answer arrived, so no [AgentFinishedEvent] follows the legitimate answer.
+     * The guard therefore lets exactly the right cases through.
+     */
+    private fun findUnresolvedQuestion(events: List<CaseEvent>): QuestionEvent? {
+        val lastQuestion = events.filterIsInstance<QuestionEvent>().lastOrNull() ?: return null
+
+        // Find the first LEGITIMATE answer: paired by questionId AND from the right recipient.
+        // The recipient check is intentionally inside this predicate — see KDoc for why moving
+        // it outside causes a permanent-deadlock bug on shared cases.
+        val legitimateAnswerIndex = events.indexOfFirst { event ->
+            if (event !is AnswerEvent || event.questionId != lastQuestion.id) return@indexOfFirst false
+            val targetUserId = lastQuestion.userId
+                ?: return@indexOfFirst true // unaddressed question: any respondent qualifies
+            val respondentId = runCatching { UUID.fromString(event.actor.id) }.getOrElse {
+                logger.debug {
+                    "[CaseRuntime $id] AnswerEvent actor id '${event.actor.id}' is not a UUID — " +
+                        "does not qualify as a legitimate answer for question ${lastQuestion.id}"
+                }
+                return@indexOfFirst false
+            }
+            respondentId == targetUserId
+        }
+        if (legitimateAnswerIndex < 0) return null // no legitimate answer yet
+
+        // OAuth guard: if any AgentFinishedEvent appears STRICTLY AFTER the legitimate
+        // answer, the agent already handled it — do not wake up again.
+        val hasAgentFinishedAfterAnswer = events
+            .subList(legitimateAnswerIndex + 1, events.size)
+            .any { it is AgentFinishedEvent }
+
+        return if (hasAgentFinishedAfterAnswer) null else lastQuestion
     }
 
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserConfigProperties.kt
@@ -1,0 +1,37 @@
+package io.whozoss.agentos.queryUser
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Platform-level policy for the built-in `queryUser` tool.
+ *
+ * Bound from the `agentos.query-user` prefix in `application.yml`.
+ *
+ * The `queryUser` tool lets an agent pause its run and ask the user a question
+ * asynchronously. It is a primitive of conversation, not an integration like Jira:
+ * agents should not have to declare it. The platform default is therefore **on**,
+ * matching the behaviour of the legacy Express backend.
+ *
+ * An agent can still opt out by mapping the key [QueryUserToolPlugin.INTEGRATION_TYPE]
+ * to an empty list `[]` in its `integrations` map — the same opt-out signal used by
+ * the file-exchange tools. This is the only escape hatch: for a fully autonomous agent
+ * triggered by a webhook where nobody is listening, leaving the question unanswered
+ * would block the case indefinitely.
+ *
+ * Override with environment variable:
+ * - `AGENTOS_QUERY_USER_ENABLED_BY_DEFAULT` (boolean, default `true`)
+ */
+@ConfigurationProperties(prefix = "agentos.query-user")
+data class QueryUserConfigProperties(
+    /**
+     * When `true` (default), every agent that does not mention
+     * [QueryUserToolPlugin.INTEGRATION_TYPE] in its `integrations` map receives the
+     * `queryUser` tool automatically.
+     *
+     * When `false`, an agent must declare the key explicitly (with a null value or a
+     * non-empty list) to get the tool.
+     *
+     * An empty list `[]` always opts the agent out, regardless of this default.
+     */
+    val enabledByDefault: Boolean = true,
+)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserConfigProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserConfigProperties.kt
@@ -7,31 +7,27 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *
  * Bound from the `agentos.query-user` prefix in `application.yml`.
  *
- * The `queryUser` tool lets an agent pause its run and ask the user a question
- * asynchronously. It is a primitive of conversation, not an integration like Jira:
- * agents should not have to declare it. The platform default is therefore **on**,
- * matching the behaviour of the legacy Express backend.
+ * The `queryUser` tool lets an agent ask the user a question asynchronously. It is a
+ * primitive of conversation, not an integration like Jira, but is disabled by default
+ * to limit its impact while it is being controlled and tested.
  *
- * An agent can still opt out by mapping the key [QueryUserToolPlugin.INTEGRATION_TYPE]
- * to an empty list `[]` in its `integrations` map — the same opt-out signal used by
- * the file-exchange tools. This is the only escape hatch: for a fully autonomous agent
- * triggered by a webhook where nobody is listening, leaving the question unanswered
- * would block the case indefinitely.
+ * An agent can opt in by mapping the key [QueryUserToolPlugin.INTEGRATION_TYPE] in its
+ * `integrations` map. For a fully autonomous agent triggered by a webhook where nobody
+ * is listening, leaving the tool disabled avoids blocking the case indefinitely when a
+ * question remains unanswered.
  *
  * Override with environment variable:
- * - `AGENTOS_QUERY_USER_ENABLED_BY_DEFAULT` (boolean, default `true`)
+ * - `AGENTOS_QUERY_USER_ENABLED_BY_DEFAULT` (boolean, default `false`)
  */
 @ConfigurationProperties(prefix = "agentos.query-user")
 data class QueryUserConfigProperties(
     /**
-     * When `true` (default), every agent that does not mention
-     * [QueryUserToolPlugin.INTEGRATION_TYPE] in its `integrations` map receives the
-     * `queryUser` tool automatically.
+     * When `false` (default), an agent must declare
+     * [QueryUserToolPlugin.INTEGRATION_TYPE] explicitly (with a null value or a
+     * non-empty list) in its `integrations` map to get the `queryUser` tool.
      *
-     * When `false`, an agent must declare the key explicitly (with a null value or a
-     * non-empty list) to get the tool.
-     *
-     * An empty list `[]` always opts the agent out, regardless of this default.
+     * When `true`, every agent receives the tool unless it maps the key to an empty
+     * list `[]`, which always opts the agent out.
      */
-    val enabledByDefault: Boolean = true,
+    val enabledByDefault: Boolean = false,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserTool.kt
@@ -1,0 +1,150 @@
+package io.whozoss.agentos.queryUser
+
+import io.whozoss.agentos.agent.AgentInterrupt
+import io.whozoss.agentos.sdk.caseEvent.QuestionType
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+
+/**
+ * Internal tool that pauses the current agent run to ask the user a question.
+ *
+ * The agent calls this tool when it genuinely cannot proceed without information that
+ * only the user can provide — for example a preference, a clarification, or a decision
+ * that cannot be inferred from the conversation history or available data sources.
+ *
+ * **Use sparingly.** Do NOT use this tool:
+ * - to confirm destructive actions (use the confirmation gate instead, configured via
+ *   [io.whozoss.agentos.sdk.tool.StandardTool.getConfirmationMode]);
+ * - to be polite or to summarise what you are about to do;
+ * - when a reasonable default exists and the user can always correct it afterward.
+ *
+ * ## Execution contract
+ *
+ * - When [input] is null or [Input.question] is blank, [execute] returns a
+ *   human-readable [ToolExecutionResult.error] so the LLM can surface the problem
+ *   gracefully without crashing the run.
+ * - On the happy path, [execute] throws [AgentInterrupt.AwaitAnswer] — a control-flow
+ *   signal, not an error. The caller
+ *   ([io.whozoss.agentos.agent.AgentSimple]'s tool-callback wrapper or
+ *   [io.whozoss.agentos.agent.AgentAdvanced.handleToolExecution]) emits
+ *   [io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent] and
+ *   [io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent] before the exception propagates,
+ *   so the event history is always well-formed.
+ * - [AgentInterruptHandler.emitInterruptAndFinishEvents] then emits
+ *   [io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent] (closing the turn) followed by
+ *   a [io.whozoss.agentos.sdk.caseEvent.QuestionEvent] addressed to any user of the case.
+ * - The run resumes automatically via the pre-flight check in
+ *   [io.whozoss.agentos.caseFlow.CaseRuntime.run] once the user's answer has been stored.
+ *
+ * @param configName The [io.whozoss.agentos.integrationConfig.IntegrationConfig] name
+ *   used as tool-name prefix (e.g. `"QUERY_USER__queryUser"`). Null for the bare name.
+ */
+class QueryUserTool(
+    private val configName: String? = null,
+) : StandardTool<QueryUserTool.Input> {
+    /**
+     * @param question The question text to display to the user.
+     * @param options Optional list of answer choices. Null or empty → free-text input.
+     *   Non-empty → the UI renders buttons. Combine with [allowCustomAnswer] to decide
+     *   whether the user may also type a custom answer.
+     * @param allowCustomAnswer When true and [options] is non-empty, the UI adds a free-text
+     *   field alongside the option buttons ([QuestionType.OPEN_CHOICE]).
+     *   When false (default), only the listed options are accepted ([QuestionType.SINGLE_CHOICE]).
+     *   Ignored when [options] is null or empty.
+     */
+    data class Input(
+        val question: String,
+        val options: List<String>? = null,
+        val allowCustomAnswer: Boolean = false,
+    )
+
+    override val name: String = configName?.let { "${it}__queryUser" } ?: "queryUser"
+
+    override val description: String =
+        """
+        Ask the user a question and pause the current run until they answer.
+        The run will resume automatically with the user's answer in the conversation history.
+
+        IMPORTANT — only use this tool when:
+        - The information is genuinely required to proceed and cannot be inferred, guessed, or
+          found through any available tool or data source.
+        - There is no reasonable default that the user could correct afterward.
+
+        Do NOT use this tool:
+        - to confirm destructive actions (use the built-in confirmation gate instead);
+        - to be polite, to summarise what you are about to do, or to check in;
+        - when you already have enough information to act.
+
+        For multiple-choice questions, provide the options list. Set allowCustomAnswer=true
+        if the user should also be able to type a custom answer beyond the listed options.
+        """.trimIndent()
+
+    override val inputSchema: String =
+        """
+        {
+          "type": "object",
+          "properties": {
+            "question": {
+              "type": "string",
+              "description": "The question to display to the user."
+            },
+            "options": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Optional list of answer choices rendered as buttons. Omit for free-text input."
+            },
+            "allowCustomAnswer": {
+              "type": "boolean",
+              "description": "When true and options are provided, the user may also type a custom answer. Default: false.",
+              "default": false
+            }
+          },
+          "required": ["question"]
+        }
+        """.trimIndent()
+
+    override val version: String = "1.0.0"
+    override val paramType: Class<Input> = Input::class.java
+
+    /**
+     * Validates input, derives the [QuestionType], and throws [AgentInterrupt.AwaitAnswer]
+     * to hand control back to the orchestrator.
+     *
+     * Returns a human-readable [ToolExecutionResult.error] when [input] is null or
+     * [Input.question] is blank — the LLM receives this string and can surface it as a
+     * plain-language message to the user without crashing the run.
+     *
+     * On the happy path, throws [AgentInterrupt.AwaitAnswer] — this is a control-flow
+     * signal, not an error (see class KDoc).
+     */
+    override suspend fun execute(
+        input: Input?,
+        context: ToolContext,
+    ): ToolExecutionResult {
+        if (input == null || input.question.isBlank()) {
+            return ToolExecutionResult.error("A question is required.", errorType = "MISSING_INPUT")
+        }
+
+        val hasOptions = !input.options.isNullOrEmpty()
+        val questionType =
+            when {
+                !hasOptions -> QuestionType.FREE_TEXT
+                input.allowCustomAnswer -> QuestionType.OPEN_CHOICE
+                else -> QuestionType.SINGLE_CHOICE
+            }
+        // Normalise: pass null when there are no options so the QuestionEvent is clean.
+        val options = input.options?.takeIf { it.isNotEmpty() }
+
+        throw AgentInterrupt.AwaitAnswer(
+            question = input.question,
+            options = options,
+            questionType = questionType,
+            // userId identifies the user for whom the agent is running — the one whose
+            // answer is awaited. Null when the execution context has no resolved user
+            // (webhook, system call, etc.). No fallback is applied: if it is null here,
+            // the QuestionEvent remains addressed to any user of the case.
+            userId = context.userId,
+        )
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserTool.kt
@@ -7,7 +7,7 @@ import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
 
 /**
- * Internal tool that pauses the current agent run to ask the user a question.
+ * Internal tool that asks the user a question.
  *
  * The agent calls this tool when it genuinely cannot proceed without information that
  * only the user can provide — for example a preference, a clarification, or a decision
@@ -63,8 +63,8 @@ class QueryUserTool(
 
     override val description: String =
         """
-        Ask the user a question and pause the current run until they answer.
-        The run will resume automatically with the user's answer in the conversation history.
+        Ask the user a question. The run resumes automatically with the user's answer
+        in the conversation history.
 
         IMPORTANT — only use this tool when:
         - The information is genuinely required to proceed and cannot be inferred, guessed, or

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserToolGrantService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserToolGrantService.kt
@@ -1,0 +1,85 @@
+package io.whozoss.agentos.queryUser
+
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import mu.KLogging
+import org.springframework.stereotype.Service
+
+/**
+ * Owns the grant decision for the built-in `queryUser` tool.
+ *
+ * Mirrors the pattern of
+ * [io.whozoss.agentos.exchange.ExchangeToolGrantService]: resolution and granting are
+ * two separate calls so callers can check enablement cheaply before paying any
+ * further cost.
+ *
+ * ## Why a separate service?
+ *
+ * [io.whozoss.agentos.tool.ToolResolverService.resolveToolsForRun] only resolves
+ * tools for declared [io.whozoss.agentos.integrationConfig.IntegrationConfig] entries.
+ * `queryUser` has no config schema ([QueryUserToolPlugin.configSchema] is `null`) and
+ * therefore never appears in the namespace integration catalogue — it cannot be
+ * declared. This service provides the parallel grant path that bypasses the
+ * integration-config resolver, exactly as
+ * [io.whozoss.agentos.exchange.ExchangeToolGrantService] does for file-exchange tools.
+ *
+ * ## Enablement table
+ *
+ * The [integrations] map on [io.whozoss.agentos.agentConfig.AgentConfig] drives the
+ * decision; [QueryUserConfigProperties.enabledByDefault] is the fallback when the key
+ * is absent:
+ *
+ * | Condition | Result |
+ * |---|---|
+ * | key absent + `enabledByDefault = true` | granted |
+ * | key absent + `enabledByDefault = false` | not granted |
+ * | key present, value `null` | granted |
+ * | key present, value `[]` (empty list) | **opt-out** — not granted |
+ * | key present, value non-empty list | granted (only one tool anyway) |
+ *
+ * The empty-list opt-out is the escape hatch for fully autonomous agents triggered by
+ * webhooks where nobody is listening: an unanswered question would block the case
+ * indefinitely.
+ *
+ * `containsKey` and `get` are both used: a key absent and a key mapped to `null` are
+ * indistinguishable through `get` alone, yet they mean opposite things.
+ */
+@Service
+class QueryUserToolGrantService(
+    private val properties: QueryUserConfigProperties,
+    private val plugin: QueryUserToolPlugin,
+) {
+    /**
+     * Returns `true` when the agent should receive the `queryUser` tool, `false` when
+     * it should not.
+     *
+     * Cheap: only reads the [integrations] map and the bound [properties]. No I/O.
+     */
+    fun isGranted(integrations: Map<String, List<String>?>?): Boolean {
+        val key = QueryUserToolPlugin.INTEGRATION_TYPE
+        val declared = integrations?.containsKey(key) == true
+        val declaration = integrations?.get(key)
+        return when {
+            !declared -> properties.enabledByDefault
+            declaration == null -> true
+            declaration.isEmpty() -> false // explicit opt-out
+            else -> true
+        }
+    }
+
+    /**
+     * Builds the `queryUser` tool list (always exactly one tool when granted).
+     *
+     * [configName] is passed as `null` so the tool is registered under its bare name
+     * `"queryUser"` — more readable for the LLM and consistent with the legacy Express
+     * backend. If an agent also has a `QUERY_USER` [io.whozoss.agentos.integrationConfig.IntegrationConfig]
+     * declared (which creates a prefixed name like `MY_CONF__queryUser`), the caller's
+     * `dedupToolsByName` keeps the first occurrence and warns on the collision.
+     */
+    fun grantTools(toolContext: ToolContext): List<StandardTool<*>> {
+        logger.debug { "Granting built-in queryUser tool to agent '${toolContext.agentName}'" }
+        return plugin.provideTools(config = null, configName = null, context = toolContext)
+    }
+
+    companion object : KLogging()
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/queryUser/QueryUserToolPlugin.kt
@@ -1,0 +1,52 @@
+package io.whozoss.agentos.queryUser
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolPlugin
+import org.springframework.stereotype.Component
+
+/**
+ * Spring-managed [ToolPlugin] that provides the QUERY_USER integration.
+ *
+ * Unlike PF4J plugins, this class is annotated with `@Component` directly — no
+ * separate `@Configuration` class is needed because [QueryUserToolPlugin] has no
+ * Spring dependencies to inject and therefore creates no circular-dependency risk.
+ *
+ * Compare with [io.whozoss.agentos.redirect.RedirectToolPlugin], which requires a
+ * `@Configuration` class ([io.whozoss.agentos.redirect.RedirectConfiguration]) to
+ * inject an [io.whozoss.agentos.agentConfig.AgentConfigService]-backed lambda without
+ * creating a cycle through [io.whozoss.agentos.agent.AgentServiceImpl]. Here the tool
+ * is pure Kotlin with no external state, so `@Component` is both simpler and correct.
+ *
+ * [io.whozoss.agentos.tool.ToolRegistryService] collects all `ToolPlugin` beans via
+ * its `springToolPlugins: List<ToolPlugin>` constructor parameter, so this bean is
+ * automatically discovered alongside PF4J-loaded plugins.
+ *
+ * The integration has no configuration parameters — an agent that declares
+ * `QUERY_USER` in its integrations map gets the tool unconditionally. The config schema
+ * is therefore `null`, which marks it as a config-less plugin (instantiated once per
+ * agent run rather than per namespace integration config).
+ */
+@Component
+class QueryUserToolPlugin : ToolPlugin {
+    override val integrationType: String = INTEGRATION_TYPE
+
+    /**
+     * No configuration parameters needed — the tool derives all its behaviour from the
+     * LLM-provided input at call time. A null schema marks this as a config-less plugin:
+     * it is instantiated directly per agent run without requiring a persisted
+     * [io.whozoss.agentos.integrationConfig.IntegrationConfig].
+     */
+    override val configSchema: JsonNode? = null
+
+    override fun provideTools(
+        config: JsonNode?,
+        configName: String?,
+        context: ToolContext?,
+    ): List<StandardTool<*>> = listOf(QueryUserTool(configName = configName))
+
+    companion object {
+        const val INTEGRATION_TYPE = "QUERY_USER"
+    }
+}

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -166,6 +166,14 @@ agentos:
       # A single table cell longer than this is truncated by readDocument.
       # Override with env var: AGENTOS_EXCHANGE_TOOLS_DOCUMENT_MAX_CELL_CHARS
       # document-max-cell-chars: 5000
+  query-user:
+    # Grant the built-in queryUser tool to every agent that does not mention QUERY_USER in its
+    # integrations map. On by default: asking a question is a primitive of conversation, not an
+    # integration, so agents should not have to declare it. An agent can still opt out by mapping
+    # the QUERY_USER key to an empty list [] in its integrations map — the right choice for fully
+    # autonomous agents triggered by webhooks where nobody is listening.
+    # Override with env var: AGENTOS_QUERY_USER_ENABLED_BY_DEFAULT
+    # enabled-by-default: true
   defaults:
   # Environment-level fallback agent name. Consulted when a namespace has no
   # defaultAgentName configured. The named agent must exist in the case's namespace.

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentAdvancedContextSpec.kt
@@ -10,9 +10,12 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
 import io.whozoss.agentos.sdk.actor.Actor
 import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
 import io.whozoss.agentos.sdk.caseEvent.IntentionGeneratedEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionType
 import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
@@ -690,6 +693,97 @@ class AgentAdvancedContextSpec :
             mediaMessages shouldHaveSize 2
             val evictedResponse = messages[1].shouldBeInstanceOf<ToolResponseMessage>()
             evictedResponse.responses[0].responseData() shouldContain "no longer attached"
+        }
+
+        // -------------------------------------------------------------------------
+        // QuestionEvent and AnswerEvent conversion
+        // -------------------------------------------------------------------------
+
+        "QuestionEvent is converted to AssistantMessage with the question text" {
+            val questionEvent = QuestionEvent(
+                namespaceId = ns,
+                caseId = case,
+                agentId = agentId,
+                agentName = "Agent",
+                question = "What is your preference?",
+            )
+            val messages = context.convertEventsToMessages(listOf(questionEvent))
+
+            messages shouldHaveSize 1
+            val msg = messages[0].shouldBeInstanceOf<AssistantMessage>()
+            msg.text shouldBe "What is your preference?"
+        }
+
+        "QuestionEvent with options includes them in the AssistantMessage text" {
+            val questionEvent = QuestionEvent(
+                namespaceId = ns,
+                caseId = case,
+                agentId = agentId,
+                agentName = "Agent",
+                question = "Pick one",
+                options = listOf("A", "B", "C"),
+                questionType = QuestionType.SINGLE_CHOICE,
+            )
+            val messages = context.convertEventsToMessages(listOf(questionEvent))
+
+            messages shouldHaveSize 1
+            val msg = messages[0].shouldBeInstanceOf<AssistantMessage>()
+            msg.text shouldContain "Pick one"
+            msg.text shouldContain "\"A\""
+            msg.text shouldContain "\"B\""
+            msg.text shouldContain "\"C\""
+        }
+
+        "AnswerEvent is converted to UserMessage with the answer text" {
+            val questionEvent = QuestionEvent(
+                namespaceId = ns,
+                caseId = case,
+                agentId = agentId,
+                agentName = "Agent",
+                question = "What is your preference?",
+            )
+            val answerEvent = questionEvent.createAnswer(
+                Actor("user1", "User", ActorRole.USER),
+                "My answer",
+            )
+            val messages = context.convertEventsToMessages(listOf(questionEvent, answerEvent))
+
+            messages shouldHaveSize 2
+            messages[0].shouldBeInstanceOf<AssistantMessage>()
+            val userMsg = messages[1].shouldBeInstanceOf<UserMessage>()
+            userMsg.text shouldBe "My answer"
+        }
+
+        "QuestionEvent and AnswerEvent produce correct message order in a full conversation" {
+            // Full scenario: user message -> agent runs -> asks question -> user answers ->
+            // agent resumes. The LLM must see its question as AssistantMessage and the
+            // answer as UserMessage so it can continue naturally.
+            val questionEvent = QuestionEvent(
+                namespaceId = ns,
+                caseId = case,
+                agentId = agentId,
+                agentName = "Agent",
+                question = "Which environment?",
+                options = listOf("staging", "prod"),
+                questionType = QuestionType.SINGLE_CHOICE,
+            )
+            val answerEvent = questionEvent.createAnswer(
+                Actor("user1", "User", ActorRole.USER),
+                "staging",
+            )
+            val events = listOf(
+                userMessage("deploy the app"),
+                questionEvent,
+                answerEvent,
+            )
+            val messages = context.convertEventsToMessages(events)
+
+            messages shouldHaveSize 3
+            messages[0].shouldBeInstanceOf<UserMessage>()
+            val questionMsg = messages[1].shouldBeInstanceOf<AssistantMessage>()
+            questionMsg.text shouldContain "Which environment?"
+            val answerMsg = messages[2].shouldBeInstanceOf<UserMessage>()
+            answerMsg.text shouldBe "staging"
         }
 
         "extractText never dumps base64 for image output" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentInterruptHandlerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentInterruptHandlerUnitSpec.kt
@@ -1,0 +1,144 @@
+package io.whozoss.agentos.agent
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.sdk.agent.Agent
+import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionType
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import kotlinx.coroutines.flow.FlowCollector
+import mu.KLogger
+import java.util.UUID
+
+/**
+ * Unit tests for [emitInterruptAndFinishEvents].
+ *
+ * Verifies that the [QuestionEvent] emitted on [AgentInterrupt.AwaitAnswer] carries
+ * exactly the fields supplied by the interrupt — in particular [QuestionEvent.userId],
+ * which must flow from [AgentInterrupt.AwaitAnswer.userId] without any transformation.
+ */
+class AgentInterruptHandlerUnitSpec : StringSpec({
+
+    val namespaceId: UUID = UUID.randomUUID()
+    val caseId: UUID = UUID.randomUUID()
+    val agentId: UUID = UUID.randomUUID()
+    val logger = mockk<KLogger>(relaxed = true)
+
+    fun buildAgent(id: UUID = agentId): Agent =
+        mockk<Agent> {
+            every { metadata } returns EntityMetadata(id = id)
+            // Agent.id is defined as `get() = metadata.id` on the Entity interface,
+            // but MockK does not automatically delegate getId() to the metadata stub.
+            // Stubbing it explicitly is required whenever the production code calls agent.id.
+            every { this@mockk.id } returns id
+            every { name } returns "test-agent"
+            every { llmProvider } returns "anthropic"
+            every { llmModel } returns "claude-3"
+        }
+
+    // -----------------------------------------------------------------------
+    // AwaitAnswer: QuestionEvent fields
+    // -----------------------------------------------------------------------
+
+    "emitInterruptAndFinishEvents emits AgentFinishedEvent then QuestionEvent for AwaitAnswer" {
+        val emitted = mutableListOf<CaseEvent>()
+        val collector = FlowCollector<CaseEvent> { emitted.add(it) }
+
+        val interrupt = AgentInterrupt.AwaitAnswer(
+            question = "What is your name?",
+            questionType = QuestionType.FREE_TEXT,
+        )
+
+        collector.emitInterruptAndFinishEvents(buildAgent(), interrupt, namespaceId, caseId, logger)
+
+        emitted.size shouldBe 2
+        emitted[0].shouldBeInstanceOf<AgentFinishedEvent>()
+        emitted[1].shouldBeInstanceOf<QuestionEvent>()
+    }
+
+    "QuestionEvent carries userId from AwaitAnswer when userId is non-null" {
+        // This is the primary use-case: the tool has a resolved user from ToolContext
+        // and stamps AwaitAnswer.userId with it. The handler must forward it verbatim
+        // to the QuestionEvent so downstream consumers (push notifications, UI) know
+        // which user the question is directed at.
+        val userId = UUID.randomUUID()
+        val emitted = mutableListOf<CaseEvent>()
+        val collector = FlowCollector<CaseEvent> { emitted.add(it) }
+
+        val interrupt = AgentInterrupt.AwaitAnswer(
+            question = "Pick one?",
+            questionType = QuestionType.FREE_TEXT,
+            userId = userId,
+        )
+
+        collector.emitInterruptAndFinishEvents(buildAgent(), interrupt, namespaceId, caseId, logger)
+
+        val questionEvent = emitted.filterIsInstance<QuestionEvent>().single()
+        questionEvent.userId shouldBe userId
+    }
+
+    "QuestionEvent has null userId when AwaitAnswer.userId is null" {
+        // When the execution context has no resolved user (webhook, system call, etc.),
+        // AwaitAnswer.userId is null and the QuestionEvent must stay unaddressed.
+        // No fallback is applied — null in, null out.
+        val emitted = mutableListOf<CaseEvent>()
+        val collector = FlowCollector<CaseEvent> { emitted.add(it) }
+
+        val interrupt = AgentInterrupt.AwaitAnswer(
+            question = "Any user can answer?",
+            questionType = QuestionType.FREE_TEXT,
+            userId = null,
+        )
+
+        collector.emitInterruptAndFinishEvents(buildAgent(), interrupt, namespaceId, caseId, logger)
+
+        val questionEvent = emitted.filterIsInstance<QuestionEvent>().single()
+        questionEvent.userId shouldBe null
+    }
+
+    "QuestionEvent carries question text, options and questionType from AwaitAnswer" {
+        val emitted = mutableListOf<CaseEvent>()
+        val collector = FlowCollector<CaseEvent> { emitted.add(it) }
+
+        val interrupt = AgentInterrupt.AwaitAnswer(
+            question = "Choose a colour",
+            options = listOf("Red", "Blue"),
+            questionType = QuestionType.SINGLE_CHOICE,
+            userId = null,
+        )
+
+        collector.emitInterruptAndFinishEvents(buildAgent(), interrupt, namespaceId, caseId, logger)
+
+        val questionEvent = emitted.filterIsInstance<QuestionEvent>().single()
+        questionEvent.question shouldBe "Choose a colour"
+        questionEvent.options shouldBe listOf("Red", "Blue")
+        questionEvent.questionType shouldBe QuestionType.SINGLE_CHOICE
+    }
+
+    // -----------------------------------------------------------------------
+    // AwaitAnswer: AgentFinishedEvent fields
+    // -----------------------------------------------------------------------
+
+    "AgentFinishedEvent carries agent identity from the Agent parameter" {
+        val emitted = mutableListOf<CaseEvent>()
+        val collector = FlowCollector<CaseEvent> { emitted.add(it) }
+        val agent = buildAgent(agentId)
+
+        collector.emitInterruptAndFinishEvents(
+            agent,
+            AgentInterrupt.AwaitAnswer(question = "?"),
+            namespaceId,
+            caseId,
+            logger,
+        )
+
+        val finished = emitted.filterIsInstance<AgentFinishedEvent>().single()
+        finished.agentId shouldBe agentId
+        finished.agentName shouldBe "test-agent"
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentServiceImplUnitSpec.kt
@@ -32,6 +32,9 @@ import io.whozoss.agentos.exchange.ExchangeStorageConfigProperties
 import io.whozoss.agentos.exchange.ExchangeStorageService
 import io.whozoss.agentos.exchange.ExchangeToolGrantService
 import io.whozoss.agentos.exchange.ExchangeToolsConfigProperties
+import io.whozoss.agentos.queryUser.QueryUserConfigProperties
+import io.whozoss.agentos.queryUser.QueryUserToolGrantService
+import io.whozoss.agentos.queryUser.QueryUserToolPlugin
 import io.whozoss.agentos.integrationConfig.IntegrationConfig
 import io.whozoss.agentos.integrationConfig.IntegrationConfigService
 import io.whozoss.agentos.metrics.ToolMetricsService
@@ -83,6 +86,9 @@ class AgentServiceImplUnitSpec : StringSpec() {
     // Strict on purpose: a relaxed mock would return a non-null ExchangeGrant and silently grant the
     // exchange in every unrelated test. The defaults stubbed in init deny both scopes.
     private val exchangeToolGrantService: ExchangeToolGrantService = mockk()
+    // Relaxed: queryUser grant is a side concern for most tests in this spec; a relaxed mock returns
+    // false for isGranted() (Boolean default) which means no tools are added — a safe neutral state.
+    private val queryUserToolGrantService: QueryUserToolGrantService = mockk(relaxed = true)
     private val agentService =
         AgentServiceImpl(
             chatClientProvider = chatClientProvider,
@@ -107,6 +113,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
             agentDocumentResolver = agentDocumentResolver,
             idCompressorService = IdCompressorService(),
             agentConfigProperties = AgentConfigProperties(),
+            queryUserToolGrantService = queryUserToolGrantService,
         )
 
     private val namespaceId: UUID = UUID.randomUUID()
@@ -444,6 +451,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     agentDocumentResolver = agentDocumentResolver,
                     idCompressorService = IdCompressorService(),
                     agentConfigProperties = AgentConfigProperties(),
+                    queryUserToolGrantService = queryUserToolGrantService,
                 )
             val caseTool = mockk<StandardTool<*>>()
             every { caseTool.name } returns "case-exchange__readFile"
@@ -773,6 +781,7 @@ class AgentServiceImplUnitSpec : StringSpec() {
                     agentDocumentResolver = agentDocumentResolver,
                     idCompressorService = IdCompressorService(),
                     agentConfigProperties = AgentConfigProperties(),
+                    queryUserToolGrantService = queryUserToolGrantService,
                 )
             val configs =
                 listOf(

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseRuntimeSpec.kt
@@ -15,9 +15,11 @@ import io.whozoss.agentos.sdk.agent.Agent
 import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentRunningEvent
 import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
+import io.whozoss.agentos.sdk.caseEvent.AnswerEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
 import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.entity.EntityMetadata
@@ -749,6 +751,625 @@ class CaseRuntimeSpec : StringSpec() {
             runtime.run()
 
             runtime.statusFlow.value shouldBe CaseStatus.KILLED
+        }
+
+        // -------------------------------------------------------------------------
+        // Pre-flight: findUnresolvedQuestion — tested via observable runtime behaviour
+        // -------------------------------------------------------------------------
+
+        "pre-flight emits AgentSelectedEvent when a question has been answered and no AgentFinishedEvent follows" {
+            // Simulate the AwaitAnswer path: QuestionEvent was emitted, agent finished,
+            // THEN the user answered. No AgentFinishedEvent after the answer.
+            // Expected: pre-flight finds the question and emits AgentSelectedEvent for
+            // the original agent, causing runAgent to be called.
+            //
+            // IMPORTANT: timestamps must be explicit and strictly increasing.
+            // InMemoryCaseEventList re-sorts all events by timestamp on insertion, so
+            // the order in which events appear in the source list is irrelevant — only
+            // the timestamp determines their position. Without explicit timestamps every
+            // event gets Instant.now() and the sort order is undefined, which breaks
+            // findUnresolvedQuestion's subList-based OAuth guard.
+            val agentName = "qa-agent"
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val caseId = UUID.randomUUID()
+            val savedEvents = mutableListOf<CaseEvent>()
+            val runCalls = mutableListOf<String>()
+
+            // Chronological order: MessageEvent(t1) -> AgentSelectedEvent(t2) ->
+            //   AgentFinishedEvent(t3) -> QuestionEvent(t4) -> AnswerEvent(t5).
+            // No AgentFinishedEvent after AnswerEvent → pre-flight must fire.
+            val t1 = Instant.EPOCH.plusSeconds(1)
+            val t2 = Instant.EPOCH.plusSeconds(2)
+            val t3 = Instant.EPOCH.plusSeconds(3)
+            val t4 = Instant.EPOCH.plusSeconds(4)
+            val t5 = Instant.EPOCH.plusSeconds(5)
+
+            val questionEvent = QuestionEvent(
+                timestamp = t4,
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+                question = "What is your choice?",
+            )
+            // createAnswer() defaults timestamp to Instant.now(); override it to t5
+            // so the sort order is deterministic and AnswerEvent lands after QuestionEvent.
+            val answerEvent = questionEvent.createAnswer(
+                Actor("user-1", "User", ActorRole.USER),
+                "My answer",
+            ).copy(timestamp = t5)
+
+            val existingEvents = listOf(
+                MessageEvent(
+                    timestamp = t1,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = userActor,
+                    content = userMessage,
+                ),
+                AgentSelectedEvent(
+                    timestamp = t2,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                AgentFinishedEvent(
+                    timestamp = t3,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                questionEvent,
+                answerEvent,
+            )
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { event -> savedEvents.add(event); event },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { name, _, _, _, _ ->
+                    runCalls += name
+                    // Push AgentFinishedEvent so the loop terminates cleanly.
+                    runtime.pushEvents(
+                        listOf(
+                            AgentFinishedEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                agentId = UUID.nameUUIDFromBytes(name.toByteArray()),
+                                agentName = name,
+                            ),
+                        ),
+                    )
+                },
+            )
+            runtime.pushEvents(existingEvents)
+
+            // run() is called as it would be when CaseServiceImpl.addMessage triggers it
+            // after the user posts an AnswerEvent.
+            runtime.run()
+
+            // runCalls proves runAgent was triggered (i.e. the AgentSelectedEvent from
+            // the pre-flight was stored and picked up by processNextStep).
+            runCalls shouldBe listOf(agentName)
+            // savedEvents must contain the AgentSelectedEvent emitted by the pre-flight
+            // (it passes through storeEvent, which appends to savedEvents).
+            savedEvents.filterIsInstance<AgentSelectedEvent>()
+                .any { it.agentName == agentName } shouldBe true
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "pre-flight does NOT wake up agent when answer is followed by AgentFinishedEvent (OAuth guard)" {
+            // Simulate the OAuth path: agent was running INSIDE its run when the answer
+            // arrived, finished its turn normally, so AgentFinishedEvent comes AFTER the
+            // answer. The pre-flight must NOT emit another AgentSelectedEvent.
+            //
+            // IMPORTANT: timestamps must be explicit and strictly increasing.
+            // InMemoryCaseEventList re-sorts all events by timestamp on insertion, so
+            // the order in which events appear in the source list is irrelevant — only
+            // the timestamp determines their position. Without explicit timestamps every
+            // event gets Instant.now() and the sort order is undefined, which would make
+            // this test pass for the wrong reason (AgentFinishedEvent landing before
+            // AnswerEvent instead of after it).
+            val agentName = "oauth-agent"
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val caseId = UUID.randomUUID()
+            val runCalls = mutableListOf<String>()
+
+            // Chronological order: MessageEvent(t1) -> AgentSelectedEvent(t2) ->
+            //   QuestionEvent(t3) -> AnswerEvent(t4) -> AgentFinishedEvent(t5).
+            // AgentFinishedEvent is AFTER AnswerEvent → OAuth guard must suppress wake-up.
+            val t1 = Instant.EPOCH.plusSeconds(1)
+            val t2 = Instant.EPOCH.plusSeconds(2)
+            val t3 = Instant.EPOCH.plusSeconds(3)
+            val t4 = Instant.EPOCH.plusSeconds(4)
+            val t5 = Instant.EPOCH.plusSeconds(5)
+
+            val questionEvent = QuestionEvent(
+                timestamp = t3,
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+                question = "Authorize OAuth?",
+            )
+            // createAnswer() defaults timestamp to Instant.now(); override it to t4
+            // so the sort order is deterministic and AnswerEvent lands before AgentFinishedEvent.
+            val answerEvent = questionEvent.createAnswer(
+                Actor("user-1", "User", ActorRole.USER),
+                "yes",
+            ).copy(timestamp = t4)
+
+            // OAuth order: MessageEvent -> AgentSelectedEvent -> QuestionEvent ->
+            //   AnswerEvent -> AgentFinishedEvent
+            // (agent finished AFTER the answer because it was already running)
+            val existingEvents = listOf(
+                MessageEvent(
+                    timestamp = t1,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = userActor,
+                    content = userMessage,
+                ),
+                AgentSelectedEvent(
+                    timestamp = t2,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                questionEvent,
+                answerEvent,
+                AgentFinishedEvent(
+                    timestamp = t5,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+            )
+
+            val runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { it },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { name, _, _, _, _ -> runCalls += name },
+            )
+            runtime.pushEvents(existingEvents)
+
+            runtime.run()
+
+            // The pre-flight must NOT have fired: AgentFinishedEvent is after AnswerEvent,
+            // so the OAuth guard in findUnresolvedQuestion returns null.
+            runCalls shouldBe emptyList()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "pre-flight does NOT wake up agent when question has no answer yet" {
+            // QuestionEvent present but no AnswerEvent: the user has not replied yet.
+            // The pre-flight must stay silent.
+            //
+            // IMPORTANT: timestamps must be explicit and strictly increasing.
+            // InMemoryCaseEventList re-sorts all events by timestamp on insertion, so
+            // the order in which events appear in the source list is irrelevant — only
+            // the timestamp determines their position.
+            val agentName = "waiting-agent"
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val caseId = UUID.randomUUID()
+            val runCalls = mutableListOf<String>()
+
+            // Chronological order: MessageEvent(t1) -> AgentFinishedEvent(t2) -> QuestionEvent(t3).
+            // No AnswerEvent → findUnresolvedQuestion returns null → no wake-up.
+            val t1 = Instant.EPOCH.plusSeconds(1)
+            val t2 = Instant.EPOCH.plusSeconds(2)
+            val t3 = Instant.EPOCH.plusSeconds(3)
+
+            val questionEvent = QuestionEvent(
+                timestamp = t3,
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+                question = "Still waiting?",
+            )
+            val existingEvents = listOf(
+                MessageEvent(
+                    timestamp = t1,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = userActor,
+                    content = userMessage,
+                ),
+                AgentFinishedEvent(
+                    timestamp = t2,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                questionEvent,
+                // No AnswerEvent
+            )
+
+            val runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { it },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { name, _, _, _, _ -> runCalls += name },
+            )
+            runtime.pushEvents(existingEvents)
+
+            runtime.run()
+
+            runCalls shouldBe emptyList()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        // -------------------------------------------------------------------------
+        // Pre-flight: recipient check on addressed QuestionEvent
+        // -------------------------------------------------------------------------
+
+        "pre-flight fires when addressed question is answered by the right user" {
+            // QuestionEvent.userId = aliceId. Alice answers. Pre-flight must wake the agent.
+            //
+            // IMPORTANT: timestamps must be explicit and strictly increasing.
+            // InMemoryCaseEventList re-sorts all events by timestamp on insertion — only
+            // the timestamp determines their position, not the order in the source list.
+            // createAnswer() forces Instant.now(), so always .copy(timestamp = tN).
+            val agentName = "addressed-agent"
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val caseId = UUID.randomUUID()
+            val aliceId = UUID.randomUUID()
+            val runCalls = mutableListOf<String>()
+
+            val t1 = Instant.EPOCH.plusSeconds(1)
+            val t2 = Instant.EPOCH.plusSeconds(2)
+            val t3 = Instant.EPOCH.plusSeconds(3)
+            val t4 = Instant.EPOCH.plusSeconds(4)
+            val t5 = Instant.EPOCH.plusSeconds(5)
+
+            // QuestionEvent is addressed to Alice (userId = aliceId).
+            val questionEvent = QuestionEvent(
+                timestamp = t4,
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+                question = "Alice, which option?",
+                userId = aliceId,
+            )
+            // Alice answers: actor.id must be aliceId.toString() so UUID.fromString succeeds.
+            val aliceActor = Actor(id = aliceId.toString(), displayName = "Alice", role = ActorRole.USER)
+            val answerEvent = questionEvent.createAnswer(aliceActor, "Option A").copy(timestamp = t5)
+
+            val existingEvents = listOf(
+                MessageEvent(
+                    timestamp = t1,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = userActor,
+                    content = userMessage,
+                ),
+                AgentSelectedEvent(
+                    timestamp = t2,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                AgentFinishedEvent(
+                    timestamp = t3,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                questionEvent,
+                answerEvent,
+            )
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { it },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { name, _, _, _, _ ->
+                    runCalls += name
+                    runtime.pushEvents(
+                        listOf(
+                            AgentFinishedEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                agentId = UUID.nameUUIDFromBytes(name.toByteArray()),
+                                agentName = name,
+                            ),
+                        ),
+                    )
+                },
+            )
+            runtime.pushEvents(existingEvents)
+            runtime.run()
+
+            runCalls shouldBe listOf(agentName)
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "pre-flight does NOT fire when addressed question is answered by a different user" {
+            // QuestionEvent.userId = aliceId. Bob answers. Pre-flight must stay silent.
+            //
+            // IMPORTANT: timestamps must be explicit and strictly increasing.
+            val agentName = "addressed-agent-2"
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val caseId = UUID.randomUUID()
+            val aliceId = UUID.randomUUID()
+            val bobId = UUID.randomUUID()
+            val runCalls = mutableListOf<String>()
+
+            val t1 = Instant.EPOCH.plusSeconds(1)
+            val t2 = Instant.EPOCH.plusSeconds(2)
+            val t3 = Instant.EPOCH.plusSeconds(3)
+            val t4 = Instant.EPOCH.plusSeconds(4)
+            val t5 = Instant.EPOCH.plusSeconds(5)
+
+            val questionEvent = QuestionEvent(
+                timestamp = t4,
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+                question = "Alice, which option?",
+                userId = aliceId,
+            )
+            // Bob answers — actor.id = bobId, which != aliceId.
+            val bobActor = Actor(id = bobId.toString(), displayName = "Bob", role = ActorRole.USER)
+            val bobAnswerEvent = questionEvent.createAnswer(bobActor, "Option B").copy(timestamp = t5)
+
+            val existingEvents = listOf(
+                MessageEvent(
+                    timestamp = t1,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = userActor,
+                    content = userMessage,
+                ),
+                AgentSelectedEvent(
+                    timestamp = t2,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                AgentFinishedEvent(
+                    timestamp = t3,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                questionEvent,
+                bobAnswerEvent,
+            )
+
+            val runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { it },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { name, _, _, _, _ -> runCalls += name },
+            )
+            runtime.pushEvents(existingEvents)
+            runtime.run()
+
+            // Bob's answer does not qualify — Alice has not answered yet.
+            runCalls shouldBe emptyList()
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "pre-flight fires when wrong user answers first then right user answers (anti-deadlock regression)" {
+            // Anti-regression for the permanent-deadlock bug: if the recipient check were
+            // applied AFTER indexOfFirst (instead of inside its predicate), Bob's answer
+            // would anchor the search forever and Alice's subsequent answer would never be
+            // found — the agent would be stuck permanently.
+            //
+            // QuestionEvent.userId = aliceId.
+            // Bob answers first (t5), Alice answers second (t6).
+            // Expected: pre-flight finds Alice's answer as the first LEGITIMATE response
+            // and wakes the agent.
+            //
+            // IMPORTANT: timestamps must be explicit and strictly increasing.
+            val agentName = "deadlock-guard-agent"
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val caseId = UUID.randomUUID()
+            val aliceId = UUID.randomUUID()
+            val bobId = UUID.randomUUID()
+            val runCalls = mutableListOf<String>()
+
+            val t1 = Instant.EPOCH.plusSeconds(1)
+            val t2 = Instant.EPOCH.plusSeconds(2)
+            val t3 = Instant.EPOCH.plusSeconds(3)
+            val t4 = Instant.EPOCH.plusSeconds(4)
+            val t5 = Instant.EPOCH.plusSeconds(5) // Bob answers first
+            val t6 = Instant.EPOCH.plusSeconds(6) // Alice answers second
+
+            val questionEvent = QuestionEvent(
+                timestamp = t4,
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+                question = "Alice, confirm?",
+                userId = aliceId,
+            )
+            val bobActor = Actor(id = bobId.toString(), displayName = "Bob", role = ActorRole.USER)
+            val aliceActor = Actor(id = aliceId.toString(), displayName = "Alice", role = ActorRole.USER)
+            val bobAnswerEvent = questionEvent.createAnswer(bobActor, "I'll answer for Alice").copy(timestamp = t5)
+            val aliceAnswerEvent = questionEvent.createAnswer(aliceActor, "Confirmed").copy(timestamp = t6)
+
+            val existingEvents = listOf(
+                MessageEvent(
+                    timestamp = t1,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = userActor,
+                    content = userMessage,
+                ),
+                AgentSelectedEvent(
+                    timestamp = t2,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                AgentFinishedEvent(
+                    timestamp = t3,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                questionEvent,
+                bobAnswerEvent,
+                aliceAnswerEvent,
+            )
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { it },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { name, _, _, _, _ ->
+                    runCalls += name
+                    runtime.pushEvents(
+                        listOf(
+                            AgentFinishedEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                agentId = UUID.nameUUIDFromBytes(name.toByteArray()),
+                                agentName = name,
+                            ),
+                        ),
+                    )
+                },
+            )
+            runtime.pushEvents(existingEvents)
+            runtime.run()
+
+            // Alice's answer qualifies — agent must have been woken up despite Bob
+            // having answered first.
+            runCalls shouldBe listOf(agentName)
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
+        }
+
+        "pre-flight fires when question has no userId and any user answers (non-regression)" {
+            // QuestionEvent.userId = null (unaddressed). Any respondent qualifies.
+            // This is the existing behaviour — must not regress.
+            //
+            // IMPORTANT: timestamps must be explicit and strictly increasing.
+            val agentName = "open-question-agent"
+            val agentId = UUID.nameUUIDFromBytes(agentName.toByteArray())
+            val caseId = UUID.randomUUID()
+            val someUserId = UUID.randomUUID()
+            val runCalls = mutableListOf<String>()
+
+            val t1 = Instant.EPOCH.plusSeconds(1)
+            val t2 = Instant.EPOCH.plusSeconds(2)
+            val t3 = Instant.EPOCH.plusSeconds(3)
+            val t4 = Instant.EPOCH.plusSeconds(4)
+            val t5 = Instant.EPOCH.plusSeconds(5)
+
+            // userId = null → unaddressed question.
+            val questionEvent = QuestionEvent(
+                timestamp = t4,
+                namespaceId = namespaceId,
+                caseId = caseId,
+                agentId = agentId,
+                agentName = agentName,
+                question = "Anyone can answer this",
+                userId = null,
+            )
+            val someActor = Actor(id = someUserId.toString(), displayName = "Someone", role = ActorRole.USER)
+            val answerEvent = questionEvent.createAnswer(someActor, "Here").copy(timestamp = t5)
+
+            val existingEvents = listOf(
+                MessageEvent(
+                    timestamp = t1,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    actor = userActor,
+                    content = userMessage,
+                ),
+                AgentSelectedEvent(
+                    timestamp = t2,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                AgentFinishedEvent(
+                    timestamp = t3,
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    agentName = agentName,
+                ),
+                questionEvent,
+                answerEvent,
+            )
+
+            lateinit var runtime: CaseRuntime
+            runtime = CaseRuntime(
+                id = caseId,
+                namespaceId = namespaceId,
+                caseCreatedAt = Instant.EPOCH,
+                updateStatusCallback = { _, _ -> },
+                storeEvent = { it },
+                selectAgent = { _, _ -> listOf(agentSelectedEvent(caseId, agentName)) },
+                isAgentAuthorized = TRUE_FOR_ANY_AGENTS,
+                runAgent = { name, _, _, _, _ ->
+                    runCalls += name
+                    runtime.pushEvents(
+                        listOf(
+                            AgentFinishedEvent(
+                                namespaceId = namespaceId,
+                                caseId = caseId,
+                                agentId = UUID.nameUUIDFromBytes(name.toByteArray()),
+                                agentName = name,
+                            ),
+                        ),
+                    )
+                },
+            )
+            runtime.pushEvents(existingEvents)
+            runtime.run()
+
+            // Unaddressed question: any respondent qualifies.
+            runCalls shouldBe listOf(agentName)
+            runtime.statusFlow.value shouldBe CaseStatus.IDLE
         }
 
         "command queue is cleared on error (max iterations)" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/queryUser/QueryUserToolGrantServiceUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/queryUser/QueryUserToolGrantServiceUnitSpec.kt
@@ -1,0 +1,116 @@
+package io.whozoss.agentos.queryUser
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.sdk.tool.ToolContext
+import java.util.UUID
+
+/**
+ * Unit tests for [QueryUserToolGrantService]: the enablement table and the tool name.
+ *
+ * The plugin is instantiated directly (not mocked) so the tool name assertion is pinned
+ * to the real [QueryUserTool.name] logic rather than to a stub, and any future rename
+ * of the bare tool name shows up here immediately.
+ */
+class QueryUserToolGrantServiceUnitSpec : StringSpec() {
+
+    private val plugin = QueryUserToolPlugin()
+
+    private fun service(enabledByDefault: Boolean = true) =
+        QueryUserToolGrantService(
+            properties = QueryUserConfigProperties(enabledByDefault = enabledByDefault),
+            plugin = plugin,
+        )
+
+    private val toolContext =
+        ToolContext(
+            namespaceId = UUID.randomUUID(),
+            userId = null,
+            userExternalId = null,
+            caseEvents = emptyList(),
+            agentName = "test-agent",
+        )
+
+    init {
+
+        // -------------------------------------------------------------------------
+        // Enablement table — five cases
+        // -------------------------------------------------------------------------
+
+        "key absent + enabledByDefault=true → granted" {
+            // The most common case: agent declares no integrations at all.
+            service(enabledByDefault = true).isGranted(integrations = null) shouldBe true
+        }
+
+        "key absent + enabledByDefault=false → not granted" {
+            // Platform default turned off: no tool unless the agent opts in.
+            service(enabledByDefault = false).isGranted(integrations = null) shouldBe false
+        }
+
+        "key absent from non-null map + enabledByDefault=true → granted" {
+            // Agent has other integrations but did not mention QUERY_USER.
+            val integrations = mapOf("SOME_OTHER_TOOL" to null)
+            service(enabledByDefault = true).isGranted(integrations) shouldBe true
+        }
+
+        "key present with null value → granted" {
+            // Agent explicitly enables the tool (null = all tools).
+            val integrations = mapOf(QueryUserToolPlugin.INTEGRATION_TYPE to null)
+            service().isGranted(integrations) shouldBe true
+        }
+
+        "key present with empty list → opt-out, not granted" {
+            // The escape hatch for autonomous agents triggered by webhooks:
+            // an empty list is a deliberate opt-out, not an empty allow-list.
+            // Without this, an unanswered question would block the case indefinitely.
+            val integrations = mapOf(QueryUserToolPlugin.INTEGRATION_TYPE to emptyList<String>())
+            service().isGranted(integrations) shouldBe false
+        }
+
+        "key present with non-empty list → granted" {
+            // A non-empty list is also a grant (there is only one tool anyway).
+            val integrations = mapOf(QueryUserToolPlugin.INTEGRATION_TYPE to listOf("queryUser"))
+            service().isGranted(integrations) shouldBe true
+        }
+
+        "opt-out wins even when enabledByDefault=true" {
+            // The explicit declaration always overrides the platform default.
+            val integrations = mapOf(QueryUserToolPlugin.INTEGRATION_TYPE to emptyList<String>())
+            service(enabledByDefault = true).isGranted(integrations) shouldBe false
+        }
+
+        // -------------------------------------------------------------------------
+        // Tool name
+        // -------------------------------------------------------------------------
+
+        "grantTools returns a single tool named 'queryUser' (bare, no prefix)" {
+            // configName=null is intentional: the bare name is more readable for the LLM
+            // and consistent with the legacy Express backend.
+            val tools = service().grantTools(toolContext)
+            tools shouldHaveSize 1
+            tools.single().name shouldBe "queryUser"
+        }
+
+        // -------------------------------------------------------------------------
+        // No tools when not granted
+        // -------------------------------------------------------------------------
+
+        "grantTools is not called when isGranted returns false (opt-out produces no tools)" {
+            // This test pins the caller contract: when isGranted() is false, grantTools()
+            // must not be called. Here we verify that the service itself produces no tools
+            // when the grant is absent (empty-list opt-out).
+            // The actual guard lives in AgentServiceImpl, but the service's own grantTools
+            // is independent of isGranted — this test documents the expected call pattern.
+            val integrations = mapOf(QueryUserToolPlugin.INTEGRATION_TYPE to emptyList<String>())
+            val svc = service()
+            svc.isGranted(integrations) shouldBe false
+            // If the caller respected isGranted, grantTools would not be called;
+            // if it is called anyway, it still returns a tool — the guard is in isGranted.
+            // We assert the opt-out flag only, not the tool list.
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/queryUser/QueryUserToolPluginSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/queryUser/QueryUserToolPluginSpec.kt
@@ -1,0 +1,68 @@
+package io.whozoss.agentos.queryUser
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.whozoss.agentos.sdk.tool.ToolContext
+import java.util.UUID
+
+class QueryUserToolPluginSpec : StringSpec({
+
+    val namespaceId: UUID = UUID.randomUUID()
+
+    fun context(configName: String? = null) =
+        ToolContext(
+            namespaceId = namespaceId,
+            userId = null,
+            userExternalId = null,
+            caseEvents = emptyList(),
+        )
+
+    // -------------------------------------------------------------------------
+    // integrationType
+    // -------------------------------------------------------------------------
+
+    "integrationType is QUERY_USER" {
+        QueryUserToolPlugin().integrationType shouldBe "QUERY_USER"
+    }
+
+    // -------------------------------------------------------------------------
+    // configSchema
+    // -------------------------------------------------------------------------
+
+    "configSchema is null (config-less plugin)" {
+        QueryUserToolPlugin().configSchema shouldBe null
+    }
+
+    // -------------------------------------------------------------------------
+    // provideTools
+    // -------------------------------------------------------------------------
+
+    "provideTools returns a single QueryUserTool" {
+        val plugin = QueryUserToolPlugin()
+        val tools = plugin.provideTools(config = null, configName = null, context = context())
+        tools shouldHaveSize 1
+        tools.first().shouldBeInstanceOf<QueryUserTool>()
+    }
+
+    "provideTools returns QueryUserTool with bare name when configName is null" {
+        val plugin = QueryUserToolPlugin()
+        val tools = plugin.provideTools(config = null, configName = null, context = context())
+        tools.first().name shouldBe "queryUser"
+    }
+
+    "provideTools returns QueryUserTool with prefixed name when configName is provided" {
+        val plugin = QueryUserToolPlugin()
+        val tools = plugin.provideTools(config = null, configName = "MY_QUERY", context = context())
+        tools.first().name shouldBe "MY_QUERY__queryUser"
+    }
+
+    "provideTools returns a single tool even when context is null" {
+        // Unlike RedirectToolPlugin, QueryUserToolPlugin does not need the context
+        // to resolve anything — it should return a tool regardless.
+        val plugin = QueryUserToolPlugin()
+        val tools = plugin.provideTools(config = null, configName = null, context = null)
+        tools shouldHaveSize 1
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/queryUser/QueryUserToolSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/queryUser/QueryUserToolSpec.kt
@@ -1,0 +1,146 @@
+package io.whozoss.agentos.queryUser
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.agent.AgentInterrupt
+import io.whozoss.agentos.sdk.caseEvent.QuestionType
+import io.whozoss.agentos.sdk.tool.ToolContext
+import java.util.UUID
+
+private val CONTEXT = mockk<ToolContext>(relaxed = true)
+
+class QueryUserToolSpec : StringSpec({
+
+    // -------------------------------------------------------------------------
+    // Error cases: null input and blank question
+    // -------------------------------------------------------------------------
+
+    "execute returns a human-readable error when input is null" {
+        val tool = QueryUserTool()
+        val result = tool.execute(null, CONTEXT)
+        result.success shouldBe false
+        result.output shouldBe "A question is required."
+    }
+
+    "execute returns a human-readable error when question is blank" {
+        val tool = QueryUserTool()
+        val result = tool.execute(QueryUserTool.Input(question = "   "), CONTEXT)
+        result.success shouldBe false
+        result.output shouldBe "A question is required."
+    }
+
+    "execute returns a human-readable error when question is empty" {
+        val tool = QueryUserTool()
+        val result = tool.execute(QueryUserTool.Input(question = ""), CONTEXT)
+        result.success shouldBe false
+        result.output shouldBe "A question is required."
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path: QuestionType derivation
+    // -------------------------------------------------------------------------
+
+    "execute throws AwaitAnswer with FREE_TEXT when options is null" {
+        val tool = QueryUserTool()
+        val ex = shouldThrow<AgentInterrupt.AwaitAnswer> {
+            tool.execute(QueryUserTool.Input(question = "What is your preference?"), CONTEXT)
+        }
+        ex.question shouldBe "What is your preference?"
+        ex.questionType shouldBe QuestionType.FREE_TEXT
+        ex.options shouldBe null
+    }
+
+    "execute throws AwaitAnswer with FREE_TEXT when options is empty" {
+        val tool = QueryUserTool()
+        val ex = shouldThrow<AgentInterrupt.AwaitAnswer> {
+            tool.execute(
+                QueryUserTool.Input(question = "What is your preference?", options = emptyList()),
+                CONTEXT,
+            )
+        }
+        ex.questionType shouldBe QuestionType.FREE_TEXT
+        ex.options shouldBe null // empty list normalised to null
+    }
+
+    "execute throws AwaitAnswer with SINGLE_CHOICE when options non-empty and allowCustomAnswer false" {
+        val tool = QueryUserTool()
+        val ex = shouldThrow<AgentInterrupt.AwaitAnswer> {
+            tool.execute(
+                QueryUserTool.Input(
+                    question = "Pick one",
+                    options = listOf("A", "B"),
+                    allowCustomAnswer = false,
+                ),
+                CONTEXT,
+            )
+        }
+        ex.question shouldBe "Pick one"
+        ex.questionType shouldBe QuestionType.SINGLE_CHOICE
+        ex.options shouldBe listOf("A", "B")
+    }
+
+    "execute throws AwaitAnswer with OPEN_CHOICE when options non-empty and allowCustomAnswer true" {
+        val tool = QueryUserTool()
+        val ex = shouldThrow<AgentInterrupt.AwaitAnswer> {
+            tool.execute(
+                QueryUserTool.Input(
+                    question = "Pick or type",
+                    options = listOf("X", "Y", "Z"),
+                    allowCustomAnswer = true,
+                ),
+                CONTEXT,
+            )
+        }
+        ex.question shouldBe "Pick or type"
+        ex.questionType shouldBe QuestionType.OPEN_CHOICE
+        ex.options shouldBe listOf("X", "Y", "Z")
+    }
+
+    // -------------------------------------------------------------------------
+    // userId propagation from ToolContext
+    // -------------------------------------------------------------------------
+
+    "execute throws AwaitAnswer carrying the userId from ToolContext" {
+        // ToolContext.userId must flow into AwaitAnswer.userId so that
+        // AgentInterruptHandler can stamp the QuestionEvent with the right user.
+        val userId = UUID.randomUUID()
+        val context = mockk<ToolContext>(relaxed = true)
+        every { context.userId } returns userId
+
+        val tool = QueryUserTool()
+        val ex = shouldThrow<AgentInterrupt.AwaitAnswer> {
+            tool.execute(QueryUserTool.Input(question = "Which one?"), context)
+        }
+        ex.userId shouldBe userId
+    }
+
+    "execute throws AwaitAnswer with null userId when ToolContext.userId is null" {
+        // When the execution context has no resolved user (webhook, system call, etc.),
+        // userId stays null — no artificial fallback is applied.
+        // mockk<ToolContext>(relaxed = true) already returns null for UUID? properties,
+        // but we make the intent explicit here.
+        val context = mockk<ToolContext>(relaxed = true)
+        every { context.userId } returns null
+
+        val tool = QueryUserTool()
+        val ex = shouldThrow<AgentInterrupt.AwaitAnswer> {
+            tool.execute(QueryUserTool.Input(question = "Which one?"), context)
+        }
+        ex.userId shouldBe null
+    }
+
+    // -------------------------------------------------------------------------
+    // Tool name convention
+    // -------------------------------------------------------------------------
+
+    "name is bare 'queryUser' when configName is null" {
+        QueryUserTool(configName = null).name shouldBe "queryUser"
+    }
+
+    "name is prefixed when configName is provided" {
+        QueryUserTool(configName = "QUERY_USER").name shouldBe "QUERY_USER__queryUser"
+    }
+})

--- a/docs/study/agentos-query-user.md
+++ b/docs/study/agentos-query-user.md
@@ -1,0 +1,414 @@
+# AgentOS — generic `queryUser`: analysis and implementation
+
+> Code analysis carried out July 2026, **both** back end and front end verified.
+> **Implemented August 2026** — see "What was built" near the end.
+> The body of the document keeps the original analysis: it records the *why* behind the choices.
+
+## The problem
+
+An AgentOS agent could not ask the user a free-form question mid-run and resume its work with the
+answer. There was no generic equivalent of Coday's `queryUser`.
+
+## One-sentence summary
+
+The model, the persistence, the REST transport and **the entire front end** were already shipped and
+working. The only missing pieces were on the back end: a non-OAuth producer of `QuestionEvent`, and
+waking the runtime up when the `AnswerEvent` arrives.
+
+---
+
+## What already existed
+
+### 1. The confirmation gate (WZ-31596) — the right pattern
+
+A tool opts into the gate by overriding `StandardTool.getConfirmationMode()`
+(`NONE` / `INFER` / `EVERY_TIME`). The orchestrator then emits a `PendingConfirmationEvent`,
+**ends the run**, and the state lives in the persisted events. Resumption happens through a
+pre-flight check at the top of the run (`findUnresolvedPendingConfirmation()`), and the cycle closes
+with a `ConfirmationResolvedEvent` paired via `pendingEventId`. It survives a server restart.
+
+**Commonly misunderstood point**: the gate does NOT ask its question through a `QuestionEvent`. It
+emits an in-channel `MessageEvent` — an ordinary agent message. The user's reply therefore arrives as
+an ordinary USER `MessageEvent`, goes through `selectAgent`, produces an `AgentSelectedEvent`, and
+restarts the runtime along the nominal path.
+
+> The gate is robust **because it grafts onto the nominal path**, not because it has a resumption
+> mechanism of its own.
+
+Limitation: it is built on `AgentAdvanced`'s intention loop. `AgentSimple` does not benefit from it.
+
+### 2. Interactive OAuth — blocking, to be reworked (#1198)
+
+`OAuthFlowService.runInteractiveFlow()` emits a `QuestionEvent` of type `OAUTH_AUTHORIZE` then
+**blocks** on `future.get(timeout)` inside a `withContext(Dispatchers.IO)`.
+
+The price (accepted and documented in `OAuthPendingRegistry`'s KDoc): single-instance, does not
+survive a restart, capped at roughly 64 concurrent flows by the IO pool, in-memory state.
+
+This path cannot be made non-blocking cheaply: turning the chain into `suspend` would touch three
+elements of the SDK's public contract.
+
+### 3. `QuestionEvent` / `AnswerEvent` — complete chain except the wake-up
+
+**What existed and worked:**
+
+- SDK types, Neo4j persistence (`QuestionEventNode`, `AnswerEventNode`, tested bidirectional mapping)
+- `questionType`, `options`, targeting `userId`, `createAnswer()`
+- REST transport: `AddMessageRequest.answerToEventId`
+- push notifications: `PushNotificationDispatcher`
+- transcript rendering: `CaseTranscriptFormatter`
+- **the front end, in full** (see below)
+
+**What was missing — the wake-up.** In `CaseRuntime.addUserMessage`:
+
+```kotlin
+if (answerToEventId != null) { ...
+    storeAndEmitEvent(questionEvent.createAnswer(actor, answerText))
+    return // answer is passive — waits for agent to process it
+}
+```
+
+No `selectAgent`, therefore no `AgentSelectedEvent`. `CaseServiceImpl.addMessage` does launch
+`runtime.run()` behind it, but `processNextStep()` walks the history backwards, hits the previous
+turn's `AgentFinishedEvent`, and returns `AGENT_FINISHED` → IDLE.
+
+**Observable symptom** if an agent emitted a `SINGLE_CHOICE` today: the panel appears, the user
+clicks, the panel switches to "✅ Question answered", the status flickers RUNNING then falls back to
+IDLE, and **nothing happens**. No error, no hang — just silence.
+
+**Only producer of `QuestionEvent` in production code**: `OAuthFlowService`, and only for
+`OAUTH_AUTHORIZE`.
+
+---
+
+## The front end is complete (verified)
+
+`QuestionPanelComponent` (`libs/agentos-ui/src/lib/components/question-panel/`) renders all four types:
+
+| Type | Rendering |
+|---|---|
+| `FREE_TEXT` | text input + Submit, Enter to confirm |
+| `SINGLE_CHOICE` | one button per option, click answers immediately |
+| `OPEN_CHOICE` | option buttons **plus** a free-text field "Or type a custom answer…" |
+| `OAUTH_AUTHORIZE` | Authorize / Cancel, delegates the popup to `OAuthAgentosService` |
+
+`CaseChatComponent` has a `TimelineItem` of kind `'question'`, computes `answered` by looking for the
+`AnswerEvent` paired on `questionId`, and shows "✅ Question answered" once replied to. Crucially,
+`onQuestionAnswered()` does:
+
+```typescript
+this.isRunning.set(true)   // ← the front end explicitly expects the agent to resume
+this.http.post(.../messages, { content: answer, answerToEventId: questionEvent.id })
+```
+
+`CompanionStateService` (PiP window) treats `QuestionEvent` as a **blocking** notification, plays a
+chime, and clears it on `AnswerEvent`.
+
+`OAuthAgentosService.answerQuestion()` is a public method whose KDoc explicitly says
+"for FREE_TEXT, SINGLE_CHOICE, OPEN_CHOICE".
+
+> **No front-end work was needed.** It was finished work waiting on the back end.
+
+---
+
+## Decision: `AgentInterrupt.AwaitAnswer` + pre-flight wake-up (A2)
+
+### The vehicle: `AgentInterrupt.AwaitAnswer`
+
+`AgentInterrupt` is a `sealed class` of exceptions used as a control signal from inside a tool.
+**Its KDoc already documented `AwaitAnswer` as a planned member**: "suspend and wait for a human
+answer to a QuestionEvent".
+
+Why it is the right vehicle:
+
+- `sealed class` → every `when` is checked at compile time. Adding a member without handling it is a
+  **compilation error**, not a silent bug.
+- It travels through `ToolCallback.call` (whose contract returns a bare `String`) without polluting
+  the result. That is the explicit justification the KDoc gives for using exceptions here.
+- It is handled by `emitInterruptAndFinishEvents`, **shared by `AgentSimple` AND `AgentAdvanced`** →
+  both agents are covered for free.
+- It touches **no public SDK type** (the class is internal to the service).
+
+Shape: `AgentInterrupt.AwaitAnswer(question, options?, questionType, userId)`. The tool throws it →
+`emitInterruptAndFinishEvents` emits `AgentFinishedEvent` + `QuestionEvent` → the run ends. Stateless,
+persisted, survives a restart.
+
+### Options rejected
+
+| Option | Why not |
+|---|---|
+| `ToolExecutionResult.AwaitingUserInput` | In `AgentSimple` the tool result is consumed by Spring AI's internal loop, which feeds it back to the LLM as a `String` — there is no way to interrupt that loop from a return value. It would only work in `AgentAdvanced`. It also touches a public SDK type. |
+| An event emitter on `ToolContext` | Breaks the "only the orchestrator emits" invariant, and reopens the door to OAuth-style blocking. |
+
+### The wake-up: A2 (pre-flight), not A1 (active AnswerEvent)
+
+Two routes were possible:
+
+- **A1** — drop the `return` in `addUserMessage` and call `selectAgent`. Three lines.
+- **A2** — a `findUnresolvedQuestion()` at the top of `run()`, symmetric with the confirmation gate's
+  pre-flight.
+
+**A2 was chosen.** The decisive reason is not architectural taste but a concrete risk:
+
+During an OAuth flow the agent is **blocked inside its own run** (`runInFlight == true`, coroutine
+suspended in `future.get()`). Yet the front end still posts an `AnswerEvent` when OAuth succeeds
+(`OAuthAgentosService.postAnswer`), purely to close the question visually. That therefore happens
+**while** the agent is still running.
+
+With A1, that POST would trigger `selectAgent` → a spurious `AgentSelectedEvent` would be planted in
+the history in the middle of an ongoing turn. The subsequent `run()` is correctly ignored
+(`runInFlight` guards it), but `processNextStep()` works by **walking the history backwards** to the
+first orchestration event it finds. Depending on the exact arrival order — which depends on the OAuth
+popup's network latency — that stray event can trigger a phantom agent turn.
+
+An intermittent, timing-dependent bug that cannot be reproduced locally. Not worth it to save three
+lines.
+
+**A2 is purely additive**: it changes no existing behaviour. Every current path, OAuth included,
+bypasses it entirely.
+
+### Pre-flight principle
+
+> At the start of a turn, before anything else: is there a question that has received its answer and
+> for which the agent never resumed? If so, emit an `AgentSelectedEvent` and let the normal loop do
+> the rest.
+
+Two conveniences offered by the existing model:
+
+- **`QuestionEvent` already carries `agentId` and `agentName`.** We know exactly which agent to wake —
+  no need to go back through `selectAgent` and its resolution cascade (`@` mention, last agent,
+  default agent).
+- **The guard protecting OAuth is a single condition**: only wake up if there is **no**
+  `AgentFinishedEvent` after the `AnswerEvent`.
+  - OAuth: the unblocked agent finishes its turn normally → `AgentFinishedEvent` arrives afterwards →
+    no wake-up.
+  - `AwaitAnswer`: the run ended *before* the answer → no `AgentFinishedEvent` after → wake-up.
+
+---
+
+## Implementation points
+
+The initial plan had four. A re-read of the code before implementation revealed a decisive fifth
+(point 5), implementation produced a sixth (refactor), and real-world testing exposed a seventh
+(tool availability).
+
+1. `AwaitAnswer` member in the `AgentInterrupt` sealed class
+2. Its handling in `emitInterruptAndFinishEvents` (`QuestionEvent` after the `AgentFinishedEvent`)
+3. The `ToolResponseEvent` message branches in `AgentSimple` and `AgentAdvanced`
+4. The `queryUser` tool and its plugin (`QueryUserTool`, `QueryUserToolPlugin`)
+5. The `findUnresolvedQuestion()` pre-flight at the top of `run()`
+6. **Translating `QuestionEvent`/`AnswerEvent` into LLM messages** — see below
+7. **Tool availability**: a default grant, not a declared integration — see below
+
+### The fifth point, absent from the initial analysis
+
+Neither `AgentSimple.convertEventsToMessages` nor `AgentAdvancedContext.convertEventsToMessages`
+handled `QuestionEvent` and `AnswerEvent`: both fell into `else -> ignore`. Yet
+`CaseEventType.isFirstLevel()` explicitly classes them as conversational alongside `MESSAGE`. The
+intent was there, the translation was not.
+
+Without this point, the first four produce an agent that resumes **blind**: neither its own question
+nor the user's answer is in its context. It asks again, or hallucinates. A symptom as silent as the
+missing wake-up, and harder to diagnose.
+
+Why nobody had spotted it: the only producer of `QuestionEvent` was OAuth, where the agent stays
+blocked *inside* its run and therefore never has to re-read the exchange from persisted history.
+Exactly the same producer/consumer asymmetry noted under "Method note".
+
+Mapping chosen: `QuestionEvent` → `AssistantMessage` (the agent's own voice, options listed when
+present), `AnswerEvent` → `UserMessage` (consistent with how USER `MessageEvent`s are rendered).
+
+### The seventh point, exposed by real-world testing
+
+First live test: the agent did **not** call the tool. It wrote its question out in markdown, complete
+with a bulleted list of the options. No `QuestionEvent`, therefore no panel — the front end was
+behaving correctly.
+
+Two chained causes:
+
+- `ToolResolverService.resolveToolsForRun` only serves tools for integrations declared in
+  `AgentConfig.integrations` (`agentIntegrations?.keys?.toList() ?: emptyList()`). With no
+  `QUERY_USER` `IntegrationConfig` declared, the tool never reaches the agent.
+- Worse, such an integration **cannot be created through the UI**:
+  `CompositeIntegrationTypeRegistry.registerFromPlugin` does `plugin.configSchema ?: return`. Since
+  `QueryUserToolPlugin.configSchema` is `null`, the type is never catalogued and never appears in the
+  "Type" dropdown of the integration form.
+
+**Resolution**: `QueryUserToolGrantService`, modelled on `ExchangeToolGrantService` — a parallel grant
+path alongside the resolver, explicitly legitimised by `resolveToolsForRun`'s own KDoc.
+
+Decision table (identical to the exchange pattern; both `containsKey` and `get` are required, since a
+key that is absent and a key mapped to `null` are indistinguishable through `get` alone yet mean
+opposite things):
+
+| Condition | Result |
+|---|---|
+| key absent + `enabledByDefault = true` | granted |
+| key absent + `enabledByDefault = false` | not granted |
+| key present, value `null` | granted |
+| key present, empty list `[]` | **opt-out** — not granted |
+| key present, non-empty list | granted |
+
+`QueryUserConfigProperties.enabledByDefault = true` (prefix `agentos.query-user`, registered in
+`AgentOSApplication`). Asking a question is a primitive of conversation, not an integration like Jira:
+agents should not have to declare it. This also matches the legacy Express backend, which users
+expect.
+
+**The empty-list opt-out is the escape hatch** for a fully autonomous agent triggered by a webhook:
+nobody is listening, so an unanswered question would block the case indefinitely.
+
+Wired into `AgentServiceImpl` through `dedupToolsByName`, so an agent that also has a declared
+`QUERY_USER` `IntegrationConfig` does not end up with the tool twice. `configName = null` gives the
+bare name `queryUser`.
+
+---
+
+## Recipient control — the permanent-deadlock trap
+
+`QuestionEvent.userId` identifies the user on whose behalf the agent is running — the one whose answer
+is awaited. `null` means "any user of the case" (webhook, system call); no artificial fallback is
+applied. The value travels `ToolContext.userId` → `AwaitAnswer.userId` → `QuestionEvent.userId`, which
+avoids touching `Agent`, a public SDK type.
+
+The pre-flight verifies that the respondent is the intended recipient. **The check lives INSIDE the
+`indexOfFirst` predicate, never after it.**
+
+If the check were applied after the search:
+
+1. Bob answers a question addressed to Alice.
+2. `indexOfFirst` finds Bob's answer (first one paired by `questionId`).
+3. The recipient check fails → return `null`.
+4. Alice answers later.
+5. `indexOfFirst` **still** finds Bob's answer first → stuck forever.
+
+The question would be dead and the agent blocked for good, with no error anywhere. The KDoc on
+`findUnresolvedQuestion` records this reasoning explicitly, because it is precisely the kind of
+subtlety a future reader would "simplify" away.
+
+Defensive case: an actor whose `actor.id` does not parse as a UUID (system actor, external identifier)
+does not qualify as a legitimate answer; a debug log is emitted for diagnosability.
+
+---
+
+## What was built
+
+Persistence, transport, rendering, notification, transcript: already there, untouched. No front-end
+file modified. No public SDK type modified. `CaseRuntime.addUserMessage` unchanged — the
+`return // answer is passive` is intact, the pre-flight is purely additive.
+
+Files created:
+
+- `agentos-service/.../queryUser/QueryUserTool.kt` — derives `QuestionType` from
+  `options`/`allowCustomAnswer`, throws `AwaitAnswer` on the happy path, returns a readable error on
+  invalid input (same contract as `RedirectTool`)
+- `agentos-service/.../queryUser/QueryUserToolPlugin.kt` — plain `@Component`, `configSchema = null`
+  (config-less plugin, conforming to the `ToolPlugin` contract). No `@Configuration`: unlike
+  `RedirectToolPlugin` it has no Spring dependency to inject, hence no cycle risk.
+- `agentos-service/.../queryUser/QueryUserToolGrantService.kt` — the default grant and its decision
+  table
+- `agentos-service/.../queryUser/QueryUserConfigProperties.kt` — platform-level policy
+
+Files modified: `AgentInterrupt.kt`, `AgentInterruptHandler.kt`, `AgentSimple.kt`, `AgentAdvanced.kt`,
+`AgentAdvancedContext.kt`, `CaseRuntime.kt`, `AgentServiceImpl.kt`, `AgentOSApplication.kt`,
+`application.yml`.
+
+Refactor along the way: the tool-call flush in `AgentSimple.convertEventsToMessages` had become
+duplicated four times once the `QuestionEvent`/`AnswerEvent` branches were added. Extracted into
+`flushPendingToolCalls()`, with a KDoc explaining the OpenAI invariant (any `AssistantMessage`
+carrying `tool_calls` must be followed by a `ToolResponseMessage` covering every `tool_call_id`, on
+pain of HTTP 400). It is the most fragile invariant in the file; leaving it copied guaranteed that a
+future change would miss one occurrence.
+
+Build: `./gradlew :agentos-service:build` green.
+
+Confirmed working in production use: three consecutive question/answer cycles in a single case, the
+tool appearing under its bare name `queryUser` (proving the default grant path), rendering as
+`SINGLE_CHOICE` with option buttons and no free-text field.
+
+---
+
+## Trap encountered: `InMemoryCaseEventList` re-sorts by timestamp
+
+Worth remembering for any future `CaseRuntime` test that manipulates event ordering.
+
+`InMemoryCaseEventList.add()` inserts **chronologically**, and the constructor does
+`inputEvents.sortedBy { it.timestamp }`. The order in which events are passed to `pushEvents` is
+therefore **ignored**: only the timestamp counts. Since every `CaseEvent` defaults to
+`timestamp = Instant.now()`, the order in which fixtures are *declared in the source* determines the
+effective order — counter-intuitively.
+
+The first three pre-flight tests built `questionEvent` and `answerEvent` before the `existingEvents`
+list, whose other events are created inline and therefore later. After sorting, the
+`AgentFinishedEvent` ended up *after* the `AnswerEvent`, the anti-OAuth guard fired, and the
+pre-flight never ran.
+
+The happy-path test failed outright (`runCalls` empty). More troubling: the two negative tests
+**passed for the wrong reason** — they were not testing the ordering they claimed to test. A green
+test that verifies nothing is worse than a red one, and here it covered the mechanism's most critical
+guard.
+
+Fix: explicit, strictly increasing timestamps (`Instant.EPOCH.plusSeconds(n)`) in all such tests, with
+`.copy(timestamp = ...)` on the `AnswerEvent` produced by `createAnswer()`, which otherwise forces
+`Instant.now()`.
+
+---
+
+## Known noise in this module's builds
+
+`GlobalCaseEventSseController` repeatedly emits `MockKException: no answer found for
+CaseService.findConcerningUser`, with a full stack trace, into the `system-out` of many specs.
+
+It **predates this work and fails no test** (it is swallowed by a `catch` in the reconciliation loop),
+but it saturates agent stdout buffers and derailed several diagnostics during implementation —
+including one report that claimed tests were failing when they were in fact passing. Fix: stub
+`findConcerningUser` in the affected spec. Still outstanding.
+
+---
+
+## Open question (non-blocking)
+
+Was `return // answer is passive — waits for agent to process it` a deliberate choice or an unfinished
+step? The comment describes an agent that *blocks* while waiting — that is, precisely the OAuth model.
+
+**This does not block the implementation**: A2 being additive, it respects that choice either way. The
+passive path stays passive; a door was added beside it.
+
+---
+
+## Key files
+
+### Back end
+
+- `agentos-service/.../agent/AgentInterrupt.kt` + `AgentInterruptHandler.kt`
+- `agentos-service/.../agent/AgentServiceImpl.kt` — tool assembly, grant wiring
+- `agentos-service/.../queryUser/` — tool, plugin, grant service, config properties
+- `agentos-service/.../caseFlow/CaseRuntime.kt` — `addUserMessage`, `processNextStep`, `runTurns`,
+  `run`, `findUnresolvedQuestion`
+- `agentos-service/.../caseFlow/CaseServiceImpl.kt` — `addMessage`, `runAgent`
+- `agentos-service/.../tool/ToolResolverService.kt` — declared-integration resolution
+- `agentos-service/.../exchange/ExchangeToolGrantService.kt` — the pattern the grant service follows
+- `agentos-sdk/.../tool/StandardTool.kt` — confirmation opt-in
+- `agentos-sdk/.../caseEvent/CaseEvent.kt` — `QuestionEvent`, `AnswerEvent`, `PendingConfirmationEvent`
+- `agentos-sdk/.../caseEvent/QuestionType.kt`
+- `agentos-service/.../auth/OAuthFlowService.kt` — the only other producer of `QuestionEvent`
+
+### Front end (already complete, no changes expected)
+
+- `libs/agentos-ui/src/lib/components/question-panel/` — renders all 4 types
+- `libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts` — `onQuestionAnswered`,
+  timeline kind `'question'`
+- `libs/agentos-ui/src/lib/services/companion-state.service.ts` — PiP notification
+- `libs/agentos-ui/src/lib/services/oauth-agentos.service.ts` — `answerQuestion`, `postAnswer`
+
+---
+
+## Method note
+
+A first pass of this analysis dismissed `QuestionType` as a "design fossil", based solely on back-end
+producers — without looking at the consumers. That was wrong: the front end was complete. The lesson
+is worth recording for future analyses of this repository: **a type with no producer may well have a
+finished consumer**, and the asymmetry tells you about the order in which the work was done, not about
+dead code.
+
+The same asymmetry bit twice: point 5 (LLM message translation) was missed for exactly the same
+reason — the only existing producer was OAuth, a path that never exercises the consumer.


### PR DESCRIPTION
An agent can now ask the user a question mid-run, stop, and resume with the answer — the generic equivalent of Coday's queryUser, which AgentOS lacked. Supports free text, closed choice, and open choice.

How it works. The queryUser tool throws AgentInterrupt.AwaitAnswer; the orchestrator emits AgentFinishedEvent + QuestionEvent and the run ends. Nothing blocks, nothing stays in memory — state lives in persisted events and survives a restart. When the user answers, a pre-flight check at the top of the next run() wakes the original agent. Same pattern as the confirmation gate (WZ-31596).

Design notes.

AwaitAnswer was already documented as a planned member of the AgentInterrupt sealed class. Handled in emitInterruptAndFinishEvents, so AgentSimple and AgentAdvanced are both covered with no duplication.
Resume via pre-flight rather than an active AnswerEvent: the latter would plant a spurious AgentSelectedEvent mid-turn during OAuth flows (intermittent phantom turns). The pre-flight is purely additive — addUserMessage is unchanged.
The tool is granted by default (QueryUserToolGrantService, modelled on ExchangeToolGrantService), not declared as an integration: asking a question is a primitive of conversation. Agents opt out by mapping QUERY_USER to an empty list — needed for webhook-triggered agents where nobody is listening.
Two traps handled explicitly. QuestionEvent/AnswerEvent are now translated into LLM messages (without this the agent resumes blind and repeats itself). And the pre-flight's recipient check sits inside the search predicate — applying it afterwards would let a wrong respondent anchor the search permanently, killing the question with no error.

Scope. No front-end changes (it was already complete). No public SDK types touched.

Tests. Build green. New coverage on the tool, the interrupt handler, the grant decision table, and the pre-flight — including the anti-deadlock regression. Note for future CaseRuntime tests: InMemoryCaseEventList re-sorts by timestamp, so fixtures need explicit increasing timestamps; this initially produced two green tests that verified nothing.

Verified in real use. Three consecutive question/answer cycles, tool exposed under its bare name queryUser, SINGLE_CHOICE rendering as expected.

Full analysis, rejected alternatives, and reasoning: docs/study/agentos-query-user.md.

<img width="1521" height="859" alt="image" src="https://github.com/user-attachments/assets/e4073364-2989-40e4-814e-d8528fa4dbeb" />
