### PR TITLE
feat: #33829 share a case with other users (multi-user case)

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
@@ -1,5 +1,11 @@
 <ds-drawer position="end" [(open)]="exchangeOpen" drawerWidth="400px" [mobileFullWidth]="true">
-  <agentos-exchange-shell dsDrawerSide (closeRequested)="exchangeOpen.set(false)" />
+  <div dsDrawerSide class="case-chat__drawer-side">
+    @if (drawerPanel() === 'members') {
+      <agentos-case-members [caseId]="caseId" (closeRequested)="exchangeOpen.set(false)" />
+    } @else {
+      <agentos-exchange-shell (closeRequested)="exchangeOpen.set(false)" />
+    }
+  </div>
 
   <div dsDrawerContent class="case-chat__host">
     <!-- ── Case header: glyph + title + status badge ─────────────────────── -->
@@ -24,12 +30,15 @@
           icon="folder"
           variant="default"
           [title]="'Files (' + exchangeFileCount() + ')'"
-          (action)="toggleExchange()"
+          (action)="openFilesPanel()"
         />
         @if (exchangeFileCount() > 0 && !exchangeOpen()) {
           <span class="case-chat__exchange-badge" aria-hidden="true">{{ exchangeFileCount() }}</span>
         }
       </div>
+
+      <!-- Share case -->
+      <ds-icon-button icon="group_add" variant="default" title="Share case" (action)="openMembersPanel()" />
 
       <!-- Separator -->
       <span class="case-chat__header-sep"></span>

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -14,8 +14,6 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  width: 100%;
-  min-width: 0;
 }
 
 // Main content slot of the right-side exchange drawer

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -8,6 +8,14 @@
   overflow: hidden;
 }
 
+// Wrapper for the right-side drawer side panel — fills the sidenav height
+.case-chat__drawer-side {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
 // Main content slot of the right-side exchange drawer
 .case-chat__host {
   position: relative;

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -14,6 +14,8 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  width: 100%;
+  min-width: 0;
 }
 
 // Main content slot of the right-side exchange drawer

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -13,7 +13,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
 }
 
 // Main content slot of the right-side exchange drawer

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -55,6 +55,7 @@ import { USER_PREFERENCES_PORT } from '../../services/user-preferences.service'
 import { ExchangeStateService } from '../../services/exchange-state.service'
 import { exchangeMutationScope } from '../../services/exchange-content.utils'
 import { ExchangeShellComponent } from '../exchange-shell/exchange-shell.component'
+import { CaseMembersComponent } from '../case-members/case-members.component'
 import { ComposerAttachmentsService } from '../composer-attachments/composer-attachments.service'
 import { ComposerAttachmentsComponent } from '../composer-attachments/composer-attachments.component'
 import { isNamespaceTargeted, resolveUploadScope } from '../composer-attachments/composer-attachments.utils'
