### PR TITLE
bugfix/vico/1242/fix image processing in simple agent

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvancedContext.kt
@@ -71,18 +71,19 @@ data class AgentAdvancedContext(
         events: List<CaseEvent>,
         maxDetailedChars: Int = 300_000,
     ): List<Message> {
-        val responsesByRequestId = indexToolResponses(events)
-        val (detailedRequestIds, mediaRequestIds) =
-            selectDetailedToolRequestIds(
-                events = events,
-                responsesByRequestId = responsesByRequestId,
+        val plan =
+            ToolReplayPlanner(
                 maxDetailedChars = maxDetailedChars,
-            )
+                maxAttachedImages = maxAttachedImages,
+                imageCharCost = imageCharCost,
+            ).plan(events)
 
         val lastUserMsgIndex =
             events.indexOfLast {
                 it is MessageEvent && it.actor.role == ActorRole.USER
             }
+
+        val responsesByRequestId = events.filterIsInstance<ToolResponseEvent>().associateBy { it.toolRequestId }
 
         return events.flatMapIndexed { index, event ->
             when (event) {
@@ -99,8 +100,7 @@ data class AgentAdvancedContext(
                 is ToolRequestEvent -> {
                     toToolMessages(
                         event = event,
-                        detailedRequestIds = detailedRequestIds,
-                        mediaRequestIds = mediaRequestIds,
+                        plan = plan,
                         responsesByRequestId = responsesByRequestId,
                     )
                 }
@@ -132,87 +132,20 @@ data class AgentAdvancedContext(
         }
     }
 
-    private fun indexToolResponses(events: List<CaseEvent>): Map<String, ToolResponseEvent> =
-        events.filterIsInstance<ToolResponseEvent>().associateBy { it.toolRequestId }
-
-    /**
-     * Selection of the tool requests replayed in detail, and among them the ones whose
-     * response images are actually attached as [Media].
-     */
-    private data class ToolReplaySelection(
-        val detailedRequestIds: Set<String>,
-        val mediaRequestIds: Set<String>,
-    )
-
-    /**
-     * Single newest-first walk deciding both selections coherently:
-     * - a request is detailed while its cumulated char cost fits [maxDetailedChars];
-     * - its images are attached while they fit [maxAttachedImages], and only attached
-     *   images are charged [imageCharCost] against the budget. Responses whose images
-     *   are not attached keep their text summary plus a marker (see
-     *   [toDetailedToolMessages]) and cost only that text.
-     */
-    private fun selectDetailedToolRequestIds(
-        events: List<CaseEvent>,
-        responsesByRequestId: Map<String, ToolResponseEvent>,
-        maxDetailedChars: Int,
-    ): ToolReplaySelection {
-        val detailed = mutableSetOf<String>()
-        val withMedia = mutableSetOf<String>()
-        var charsCollected = 0
-        var imagesAttached = 0
-
-        for (event in events.reversed()) {
-            if (event !is ToolRequestEvent) continue
-
-            val response = responsesByRequestId[event.toolRequestId]
-            val images = response?.images ?: emptyList()
-            val attachMedia = images.isNotEmpty() && imagesAttached + images.size <= maxAttachedImages
-
-            val cost = detailedCharCost(event, response, attachMedia)
-            if (charsCollected + cost > maxDetailedChars) break
-
-            detailed.add(event.toolRequestId)
-            charsCollected += cost
-            if (attachMedia) {
-                withMedia.add(event.toolRequestId)
-                imagesAttached += images.size
-            }
-        }
-        return ToolReplaySelection(detailed, withMedia)
-    }
-
-    /**
-     * Char-equivalent cost charged against the detailed-tool budget for one request/response:
-     * the request args, the response text, and — only when [attachMedia] is true — the attached
-     * images at [imageCharCost] each.
-     */
-    private fun detailedCharCost(
-        event: ToolRequestEvent,
-        response: ToolResponseEvent?,
-        attachMedia: Boolean,
-    ): Int {
-        val argsCost = event.args?.length ?: 0
-        val responseCost = response?.let { extractText(it.output).length } ?: 0
-        val imagesCost = if (attachMedia) (response?.images?.size ?: 0) * imageCharCost else 0
-        return argsCost + responseCost + imagesCost
-    }
-
     private fun toToolMessages(
         event: ToolRequestEvent,
-        detailedRequestIds: Set<String>,
-        mediaRequestIds: Set<String>,
+        plan: ToolReplayPlan,
         responsesByRequestId: Map<String, ToolResponseEvent>,
     ): List<Message> =
-        if (event.toolRequestId in detailedRequestIds) {
-            toDetailedToolMessages(event, mediaRequestIds, responsesByRequestId)
+        if (plan.isDetailed(event.toolRequestId)) {
+            toDetailedToolMessages(event, plan, responsesByRequestId)
         } else {
             listOf(toToolSummaryMessage(event, responsesByRequestId))
         }
 
     private fun toDetailedToolMessages(
         event: ToolRequestEvent,
-        mediaRequestIds: Set<String>,
+        plan: ToolReplayPlan,
         responsesByRequestId: Map<String, ToolResponseEvent>,
     ): List<Message> {
         val args = normalizeArgs(event.args)
@@ -224,11 +157,7 @@ data class AgentAdvancedContext(
         // for each tool_call_id — OpenAI returns 400 otherwise. Use the real response if
         // available, or synthesize a placeholder so the message list stays well-formed.
         val response = responsesByRequestId[event.toolRequestId]
-        val attachMedia = response != null && response.images.isNotEmpty() && event.toolRequestId in mediaRequestIds
-        var responseText = response?.let { extractText(it.output) } ?: "[No response recorded]"
-        if (response != null && response.images.isNotEmpty() && !attachMedia) {
-            responseText += "\n[${response.images.size} image(s) no longer attached, call the tool again if needed]"
-        }
+        val responseText = response?.let { toolResponseText(it, plan) } ?: "[No response recorded]"
 
         messages.add(
             ToolResponseMessage
@@ -245,8 +174,8 @@ data class AgentAdvancedContext(
         )
         // Provider tool responses are text-only: the images ride in a follow-up user
         // message with Media attachments right after the tool response.
-        if (attachMedia) {
-            messages.add(toolImagesUserMessage(event.toolName, response!!.images))
+        if (response != null && plan.hasAttachedMedia(event.toolRequestId)) {
+            messages.add(toolImagesUserMessage(event.toolName, response.images))
         }
         return messages
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentServiceImpl.kt
@@ -505,6 +505,7 @@ class AgentServiceImpl(
                 llmProvider = providerConfig.name,
                 llmModel = modelConfig.apiModelName,
                 toolMetricsService = toolMetricsService,
+                maxAttachedImages = agentConfigProperties.maxAttachedImages,
             )
         }
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -47,11 +47,16 @@ import kotlin.time.measureTime
  * Simple agent implementation with single LLM call.
  *
  * This agent delegates tool orchestration to the LLM itself:
- * 1. Converts events to messages (including tool calls/responses)
+ * 1. Converts events to messages (including tool calls/responses and image attachments)
  * 2. Makes a single LLM call with available tools
  * 3. LLM decides which tools to call and when
  * 4. Tools are wrapped to emit ToolRequestEvent and ToolResponseEvent
  * 5. Streams text progressively with TextChunkEvent
+ *
+ * Image handling mirrors AgentAdvanced: tool responses that produced images are injected
+ * as follow-up [UserMessage] with [org.springframework.ai.content.Media] attachments in
+ * [convertEventsToMessages]. Budget management (newest-first selection) is governed by
+ * [imageCharCost] and [maxAttachedImages].
  *
  * This is simpler but gives less control over the orchestration loop
  * compared to AgentAdvanced.
@@ -76,6 +81,11 @@ class AgentSimple(
     override val llmModel: String,
     /** Metrics service for recording tool call telemetry. Null in tests that don't inject it. */
     private val toolMetricsService: ToolMetricsService? = null,
+    /**
+     * Maximum images attached as Media across the whole prompt, newest first.
+     * Mirrors [AgentConfigProperties.maxAttachedImages] (default 20).
+     */
+    val maxAttachedImages: Int = 20,
 ) : Agent {
     override fun run(
         events: List<CaseEvent>,
@@ -280,8 +290,14 @@ class AgentSimple(
      * it is injected as an extra [UserMessage] immediately before that message.
      * Session context on earlier messages is ignored — only the current turn's context
      * is relevant to the LLM.
+     *
+     * Image handling: tool responses that include images are replayed with a follow-up
+     * [UserMessage] carrying [org.springframework.ai.content.Media] attachments, mirroring
+     * the pattern used by AgentAdvancedContext. Budget management (newest-first) is governed
+     * by [maxAttachedImages] and [imageCharCost]. Tool responses whose images exceed the budget
+     * receive a text marker instead.
      */
-    private fun convertEventsToMessages(events: List<CaseEvent>): List<Message> {
+    internal fun convertEventsToMessages(events: List<CaseEvent>): List<Message> {
         val messages = mutableListOf<Message>()
         val toolCallsForCurrentMessage = mutableListOf<AssistantMessage.ToolCall>()
         val toolResponses = mutableMapOf<String, ToolResponseEvent>()
@@ -290,6 +306,17 @@ class AgentSimple(
         events.filterIsInstance<ToolResponseEvent>().forEach { toolResponse ->
             toolResponses[toolResponse.toolRequestId] = toolResponse
         }
+
+        // Determine which tool responses get image Media attachments (newest-first budget walk).
+        // maxDetailedChars = Int.MAX_VALUE disables text compression — AgentSimple has no history
+        // compression; imageCharCost value is neutral since it is only multiplied when images are
+        // attached and the budget break never triggers.
+        val plan =
+            ToolReplayPlanner(
+                maxDetailedChars = Int.MAX_VALUE,
+                maxAttachedImages = maxAttachedImages,
+                imageCharCost = 0,
+            ).plan(events)
 
         val lastUserMessageIndex =
             events.indexOfLast {
@@ -304,7 +331,7 @@ class AgentSimple(
                     if (index == lastUserMessageIndex) {
                         event.sessionContextPromptText()?.let { messages.add(UserMessage(it)) }
                     }
-                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
+                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses, plan)
                     messages.add(event.toSpringAiMessage(id.toString()))
                 }
 
@@ -329,7 +356,7 @@ class AgentSimple(
                 // calls are flushed first so the message list stays well-formed (every
                 // AssistantMessage with tool_calls must be followed by a ToolResponseMessage).
                 is QuestionEvent -> {
-                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
+                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses, plan)
                     messages.add(AssistantMessage(event.toPromptText()))
                 }
 
@@ -337,7 +364,7 @@ class AgentSimple(
                 // Rendered as UserMessage, consistent with MessageEvent USER rendering.
                 // Tool calls are flushed first for the same well-formedness reason.
                 is AnswerEvent -> {
-                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
+                    flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses, plan)
                     messages.add(UserMessage(event.answer))
                 }
 
@@ -350,7 +377,7 @@ class AgentSimple(
         // Flush any tool calls that trail the end of the event list without a following
         // conversational message (e.g. the last thing the agent did was call a tool, then
         // the run was interrupted). Args are already normalised in the accumulation loop above.
-        flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses)
+        flushPendingToolCalls(messages, toolCallsForCurrentMessage, toolResponses, plan)
 
         return messages
     }
@@ -380,6 +407,7 @@ class AgentSimple(
         messages: MutableList<Message>,
         pendingToolCalls: MutableList<AssistantMessage.ToolCall>,
         toolResponses: Map<String, ToolResponseEvent>,
+        plan: ToolReplayPlan,
     ) {
         if (pendingToolCalls.isEmpty()) return
 
@@ -392,28 +420,19 @@ class AgentSimple(
         val toolResponseMessages =
             pendingToolCalls.map { toolCall ->
                 val response = toolResponses[toolCall.id()]
-                val output = response?.let { toolResponseText(it) } ?: "[No response recorded]"
+                val output = response?.let { toolResponseText(it, plan) } ?: "[No response recorded]"
                 ToolResponseMessage.ToolResponse(toolCall.id(), toolCall.name(), output)
             }
         messages.add(ToolResponseMessage.builder().responses(toolResponseMessages).build())
-        pendingToolCalls.clear()
-    }
 
-    /**
-     * Textual rendering of a tool response for the LLM prompt. Never stringifies
-     * non-text content (a raw data-class toString would dump base64 payloads).
-     *
-     * AgentSimple does not support image attachments (its Spring AI tool loop is
-     * text-only), so when the response carries images the model is explicitly told
-     * they are not viewable here instead of being led to believe they are attached.
-     */
-    private fun toolResponseText(response: ToolResponseEvent): String {
-        val text =
-            when (val content = response.output) {
-                is MessageContent.Text -> content.content
-                is MessageContent.Image -> "[image ${content.mimeType} ${content.width}x${content.height}]"
+        // Inject image Media messages for tool calls within the image budget
+        pendingToolCalls.forEach { toolCall ->
+            val response = toolResponses[toolCall.id()]
+            if (response != null && plan.hasAttachedMedia(toolCall.id())) {
+                messages.add(toolImagesUserMessage(toolCall.name(), response.images))
             }
-        return if (response.images.isEmpty()) text else text + "\n" + imagesNotSupportedNote(response.images.size)
+        }
+        pendingToolCalls.clear()
     }
 
     /**
@@ -585,28 +604,18 @@ class AgentSimple(
                         success = executionResult.success,
                         durationMs = toolDuration.inWholeMilliseconds,
                         toolMetadata = executionResult.metadata,
-                        // Preserved on the event (persistence, SSE) even though this
-                        // runtime cannot deliver them to the LLM.
+                        // Images are preserved on the event (persistence, SSE).
+                        // They will be delivered to the LLM via the conversation history
+                        // on subsequent turns (convertEventsToMessages injects UserMessage+Media).
                         images = executionResult.images,
                     ),
                 )
 
-                return if (executionResult.images.isEmpty()) {
-                    executionResult.output
-                } else {
-                    executionResult.output + "\n" + imagesNotSupportedNote(executionResult.images.size)
-                }
+                // ToolCallback.call() returns text only — images reach the LLM via the
+                // rebuilt conversation context in convertEventsToMessages(), not here.
+                return executionResult.output
             }
         }
 
-    companion object : KLogging() {
-        /**
-         * Appended to a tool response whose result carries images: AgentSimple's
-         * Spring AI tool loop is text-only, so the model must not be led to believe
-         * the images are attached (image delivery is an AgentAdvanced feature).
-         */
-        internal fun imagesNotSupportedNote(count: Int): String =
-            "[Note: $count image(s) were produced but this agent runtime does not support image attachments;" +
-                " only this text summary is available. Image viewing requires an advanced-execution agent.]"
-    }
+    companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/MessageConversions.kt
@@ -4,6 +4,7 @@ import io.whozoss.agentos.sdk.actor.ActorRole
 import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
 import org.springframework.web.util.HtmlUtils
 import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
@@ -93,6 +94,33 @@ internal fun toolImagesUserMessage(
         .text("[Attached: ${images.size} image(s) produced by tool $toolName, see tool result above]")
         .media(images.map { it.toSpringAiMedia() })
         .build()
+
+/**
+ * Render a [ToolResponseEvent] as the text for its [ToolResponseMessage] slot.
+ *
+ * When the response has images within [plan]'s media budget, the text is left plain —
+ * the LLM will see them via the follow-up [UserMessage] with [Media] attachments.
+ * When images fall outside the budget (oldest, evicted), a marker is appended telling
+ * the LLM the images are no longer attached and it should re-call the tool if needed.
+ *
+ * Shared by both runtimes so the marker text cannot drift between them.
+ */
+internal fun toolResponseText(
+    response: ToolResponseEvent,
+    plan: ToolReplayPlan,
+): String {
+    val text =
+        when (val content = response.output) {
+            is MessageContent.Text -> content.content
+            is MessageContent.Image -> "[image ${content.mimeType} ${content.width}x${content.height}]"
+        }
+    return when {
+        response.images.isEmpty() -> text
+        plan.hasAttachedMedia(response.toolRequestId) -> text
+        // images come via follow-up UserMessage
+        else -> text + "\n[${response.images.size} image(s) no longer attached, call the tool again if needed]"
+    }
+}
 
 /**
  * Render a [QuestionEvent] as the text of the [AssistantMessage] replayed to the LLM.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ToolReplayPlanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/ToolReplayPlanner.kt
@@ -1,0 +1,114 @@
+package io.whozoss.agentos.agent
+
+import io.whozoss.agentos.sdk.caseEvent.CaseEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
+
+/** Which tool exchanges are replayed in full, and which keep their image attachments. */
+data class ToolReplayPlan(
+    private val detailedRequestIds: Set<String>,
+    private val mediaRequestIds: Set<String>,
+) {
+    fun isDetailed(requestId: String): Boolean = requestId in detailedRequestIds
+
+    fun hasAttachedMedia(requestId: String): Boolean = requestId in mediaRequestIds
+}
+
+/**
+ * Newest-first budget walk over tool exchanges.
+ *
+ * A request is replayed in detail while its cumulated char cost fits [maxDetailedChars].
+ * Its images are attached while they fit [maxAttachedImages], and only attached images
+ * are charged [imageCharCost] against the budget. Responses whose images are not attached
+ * keep their text summary plus a marker and cost only that text.
+ *
+ * Setting [maxDetailedChars] to [Int.MAX_VALUE] disables text compression entirely
+ * (AgentSimple behaviour: all exchanges are detailed, only the image cap applies).
+ */
+class ToolReplayPlanner(
+    private val maxDetailedChars: Int,
+    private val maxAttachedImages: Int,
+    private val imageCharCost: Int,
+) {
+    /**
+     * Immutable state of the newest-first walk after considering one exchange.
+     *
+     * [fits] tells whether this exchange itself still fits the budget; once it is `false`,
+     * the walk must stop (prefix policy: all older exchanges are dropped too), which is why
+     * [plan] uses [Sequence.takeWhile] rather than a filter.
+     */
+    private data class Step(
+        val requestId: String,
+        val fits: Boolean,
+        val withMedia: Boolean,
+        val chars: Long,
+        val images: Int,
+    )
+
+    fun plan(events: List<CaseEvent>): ToolReplayPlan {
+        val responses = events.filterIsInstance<ToolResponseEvent>().associateBy { it.toolRequestId }
+
+        val kept =
+            events
+                .filterIsInstance<ToolRequestEvent>()
+                .asReversed()
+                .asSequence()
+                .map { it to responses[it.toolRequestId] }
+                .runningFold(START) { acc, (request, response) -> acc.next(request, response) }
+                .drop(1)
+                .takeWhile { it.fits }
+                .toList()
+
+        return ToolReplayPlan(
+            detailedRequestIds = kept.mapTo(mutableSetOf()) { it.requestId },
+            mediaRequestIds = kept.filter { it.withMedia }.mapTo(mutableSetOf()) { it.requestId },
+        )
+    }
+
+    /**
+     * Pure transition from this [Step] to the next one, given the following exchange
+     * (older, since the walk proceeds newest-first) in the sequence.
+     */
+    private fun Step.next(
+        request: ToolRequestEvent,
+        response: ToolResponseEvent?,
+    ): Step {
+        val responseImages = response?.images.orEmpty()
+        val attachMedia = responseImages.isNotEmpty() && images + responseImages.size <= maxAttachedImages
+        val cost = charCost(request, response, attachMedia)
+        val fits = chars + cost <= maxDetailedChars
+        return Step(
+            requestId = request.toolRequestId,
+            fits = fits,
+            withMedia = fits && attachMedia,
+            chars = if (fits) chars + cost else chars,
+            images = if (fits && attachMedia) images + responseImages.size else images,
+        )
+    }
+
+    /**
+     * Char-equivalent cost for one request/response pair:
+     * args length + response text length + image cost (only when [attachMedia] is true).
+     */
+    private fun charCost(
+        request: ToolRequestEvent,
+        response: ToolResponseEvent?,
+        attachMedia: Boolean,
+    ): Long {
+        val argsCost = request.args?.length ?: 0
+        val responseCost = response?.let { extractText(it.output).length } ?: 0
+        val imagesCount = if (attachMedia) response?.images?.size ?: 0 else 0
+        return argsCost.toLong() + responseCost.toLong() + imagesCount.toLong() * imageCharCost.toLong()
+    }
+
+    private fun extractText(content: MessageContent): String =
+        when (content) {
+            is MessageContent.Text -> content.content
+            is MessageContent.Image -> "[image ${content.mimeType} ${content.width}x${content.height}]"
+        }
+
+    private companion object {
+        val START = Step(requestId = "", fits = true, withMedia = false, chars = 0L, images = 0)
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleToolCallbackUnitSpec.kt
@@ -3,6 +3,7 @@ package io.whozoss.agentos.agent
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldHaveSize as mediaHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -27,6 +28,7 @@ import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
 import kotlinx.coroutines.flow.toList
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.ai.retry.NonTransientAiException
 import org.springframework.ai.tool.ToolCallback
@@ -60,6 +62,7 @@ class AgentSimpleToolCallbackUnitSpec :
             agentId: UUID,
             chatClient: ChatClient,
             tools: Collection<StandardTool<*>>,
+            maxAttachedImages: Int = 20,
         ): AgentSimple =
             AgentSimple(
                 metadata = EntityMetadata(id = agentId),
@@ -68,6 +71,7 @@ class AgentSimpleToolCallbackUnitSpec :
                 tools = tools,
                 llmProvider = "test-provider",
                 llmModel = "test-model",
+                maxAttachedImages = maxAttachedImages,
             )
 
         fun userMessage(
@@ -356,11 +360,11 @@ class AgentSimpleToolCallbackUnitSpec :
             events.filterIsInstance<AgentFinishedEvent>().firstOrNull() shouldNotBe null
         }
 
-        "image-producing tool: images are kept on the event and the LLM sees the not-supported note" {
-            // AgentSimple cannot deliver image attachments to the LLM. The images must
-            // still be preserved on the ToolResponseEvent (persistence, SSE), and the
-            // text handed back to the LLM must say the images are NOT viewable here,
-            // instead of letting the tool summary claim they are attached.
+        "image-producing tool: images are kept on the event and the callback returns plain text (images go via history)" {
+            // AgentSimple now supports image delivery via the conversation history.
+            // The ToolCallback.call() return value must be plain text only — images reach
+            // the LLM on subsequent turns via convertEventsToMessages() injecting UserMessage+Media.
+            // The images must still be preserved on the ToolResponseEvent (persistence, SSE).
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
             val agentId = UUID.randomUUID()
@@ -400,12 +404,18 @@ class AgentSimpleToolCallbackUnitSpec :
             toolResponse.images shouldBe images
             (toolResponse.output as MessageContent.Text).content shouldBe "Rendered PDF cv.pdf: page(s) 1 of 1"
 
+            // The callback returns only the text output — no "not supported" note
             callbackReturn shouldNotBe null
-            callbackReturn!! shouldContain "does not support image attachments"
-            callbackReturn!! shouldContain "Rendered PDF cv.pdf"
+            callbackReturn!! shouldBe "Rendered PDF cv.pdf: page(s) 1 of 1"
+            callbackReturn!! shouldNotContain "does not support image attachments"
         }
 
-        "history replay renders image tool responses as text with the note, never base64" {
+        "history replay injects UserMessage with Media for image tool responses, never base64 in ToolResponseMessage" {
+            // When the conversation history contains a ToolResponseEvent with images,
+            // convertEventsToMessages() must:
+            // 1. Put plain text (no note) in the ToolResponseMessage
+            // 2. Inject a follow-up UserMessage with Media attachments (base64 decoded)
+            // 3. Never put raw base64 directly in the ToolResponseMessage text
             val namespaceId = UUID.randomUUID()
             val caseId = UUID.randomUUID()
             val agentId = UUID.randomUUID()
@@ -443,14 +453,28 @@ class AgentSimpleToolCallbackUnitSpec :
 
             agent.run(history).toList()
 
+            val promptMessages = promptSlot.captured.instructions
+
+            // ToolResponseMessage must have plain text only — no base64, no "not supported" note
             val toolResponseMessage =
-                promptSlot.captured.instructions
+                promptMessages
                     .filterIsInstance<org.springframework.ai.chat.messages.ToolResponseMessage>()
                     .single()
             val responseData = toolResponseMessage.responses.single().responseData()
             responseData shouldContain "Rendered PDF cv.pdf"
-            responseData shouldContain "does not support image attachments"
             responseData shouldNotContain "aGVsbG8="
+            responseData shouldNotContain "does not support image attachments"
+            responseData shouldNotContain "no longer attached"
+
+            // A follow-up UserMessage with Media must have been injected after the ToolResponseMessage
+            val toolResponseIdx = promptMessages.indexOf(toolResponseMessage)
+            val imageUserMsg = promptMessages
+                .drop(toolResponseIdx + 1)
+                .filterIsInstance<UserMessage>()
+                .firstOrNull { it.text.contains("FILES__readAsImage") }
+            imageUserMsg shouldNotBe null
+            imageUserMsg!!.text shouldContain "Attached"
+            imageUserMsg.media shouldHaveSize 1
         }
 
         "NonTransientAiException from LLM provider surfaces as ErrorEvent + AgentFinishedEvent, no generic error" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ToolReplayPlannerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/ToolReplayPlannerSpec.kt
@@ -1,0 +1,216 @@
+package io.whozoss.agentos.agent
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
+import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import java.util.UUID
+
+class ToolReplayPlannerSpec : StringSpec({
+
+    val ns = UUID.randomUUID()
+    val case = UUID.randomUUID()
+
+    fun request(id: String, toolName: String = "TOOL__x", args: String = "arg") =
+        ToolRequestEvent(namespaceId = ns, caseId = case, toolRequestId = id, toolName = toolName, args = args)
+
+    fun response(
+        id: String,
+        toolName: String = "TOOL__x",
+        output: String = "ok",
+        images: List<MessageContent.Image> = emptyList(),
+    ) = ToolResponseEvent(
+        namespaceId = ns,
+        caseId = case,
+        toolRequestId = id,
+        toolName = toolName,
+        output = MessageContent.Text(output),
+        success = true,
+        images = images,
+    )
+
+    fun image() = MessageContent.Image(content = "aGVsbG8=", mimeType = "image/jpeg", width = 10, height = 10)
+
+    // -------------------------------------------------------------------------
+    // Newest-first ordering
+    // -------------------------------------------------------------------------
+
+    "newest-first: last exchange is always detailed when budget allows" {
+        val events = listOf(
+            request("r1"), response("r1", output = "A".repeat(100)),
+            request("r2"), response("r2", output = "B".repeat(100)),
+        )
+        // budget only fits r2 (200 chars per pair, budget = 120)
+        val plan = ToolReplayPlanner(maxDetailedChars = 120, maxAttachedImages = 20, imageCharCost = 6_000).plan(events)
+
+        plan.isDetailed("r2") shouldBe true
+        plan.isDetailed("r1") shouldBe false
+    }
+
+    "newest-first: both exchanges detailed when budget is large enough" {
+        val events = listOf(
+            request("r1"), response("r1", output = "ok"),
+            request("r2"), response("r2", output = "ok"),
+        )
+        val plan = ToolReplayPlanner(maxDetailedChars = 10_000, maxAttachedImages = 20, imageCharCost = 6_000).plan(events)
+
+        plan.isDetailed("r1") shouldBe true
+        plan.isDetailed("r2") shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // maxAttachedImages cap
+    // -------------------------------------------------------------------------
+
+    "images: newest responses keep media up to the cap" {
+        // 3 responses of 5 images each, cap = 10 → r3 and r2 get media, r1 does not
+        val events = listOf(
+            request("r1"), response("r1", images = List(5) { image() }),
+            request("r2"), response("r2", images = List(5) { image() }),
+            request("r3"), response("r3", images = List(5) { image() }),
+        )
+        val plan = ToolReplayPlanner(maxDetailedChars = Int.MAX_VALUE, maxAttachedImages = 10, imageCharCost = 0).plan(events)
+
+        plan.hasAttachedMedia("r3") shouldBe true
+        plan.hasAttachedMedia("r2") shouldBe true
+        plan.hasAttachedMedia("r1") shouldBe false
+    }
+
+    "images: response without images never gets media attached" {
+        val events = listOf(request("r1"), response("r1"))
+        val plan = ToolReplayPlanner(maxDetailedChars = Int.MAX_VALUE, maxAttachedImages = 20, imageCharCost = 0).plan(events)
+
+        plan.hasAttachedMedia("r1") shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // maxDetailedChars budget with break
+    // -------------------------------------------------------------------------
+
+    "budget break stops processing older exchanges once limit is reached" {
+        // Each pair costs ~6 chars (3 args + 3 output), budget = 7 → only r3 fits
+        val events = listOf(
+            request("r1", args = "aaa"), response("r1", output = "bbb"),
+            request("r2", args = "aaa"), response("r2", output = "bbb"),
+            request("r3", args = "aaa"), response("r3", output = "bbb"),
+        )
+        val plan = ToolReplayPlanner(maxDetailedChars = 7, maxAttachedImages = 20, imageCharCost = 6_000).plan(events)
+
+        plan.isDetailed("r3") shouldBe true
+        plan.isDetailed("r2") shouldBe false
+        plan.isDetailed("r1") shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // Image cost is not charged when media is evicted
+    // -------------------------------------------------------------------------
+
+    "evicted images are not charged against the char budget" {
+        // 3 responses of 10 images each, cap = 20 → r3 and r2 get media, r1 does not
+        // r1 must NOT be charged imageCharCost * 10 — it must remain detailed (only text cost)
+        val imageCharCost = 6_000
+        val textCostPerPair = 3 // args="a" (1) + output="ok" (2)
+        val budget = 20 * imageCharCost + 3 * textCostPerPair + 10 // enough for all text, 20 images
+
+        val events = listOf(
+            request("r1", args = "a"), response("r1", output = "ok", images = List(10) { image() }),
+            request("r2", args = "a"), response("r2", output = "ok", images = List(10) { image() }),
+            request("r3", args = "a"), response("r3", output = "ok", images = List(10) { image() }),
+        )
+        val plan = ToolReplayPlanner(
+            maxDetailedChars = budget,
+            maxAttachedImages = 20,
+            imageCharCost = imageCharCost,
+        ).plan(events)
+
+        // All three are detailed (r1 text cost only, r2 and r3 text + image cost)
+        plan.isDetailed("r1") shouldBe true
+        plan.isDetailed("r2") shouldBe true
+        plan.isDetailed("r3") shouldBe true
+        // Only r2 and r3 have media (r1 evicted by cap)
+        plan.hasAttachedMedia("r3") shouldBe true
+        plan.hasAttachedMedia("r2") shouldBe true
+        plan.hasAttachedMedia("r1") shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // Int.MAX_VALUE disables compression (AgentSimple behaviour)
+    // -------------------------------------------------------------------------
+
+    "Int.MAX_VALUE maxDetailedChars: all exchanges are detailed regardless of content size" {
+        val events =
+            (1..10).flatMap { i ->
+                listOf(
+                    request("r$i", args = "A".repeat(50_000)),
+                    response("r$i", output = "B".repeat(50_000)),
+                )
+            }
+        val plan = ToolReplayPlanner(maxDetailedChars = Int.MAX_VALUE, maxAttachedImages = 20, imageCharCost = 0).plan(events)
+
+        (1..10).forEach { i ->
+            plan.isDetailed("r$i") shouldBe true
+        }
+    }
+
+    "budget accumulation uses Long: break triggers correctly when cumulated cost exceeds Int.MAX_VALUE" {
+        // imageCharCost = 600_000_000 so each pair with 1 image costs ~600M chars.
+        // r4+r3+r2 = ~1.8B < Int.MAX_VALUE (2_147_483_647) → all detailed.
+        // r1 would push total to ~2.4B > Int.MAX_VALUE → break, r1 NOT detailed.
+        //
+        // With a naive Int accumulator: after r2 charsCollected = ~1.8B (fits in Int);
+        // adding r1's cost overflows to a negative value; `negative > Int.MAX_VALUE` is
+        // false → no break → r1 would be wrongly marked detailed.
+        val bigImageCost = 600_000_000
+        val events =
+            (1..4).flatMap { i ->
+                listOf(
+                    request("r$i", args = "a"),
+                    response("r$i", output = "ok", images = List(1) { image() }),
+                )
+            }
+        val plan = ToolReplayPlanner(
+            maxDetailedChars = Int.MAX_VALUE,
+            maxAttachedImages = 20,
+            imageCharCost = bigImageCost,
+        ).plan(events)
+
+        plan.isDetailed("r4") shouldBe true  // newest, always fits
+        plan.isDetailed("r3") shouldBe true  // cumulated ~1.2B
+        plan.isDetailed("r2") shouldBe true  // cumulated ~1.8B < Int.MAX_VALUE
+        plan.isDetailed("r1") shouldBe false // would push to ~2.4B > Int.MAX_VALUE → break
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-tool events are ignored
+    // -------------------------------------------------------------------------
+
+    "non-tool events in the list are ignored" {
+        val userMsg = MessageEvent(
+            namespaceId = ns,
+            caseId = case,
+            actor = Actor("u1", "User", ActorRole.USER),
+            content = listOf(MessageContent.Text("hello")),
+        )
+        val events = listOf(userMsg, request("r1"), response("r1"))
+        val plan = ToolReplayPlanner(maxDetailedChars = Int.MAX_VALUE, maxAttachedImages = 20, imageCharCost = 0).plan(events)
+
+        plan.isDetailed("r1") shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // Orphaned requests (no matching response)
+    // -------------------------------------------------------------------------
+
+    "orphaned request with no response is still considered for the plan" {
+        val events = listOf(request("orphan"))
+        // No response — cost is only args length = 3
+        val plan = ToolReplayPlanner(maxDetailedChars = 10, maxAttachedImages = 20, imageCharCost = 0).plan(events)
+
+        plan.isDetailed("orphan") shouldBe true
+        plan.hasAttachedMedia("orphan") shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Brings image processing support to AgentSimple, aligning it with AgentAdvanced's capability. Previously, AgentSimple's Spring AI `ToolCallback.call()` text-only constraint prevented image delivery to the LLM — tools that produced images had their output degraded to a "not supported" note.

The solution injects images into the **conversation history** (via `convertEventsToMessages()`) as follow-up `UserMessage` with `Media` attachments, without altering the `ToolCallback.call()` return signature. Spring AI rebuilds the full context on each tool-calling turn, so images become visible to the LLM on subsequent turns.

## Changes

### `AgentSimple.kt`
- Added `imageCharCost` (default 6 000) and `maxAttachedImages` (default 20) constructor parameters, mirroring `AgentConfigProperties`.
- New `selectImageRequestIds()`: newest-first budget walk that decides which tool responses get image `Media` attachments within the `maxAttachedImages` cap.
- `convertEventsToMessages()` now injects `toolImagesUserMessage()` (from `MessageConversions.kt`) as a follow-up `UserMessage` after each `ToolResponseMessage` whose images are within budget. Changed visibility to `internal` for testability.
- `toolResponseText()` updated with 3-way logic: no images → plain text / images in budget → plain text (images come via follow-up `UserMessage`) / images outside budget → text + marker `[N image(s) no longer attached, call the tool again if needed]`.
- `ToolCallback.call()` now returns plain `executionResult.output` — no longer appends "not supported" note.
- Removed `imagesNotSupportedNote()` companion method.

### `AgentServiceImpl.kt`
- Wires `imageCharCost` and `maxAttachedImages` from `AgentConfigProperties` into the `AgentSimple` constructor.

### `AgentSimpleToolCallbackUnitSpec.kt`
- Updated "image-producing tool" test: asserts callback returns plain text only, no "not supported" note.
- Updated "history replay" test: asserts `ToolResponseMessage` contains plain text (no base64, no note), and a follow-up `UserMessage` with `Media` is injected after it.