### PR TITLE
fix: optimize findFilesByName to prevent TimeoutError on large projects

### DIFF
--- a/libs/function/src/lib/find-files-by-name.ts
+++ b/libs/function/src/lib/find-files-by-name.ts
@@ -22,7 +22,27 @@ export const findFilesByName = async ({ text, path, root, timeout, limit }: Find
     dotRelative: false,
     follow: false,
     signal: AbortSignal.timeout(timeout || defaultTimeout),
-    ignore: ['**/node_modules/**', '**/build/**'],
+    maxDepth: 5,
+    ignore: [
+      '**/node_modules',
+      '**/node_modules/**',
+      '**/build',
+      '**/build/**',
+      '**/dist',
+      '**/dist/**',
+      '**/.git',
+      '**/.git/**',
+      '**/.nx',
+      '**/.nx/**',
+      '**/.angular',
+      '**/.angular/**',
+      '**/coverage',
+      '**/coverage/**',
+      '**/tmp',
+      '**/tmp/**',
+      '**/out-tsc',
+      '**/out-tsc/**',
+    ],
   })
 
   return !limit || results.length < limit


### PR DESCRIPTION
 • **/node_modules (Le videur) : Interdit au programme d'entrer dans le dossier. C'est ce qui fait gagner tout le temps d'exploration (Performance).
 
  • **/node_modules/** (Le filtre) : Rejette les fichiers contenus dans ce dossier. C'est la sécurité anti-fuite au cas où le programme y aurait accédé par un autre moyen, comme un lien symbolique (Fiabilité).