### PR TITLE
Fix/marc/mcp tool name sanitization

### DIFF
--- a/libs/mcp/src/lib/mcp-tools-factory.ts
+++ b/libs/mcp/src/lib/mcp-tools-factory.ts
@@ -711,6 +711,14 @@ export class McpToolsFactory extends AssistantToolFactory {
   }
 
   /**
+   * Sanitize a tool name to match the pattern required by AI providers: ^[a-zA-Z0-9_-]{1,128}$
+   * Replaces any invalid character with '_' and truncates to 128 characters.
+   */
+  private sanitizeToolName(name: string): string {
+    return name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 128)
+  }
+
+  /**
    * Create a Coday tool for an MCP resource
    *
    * @param serverConfig The MCP server configuration
@@ -718,7 +726,7 @@ export class McpToolsFactory extends AssistantToolFactory {
    * @param resource The MCP resource definition
    */
   private createResourceTool(serverConfig: McpServerConfig, client: Client, resource: ResourceTemplate): CodayTool {
-    const resourceName = `mcp__${serverConfig.id}__${resource.name}`
+    const resourceName = this.sanitizeToolName(`mcp__${serverConfig.id}__${resource.name}`)
 
     const getResource = async (args: Record<string, any>) => {
       try {
@@ -794,7 +802,7 @@ export class McpToolsFactory extends AssistantToolFactory {
    * @param tool The MCP tool definition
    */
   private createFunctionTool(serverConfig: McpServerConfig, client: Client, tool: ToolInfo): CodayTool {
-    const toolName = `${serverConfig.name}__${tool.name}`
+    const toolName = this.sanitizeToolName(`${serverConfig.name}__${tool.name}`)
 
     const callFunction = async (args: Record<string, any>) => {
       // Update last used timestamp


### PR DESCRIPTION
## Problem
Anthropic's API requires tool names to match ^[a-zA-Z0-9_-]{1,128}$. Recent versions of Angular MCP expose tools with dots in their names (e.g. devserver.stop), which after Coday's namespacing becomes Angular__devserver.stop. The dot character is not allowed, causing Anthropic to reject the entire API request with a 400 error, making all tools unavailable for that agent.

## Fix
Added a sanitizeToolName() method in McpToolsFactory that replaces any character outside [a-zA-Z0-9_-] with _ and truncates to 128 characters. Applied at name construction time in both createFunctionTool and createResourceTool.

The fix is transparent to MCP dispatch: the callFunction closure captures the original tool.name (e.g. devserver.stop) and passes it directly to client.callTool(), so the sanitized name is only ever seen by the AI provider — never by the MCP server.