### PR TITLE
fix(mcp): explicitly pass undici fetch to prevent SSE stream buffering

### DIFF
--- a/libs/mcp/src/lib/mcp-tools-factory.ts
+++ b/libs/mcp/src/lib/mcp-tools-factory.ts
@@ -1,5 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { fetch as undiciFetch } from 'undici'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
@@ -583,7 +584,10 @@ export class McpToolsFactory extends AssistantToolFactory {
       console.log(
         `[MCP] ${this.serverConfig.name}: McpOAuthProvider created for mcpId=${this.serverConfig.id}${this.serverConfig.oauthClientId ? ` (static client_id=${this.serverConfig.oauthClientId})` : ' (dynamic registration)'}`
       )
-      const transport = new StreamableHTTPClientTransport(url, { authProvider: this.oauthProvider })
+      const transport = new StreamableHTTPClientTransport(url, {
+        authProvider: this.oauthProvider,
+        fetch: undiciFetch as any,
+      })
       // Wire finishAuth so handleCallback() can complete the code exchange
       this.oauthProvider.setFinishAuth((code) => transport.finishAuth(code))
       console.log(`[MCP] ${this.serverConfig.name}: OAuth transport ready`)
@@ -595,11 +599,11 @@ export class McpToolsFactory extends AssistantToolFactory {
         headers: { Authorization: `Bearer ${this.serverConfig.authToken}` },
       }
       console.log(`[MCP] ${this.serverConfig.name}: using static Bearer token`)
-      return new StreamableHTTPClientTransport(url, { requestInit })
+      return new StreamableHTTPClientTransport(url, { requestInit, fetch: undiciFetch as any })
     }
 
     console.log(`[MCP] ${this.serverConfig.name}: connecting without authentication`)
-    return new StreamableHTTPClientTransport(url)
+    return new StreamableHTTPClientTransport(url, { fetch: undiciFetch as any })
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@angular/core": "catalog:",
     "glob": "catalog:",
+    "undici": "catalog:",
     "yargs": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ catalogs:
     turndown:
       specifier: 7.2.2
       version: 7.2.2
+    undici:
+      specifier: 8.10.0
+      version: 8.10.0
     yaml:
       specifier: 2.8.1
       version: 2.8.1
@@ -291,6 +294,9 @@ importers:
       glob:
         specifier: 'catalog:'
         version: 11.1.0
+      undici:
+        specifier: 'catalog:'
+        version: 8.10.0
       yargs:
         specifier: 'catalog:'
         version: 18.0.0
@@ -599,33 +605,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/agent/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/coday-services:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/coday-services/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -645,42 +625,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/core/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/function:
-    dependencies:
-      '@vscode/ripgrep':
-        specifier: 'catalog:'
-        version: 1.15.9
-      glob:
-        specifier: 'catalog:'
-        version: 11.1.0
-      pdf2json:
-        specifier: 'catalog:'
-        version: 4.0.0
-      sharp:
-        specifier: 'catalog:'
-        version: 0.34.4
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      '@jest/globals':
-        specifier: catalog:dev
-        version: 30.2.0
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/function/dist:
     dependencies:
       '@vscode/ripgrep':
         specifier: 'catalog:'
@@ -724,36 +669,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handler/dist:
-    dependencies:
-      '@anthropic-ai/sdk':
-        specifier: 'catalog:'
-        version: 0.115.0(zod@4.3.6)
-      openai:
-        specifier: 'catalog:'
-        version: 6.49.0(ws@8.20.0)(zod@4.3.6)
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/config:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/handlers/config/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -773,16 +689,6 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/load/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/looper:
     dependencies:
       tslib:
@@ -793,27 +699,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/looper/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/memory:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/handlers/memory/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -836,19 +722,6 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/openai/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/handlers/stats:
     dependencies:
       tslib:
@@ -859,27 +732,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/handlers/stats/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integration:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integration/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -902,33 +755,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/ai/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/basecamp:
-    dependencies:
-      oauth4webapi:
-        specifier: 'catalog:'
-        version: 3.8.3
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/basecamp/dist:
     dependencies:
       oauth4webapi:
         specifier: 'catalog:'
@@ -960,39 +787,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/confluence/dist:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      turndown:
-        specifier: 'catalog:'
-        version: 7.2.2
-    devDependencies:
-      '@types/turndown':
-        specifier: catalog:dev
-        version: 5.0.6
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/excel:
-    dependencies:
-      exceljs:
-        specifier: 4.4.0
-        version: 4.4.0
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/excel/dist:
     dependencies:
       exceljs:
         specifier: 4.4.0
