### PR TITLE
fix(agentos): fix missed favorite and role enrichment in case read and list endpoints #33653

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseDto.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseDto.kt
@@ -25,10 +25,10 @@ import java.util.UUID
  * @property lastMessageAt Timestamp of the most recent message in this case. Present in responses only.
  *   Null for cases that have never received a message. Used as the primary sort key in conversation lists.
  * @property removed Soft-delete flag. False by default.
- * @property favorite Per-user favorite flag. Populated by list endpoints; defaults to false on single-case fetches.
+ * @property favorite Per-user favorite flag. Populated by all read endpoints except `listByUser` and
+ *   `listByUserExternalId` where the target user may differ from the caller. Defaults to false on create.
  * @property role The caller's direct relation on this case (`ADMIN` or `MEMBER`), or null when the
- *   caller has no direct edge (e.g. transitive namespace-admin access). Populated by list endpoints;
- *   null on single-case fetches.
+ *   caller has no direct edge (e.g. transitive namespace-admin access). Same population rules as `favorite`.
  */
 @Schema(name = "Case")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -48,14 +48,14 @@ data class CaseDto(
     val lastMessageAt: Instant? = null,
     val removed: Boolean = false,
     /**
-     * Per-user favorite flag. Populated by the case-list endpoints;
-     * single-case fetches (get/create/update) return the default `false`.
+     * Per-user favorite flag. Populated by all read endpoints (list, getById, getByIds, update);
+     * create returns the default `false`.
      */
     val favorite: Boolean = false,
     /**
      * The caller's direct relation on this case (`ADMIN` or `MEMBER`), or `null` when the
-     * caller has no direct edge (e.g. transitive namespace-admin access). Populated by the
-     * case-list endpoints; lets the UI gate ADMIN-only actions (delete). Null on single-case fetches.
+     * caller has no direct edge (e.g. transitive namespace-admin access). Populated by all
+     * read endpoints; null on create and on "list by target user" endpoints.
      */
     @field:Schema(description = "The caller's direct relation on this case", allowableValues = ["ADMIN", "MEMBER"])
     val role: String? = null,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -32,8 +32,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
 import io.whozoss.agentos.sdk.api.common.GetByIdsRequest as SdkGetByIdsRequest
 
 /**
@@ -68,13 +68,13 @@ class CaseController(
     @HideOnAccessDenied
     override fun getById(
         @PathVariable id: UUID,
-    ): CaseDto = caseService.getById(id).withLastMessageAt()
+    ): CaseDto = caseService.getById(id).withCallerMeta(userService.getCurrentUser().id.toString())
 
     @PostMapping("/by-ids", consumes = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("isAuthenticated()")
     override fun getByIds(
         @RequestBody request: SdkGetByIdsRequest,
-    ): List<CaseDto> = caseService.findByIds(request.ids, request.withRemoved).withLastMessageAt()
+    ): List<CaseDto> = caseService.findByIds(request.ids, request.withRemoved).withCallerMeta(userService.getCurrentUser().id.toString())
 
     /**
      * GET /api/cases/by-parentId/{parentId} — list cases in a namespace.
@@ -107,7 +107,7 @@ class CaseController(
                 logger.debug { "User $userId not namespace-ADMIN on $parentId — using permission-filtered listing" }
                 caseService.findAccessibleByUserInNamespace(user.id, parentId)
             }
-        return withCallerMeta(cases, userId)
+        return cases.withCallerMeta(userId)
     }
 
     /**
@@ -129,7 +129,7 @@ class CaseController(
         val user = userService.getCurrentUser()
         logger.debug { "Listing directly-related cases for user ${user.id} in namespace $parentId" }
         val cases = caseService.findConcerningUserInNamespace(user.id, parentId)
-        return withCallerMeta(cases, user.id.toString())
+        return cases.withCallerMeta(user.id.toString())
     }
 
     /**
@@ -144,13 +144,10 @@ class CaseController(
      * Cases the user has no direct edge on get `role = null` and `favorite = false`
      * (e.g. the namespace-admin fast path in [listByParent]).
      */
-    private fun withCallerMeta(
-        cases: List<Case>,
-        userId: String,
-    ): List<CaseDto> {
+    private fun List<Case>.withCallerMeta(userId: String): List<CaseDto> {
         val starred = starredService.listDirectRelations(userId, EntityType.CASE)
-        val lastMessageTimestamps = caseEventService.findLastMessageTimestamps(cases.map { it.id })
-        return cases.map {
+        val lastMessageTimestamps = caseEventService.findLastMessageTimestamps(this.map { it.id })
+        return this.map {
             val meta = starred[it.metadata.id.toString()]
             toDto(it).copy(
                 favorite = meta?.starred ?: false,
@@ -159,6 +156,8 @@ class CaseController(
             )
         }
     }
+
+    private fun Case.withCallerMeta(userId: String): CaseDto = listOf(this).withCallerMeta(userId).first()
 
     /**
      * POST /api/cases — create a Case. Permission gate is namespace READ (a MEMBER may
@@ -214,15 +213,16 @@ class CaseController(
         val existing =
             caseService.findById(id)
                 ?: throw ResourceNotFoundException("Case not found: $id")
-        return caseService
-            .update(
+        val updated =
+            caseService.update(
                 existing.copy(
                     // namespaceId and status are mass-assignment-guarded:
                     // namespaceId is the transitivity key for permissions;
                     // status is driven by the runtime lifecycle, not PUT.
                     title = resource.title ?: existing.title,
                 ),
-            ).withLastMessageAt()
+            )
+        return updated.withCallerMeta(userService.getCurrentUser().id.toString())
     }
 
     @DeleteMapping("/{id}")
@@ -239,9 +239,11 @@ class CaseController(
         @PathVariable userId: UUID,
     ): List<CaseDto> {
         logger.debug { "Listing cases for user $userId" }
-        // role/favorite are caller-relative and would be misleading here, so they stay
-        // at their defaults. lastMessageAt is objective data and is always populated.
-        return caseService.findConcerningUser(userId).withLastMessageAt()
+        val caller = userService.getCurrentUser()
+        val cases = caseService.findConcerningUser(userId)
+        // Enrich with caller's meta only when the caller is the target user;
+        // otherwise the caller has no direct relation on these cases so favorite would always be false.
+        return if (caller.id == userId) cases.withCallerMeta(caller.id.toString()) else cases.withLastMessageAt()
     }
 
     @GetMapping("/by-user/external/{externalId}")
@@ -252,7 +254,11 @@ class CaseController(
             userService.findByExternalId(externalId)
                 ?: throw ResourceNotFoundException("User not found: $externalId")
         logger.debug { "Listing cases for user ${user.id} (externalId=$externalId)" }
-        return caseService.findConcerningUser(user.id).withLastMessageAt()
+        val caller = userService.getCurrentUser()
+        val cases = caseService.findConcerningUser(user.id)
+        // Enrich with caller's meta only when the caller is the target user;
+        // otherwise the caller has no direct relation on these cases so favorite would always be false.
+        return if (caller.id == user.id) cases.withCallerMeta(caller.id.toString()) else cases.withLastMessageAt()
     }
 
     @PostMapping("/by-user/in-namespace", consumes = [MediaType.APPLICATION_JSON_VALUE])
@@ -266,7 +272,11 @@ class CaseController(
             namespaceService.findByExternalId(request.namespaceExternalId)
                 ?: throw ResourceNotFoundException("Namespace not found: ${request.namespaceExternalId}")
         logger.debug { "Listing cases for user ${user.id} in namespace ${namespace.id}" }
-        return caseService.findConcerningUserInNamespace(user.id, namespace.id).withLastMessageAt()
+        val caller = userService.getCurrentUser()
+        val cases = caseService.findConcerningUserInNamespace(user.id, namespace.id)
+        // Enrich with caller's meta only when the caller is the target user;
+        // otherwise the caller has no direct relation on these cases so favorite would always be false.
+        return if (caller.id == user.id) cases.withCallerMeta(caller.id.toString()) else cases.withLastMessageAt()
     }
 
     @PostMapping("/{caseId}/messages")
@@ -354,11 +364,6 @@ class CaseController(
             )
         }
     }
-
-    /**
-     * Enrich a single [Case] with [CaseDto.lastMessageAt].
-     */
-    private fun Case.withLastMessageAt(): CaseDto = listOf(this).withLastMessageAt().first()
 
     /**
      * Enrich a list of [Case]s with [CaseDto.lastMessageAt] only — no role/favorite.

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
@@ -507,6 +507,7 @@ class CaseControllerSpec :
             val ns2 = UUID.randomUUID()
             val case1 = caseEntity(title = "in ns1")
             val case2 = caseEntity(title = "in ns2").copy(namespaceId = ns2)
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findConcerningUser(callerId) } returns listOf(case1, case2)
 
             val result = controller.listByUser(callerId)
@@ -516,6 +517,7 @@ class CaseControllerSpec :
         }
 
         "listByUser returns empty list when no cases concern the requested user" {
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findConcerningUser(callerId) } returns emptyList()
 
             controller.listByUser(callerId) shouldBe emptyList()
@@ -525,6 +527,7 @@ class CaseControllerSpec :
             val withMsg = caseEntity(title = "has messages")
             val noMsg = caseEntity(title = "no messages")
             val msgTimestamp = Instant.parse("2025-06-01T10:00:00Z")
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findConcerningUser(callerId) } returns listOf(withMsg, noMsg)
             every {
                 caseEventService.findLastMessageTimestamps(listOf(withMsg.id, noMsg.id))
@@ -536,6 +539,31 @@ class CaseControllerSpec :
             result.single { it.id == noMsg.metadata.id }.lastMessageAt shouldBe null
         }
 
+        "listByUser enriches with favorite when caller is the target user" {
+            val starredCase = caseEntity(title = "starred")
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.findConcerningUser(callerId) } returns listOf(starredCase)
+            every {
+                starredService.listDirectRelations(callerId.toString(), EntityType.CASE)
+            } returns mapOf(starredCase.metadata.id.toString() to DirectRelation(PermissionRelation.MEMBER, starred = true))
+
+            val result = controller.listByUser(callerId)
+
+            result.single().favorite shouldBe true
+        }
+
+        "listByUser skips enrichment when caller is not the target user" {
+            val otherId = UUID.randomUUID()
+            val otherCase = caseEntity(title = "other user case")
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.findConcerningUser(otherId) } returns listOf(otherCase)
+
+            val result = controller.listByUser(otherId)
+
+            result.single().favorite shouldBe false
+            verify(exactly = 0) { starredService.listDirectRelations(any(), any()) }
+        }
+
         // -------------------------------------------------------------------------
         // listByUserExternalId — GET /api/cases/by-user/external/{externalId}
         // -------------------------------------------------------------------------
@@ -545,6 +573,7 @@ class CaseControllerSpec :
             val noMsg = caseEntity(title = "no messages")
             val msgTimestamp = Instant.parse("2025-06-01T10:00:00Z")
             every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findConcerningUser(callerId) } returns listOf(withMsg, noMsg)
             every {
                 caseEventService.findLastMessageTimestamps(listOf(withMsg.id, noMsg.id))
@@ -561,6 +590,7 @@ class CaseControllerSpec :
             val case1 = caseEntity(title = "in ns1")
             val case2 = caseEntity(title = "in ns2").copy(namespaceId = ns2)
             every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findConcerningUser(callerId) } returns listOf(case1, case2)
 
             val result = controller.listByUserExternalId(caller.externalId)
@@ -579,9 +609,42 @@ class CaseControllerSpec :
 
         "listByUserExternalId returns empty list when the resolved user has no cases" {
             every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findConcerningUser(callerId) } returns emptyList()
 
             controller.listByUserExternalId(caller.externalId) shouldBe emptyList()
+        }
+
+        "listByUserExternalId enriches with favorite when caller is the target user" {
+            val starredCase = caseEntity(title = "starred")
+            every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.findConcerningUser(callerId) } returns listOf(starredCase)
+            every {
+                starredService.listDirectRelations(callerId.toString(), EntityType.CASE)
+            } returns mapOf(starredCase.metadata.id.toString() to DirectRelation(PermissionRelation.MEMBER, starred = true))
+
+            val result = controller.listByUserExternalId(caller.externalId)
+
+            result.single().favorite shouldBe true
+        }
+
+        "listByUserExternalId skips enrichment when caller is not the target user" {
+            val otherUser =
+                caller.copy(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    externalId = "other@example.com",
+                    email = "other@example.com",
+                )
+            val otherCase = caseEntity(title = "other user case")
+            every { userService.findByExternalId(otherUser.externalId) } returns otherUser
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.findConcerningUser(otherUser.id) } returns listOf(otherCase)
+
+            val result = controller.listByUserExternalId(otherUser.externalId)
+
+            result.single().favorite shouldBe false
+            verify(exactly = 0) { starredService.listDirectRelations(any(), any()) }
         }
 
         // -------------------------------------------------------------------------
@@ -600,6 +663,7 @@ class CaseControllerSpec :
                     externalId = namespaceExternalId,
                 )
             every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
             every { namespaceService.findByExternalId(namespaceExternalId) } returns namespace
             every { caseService.findConcerningUserInNamespace(callerId, namespaceId) } returns listOf(withMsg, noMsg)
             every {
@@ -628,6 +692,7 @@ class CaseControllerSpec :
                     externalId = namespaceExternalId,
                 )
             every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
             every { namespaceService.findByExternalId(namespaceExternalId) } returns namespace
             every { caseService.findConcerningUserInNamespace(callerId, namespaceId) } returns listOf(caseInNs)
 
@@ -644,6 +709,36 @@ class CaseControllerSpec :
             verify(exactly = 0) { caseService.findConcerningUser(any()) }
         }
 
+        "listByUserInNamespace enriches with favorite when caller is the target user" {
+            val starredCase = caseEntity(title = "starred")
+            val plainCase = caseEntity(title = "plain")
+            val namespaceExternalId = "ext-ns-fav"
+            val namespace =
+                io.whozoss.agentos.namespace.Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-ns",
+                    externalId = namespaceExternalId,
+                )
+            every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
+            every { namespaceService.findByExternalId(namespaceExternalId) } returns namespace
+            every { caseService.findConcerningUserInNamespace(callerId, namespaceId) } returns listOf(starredCase, plainCase)
+            every {
+                starredService.listDirectRelations(callerId.toString(), EntityType.CASE)
+            } returns mapOf(starredCase.metadata.id.toString() to DirectRelation(PermissionRelation.MEMBER, starred = true))
+
+            val result =
+                controller.listByUserInNamespace(
+                    ListByUserInNamespaceRequest(
+                        userExternalId = caller.externalId,
+                        namespaceExternalId = namespaceExternalId,
+                    ),
+                )
+
+            result.single { it.id == starredCase.metadata.id }.favorite shouldBe true
+            result.single { it.id == plainCase.metadata.id }.favorite shouldBe false
+        }
+
         "listByUserInNamespace returns empty list when user has no cases in the namespace" {
             val namespaceExternalId = "ext-ns-empty"
             val namespace =
@@ -653,6 +748,7 @@ class CaseControllerSpec :
                     externalId = namespaceExternalId,
                 )
             every { userService.findByExternalId(caller.externalId) } returns caller
+            every { userService.getCurrentUser() } returns caller
             every { namespaceService.findByExternalId(namespaceExternalId) } returns namespace
             every { caseService.findConcerningUserInNamespace(callerId, namespaceId) } returns emptyList()
 
@@ -662,6 +758,38 @@ class CaseControllerSpec :
                     namespaceExternalId = namespaceExternalId,
                 ),
             ) shouldBe emptyList()
+        }
+
+        "listByUserInNamespace skips enrichment when caller is not the target user" {
+            val otherUser =
+                caller.copy(
+                    metadata = EntityMetadata(id = UUID.randomUUID()),
+                    externalId = "other@example.com",
+                    email = "other@example.com",
+                )
+            val namespaceExternalId = "ext-ns-other"
+            val namespace =
+                io.whozoss.agentos.namespace.Namespace(
+                    metadata = EntityMetadata(id = namespaceId),
+                    name = "test-ns",
+                    externalId = namespaceExternalId,
+                )
+            val otherCase = caseEntity(title = "other user case")
+            every { userService.findByExternalId(otherUser.externalId) } returns otherUser
+            every { userService.getCurrentUser() } returns caller
+            every { namespaceService.findByExternalId(namespaceExternalId) } returns namespace
+            every { caseService.findConcerningUserInNamespace(otherUser.id, namespaceId) } returns listOf(otherCase)
+
+            val result =
+                controller.listByUserInNamespace(
+                    ListByUserInNamespaceRequest(
+                        userExternalId = otherUser.externalId,
+                        namespaceExternalId = namespaceExternalId,
+                    ),
+                )
+
+            result.single().favorite shouldBe false
+            verify(exactly = 0) { starredService.listDirectRelations(any(), any()) }
         }
 
         "listByUserInNamespace throws 404 when no user matches the external id" {
@@ -718,6 +846,7 @@ class CaseControllerSpec :
             val payload =
                 caseResource(id = existing.metadata.id, title = "renamed")
                     .copy(namespaceId = otherNs, status = CaseStatus.RUNNING)
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findById(existing.metadata.id) } returns existing
             every { caseService.update(any()) } answers {
                 val saved = firstArg<Case>()
@@ -744,6 +873,7 @@ class CaseControllerSpec :
         "update populates lastMessageAt from caseEventService" {
             val existing = caseEntity()
             val msgTimestamp = Instant.parse("2025-06-01T10:00:00Z")
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findById(existing.metadata.id) } returns existing
             every { caseService.update(any()) } returns existing
             every {
@@ -755,6 +885,21 @@ class CaseControllerSpec :
             result.lastMessageAt shouldBe msgTimestamp
         }
 
+        "update populates favorite and role from starredService" {
+            val existing = caseEntity()
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.findById(existing.metadata.id) } returns existing
+            every { caseService.update(any()) } returns existing
+            every {
+                starredService.listDirectRelations(callerId.toString(), EntityType.CASE)
+            } returns mapOf(existing.metadata.id.toString() to DirectRelation(PermissionRelation.MEMBER, starred = true))
+
+            val result = controller.update(existing.metadata.id, caseResource(id = existing.metadata.id))
+
+            result.favorite shouldBe true
+            result.role shouldBe "MEMBER"
+        }
+
         // -------------------------------------------------------------------------
         // getById
         // -------------------------------------------------------------------------
@@ -762,6 +907,7 @@ class CaseControllerSpec :
         "getById populates lastMessageAt from caseEventService" {
             val entity = caseEntity()
             val msgTimestamp = Instant.parse("2025-06-01T10:00:00Z")
+            every { userService.getCurrentUser() } returns caller
             every { caseService.getById(entity.metadata.id) } returns entity
             every {
                 caseEventService.findLastMessageTimestamps(listOf(entity.id))
@@ -775,11 +921,38 @@ class CaseControllerSpec :
 
         "getById returns null lastMessageAt when case has no messages" {
             val entity = caseEntity()
+            every { userService.getCurrentUser() } returns caller
             every { caseService.getById(entity.metadata.id) } returns entity
 
             val result = controller.getById(entity.metadata.id)
 
             result.lastMessageAt shouldBe null
+        }
+
+        "getById sets favorite=true when the caller has starred the case" {
+            val entity = caseEntity()
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.getById(entity.metadata.id) } returns entity
+            every {
+                starredService.listDirectRelations(callerId.toString(), EntityType.CASE)
+            } returns mapOf(entity.metadata.id.toString() to DirectRelation(PermissionRelation.ADMIN, starred = true))
+
+            val result = controller.getById(entity.metadata.id)
+
+            result.favorite shouldBe true
+            result.role shouldBe "ADMIN"
+        }
+
+        "getById sets favorite=false and role=null when the caller has no direct relation" {
+            val entity = caseEntity()
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.getById(entity.metadata.id) } returns entity
+            // default mock: emptyMap()
+
+            val result = controller.getById(entity.metadata.id)
+
+            result.favorite shouldBe false
+            result.role shouldBe null
         }
 
         // -------------------------------------------------------------------------
@@ -790,14 +963,38 @@ class CaseControllerSpec :
             val withMsg = caseEntity(title = "has messages")
             val noMsg = caseEntity(title = "no messages")
             val msgTimestamp = Instant.parse("2025-06-01T10:00:00Z")
+            every { userService.getCurrentUser() } returns caller
             every { caseService.findByIds(any(), any()) } returns listOf(withMsg, noMsg)
             every {
                 caseEventService.findLastMessageTimestamps(listOf(withMsg.id, noMsg.id))
             } returns mapOf(withMsg.id to msgTimestamp)
 
-            val result = controller.getByIds(io.whozoss.agentos.sdk.api.common.GetByIdsRequest(listOf(withMsg.metadata.id, noMsg.metadata.id)))
+            val result =
+                controller.getByIds(
+                    io.whozoss.agentos.sdk.api.common
+                        .GetByIdsRequest(listOf(withMsg.metadata.id, noMsg.metadata.id)),
+                )
 
             result.single { it.id == withMsg.metadata.id }.lastMessageAt shouldBe msgTimestamp
             result.single { it.id == noMsg.metadata.id }.lastMessageAt shouldBe null
+        }
+
+        "getByIds populates favorite from starredService for the current user" {
+            val starred = caseEntity(title = "starred")
+            val plain = caseEntity(title = "plain")
+            every { userService.getCurrentUser() } returns caller
+            every { caseService.findByIds(any(), any()) } returns listOf(starred, plain)
+            every {
+                starredService.listDirectRelations(callerId.toString(), EntityType.CASE)
+            } returns mapOf(starred.metadata.id.toString() to DirectRelation(PermissionRelation.ADMIN, starred = true))
+
+            val result =
+                controller.getByIds(
+                    io.whozoss.agentos.sdk.api.common
+                        .GetByIdsRequest(listOf(starred.metadata.id, plain.metadata.id)),
+                )
+
+            result.single { it.id == starred.metadata.id }.favorite shouldBe true
+            result.single { it.id == plain.metadata.id }.favorite shouldBe false
         }
     })


### PR DESCRIPTION
## Summary

Several Case read endpoints (`getById`, `getByIds`, `update`) were returning `favorite = false` and `role = null` because they only enriched DTOs with `lastMessageAt` but skipped the caller-relative metadata (favorite flag and direct relation role). Meanwhile, the "list by target user" endpoints (`listByUser`, `listByUserExternalId`, `listByUserInNamespace`) always skipped enrichment, even when the caller was the target user.

## Problem

- **`getById` / `getByIds`**: Returned DTOs with `favorite` and `role` at their defaults, making it impossible for the UI to display the starred state or gate admin-only actions on single-case views.
- **`update`**: Same issue — the response after a case update did not reflect the caller's favorite/role.
- **`listByUser` / `listByUserExternalId` / `listByUserInNamespace`**: Never enriched with caller metadata, even when the caller was viewing their own cases.

## Changes

### `CaseController.kt`
- Refactored `withCallerMeta` from a standalone private function to an **extension function on `List<Case>`**, and added a **`Case.withCallerMeta`** single-element convenience extension.
- **`getById`** and **`getByIds`**: Now call `withCallerMeta(currentUserId)` instead of the previous `withLastMessageAt()`, so `favorite`, `role`, and `lastMessageAt` are all populated.
- **`update`**: Response is now enriched through `withCallerMeta` instead of `withLastMessageAt`.
- **`listByUser` / `listByUserExternalId` / `listByUserInNamespace`**: Enrichment now applies **conditionally** — `withCallerMeta` is used when the caller is the target user; otherwise falls back to `withLastMessageAt` only (since favorite/role would be meaningless for a different user's cases).

### `CaseDto.kt`
- Updated KDoc for `favorite` and `role` to accurately describe the new population rules: enriched on all read endpoints except the "list by target user" variants where the target differs from the caller.

### `CaseControllerSpec.kt`
- Added tests for `getById` with favorite/role enrichment and without direct relation.
- Added tests for `getByIds` favorite enrichment.
- Added tests for `update` favorite/role enrichment.
- Added tests for `listByUser`, `listByUserExternalId`, and `listByUserInNamespace` verifying enrichment when caller = target and skip when caller ≠ target.
- Fixed existing tests to mock `userService.getCurrentUser()` where newly required.