### PR TITLE
fix(agentos): fix advancedExecution attribut mapping in case of yml agent config #1244

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agentConfig/FilesystemAgentConfigRepository.kt
@@ -29,7 +29,6 @@ class FilesystemAgentConfigRepository(
     private val yamlMapper: ObjectMapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule.Builder().build()),
     ttl: Duration = Duration.ofMinutes(5),
 ) : AgentConfigRepository by delegate {
-
     private val cacheRegistry =
         FilesystemYamlCacheRegistry(
             parser = ::parseYamlFile,
@@ -180,6 +179,7 @@ class FilesystemAgentConfigRepository(
             instructions = model.instructions,
             modelName = model.modelName,
             integrations = model.integrations,
+            advancedExecution = model.advancedExecution,
             subAgents = model.subAgents?.filter { it.isNotBlank() }?.takeIf { it.isNotEmpty() },
             docs =
                 model.docs
@@ -231,6 +231,7 @@ private data class AgentConfigYamlModel(
     val name: String = "",
     val description: String? = null,
     val instructions: String? = null,
+    val advancedExecution: Boolean = false,
     val modelName: String? = null,
     val integrations: Map<String, List<String>?>? = null,
     val subAgents: List<String>? = null,

--- a/agents/Archay.yaml
+++ b/agents/Archay.yaml
@@ -2,6 +2,7 @@ name: Archay
 description: Expert Software Architecture agent, coordinates a team with Sway and Octopuss. Archay should be the entry agent for high-level, wide-ranging holistic code-focused topics (git, github, compilation, review, story assessment and evaluation, code analysis, etc...)
 aiProvider: anthropic
 modelName: BIGGEST
+#advancedExecution: true
 integrations:
   FILES:
   AI:


### PR DESCRIPTION
## Summary

Fixes `advancedExecution` not being persisted when agent configs are loaded from filesystem YAML files. The field was present on the `AgentConfig` domain model but missing from both the YAML deserialization model and the mapping function, causing it to silently default to `false` regardless of what the YAML file declared.

## Changes

### `FilesystemAgentConfigRepository.kt`
- Added `advancedExecution` field to `AgentConfigYamlModel` (default `false`) so the YAML parser can deserialize it.
- Added `advancedExecution = model.advancedExecution` to the `toAgentConfig()` mapping function so the value propagates to the domain model.

### `agents/Archay.yaml`
- Added commented-out `#advancedExecution: true` (preparatory — ready to enable when needed).