@@ -1015,16 +810,6 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/file/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/git:
     dependencies:
       tslib:
@@ -1035,30 +820,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/git/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/gitlab:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/gitlab/dist:
     dependencies:
       axios:
         specifier: 'catalog:'
@@ -1087,36 +849,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/http/dist:
-    dependencies:
-      oauth4webapi:
-        specifier: 'catalog:'
-        version: 3.8.3
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/jira:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/jira/dist:
     dependencies:
       axios:
         specifier: 'catalog:'
@@ -1139,30 +872,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/integrations/slack/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/integrations/zendesk-articles:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.12.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/integrations/zendesk-articles/dist:
     dependencies:
       axios:
         specifier: 'catalog:'
@@ -1188,19 +898,6 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/mcp/dist:
-    dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: 'catalog:'
-        version: 1.23.1(zod@4.3.6)
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/model:
     dependencies:
       rxjs:
@@ -1214,33 +911,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/model/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/repository:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/repository/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -1269,33 +940,7 @@ importers:
         specifier: catalog:dev
         version: 5.9.3
 
-  libs/service/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
   libs/utils:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-
-  libs/utils/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -1568,6 +1213,7 @@ packages:
   '@angular/platform-browser-dynamic@21.2.7':
     resolution: {integrity: sha512-P7s9ABgJqRyUS5HNRJFRr15xaXbWfSH9KjSxkBYYJbXIA986uGb6qjnHepu+2xMyZDlt2nd9Ms+t4M60/GM+FQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    deprecated: '@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.'
     peerDependencies:
       '@angular/common': 21.2.7
       '@angular/compiler': 21.2.7
@@ -11622,6 +11268,10 @@ packages:
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -24760,6 +24410,8 @@ snapshots:
   undici@7.24.4: {}
 
   undici@7.24.7: {}
+
+  undici@8.10.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ catalog:
   sharp: '0.34.4'
   tslib: '2.8.1'
   turndown: '7.2.2'
+  undici: '8.10.0'
   yaml: '2.8.1'
   yargs: '18.0.0'
   zone.js: '0.16.1'


### PR DESCRIPTION
### 🕵️‍♂️ Analyse du bug

  Dans libs/mcp/src/lib/mcp-tools-factory.ts, on utilise la classe StreamableHTTPClientTransport fournie par le SDK officiel @modelcontextprotocol/sdk.
  Par défaut, ce transport s'appuie sur la fonction globale fetch() de l'environnement Node pour lire le flux continu (Server-Sent Events) d'Atlassian.

  Le problème survient lorsqu'on lance le backend en mode développement via nx run server:serve (sur le port 4100) : le global.fetch est affecté par cet écosystème local. Il est très probable qu'un module de
  l'environnement (outil de tracing APM, intercepteur réseau ou polyfill) vienne surcharger (patcher) ce fetch global.

  Résultat : cet intercepteur tente de bufferiser la réponse HTTP en attendant sa clôture. Cependant, comme une connexion SSE ne se termine jamais par définition, le flux reste indéfiniment bloqué, ce qui
  finit par déclencher l'erreur MCP error -32001: Request timed out.
  (C'est pour cela qu'à l'inverse, lorsqu'on lance l'application via yarn web sur le port 3100, la connexion réussit : l'environnement Node y est pur et la fonction global.fetch n'y est pas corrompue).

  ### 🛠️ Résolution

  Pour s'affranchir des effets de bord de l'environnement de développement local, la solution consiste à injecter explicitement un client HTTP pur et non altéré dans le SDK MCP.

  Les modifications apportées dans libs/mcp/src/lib/mcp-tools-factory.ts sont les suivantes :

  1. On importe la fonction native et pure fetch depuis la librairie undici (déjà présente dans les dépendances).
  2. On injecte explicitement ce fetch dans les constructeurs de StreamableHTTPClientTransport via les options ({ fetch: undiciFetch }).

  Ainsi, la connexion MCP repose sur un client réseau totalement étanche et isolé des surcharges liées à Nx ou aux outils de dev. Le streaming SSE est désormais lu correctement, garantissant la stabilité du
  transport MCP peu importe l'environnement d'exécution.
  
  
 --
 
 La dépendance `undiciFetch` était déjà présente via `@modelcontextprotocol`