### PR TITLE
feat: wz-34012: identify scheduler that initiated a case

### DIFF
--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseDto.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseDto.kt
@@ -41,10 +41,6 @@ data class CaseDto(
     val status: CaseStatus = CaseStatus.PENDING,
     val title: String? = null,
     val parentCaseId: UUID? = null,
-    /**
-     * Id of the ScheduledPrompt that triggered this case.
-     * Null for cases started by a human user or a delegation tool.
-     */
     val scheduledPromptId: UUID? = null,
     val created: Instant? = null,
     val modified: Instant? = null,

--- a/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseDto.kt
+++ b/agentos/agentos-sdk/src/main/kotlin/io/whozoss/agentos/sdk/api/case/CaseDto.kt
@@ -29,6 +29,8 @@ import java.util.UUID
  *   `listByUserExternalId` where the target user may differ from the caller. Defaults to false on create.
  * @property role The caller's direct relation on this case (`ADMIN` or `MEMBER`), or null when the
  *   caller has no direct edge (e.g. transitive namespace-admin access). Same population rules as `favorite`.
+ * @property scheduledPromptId Id of the ScheduledPrompt that triggered this case, or null when the
+ *   case was started by a human user or a delegation tool.
  */
 @Schema(name = "Case")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -39,6 +41,11 @@ data class CaseDto(
     val status: CaseStatus = CaseStatus.PENDING,
     val title: String? = null,
     val parentCaseId: UUID? = null,
+    /**
+     * Id of the ScheduledPrompt that triggered this case.
+     * Null for cases started by a human user or a delegation tool.
+     */
+    val scheduledPromptId: UUID? = null,
     val created: Instant? = null,
     val modified: Instant? = null,
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Case.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/Case.kt
@@ -27,4 +27,9 @@ data class Case(
      * Null for top-level cases created directly by a user.
      */
     val parentCaseId: UUID? = null,
+    /**
+     * Id of the [io.whozoss.agentos.scheduledPrompt.ScheduledPrompt] that triggered this case.
+     * Null for cases started by a human user or a delegation tool.
+     */
+    val scheduledPromptId: UUID? = null,
 ) : Entity

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseController.kt
@@ -386,6 +386,7 @@ internal fun toDto(entity: Case) =
         status = entity.status,
         title = entity.title,
         parentCaseId = entity.parentCaseId,
+        scheduledPromptId = entity.scheduledPromptId,
         created = entity.metadata.created,
         modified = entity.metadata.modified,
         // lastMessageAt is not stored on Case — it is resolved at list time by

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNode.kt
@@ -21,6 +21,8 @@ data class CaseNode(
     val status: String,
     val title: String,
     val parentCaseId: String? = null,
+    /** Id of the ScheduledPrompt that triggered this case. Null for user-initiated cases. */
+    val scheduledPromptId: String? = null,
     val created: Instant = Instant.now(),
     val createdBy: String? = null,
     val modified: Instant = Instant.now(),
@@ -44,6 +46,7 @@ data class CaseNode(
             status = CaseStatus.valueOf(status),
             title = title,
             parentCaseId = parentCaseId?.let { UUID.fromString(it) },
+            scheduledPromptId = scheduledPromptId?.let { UUID.fromString(it) },
         )
 
     companion object {
@@ -54,6 +57,7 @@ data class CaseNode(
                 status = case.status.name,
                 title = case.title,
                 parentCaseId = case.parentCaseId?.toString(),
+                scheduledPromptId = case.scheduledPromptId?.toString(),
                 created = case.metadata.created,
                 createdBy = case.metadata.createdBy,
                 modified = case.metadata.modified,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNode.kt
@@ -21,7 +21,6 @@ data class CaseNode(
     val status: String,
     val title: String,
     val parentCaseId: String? = null,
-    /** Id of the ScheduledPrompt that triggered this case. Null for user-initiated cases. */
     val scheduledPromptId: String? = null,
     val created: Instant = Instant.now(),
     val createdBy: String? = null,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -319,6 +319,7 @@ class ScheduledPromptExecutor(
             // Inject resolved content with @mention — selectAgent resolves the agent,
             // PromptCommandParser sees no /command and passes text through unchanged.
             message = "@$agentName $promptContent",
+            scheduledPromptId = scheduledPrompt.id,
             sessionContext = sessionContext,
         )
     }
@@ -333,7 +334,13 @@ class ScheduledPromptExecutor(
      * a UNIQUE constraint on Case keyed by (runId, userId).
      */
     private fun createAndInjectCase(userRun: ScheduledPromptUserRun, context: UserRunContext): UUID {
-        val case = caseService.create(Case(namespaceId = context.namespaceId, title = context.caseTitle))
+        val case = caseService.create(
+            Case(
+                namespaceId = context.namespaceId,
+                title = context.caseTitle,
+                scheduledPromptId = context.scheduledPromptId,
+            ),
+        )
         permissionService.grantPermission(
             userRun.userId.toString(),
             EntityType.CASE,
@@ -371,6 +378,7 @@ class ScheduledPromptExecutor(
         val caseTitle: String,
         val actor: Actor,
         val message: String,
+        val scheduledPromptId: UUID,
         val sessionContext: Map<String, Any?>? = null,
     )
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerMvcIntegrationSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerMvcIntegrationSpec.kt
@@ -77,6 +77,21 @@ class CaseControllerMvcIntegrationSpec : StringSpec() {
                 .andExpect(jsonPath("$.title").value("hello"))
         }
 
+        "POST /api/cases response body contains scheduledPromptId=null for a user-created case" {
+            val ns = namespaceService.create(
+                Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-sp-null"),
+            )
+
+            mockMvc.perform(
+                post("/api/cases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "namespaceId": "${ns.id}" }""")
+            )
+                .andExpect(status().isCreated)
+                // scheduledPromptId is null for cases created directly by a user
+                .andExpect(jsonPath("$.scheduledPromptId").doesNotExist())
+        }
+
         "POST /api/cases without title still returns 201 (title optional)" {
             val ns = namespaceService.create(
                 Namespace(metadata = EntityMetadata(id = UUID.randomUUID()), name = "team-case-no-title"),

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/caseFlow/CaseControllerSpec.kt
@@ -103,6 +103,23 @@ class CaseControllerSpec :
         // Mapping
         // -------------------------------------------------------------------------
 
+        "toDto maps scheduledPromptId when the case was started by a ScheduledPrompt" {
+            val spId = UUID.randomUUID()
+            val entity = caseEntity().copy(scheduledPromptId = spId)
+
+            val result = toDto(entity)
+
+            result.scheduledPromptId shouldBe spId
+        }
+
+        "toDto leaves scheduledPromptId null for a user-initiated case" {
+            val entity = caseEntity()
+
+            val result = toDto(entity)
+
+            result.scheduledPromptId shouldBe null
+        }
+
         "toDto maps all case fields including namespaceId, status, created and modified" {
             val now = Instant.now()
             val later = now.plusSeconds(60)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractCasePersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractCasePersistenceSpec.kt
@@ -167,6 +167,22 @@ abstract class AbstractCasePersistenceSpec : StringSpec() {
             descendants.map { it.id } shouldBe listOf(child.id)
         }
 
+        "scheduledPromptId round-trips through toDomain/fromDomain" {
+            val ns = namespaceRepo.save(namespace())
+            val spId = UUID.randomUUID()
+            val saved = repo.save(case(ns.id).copy(scheduledPromptId = spId))
+            val found = repo.findByIds(listOf(saved.id))
+            found shouldHaveSize 1
+            found.first().scheduledPromptId shouldBe spId
+        }
+
+        "scheduledPromptId is null when not set" {
+            val ns = namespaceRepo.save(namespace())
+            val saved = repo.save(case(ns.id))
+            val found = repo.findByIds(listOf(saved.id))
+            found.first().scheduledPromptId shouldBe null
+        }
+
         "deleteByParent removes all cases in namespace without touching others" {
             val ns1 = namespaceRepo.save(namespace())
             val ns2 = namespaceRepo.save(namespace())

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -692,6 +692,50 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
+        // Phase B — scheduledPromptId propagation
+        // -------------------------------------------------------------------------
+
+        "Phase B: Case created by ScheduledPrompt carries scheduledPromptId set to the ScheduledPrompt id" {
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+
+            val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
+            val caseSlot = slot<Case>()
+            val caseService = mockk<CaseService>(relaxed = true).also {
+                every { it.create(capture(caseSlot)) } returns createdCase
+                every { it.findActiveRuntime(caseId) } returns null
+                every { it.findById(caseId) } returns createdCase.copy(status = CaseStatus.IDLE)
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = runRepo,
+                userRunRepo = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).consumeAvailable()
+
+            caseSlot.captured.scheduledPromptId shouldBe sp.id
+        }
+
+        // -------------------------------------------------------------------------
         // Phase B: prompt or agent not found — UserRun marked FAILED
         // -------------------------------------------------------------------------
 

--- a/agentos/openapi/agentos-openapi.yaml
+++ b/agentos/openapi/agentos-openapi.yaml
@@ -3463,6 +3463,9 @@ components:
           enum:
           - ADMIN
           - MEMBER
+        scheduledPromptId:
+          type: string
+          format: uuid
         status:
           type: string
           enum:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,22 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
+  libs/agent/dist:
+    dependencies:
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   libs/coday-events/dist:
     dependencies:
       tslib:
@@ -636,7 +652,27 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
+  libs/coday-services/dist:
+    dependencies:
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   libs/core:
+    dependencies:
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
+  libs/core/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -744,7 +780,27 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
+  libs/handlers/config/dist:
+    dependencies:
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   libs/handlers/load:
+    dependencies:
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
+  libs/handlers/load/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -764,7 +820,27 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
+  libs/handlers/looper/dist:
+    dependencies:
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   libs/handlers/memory:
+    dependencies:
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
+  libs/handlers/memory/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -801,6 +877,16 @@ importers:
         version: 6.0.3
 
   libs/handlers/stats:
+    dependencies:
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
+  libs/handlers/stats/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -933,6 +1019,19 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
+  libs/integrations/excel/dist:
+    dependencies:
+      exceljs:
+        specifier: 4.4.0
+        version: 4.4.0
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   libs/integrations/file:
     dependencies:
       tslib:
@@ -1000,6 +1099,22 @@ importers:
         version: 6.0.3
 
   libs/integrations/http:
+    dependencies:
+      oauth4webapi:
+        specifier: 'catalog:'
+        version: 3.8.3
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
+  libs/integrations/http/dist:
     dependencies:
       oauth4webapi:
         specifier: 'catalog:'
@@ -11580,7 +11695,7 @@ snapshots:
       tinyglobby: 0.2.16
       tslib: 2.8.1
       typescript: 6.0.3
-      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 22.0.8(@angular/compiler@22.0.8)(rxjs@7.8.2)(zone.js@0.16.1)
@@ -11612,7 +11727,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 6.0.12(@types/node@26.3.0)
-      '@vitejs/plugin-basic-ssl': 2.3.0(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))
+      '@vitejs/plugin-basic-ssl': 2.3.0(vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))
       beasties: 0.4.2
       browserslist: 4.28.8
       esbuild: 0.28.1
@@ -15839,11 +15954,7 @@ snapshots:
 
   '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
-
-  '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))':
-    dependencies:
-      vite: 7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vscode/ripgrep@1.15.9':
     dependencies:
@@ -23249,7 +23360,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0):
+  vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.7)
@@ -23262,7 +23373,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       less: 4.5.1
-      sass: 1.99.0
+      sass: 1.103.1
       sass-embedded: 1.103.1
       terser: 5.51.0
       tsx: 4.20.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,22 +620,6 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
-  libs/agent/dist:
-    dependencies:
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
   libs/coday-events/dist:
     dependencies:
       tslib:
@@ -652,27 +636,7 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
-  libs/coday-services/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
   libs/core:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
-  libs/core/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -780,27 +744,7 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
-  libs/handlers/config/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
   libs/handlers/load:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
-  libs/handlers/load/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -820,27 +764,7 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
-  libs/handlers/looper/dist:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
   libs/handlers/memory:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
-  libs/handlers/memory/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -877,16 +801,6 @@ importers:
         version: 6.0.3
 
   libs/handlers/stats:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
-  libs/handlers/stats/dist:
     dependencies:
       tslib:
         specifier: 'catalog:'
@@ -1019,19 +933,6 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
-  libs/integrations/excel/dist:
-    dependencies:
-      exceljs:
-        specifier: 4.4.0
-        version: 4.4.0
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
   libs/integrations/file:
     dependencies:
       tslib:
@@ -1099,22 +1000,6 @@ importers:
         version: 6.0.3
 
   libs/integrations/http:
-    dependencies:
-      oauth4webapi:
-        specifier: 'catalog:'
-        version: 3.8.3
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
-      typescript:
-        specifier: catalog:dev
-        version: 6.0.3
-
-  libs/integrations/http/dist:
     dependencies:
       oauth4webapi:
         specifier: 'catalog:'
@@ -11695,7 +11580,7 @@ snapshots:
       tinyglobby: 0.2.16
       tslib: 2.8.1
       typescript: 6.0.3
-      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 22.0.8(@angular/compiler@22.0.8)(rxjs@7.8.2)(zone.js@0.16.1)
@@ -11727,7 +11612,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 6.0.12(@types/node@26.3.0)
-      '@vitejs/plugin-basic-ssl': 2.3.0(vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))
+      '@vitejs/plugin-basic-ssl': 2.3.0(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))
       beasties: 0.4.2
       browserslist: 4.28.8
       esbuild: 0.28.1
@@ -15954,7 +15839,11 @@ snapshots:
 
   '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
+
+  '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0))':
+    dependencies:
+      vite: 7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vscode/ripgrep@1.15.9':
     dependencies:
@@ -23360,7 +23249,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0):
+  vite@7.3.6(@types/node@24.7.2)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.103.1)(sass@1.99.0)(terser@5.51.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.7)
@@ -23373,7 +23262,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       less: 4.5.1
-      sass: 1.103.1
+      sass: 1.99.0
       sass-embedded: 1.103.1
       terser: 5.51.0
       tsx: 4.20.6


### PR DESCRIPTION
Context
The scheduler creates Case entities on behalf of users when a ScheduledPrompt fires. There was no way for downstream consumers — other services, analytics, or future agent logic — to distinguish a scheduler-initiated case from one opened by a human or a delegation tool. The Case entity carried no provenance information beyond its title, which is a fragile and informal signal.

Engineering Decisions
scheduledPromptId as a nullable UUID, not a boolean flag. A boolean scheduledBySystem: Boolean would answer "was this automated?" but nothing more. Storing the actual ScheduledPrompt id preserves the link back to the originating configuration, which is more useful for filtering, auditing, and potential future joins without requiring a schema change later. Null means user- or delegation-initiated; a non-null value means scheduler-initiated and identifies which prompt was responsible.

Field placed on Case, not on CaseEvent. The prompt injection manifests as a MessageEvent, but provenance is a property of the conversation itself, not of any individual event. Placing it on Case means any consumer that fetches the case gets the information without having to scan the event log.

Propagated through all layers without special-casing. The field flows from the domain (Case) through persistence (CaseNode) to the API contract (CaseDto), following the existing round-trip pattern used by parentCaseId. No layer is aware that the field originates from the scheduler; each layer simply carries what it is given. This keeps the scheduler as the sole writer and avoids coupling the persistence or HTTP layers to scheduler-specific logic.

Set in ScheduledPromptExecutor.createAndInjectCase, not in CaseService. The service has no knowledge of scheduled prompts and should not acquire it. The executor is the only caller that knows the originating ScheduledPrompt id at case-creation time, so it is the correct place to set the field. The UserRunContext data class was extended to carry scheduledPromptId so the value is resolved once during context resolution and flows cleanly into case creation.

Trade-offs & Alternatives
A source: CaseSource enum (USER, SCHEDULER, DELEGATION) was briefly considered. It would be more self-documenting at the cost of requiring a schema migration whenever a new source is added. The nullable foreign-key approach is more flexible and sufficient for the current use case.

Storing the ScheduledPromptRun id instead of the ScheduledPrompt id was also considered. The run id would identify a specific execution slot, but the prompt id is the more durable reference — it points to the configuration that drove the execution, which is what consumers are likely to need for filtering or display.

Assumptions
The field is intentionally write-once: once a case is created with a scheduledPromptId, nothing updates it. The PUT /api/cases/{id} endpoint already guards against mass assignment of status and namespaceId; scheduledPromptId is not exposed as an updatable field in the controller, so no additional guard was needed.

Limitations / Follow-up
The field is currently informational only — no query, index, or repository method filters by scheduledPromptId. If listing all cases for a given scheduled prompt becomes a product requirement, a dedicated findByScheduledPromptId query and a Neo4j index on the property will be needed.