### PR TITLE
fix: kill AgentOS child process on Node.js unclean exit to prevent Neo4j store_lock orphan

### DIFF
--- a/apps/server/src/lib/agentos-runtime.ts
+++ b/apps/server/src/lib/agentos-runtime.ts
@@ -354,7 +354,25 @@ export async function startAgentos(
   debugLog('AGENTOS', `[RUNTIME] AgentOS is up and healthy on port ${agentosPort}`)
 
   // ------------------------------------------------------------------
-  // 7. Build and return the handle
+  // 7. Register a synchronous exit handler to kill the child process
+  //    if Node.js exits without going through gracefulShutdown (crash,
+  //    process.exit(), or kill -9 on the Node process itself).
+  //    The 'exit' handler is the only hook that runs in all exit scenarios;
+  //    it must be synchronous — child.kill() qualifies.
+  // ------------------------------------------------------------------
+  const exitHandler = () => {
+    if (child.exitCode === null && !child.killed) {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // child already dead — ignore
+      }
+    }
+  }
+  process.on('exit', exitHandler)
+
+  // ------------------------------------------------------------------
+  // 8. Build and return the handle
   // ------------------------------------------------------------------
   const shutdown = (): Promise<void> =>
     new Promise((resolve) => {
@@ -388,5 +406,10 @@ export async function startAgentos(
       }
     })
 
-  return { port: agentosPort, spawned: true, shutdown }
+  const shutdownWithCleanup = async (): Promise<void> => {
+    process.removeListener('exit', exitHandler)
+    return shutdown()
+  }
+
+  return { port: agentosPort, spawned: true, shutdown: shutdownWithCleanup }
 }


### PR DESCRIPTION
## Problem

When Node.js terminates uncleanly (crash, `process.exit()`, or `kill -9` on the Node process), the AgentOS Java child process is left running. Its embedded Neo4j database holds a `store_lock` file, which blocks the next Coday startup with:

```
Lock file has been locked by another process: .../data/neo4j/data/databases/store_lock
```

## Root cause

The existing graceful shutdown (SIGTERM → SIGKILL after 10s) is async and only runs via `process.on('SIGTERM/SIGINT/SIGHUP/SIGUSR2', ...)`. These handlers are bypassed on unclean exits.

## Fix

Added a synchronous `process.on('exit', exitHandler)` in `agentos-runtime.ts`, registered immediately after the Java process becomes healthy. This handler sends `SIGKILL` to the child synchronously — the only viable approach since `exit` handlers must be synchronous.

The handler is removed via `removeListener` when the graceful shutdown path runs, preventing a double kill.

**Coverage after fix:**
- Normal exit (Ctrl+C, SIGTERM): graceful SIGTERM → SIGKILL fallback (unchanged)
- Unclean exit (crash, `process.exit()`, `kill -9` on Node): synchronous `exit` handler → SIGKILL

**No impact on adopted processes** (externally managed AgentOS instances): the `exit` handler is only registered for spawned processes.