@@ -119,6 +120,7 @@ function hasActiveSelection(): boolean {
     JsonPipe,
     DrawerComponent,
     ExchangeShellComponent,
+    CaseMembersComponent,
     PromptAutocompleteComponent,
     AgentAutocompleteComponent,
     BlueprintDirective,
@@ -232,6 +234,19 @@ export class CaseChatComponent implements OnInit, OnDestroy {
 
   /** Whether the delete confirmation inline is showing. */
   protected readonly confirmingDelete = signal(false)
+
+  /** Which panel is active in the right drawer: files exchange or case members. */
+  protected readonly drawerPanel = signal<'files' | 'members'>('files')
+
+  protected openFilesPanel(): void {
+    this.drawerPanel.set('files')
+    this.exchangeOpen.set(true)
+  }
+
+  protected openMembersPanel(): void {
+    this.drawerPanel.set('members')
+    this.exchangeOpen.set(true)
+  }
 
   // Header action outputs — handled by CaseShellComponent
   readonly starToggled = output<{ id: string; starred: boolean }>()

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -771,6 +771,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     this.streamingText.set('')
     this.collapsedTools.set(new Set())
     this.isAtBottom.set(true)
+    this.drawerPanel.set('files')
     this.autocomplete.reset()
     this.attachments.reset()
     this.connectSse()

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.html
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.html
@@ -27,30 +27,37 @@
         } @else {
           <ul class="case-members__members">
             @for (member of selectedMembers(); track member.userId) {
-              <li class="case-members__member">
+              <li
+                class="case-members__member"
+                [class.case-members__member--self]="member.userId === currentUserId()?.id"
+              >
                 <div class="case-members__member-info">
                   <span class="case-members__member-name">{{ member.label }}</span>
                   @if (member.email && member.email !== member.label) {
                     <span class="case-members__member-email">{{ member.email }}</span>
                   }
                 </div>
-                <select
-                  class="case-members__member-role"
-                  [value]="member.role"
-                  [attr.aria-label]="'Role of ' + member.label"
-                  (change)="setMemberRole(member.userId, $any($event.target).value)"
-                >
-                  <option value="MEMBER">Member</option>
-                  <option value="ADMIN">Admin</option>
-                </select>
-                <button
-                  class="case-members__member-remove"
-                  type="button"
-                  [title]="'Remove ' + member.label"
-                  (click)="removeMember(member.userId)"
-                >
-                  &#215;
-                </button>
+                @if (member.userId === currentUserId()?.id) {
+                  <span class="case-members__member-role-badge">{{ member.role | lowercase }}</span>
+                } @else {
+                  <select
+                    class="case-members__member-role"
+                    [value]="member.role"
+                    [attr.aria-label]="'Role of ' + member.label"
+                    (change)="setMemberRole(member.userId, $any($event.target).value)"
+                  >
+                    <option value="MEMBER">Member</option>
+                    <option value="ADMIN">Admin</option>
+                  </select>
+                  <button
+                    class="case-members__member-remove"
+                    type="button"
+                    [title]="'Remove ' + member.label"
+                    (click)="removeMember(member.userId)"
+                  >
+                    &#215;
+                  </button>
+                }
               </li>
             }
           </ul>

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.html
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.html
@@ -1,0 +1,89 @@
+<div class="case-members">
+  <header class="case-members__header">
+    <h2 class="case-members__title">Share case</h2>
+    <button class="case-members__close" type="button" title="Close" (click)="cancel()">
+      <span class="material-icons" aria-hidden="true">close</span>
+    </button>
+  </header>
+
+  @if (isLoading()) {
+    <p class="case-members__loading">Loading&hellip;</p>
+  } @else {
+    <div class="case-members__body">
+      @if (!isSuperAdmin()) {
+        <p class="case-members__hint">
+          You can change roles or remove existing members. Only a platform super-admin can add a new user to this case.
+        </p>
+      }
+
+      <fieldset class="case-members__section">
+        <legend class="case-members__label">
+          Members
+          <span class="case-members__label-hint">ADMIN or MEMBER</span>
+        </legend>
+
+        @if (selectedMembers().length === 0) {
+          <p class="case-members__empty-hint">No members yet.</p>
+        } @else {
+          <ul class="case-members__members">
+            @for (member of selectedMembers(); track member.userId) {
+              <li class="case-members__member">
+                <div class="case-members__member-info">
+                  <span class="case-members__member-name">{{ member.label }}</span>
+                  @if (member.email && member.email !== member.label) {
+                    <span class="case-members__member-email">{{ member.email }}</span>
+                  }
+                </div>
+                <select
+                  class="case-members__member-role"
+                  [value]="member.role"
+                  [attr.aria-label]="'Role of ' + member.label"
+                  (change)="setMemberRole(member.userId, $any($event.target).value)"
+                >
+                  <option value="MEMBER">Member</option>
+                  <option value="ADMIN">Admin</option>
+                </select>
+                <button
+                  class="case-members__member-remove"
+                  type="button"
+                  [title]="'Remove ' + member.label"
+                  (click)="removeMember(member.userId)"
+                >
+                  &#215;
+                </button>
+              </li>
+            }
+          </ul>
+        }
+
+        @if (wouldLockOutAdmins()) {
+          <p class="case-members__warning">At least one ADMIN must remain on the case.</p>
+        }
+
+        @if (isSuperAdmin()) {
+          <ds-autocomplete-input
+            [dataSource]="memberDataSource"
+            placeholder="Add a member…"
+            (itemSelected)="onMemberSelected($event)"
+          />
+        }
+      </fieldset>
+
+      @if (errorMessage()) {
+        <p class="case-members__error">{{ errorMessage() }}</p>
+      }
+
+      <div class="case-members__actions">
+        <button
+          class="case-members__btn case-members__btn--primary"
+          type="button"
+          [disabled]="isSubmitting() || wouldLockOutAdmins()"
+          (click)="submit()"
+        >
+          Save
+        </button>
+        <button class="case-members__btn" type="button" (click)="cancel()">Cancel</button>
+      </div>
+    </div>
+  }
+</div>

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.html
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.html
@@ -44,7 +44,7 @@
                     class="case-members__member-role"
                     [value]="member.role"
                     [attr.aria-label]="'Role of ' + member.label"
-                    (change)="setMemberRole(member.userId, $any($event.target).value)"
+                    (change)="setMemberRole(member.userId, $event)"
                   >
                     <option value="MEMBER">Member</option>
                     <option value="ADMIN">Admin</option>

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -104,20 +104,27 @@
 }
 
 .case-members__member-info {
+  flex-direction: column;
   flex: 1;
   min-width: 0;
 }
 
 .case-members__member-name {
+  display: block;
   font-size: 0.875rem;
   color: var(--color-text);
-  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .case-members__member-email {
+  display: block;
   font-size: 0.75rem;
   color: var(--color-text-secondary);
-  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .case-members__member-role {

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -5,14 +5,12 @@
   flex-direction: column;
   height: 100%;
   min-height: 0;
-  overflow: hidden;
 }
 
 .case-members {
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
 }
 
 .case-members__header {
@@ -104,6 +102,7 @@
 }
 
 .case-members__member-info {
+  display: flex;
   flex-direction: column;
   flex: 1;
   min-width: 0;

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -113,6 +113,23 @@
     padding: 6px 8px;
     border-radius: 4px;
     background: var(--color-neutral-100);
+
+    &--self {
+      background: color-mix(in srgb, var(--color-accent) 6%, var(--color-neutral-100));
+    }
+  }
+
+  &__member-role-badge {
+    font-size: 0.7rem;
+    font-family: var(--font-heading);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-neutral-600);
+    flex: none;
+    padding: 2px 6px;
+    border: 1px solid var(--color-divider);
+    border-radius: 4px;
   }
 
   &__member-info {

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -1,0 +1,220 @@
+.case-members {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--color-divider);
+    flex: none;
+  }
+
+  &__title {
+    font-size: 14px;
+    font-weight: 600;
+    font-family: var(--font-heading);
+    margin: 0;
+    color: var(--color-text);
+  }
+
+  &__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-neutral-600);
+    border-radius: 4px;
+
+    &:hover {
+      background: var(--color-bg-hover);
+      color: var(--color-text);
+    }
+
+    .material-icons {
+      font-size: 18px;
+    }
+  }
+
+  &__loading {
+    padding: 16px;
+    color: var(--color-neutral-600);
+    font-size: 0.875rem;
+  }
+
+  &__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__hint {
+    font-size: 0.8rem;
+    color: var(--color-neutral-600);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  &__section {
+    border: 1px solid var(--color-divider);
+    border-radius: 6px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 0;
+  }
+
+  &__label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text);
+    font-family: var(--font-heading);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  &__label-hint {
+    font-weight: 400;
+    color: var(--color-neutral-600);
+    font-size: 0.7rem;
+  }
+
+  &__empty-hint {
+    font-size: 0.8rem;
+    color: var(--color-neutral-600);
+    margin: 0;
+  }
+
+  &__members {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__member {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    background: var(--color-neutral-100);
+  }
+
+  &__member-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  &__member-name {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__member-email {
+    font-size: 0.7rem;
+    color: var(--color-neutral-600);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__member-role {
+    font-size: 0.75rem;
+    border: 1px solid var(--color-divider);
+    border-radius: 4px;
+    padding: 2px 6px;
+    background: var(--color-bg);
+    color: var(--color-text);
+    cursor: pointer;
+    flex: none;
+  }
+
+  &__member-remove {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-neutral-600);
+    border-radius: 3px;
+    font-size: 14px;
+    flex: none;
+
+    &:hover {
+      color: var(--color-error);
+      background: color-mix(in srgb, var(--color-error) 8%, transparent);
+    }
+  }
+
+  &__warning {
+    font-size: 0.75rem;
+    color: var(--color-warning);
+    margin: 0;
+  }
+
+  &__error {
+    font-size: 0.8rem;
+    color: var(--color-error);
+    margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  &__btn {
+    padding: 6px 14px;
+    border-radius: 4px;
+    border: 1px solid var(--color-divider);
+    font-size: 0.8rem;
+    font-family: var(--font-heading);
+    cursor: pointer;
+    background: var(--color-bg);
+    color: var(--color-text);
+
+    &:hover {
+      background: var(--color-bg-hover);
+    }
+
+    &--primary {
+      background: var(--color-accent);
+      color: var(--color-text-inverse);
+      border-color: var(--color-accent);
+
+      &:hover:not(:disabled) {
+        opacity: 0.9;
+      }
+
+      &:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+    }
+  }
+}

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -1,3 +1,5 @@
+@use 'libs/design-system/src/styles' as ds;
+
 .case-members {
   display: flex;
   flex-direction: column;
@@ -22,21 +24,7 @@
   }
 
   &__close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--color-neutral-600);
-    border-radius: 4px;
-
-    &:hover {
-      background: var(--color-bg-hover);
-      color: var(--color-text);
-    }
+    @include ds.icon-button(28px);
 
     .material-icons {
       font-size: 18px;
@@ -95,6 +83,7 @@
     font-size: 0.8rem;
     color: var(--color-neutral-600);
     margin: 0;
+    font-style: italic;
   }
 
   &__members {
@@ -103,19 +92,60 @@
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 0.375rem;
   }
 
   &__member {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 8px;
-    border-radius: 4px;
-    background: var(--color-neutral-100);
+    gap: 0.75rem;
+    padding: 0.4rem 0.5rem;
+    border-radius: 6px;
+    background: var(--color-surface-hover);
+    border: 1px solid var(--color-divider);
 
     &--self {
-      background: color-mix(in srgb, var(--color-accent) 6%, var(--color-neutral-100));
+      background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface-hover));
+    }
+  }
+
+  &__member-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+  }
+
+  &__member-name {
+    font-size: 0.875rem;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__member-email {
+    font-size: 0.75rem;
+    color: var(--color-neutral-600);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__member-role {
+    flex-shrink: 0;
+    padding: 0.3rem 0.5rem;
+    border: 1px solid var(--color-divider);
+    background: transparent;
+    color: var(--color-text);
+    font-size: 0.8rem;
+    font-family: inherit;
+    cursor: pointer;
+
+    &:focus {
+      outline: none;
+      border-color: var(--color-accent);
     }
   }
 
@@ -129,108 +159,73 @@
     flex: none;
     padding: 2px 6px;
     border: 1px solid var(--color-divider);
-    border-radius: 4px;
-  }
-
-  &__member-info {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-  }
-
-  &__member-name {
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: var(--color-text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  &__member-email {
-    font-size: 0.7rem;
-    color: var(--color-neutral-600);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  &__member-role {
-    font-size: 0.75rem;
-    border: 1px solid var(--color-divider);
-    border-radius: 4px;
-    padding: 2px 6px;
-    background: var(--color-bg);
-    color: var(--color-text);
-    cursor: pointer;
-    flex: none;
   }
 
   &__member-remove {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--color-neutral-600);
-    border-radius: 3px;
-    font-size: 14px;
-    flex: none;
+    @include ds.action-btn(24px);
 
     &:hover {
-      color: var(--color-error);
-      background: color-mix(in srgb, var(--color-error) 8%, transparent);
+      color: var(--red);
+      background: color-mix(in srgb, var(--red) 12%, transparent);
     }
   }
 
   &__warning {
-    font-size: 0.75rem;
-    color: var(--color-warning);
     margin: 0;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-warning);
+    background: color-mix(in srgb, var(--color-warning) 10%, transparent);
+    color: var(--color-warning);
+    font-size: 0.8rem;
+    line-height: 1.4;
   }
 
   &__error {
-    font-size: 0.8rem;
-    color: var(--color-error);
     margin: 0;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-error);
+    background: color-mix(in srgb, var(--color-error) 8%, transparent);
+    color: var(--color-error);
+    font-size: 0.875rem;
+    line-height: 1.4;
   }
 
   &__actions {
     display: flex;
-    gap: 8px;
-    align-items: center;
+    gap: 0.75rem;
+    padding-top: 0.25rem;
   }
 
   &__btn {
-    padding: 6px 14px;
-    border-radius: 4px;
+    @include ds.button-reset;
+
+    padding: 0.5rem 1rem;
     border: 1px solid var(--color-divider);
-    font-size: 0.8rem;
+    background: transparent;
+    color: var(--color-text);
+    font-size: 0.875rem;
     font-family: var(--font-heading);
     cursor: pointer;
-    background: var(--color-bg);
-    color: var(--color-text);
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
 
-    &:hover {
+    &:hover:not(:disabled) {
       background: var(--color-bg-hover);
+    }
+
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
     }
 
     &--primary {
       background: var(--color-accent);
-      color: var(--color-text-inverse);
       border-color: var(--color-accent);
+      color: var(--color-text-inverse);
 
       &:hover:not(:disabled) {
         opacity: 0.9;
-      }
-
-      &:disabled {
-        opacity: 0.45;
-        cursor: not-allowed;
       }
     }
   }

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -1,5 +1,13 @@
 @use 'libs/design-system/src/styles' as ds;
 
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .case-members {
   display: flex;
   flex-direction: column;

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -111,17 +111,13 @@
 .case-members__member-name {
   font-size: 0.875rem;
   color: var(--color-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-all;
 }
 
 .case-members__member-email {
   font-size: 0.75rem;
   color: var(--color-text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-all;
 }
 
 .case-members__member-role {

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.scss
@@ -5,228 +5,195 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+}
 
-  &__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--color-divider);
-    flex: none;
+.case-members__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-divider);
+  flex-shrink: 0;
+}
+
+.case-members__title {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.case-members__close {
+  @include ds.icon-button(28px);
+
+  .material-icons {
+    font-size: 18px;
+  }
+}
+
+.case-members__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.case-members__hint,
+.case-members__loading,
+.case-members__empty-hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.case-members__section {
+  border: 1px solid var(--color-divider);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.case-members__label {
+  font-size: 0.6875rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.case-members__label-hint {
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.case-members__members {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.case-members__member {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-divider);
+
+  &--self {
+    border-color: var(--color-accent-300);
+  }
+}
+
+.case-members__member-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.case-members__member-name {
+  font-size: 0.875rem;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.case-members__member-email {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.case-members__member-role {
+  flex-shrink: 0;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--color-divider);
+  background: transparent;
+  color: var(--color-text);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-accent);
+  }
+}
+
+.case-members__member-role-badge {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--color-divider);
+}
+
+.case-members__member-remove {
+  @include ds.action-btn(22px);
+
+  &:hover {
+    color: var(--red);
+    background: color-mix(in srgb, var(--red) 12%, transparent);
+  }
+}
+
+.case-members__warning {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-warning);
+}
+
+.case-members__error {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-error);
+}
+
+.case-members__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.case-members__btn {
+  @include ds.button-reset;
+
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--color-divider);
+  font-size: 0.875rem;
+  font-family: var(--font-heading);
+  color: var(--color-text);
+  transition: background 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: var(--color-bg-hover);
   }
 
