### PR TITLE
fix: discard stale MCP OAuth client registration when tokens are absent

### DIFF
--- a/libs/mcp/src/lib/mcp-oauth-provider.ts
+++ b/libs/mcp/src/lib/mcp-oauth-provider.ts
@@ -162,11 +162,21 @@ export class McpOAuthProvider implements OAuthClientProvider {
       }
     }
 
-    const raw = this.loadRaw()?.clientInfo
+    const storage = this.loadRaw()
+    const raw = storage?.clientInfo
     if (!raw) {
       this.interactor.debug(`[MCP OAuth:${this.mcpId}] no stored client info found`)
       return undefined
     }
+
+    // If clientInfo exists but tokens are absent, the previous OAuth flow was interrupted
+    // before the code exchange completed. Treat as unregistered to force a clean re-registration
+    // rather than reusing a potentially stale/revoked client_id.
+    if (!storage?.tokens) {
+      this.clearStorage()
+      return undefined
+    }
+
     const parsed = OAuthClientInformationFullSchema.safeParse(raw)
     if (!parsed.success) {
       this.interactor.warn(


### PR DESCRIPTION
## Problem

When an MCP OAuth flow is interrupted between the two phases (dynamic client registration succeeded, but authorization code exchange failed/timed out), the user.yaml ends up with a `clientInfo` but no `tokens`:

```yaml
integration:
  atlassian-rovo-sprint:
    mcpOAuth:
      clientInfo:
        client_id: NXhD21hqBscLcq9k
        # ... no tokens!
```

On the next startup, `clientInformation()` returned this orphaned `clientInfo`, causing the MCP SDK to attempt an OAuth flow with a potentially stale/revoked `client_id` — without triggering a fresh dynamic registration. The server would reject the request silently, leaving the MCP server permanently broken until the user manually deleted the entry.

## Fix

In `clientInformation()`, if `clientInfo` exists but `tokens` are absent, the previous OAuth flow was incomplete. We now discard the stale registration and return `undefined`, which forces the SDK to perform a clean re-registration.

```typescript
if (!storage?.tokens) {
  this.interactor.warn(`... previous OAuth flow was incomplete, discarding stale client registration`)
  this.clearStorage()
  return undefined
}
```

This automates the manual workaround (deleting the integration entry) that was needed before.