### PR TITLE
fix: remove ignoreDeprecations TS5 option invalid in TS6

### DIFF
--- a/apps/client-e2e/tsconfig.json
+++ b/apps/client-e2e/tsconfig.json
@@ -6,10 +6,9 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "sourceMap": false,
-    "strict": true,
-    "ignoreDeprecations": "6.0",
-    "rootDir": "."
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "include": [

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -13,8 +13,7 @@
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
-    "target": "es2022",
-    "ignoreDeprecations": "6.0"
+    "target": "es2022"
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/apps/desktop-twin/tsconfig.json
+++ b/apps/desktop-twin/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "compilerOptions": {
-    "ignoreDeprecations": "6.0"
-  },
+  "compilerOptions": {},
   "extends": "../../tsconfig.base.json",
   "files": [],
   "include": [],

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "compilerOptions": {
-    "ignoreDeprecations": "6.0"
-  },
+  "compilerOptions": {},
   "extends": "../../tsconfig.base.json",
   "files": [],
   "include": [],

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,6 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "ignoreDeprecations": "6.0"
-  }
+  "compilerOptions": {},
+  "extends": "../../tsconfig.base.json"
 }

--- a/libs/agent/tsconfig.json
+++ b/libs/agent/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/agentos-api-client/tsconfig.json
+++ b/libs/agentos-api-client/tsconfig.json
@@ -15,8 +15,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "target": "es2022",
-    "ignoreDeprecations": "6.0"
+    "target": "es2022"
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/agentos-dataflow/tsconfig.json
+++ b/libs/agentos-dataflow/tsconfig.json
@@ -7,8 +7,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-members/case-members.component.ts
@@ -84,7 +84,7 @@ export class CaseMembersComponent {
 
   constructor() {
     effect(() => {
-      const id = this.caseId() // tracked — re-runs when caseId changes
+      this.caseId() // tracked — re-runs when caseId changes
       untracked(() => this.loadData()) // untracked — signal writes inside are permitted
     })
   }

--- a/libs/agentos-ui/tsconfig.json
+++ b/libs/agentos-ui/tsconfig.json
@@ -13,8 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "target": "es2022",
-    "ignoreDeprecations": "6.0"
+    "target": "es2022"
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/coday-services/tsconfig.json
+++ b/libs/coday-services/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/design-system/tsconfig.json
+++ b/libs/design-system/tsconfig.json
@@ -13,8 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "target": "es2022",
-    "ignoreDeprecations": "6.0"
+    "target": "es2022"
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/desktop-core/tsconfig.json
+++ b/libs/desktop-core/tsconfig.json
@@ -6,8 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2021",
-    "types": ["node"],
-    "ignoreDeprecations": "6.0"
+    "types": ["node"]
   },
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*.ts"]

--- a/libs/function/tsconfig.json
+++ b/libs/function/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/handler/tsconfig.json
+++ b/libs/handler/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/integration/tsconfig.json
+++ b/libs/integration/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/model/tsconfig.json
+++ b/libs/model/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/repository/tsconfig.json
+++ b/libs/repository/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/service/tsconfig.json
+++ b/libs/service/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/libs/utils/tsconfig.json
+++ b/libs/utils/tsconfig.json
@@ -6,8 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0"
+    "strict": true
   },
   "extends": "../../tsconfig.base.json",
   "files": [],

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "node",
-    "types": ["node"],
-    "ignoreDeprecations": "6.0"
+    "types": ["node"]
   },
   "exclude": ["node_modules"],
   "extends": "../tsconfig.base.json",

--- a/tools/plugins/agentos-gradle/tsconfig.json
+++ b/tools/plugins/agentos-gradle/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "compilerOptions": {
-    "ignoreDeprecations": "6.0"
-  },
+  "compilerOptions": {},
   "extends": "../../../tsconfig.base.json",
   "files": [],
   "include": [],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,6 @@
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
     "importHelpers": true,
     "lib": ["ESNext", "dom"],
     "module": "esnext",
@@ -16,6 +15,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUncheckedIndexedAccess": true,
+    "noUncheckedSideEffectImports": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "paths": {
@@ -78,7 +78,6 @@
     "strict": true,
     "target": "ESNext",
     "typeRoots": ["node_modules/@types"],
-    "noUncheckedSideEffectImports": false,
     "types": ["*"]
   },
   "exclude": ["node_modules", "tmp", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
-  "extends": "./tsconfig.base.json",
-  "include": ["libs/**/*", "apps/**/*"],
+  "compilerOptions": {},
   "exclude": ["node_modules", "dist", "tmp"],
-  "compilerOptions": {
-    "ignoreDeprecations": "6.0"
-  }
+  "extends": "./tsconfig.base.json",
+  "include": ["libs/**/*", "apps/**/*"]
 }


### PR DESCRIPTION
## Problem

The PR #1252 (nx23 / angular22 upgrade) bumped TypeScript from 5.9.3 to **6.0.3** and added `"ignoreDeprecations": "6.0"` to `tsconfig.base.json` and all project tsconfigs.

However, `ignoreDeprecations` was a **TypeScript 5.x-only** escape hatch to opt into upcoming breaking changes early — it was **removed in TypeScript 6** because those changes are now the default. Keeping it in any tsconfig with TS6 causes:

```
TS5103: Invalid value for '--ignoreDeprecations'
```

This broke the entire frontend build chain (client, model, and all downstream libs).

## Fix

- Remove `"ignoreDeprecations": "6.0"` from all 23 tsconfig files across the workspace
- Fix a secondary `TS6133` error in `case-members.component.ts`: `const id = this.caseId()` assigned a tracked signal read to an unused variable — simplified to `this.caseId()` directly (idiomatic Angular signals pattern for side-effect tracking in `effect()`)

## Verification

`pnpm nx build client` passes ✅ (9.2s)