-  &__title {
-    font-size: 14px;
-    font-weight: 600;
-    font-family: var(--font-heading);
-    margin: 0;
-    color: var(--color-text);
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
   }
 
-  &__close {
-    @include ds.icon-button(28px);
-
-    .material-icons {
-      font-size: 18px;
-    }
-  }
-
-  &__loading {
-    padding: 16px;
-    color: var(--color-neutral-600);
-    font-size: 0.875rem;
-  }
-
-  &__body {
-    flex: 1;
-    overflow-y: auto;
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  &__hint {
-    font-size: 0.8rem;
-    color: var(--color-neutral-600);
-    margin: 0;
-    line-height: 1.5;
-  }
-
-  &__section {
-    border: 1px solid var(--color-divider);
-    border-radius: 6px;
-    padding: 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin: 0;
-  }
-
-  &__label {
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--color-text);
-    font-family: var(--font-heading);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-  }
-
-  &__label-hint {
-    font-weight: 400;
-    color: var(--color-neutral-600);
-    font-size: 0.7rem;
-  }
-
-  &__empty-hint {
-    font-size: 0.8rem;
-    color: var(--color-neutral-600);
-    margin: 0;
-    font-style: italic;
-  }
-
-  &__members {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-  }
-
-  &__member {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.4rem 0.5rem;
-    border-radius: 6px;
-    background: var(--color-surface-hover);
-    border: 1px solid var(--color-divider);
-
-    &--self {
-      background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface-hover));
-    }
-  }
-
-  &__member-info {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
-    min-width: 0;
-  }
-
-  &__member-name {
-    font-size: 0.875rem;
-    color: var(--color-text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  &__member-email {
-    font-size: 0.75rem;
-    color: var(--color-neutral-600);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  &__member-role {
-    flex-shrink: 0;
-    padding: 0.3rem 0.5rem;
-    border: 1px solid var(--color-divider);
-    background: transparent;
-    color: var(--color-text);
-    font-size: 0.8rem;
-    font-family: inherit;
-    cursor: pointer;
-
-    &:focus {
-      outline: none;
-      border-color: var(--color-accent);
-    }
-  }
-
-  &__member-role-badge {
-    font-size: 0.7rem;
-    font-family: var(--font-heading);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--color-neutral-600);
-    flex: none;
-    padding: 2px 6px;
-    border: 1px solid var(--color-divider);
-  }
-
-  &__member-remove {
-    @include ds.action-btn(24px);
-
-    &:hover {
-      color: var(--red);
-      background: color-mix(in srgb, var(--red) 12%, transparent);
-    }
-  }
-
-  &__warning {
-    margin: 0;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-warning);
-    background: color-mix(in srgb, var(--color-warning) 10%, transparent);
-    color: var(--color-warning);
-    font-size: 0.8rem;
-    line-height: 1.4;
-  }
-
-  &__error {
-    margin: 0;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-error);
-    background: color-mix(in srgb, var(--color-error) 8%, transparent);
-    color: var(--color-error);
-    font-size: 0.875rem;
-    line-height: 1.4;
-  }
-
-  &__actions {
-    display: flex;
-    gap: 0.75rem;
-    padding-top: 0.25rem;
-  }
-
-  &__btn {
-    @include ds.button-reset;
-
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--color-divider);
-    background: transparent;
-    color: var(--color-text);
-    font-size: 0.875rem;
-    font-family: var(--font-heading);
-    cursor: pointer;
-    transition:
-      background 0.15s ease,
-      border-color 0.15s ease;
+  &--primary {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: var(--color-text-inverse);
 
     &:hover:not(:disabled) {
-      background: var(--color-bg-hover);
-    }
-
-    &:disabled {
-      opacity: 0.45;
-      cursor: not-allowed;
-    }
-
-    &--primary {
-      background: var(--color-accent);
-      border-color: var(--color-accent);
-      color: var(--color-text-inverse);
-
-      &:hover:not(:disabled) {
-        opacity: 0.9;
-      }
+      opacity: 0.9;
     }
   }
 }

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
@@ -1,0 +1,215 @@
+import { HttpErrorResponse } from '@angular/common/http'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, input, OnChanges, output, signal } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
+import { MemberItem, MemberItemRoleEnum, User, UserMembershipRoleRoleEnum } from '@whoz-oss/agentos-api-client'
+import { AutocompleteInputComponent, AutocompleteItem } from '@whoz-oss/design-system'
+import { forkJoin, of } from 'rxjs'
+import { catchError } from 'rxjs/operators'
+import { CaseMemberUpdateEntry, CaseMemberStateService } from '../../services/case-member-state.service'
+import { UserStateService } from '../../services/user-state.service'
+import { NamespaceMemberAutocompleteDataSource } from '../namespace-members/namespace-member.data-source'
+import {
+  computeMemberDiff,
+  hasAtLeastOneAdmin,
+  MemberRoleEntry,
+  memberLabel,
+} from '../namespace-members/namespace-members.util'
+
+/** A member currently in the list, with a display label and their (exclusive) role. */
+interface SelectedMember {
+  userId: string
+  label: string
+  email?: string
+  role: MemberItemRoleEnum
+}
+
+/**
+ * CaseMembersComponent — presentational panel to manage a case’s ADMIN/MEMBER roster.
+ *
+ * Rendered inside the right-side drawer of CaseChatComponent (alongside ExchangeShell).
+ * Receives [caseId] as input; emits (closeRequested) when done or cancelled.
+ *
+ * Roles are EXCLUSIVE (ADMIN xor MEMBER xor absent), each row has a single role <select>.
+ * Adding a new user requires SUPER_ADMIN (user directory is SUPER_ADMIN-only on the backend).
+ */
+@Component({
+  selector: 'agentos-case-members',
+  imports: [AutocompleteInputComponent],
+  templateUrl: './case-members.component.html',
+  styleUrl: './case-members.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CaseMembersComponent implements OnChanges {
+  private readonly destroyRef = inject(DestroyRef)
+  private readonly memberState = inject(CaseMemberStateService)
+  private readonly userState = inject(UserStateService)
+
+  readonly caseId = input.required<string>()
+
+  /** Emitted when the user saves or cancels — the parent closes the panel. */
+  readonly closeRequested = output<void>()
+
+  protected readonly isLoading = signal(false)
+  protected readonly isSubmitting = signal(false)
+  protected readonly errorMessage = signal<string | null>(null)
+
+  /** Whether the current user is a platform super-admin — gates the "add member" autocomplete. */
+  protected readonly isSuperAdmin = signal(false)
+
+  protected readonly selectedMembers = signal<SelectedMember[]>([])
+  private originalMembers: MemberRoleEntry[] = []
+
+  /** Candidate pool for the autocomplete — all platform users, only loaded for super-admins. */
+  private readonly candidateUsers = signal<User[]>([])
+
+  protected readonly memberDataSource = new NamespaceMemberAutocompleteDataSource(
+    () => this.candidateUsers(),
+    () => new Set(this.selectedMembers().map((m) => m.userId))
+  )
+
+  ngOnChanges(): void {
+    this.loadData()
+  }
+
+  private loadData(): void {
+    this.isLoading.set(true)
+    this.errorMessage.set(null)
+
+    const currentUser$ = this.userState.currentUser() ? of(this.userState.currentUser()) : this.userState.loadMe()
+
+    currentUser$
+      .pipe(
+        catchError((err) => {
+          console.error('[CaseMembers] Failed to load current user', err)
+          return of(null)
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((user) => {
+        const isSuperAdmin = user?.isAdmin === true
+        this.isSuperAdmin.set(isSuperAdmin)
+        this.loadMembersAndCandidates(isSuperAdmin)
+      })
+  }
+
+  private loadMembersAndCandidates(isSuperAdmin: boolean): void {
+    forkJoin({
+      members: this.memberState.listMembers(this.caseId()),
+      // Only super-admins may call GET /api/users (backend enforces SUPER_ADMIN).
+      allUsers: isSuperAdmin ? this.memberState.listAllUsers() : of([] as User[]),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ members, allUsers }) => {
+          this.applyMembers(members)
+          this.candidateUsers.set(allUsers)
+          this.isLoading.set(false)
+        },
+        error: (err) => {
+          console.error('[CaseMembers] Failed to load case members', err)
+          this.isLoading.set(false)
+          this.errorMessage.set('Failed to load case members. Please try again.')
+        },
+      })
+  }
+
+  private applyMembers(members: MemberItem[]): void {
+    this.originalMembers = members.map((m) => ({ userId: m.id, role: m.role }))
+    this.selectedMembers.set(
+      members.map((m) => ({
+        userId: m.id,
+        label: memberLabel(m),
+        email: m.email,
+        role: m.role,
+      }))
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Member selection
+  // ---------------------------------------------------------------------------
+
+  protected onMemberSelected(item: AutocompleteItem): void {
+    if (this.selectedMembers().some((m) => m.userId === item.id)) return
+    this.selectedMembers.update((members) => [
+      ...members,
+      { userId: item.id, label: item.name, email: item.description, role: MemberItemRoleEnum.MEMBER },
+    ])
+  }
+
+  protected removeMember(userId: string): void {
+    this.selectedMembers.update((members) => members.filter((m) => m.userId !== userId))
+  }
+
+  protected setMemberRole(userId: string, role: string): void {
+    const nextRole = role === MemberItemRoleEnum.ADMIN ? MemberItemRoleEnum.ADMIN : MemberItemRoleEnum.MEMBER
+    this.selectedMembers.update((members) => members.map((m) => (m.userId === userId ? { ...m, role: nextRole } : m)))
+  }
+
+  /** True when the edited roster would leave the case with zero ADMIN — blocks submit. */
+  protected readonly wouldLockOutAdmins = () => !hasAtLeastOneAdmin(this.selectedMembers())
+
+  // ---------------------------------------------------------------------------
+  // Submit / cancel
+  // ---------------------------------------------------------------------------
+
+  protected submit(): void {
+    if (this.isSubmitting()) return
+
+    if (this.wouldLockOutAdmins()) {
+      this.errorMessage.set('At least one ADMIN must remain on the case. Assign ADMIN to someone before saving.')
+      return
+    }
+
+    this.isSubmitting.set(true)
+    this.errorMessage.set(null)
+
+    const { toUpsert, toRemove } = computeMemberDiff(
+      this.originalMembers,
+      this.selectedMembers().map((m) => ({ userId: m.userId, role: m.role }))
+    )
+
+    if (toUpsert.length === 0 && toRemove.length === 0) {
+      this.isSubmitting.set(false)
+      this.closeRequested.emit()
+      return
+    }
+
+    const updateEntries: CaseMemberUpdateEntry[] = [
+      ...toUpsert.map((entry) => ({ userId: entry.userId, role: entry.role as UserMembershipRoleRoleEnum })),
+      ...toRemove.map((userId) => ({ userId })),
+    ]
+
+    this.memberState
+      .updateMembers(this.caseId(), updateEntries)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (refreshed) => {
+          this.applyMembers(refreshed)
+          this.isSubmitting.set(false)
+          this.closeRequested.emit()
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isSubmitting.set(false)
+          this.errorMessage.set(this.describeError(err))
+        },
+      })
+  }
+
+  private describeError(err: HttpErrorResponse): string {
+    if (err.status === 403) {
+      return 'You do not have permission to add a new user to this case — only a platform super-admin can add someone new. You can still change roles or remove existing members.'
+    }
+    if (err.status === 422) {
+      return (
+        err.error?.message ??
+        'This change would leave the case without any ADMIN. Assign ADMIN to at least one member and try again.'
+      )
+    }
+    return 'An unexpected error occurred while saving case members. Please try again.'
+  }
+
+  protected cancel(): void {
+    this.closeRequested.emit()
+  }
+}

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
@@ -1,6 +1,16 @@
 import { HttpErrorResponse } from '@angular/common/http'
 import { LowerCasePipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, input, OnChanges, output, signal } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { MemberItem, MemberItemRoleEnum, User, UserMembershipRoleRoleEnum } from '@whoz-oss/agentos-api-client'
 import { AutocompleteInputComponent, AutocompleteItem } from '@whoz-oss/design-system'
@@ -40,7 +50,7 @@ interface SelectedMember {
   styleUrl: './case-members.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CaseMembersComponent implements OnChanges {
+export class CaseMembersComponent {
   private readonly destroyRef = inject(DestroyRef)
   private readonly memberState = inject(CaseMemberStateService)
   private readonly userState = inject(UserStateService)
@@ -71,15 +81,20 @@ export class CaseMembersComponent implements OnChanges {
     () => new Set(this.selectedMembers().map((m) => m.userId))
   )
 
-  ngOnChanges(): void {
-    this.loadData()
+  constructor() {
+    effect(() => {
+      // Re-load whenever caseId changes (replaces ngOnChanges).
+      this.caseId()
+      this.loadData()
+    })
   }
 
   private loadData(): void {
     this.isLoading.set(true)
     this.errorMessage.set(null)
 
-    const currentUser$ = this.userState.currentUser() ? of(this.userState.currentUser()) : this.userState.loadMe()
+    const currentUser = this.userState.currentUser()
+    const currentUser$ = currentUser ? of(currentUser) : this.userState.loadMe()
 
     currentUser$
       .pipe(
@@ -145,13 +160,14 @@ export class CaseMembersComponent implements OnChanges {
     this.selectedMembers.update((members) => members.filter((m) => m.userId !== userId))
   }
 
-  protected setMemberRole(userId: string, role: string): void {
+  protected setMemberRole(userId: string, event: Event): void {
+    const role = (event.target as HTMLSelectElement).value
     const nextRole = role === MemberItemRoleEnum.ADMIN ? MemberItemRoleEnum.ADMIN : MemberItemRoleEnum.MEMBER
     this.selectedMembers.update((members) => members.map((m) => (m.userId === userId ? { ...m, role: nextRole } : m)))
   }
 
   /** True when the edited roster would leave the case with zero ADMIN — blocks submit. */
-  protected readonly wouldLockOutAdmins = () => !hasAtLeastOneAdmin(this.selectedMembers())
+  protected readonly wouldLockOutAdmins = computed(() => !hasAtLeastOneAdmin(this.selectedMembers()))
 
   // ---------------------------------------------------------------------------
   // Submit / cancel

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
@@ -10,6 +10,7 @@ import {
   input,
   output,
   signal,
+  untracked,
 } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { MemberItem, MemberItemRoleEnum, User, UserMembershipRoleRoleEnum } from '@whoz-oss/agentos-api-client'
@@ -83,9 +84,8 @@ export class CaseMembersComponent {
 
   constructor() {
     effect(() => {
-      // Re-load whenever caseId changes (replaces ngOnChanges).
-      this.caseId()
-      this.loadData()
+      const id = this.caseId() // tracked — re-runs when caseId changes
+      untracked(() => this.loadData()) // untracked — signal writes inside are permitted
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
@@ -1,4 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http'
+import { LowerCasePipe } from '@angular/common'
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, input, OnChanges, output, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { MemberItem, MemberItemRoleEnum, User, UserMembershipRoleRoleEnum } from '@whoz-oss/agentos-api-client'
@@ -34,7 +35,7 @@ interface SelectedMember {
  */
 @Component({
   selector: 'agentos-case-members',
-  imports: [AutocompleteInputComponent],
+  imports: [AutocompleteInputComponent, LowerCasePipe],
   templateUrl: './case-members.component.html',
   styleUrl: './case-members.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -48,6 +49,9 @@ export class CaseMembersComponent implements OnChanges {
 
   /** Emitted when the user saves or cancels — the parent closes the panel. */
   readonly closeRequested = output<void>()
+
+  /** Id of the currently authenticated user — their row is read-only (no role change, no remove). */
+  protected readonly currentUserId = this.userState.currentUser
 
   protected readonly isLoading = signal(false)
   protected readonly isSubmitting = signal(false)

--- a/libs/agentos-ui/src/lib/services/case-member-state.service.ts
+++ b/libs/agentos-ui/src/lib/services/case-member-state.service.ts
@@ -1,0 +1,60 @@
+import { inject, Injectable } from '@angular/core'
+import {
+  CaseMembershipControllerService,
+  MemberItem,
+  UserControllerService,
+  UserMembershipRole,
+  UserMembershipRoleRoleEnum,
+} from '@whoz-oss/agentos-api-client'
+import { Observable } from 'rxjs'
+
+/** One entry in a batch update: upsert (with role) or revoke (without role). */
+export interface CaseMemberUpdateEntry {
+  userId: string
+  /** Omit to revoke all roles for this user. */
+  role?: UserMembershipRoleRoleEnum
+}
+
+/**
+ * CaseMemberStateService — API-layer facade for case ADMIN/MEMBER management.
+ *
+ * Follows the two-layer pattern (see NamespaceMemberStateService): components go through this
+ * facade rather than injecting CaseMembershipControllerService or UserControllerService directly.
+ *
+ * The backend endpoint accepts a flat `Array<UserMembershipRole>` where each entry carries
+ * a userId and an optional role. A missing role means "revoke all relations for this user".
+ *
+ * `listAllUsers()` wraps `UserControllerService.listAllUser()`, which is SUPER_ADMIN-only on
+ * the backend — callers must only invoke it when the current user is a super-admin.
+ */
+@Injectable({ providedIn: 'root' })
+export class CaseMemberStateService {
+  private readonly membership = inject(CaseMembershipControllerService)
+  private readonly userController = inject(UserControllerService)
+
+  /** Current members (and their role) of a case. */
+  listMembers(caseId: string): Observable<MemberItem[]> {
+    return this.membership.getMembersCaseMembership(caseId)
+  }
+
+  /**
+   * All platform users — SUPER_ADMIN only on the backend. Only call this when the current
+   * user is confirmed to be a super-admin.
+   */
+  listAllUsers() {
+    return this.userController.listAllUser()
+  }
+
+  /**
+   * Batch upsert / revoke in a single round-trip. Returns the refreshed member list.
+   *
+   * Pass entries with a role to add or change, and entries without a role to revoke.
+   */
+  updateMembers(caseId: string, entries: CaseMemberUpdateEntry[]): Observable<MemberItem[]> {
+    const payload: UserMembershipRole[] = entries.map((e) => ({
+      userId: e.userId,
+      ...(e.role !== undefined ? { role: e.role } : {}),
+    }))
+    return this.membership.updateMembersCaseMembership(caseId, payload)
+  }
+}

--- a/libs/design-system/src/lib/components/drawer/drawer.component.scss
+++ b/libs/design-system/src/lib/components/drawer/drawer.component.scss
@@ -25,6 +25,7 @@
   }
 
   &__sidenav {
+    overflow: hidden;
     background: var(--glass-bg, rgba(255, 255, 255, 0.92));
     backdrop-filter: var(--glass-backdrop-blur, blur(20px));
     -webkit-backdrop-filter: var(--glass-backdrop-blur, blur(20px));

--- a/libs/design-system/src/lib/components/drawer/drawer.component.scss
+++ b/libs/design-system/src/lib/components/drawer/drawer.component.scss
@@ -25,7 +25,6 @@
   }
 
   &__sidenav {
-    overflow: hidden;
     background: var(--glass-bg, rgba(255, 255, 255, 0.92));
     backdrop-filter: var(--glass-backdrop-blur, blur(20px));
     -webkit-backdrop-filter: var(--glass-backdrop-blur, blur(20px));


### PR DESCRIPTION
## WZ-33829 — Share a case with other users (multi-user case)

Frontend implementation for case membership management. The AgentOS backend was already ready.

### What's new

**`CaseMemberStateService`** — thin facade over the generated `CaseMembershipControllerService` + `UserControllerService`, following the two-layer pattern (same as `NamespaceMemberStateService`).

**`CaseMembersComponent`** — presentational panel to manage a case's ADMIN/MEMBER roster:
- List of current members with role selector (ADMIN / MEMBER) and remove button
- Add-member autocomplete (visible to super-admins only — backend enforces `GET /api/users` as SUPER_ADMIN)
- Own row is read-only: role shown as a badge, no remove button
- Anti-lockout guard: save is blocked if no ADMIN would remain
- Reuses `computeMemberDiff`, `hasAtLeastOneAdmin`, `memberLabel` from `namespace-members.util.ts`

**Integration in `CaseChatComponent`**:
- New `group_add` button in the case header opens the existing right-side drawer on the members panel
- The drawer now switches between two panels (`'files' | 'members'`) via a signal
- Files button explicitly sets the panel back to `'files'` before opening

### No new route
The members panel lives inside the drawer — no separate page, no router navigation.