### PR TITLE
fix(agentos-ui): add infinite scroll to ds-entity-list to prevent freeze on large user lists

### DIFF
--- a/libs/agentos-ui/src/lib/components/user-list/user-list.component.html
+++ b/libs/agentos-ui/src/lib/components/user-list/user-list.component.html
@@ -5,6 +5,7 @@
   [showCreate]="true"
   emptyMessage="No users found."
   cardMinWidth="320px"
+  [pageSize]="100"
   [itemTemplate]="userItemTpl"
   (createRequested)="navigateToCreate()"
 >

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.html
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.html
@@ -58,11 +58,12 @@
       } @else {
         <!-- Flat: no groups, or search active -->
         <div class="entity-list__grid" [style.--card-min-width]="cardMinWidth()">
-          @for (item of filteredItems(); track item.id) {
+          @for (item of pagedItems(); track item.id) {
             <ng-container *ngTemplateOutlet="itemTemplate() ?? defaultCard; context: { $implicit: item }" />
           }
         </div>
       }
+      <div #scrollSentinel class="entity-list__sentinel"></div>
     </div>
   }
 </div>

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
@@ -179,6 +179,15 @@
   color: var(--color-neutral-500);
 }
 
+// ── Infinite scroll sentinel ──────────────────────────────────────────────
+
+.entity-list__sentinel {
+  height: 40px;
+  width: 100%;
+  // Present in DOM always (when paged) so IntersectionObserver can attach on init.
+  // Acts as a trigger only when more items exist.
+}
+
 // ── Grid ───────────────────────────────────────────────────────────────────
 
 .entity-list__grid {

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.ts
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.ts
@@ -2,8 +2,10 @@ import {
   AfterViewInit,
   Component,
   computed,
+  effect,
   ElementRef,
   input,
+  OnDestroy,
   output,
   signal,
   TemplateRef,
@@ -46,7 +48,7 @@ export interface GroupedItems {
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './entity-list.component.scss',
 })
-export class EntityListComponent implements AfterViewInit {
+export class EntityListComponent implements AfterViewInit, OnDestroy {
   readonly title = input.required<string>()
   readonly items = input<EntityListItem[]>([])
   readonly searchPlaceholder = input<string>('Filter…')
@@ -58,6 +60,12 @@ export class EntityListComponent implements AfterViewInit {
   /** Hide the visible title (e.g. when a tab already labels the section); search/content stay. */
   readonly hideTitle = input<boolean>(false)
   readonly itemTemplate = input<TemplateRef<{ $implicit: EntityListItem }> | undefined>(undefined)
+  /**
+   * When > 0, enables infinite scroll: renders `pageSize` items initially and
+   * loads more as the user scrolls to the bottom sentinel.
+   * 0 (default) renders all items at once.
+   */
+  readonly pageSize = input<number>(0)
   /**
    * When true, the internal search filter is disabled — items are displayed as-is.
    * Use this when the parent manages its own filtering logic and passes pre-filtered items.
@@ -82,10 +90,15 @@ export class EntityListComponent implements AfterViewInit {
   readonly searchChanged = output<string>()
 
   @ViewChild('searchInput') private searchInputRef?: ElementRef<HTMLInputElement>
+  @ViewChild('scrollSentinel') private sentinelRef?: ElementRef<HTMLElement>
 
   protected readonly searchQuery = signal('')
+  protected readonly visibleCount = signal(0)
+  private observer?: IntersectionObserver
 
   protected readonly isSearchActive = computed(() => this.searchQuery().trim().length > 0)
+
+  protected readonly isPaged = computed(() => this.pageSize() > 0)
 
   protected readonly filteredItems = computed(() => {
     const all = this.items()
@@ -97,8 +110,15 @@ export class EntityListComponent implements AfterViewInit {
     )
   })
 
+  protected readonly pagedItems = computed(() => {
+    const all = this.filteredItems()
+    return this.isPaged() ? all.slice(0, this.visibleCount()) : all
+  })
+
+  protected readonly hasMore = computed(() => this.isPaged() && this.visibleCount() < this.filteredItems().length)
+
   protected readonly groupedItems = computed<GroupedItems[]>(() => {
-    const items = this.filteredItems()
+    const items = this.pagedItems()
     const groups: GroupedItems[] = []
     const byKey = new Map<string, GroupedItems>()
 
@@ -125,10 +145,34 @@ export class EntityListComponent implements AfterViewInit {
       (this.keepGroupsWhileSearching() || !this.isSearchActive()) && this.groupedItems().some((g) => g.groupKey !== '')
   )
 
+  constructor() {
+    // Reset visible count whenever the page size or search query changes
+    effect(() => {
+      const size = this.pageSize()
+      this.searchQuery() // track
+      this.visibleCount.set(size > 0 ? size : 0)
+    })
+  }
+
   ngAfterViewInit(): void {
     if (this.autoFocusSearch()) {
       setTimeout(() => this.searchInputRef?.nativeElement.focus(), 0)
     }
+    if (this.isPaged() && this.sentinelRef) {
+      this.observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting && this.hasMore()) {
+            this.visibleCount.update((n) => n + this.pageSize())
+          }
+        },
+        { threshold: 0.1 }
+      )
+      this.observer.observe(this.sentinelRef.nativeElement)
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect()
   }
 
   protected onSearchChange(value: string): void {


### PR DESCRIPTION
Adds a `pageSize` input to `ds-entity-list` (default `0` = disabled).
When set, an `IntersectionObserver` on a bottom sentinel progressively
loads items in chunks instead of rendering the full list at once.

`user-list` opts in with `[pageSize]="100"`.

Fixes #1258