### PR TITLE
feat: #34228 add WhatsNext tool to REDIRECT integration

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
@@ -94,7 +94,15 @@ class RedirectToolPlugin(
         } else {
             logger.info { "[RedirectToolPlugin] Resolved ${eligibleAgents.size} eligible agent(s) for namespace $namespaceId" }
         }
-        return listOf(RedirectTool(configName = configName, eligibleAgents = eligibleAgents))
+
+        val redirectTool = RedirectTool(configName = configName, eligibleAgents = eligibleAgents)
+        val guideline = config?.get("guideline")?.asText()?.takeIf { it.isNotBlank() }
+        return if (guideline != null) {
+            logger.info { "[RedirectToolPlugin] Guideline present — adding WhatsNextTool for namespace $namespaceId" }
+            listOf(redirectTool, WhatsNextTool(configName = configName, guideline = guideline))
+        } else {
+            listOf(redirectTool)
+        }
     }
 
     companion object : KLogging() {
@@ -113,6 +121,11 @@ class RedirectToolPlugin(
                         "description": "Glob patterns matching agent names this integration may redirect to. Use \"*\" for all agents. Examples: [\"*\"], [\"Github*\", \"Jira*\"].",
                         "items": { "type": "string" },
                         "default": ["*"]
+                    },
+                    "guideline": {
+                        "type": "string",
+                        "title": "Process Guideline",
+                        "description": "Optional process guideline returned verbatim by the WhatsNext tool. When present, a WhatsNextTool is added to the agent's tool set so the agent can consult the guideline at the end of its turn and decide whether to hand off to another agent."
                     }
                 },
                 "additionalProperties": false

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/RedirectToolPlugin.kt
@@ -125,7 +125,8 @@ class RedirectToolPlugin(
                     "guideline": {
                         "type": "string",
                         "title": "Process Guideline",
-                        "description": "Optional process guideline returned verbatim by the WhatsNext tool. When present, a WhatsNextTool is added to the agent's tool set so the agent can consult the guideline at the end of its turn and decide whether to hand off to another agent."
+                        "description": "Optional process guideline returned verbatim by the WhatsNext tool. When present, a WhatsNextTool is added to the agent's tool set so the agent can consult the guideline at the end of its turn and decide whether to hand off to another agent.",
+                        "x-ui-widget": "textarea"
                     }
                 },
                 "additionalProperties": false

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/WhatsNextTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/WhatsNextTool.kt
@@ -34,9 +34,11 @@ class WhatsNextTool(
     override val name: String = configName?.let { "${it}__whatsNext" } ?: "whatsNext"
 
     override val description: String =
-        "Call this tool when you have finished helping the user with their current request. " +
-            "It returns the process guideline that tells you whether another agent should take over " +
-            "and, if so, which one. Always call this tool before ending your turn."
+        "Call this tool when you have finished the part of the work that falls within your scope. " +
+            "It returns a guideline telling you what the workflow expects next: either that another agent should " +
+            "take over (and which one), or that your step was the last one. If it names another agent, don't " +
+            "attempt that agent's work and switch to it.\n\n" +
+            "Call it once, at completion, including when the request turns out to be outside your scope and you've done what you can."
 
     override val inputSchema: String =
         """
@@ -60,8 +62,10 @@ class WhatsNextTool(
      * valid JSON. Plain-text responses can be mistaken by some LLMs as argument JSON
      * for subsequent tool calls, causing a parse error.
      */
-    override suspend fun execute(input: Nothing?, context: ToolContext): ToolExecutionResult =
-        ToolExecutionResult.success(objectMapper.writeValueAsString(mapOf("guideline" to guideline)))
+    override suspend fun execute(
+        input: Nothing?,
+        context: ToolContext,
+    ): ToolExecutionResult = ToolExecutionResult.success(objectMapper.writeValueAsString(mapOf("guideline" to guideline)))
 
     companion object {
         private val objectMapper = jacksonObjectMapper()

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/WhatsNextTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/WhatsNextTool.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.redirect
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolExecutionResult
@@ -9,8 +10,8 @@ import io.whozoss.agentos.sdk.tool.ToolExecutionResult
  *
  * The LLM calls this tool when it has finished helping the user and needs to determine
  * whether a next step exists in the current workflow. The tool returns the guideline
- * verbatim; the agent then reasons over it — using the available [RedirectTool] if a
- * handoff is warranted — without any additional LLM call inside this tool.
+ * wrapped in a JSON object (`{"guideline": "..."}`) so the response is always valid JSON,
+ * which prevents downstream LLMs from misinterpreting plain text as tool-call arguments.
  *
  * ## Design rationale
  *
@@ -29,10 +30,7 @@ import io.whozoss.agentos.sdk.tool.ToolExecutionResult
 class WhatsNextTool(
     configName: String?,
     private val guideline: String,
-) : StandardTool<WhatsNextTool.Input> {
-    /** Empty input — the LLM calls this tool with no arguments. */
-    class Input
-
+) : StandardTool<Nothing> {
     override val name: String = configName?.let { "${it}__whatsNext" } ?: "whatsNext"
 
     override val description: String =
@@ -50,8 +48,22 @@ class WhatsNextTool(
         """.trimIndent()
 
     override val version: String = "1.0.0"
-    override val paramType: Class<Input> = Input::class.java
 
-    override suspend fun execute(input: Input?, context: ToolContext): ToolExecutionResult =
-        ToolExecutionResult.success(guideline)
+    /**
+     * No input type — the LLM always sends `{}`. Setting paramType to null causes
+     * [executeWithJson] to skip deserialization and call [execute] with null directly.
+     */
+    override val paramType: Class<Nothing>? = null
+
+    /**
+     * Returns the guideline wrapped in a JSON object so the tool response is always
+     * valid JSON. Plain-text responses can be mistaken by some LLMs as argument JSON
+     * for subsequent tool calls, causing a parse error.
+     */
+    override suspend fun execute(input: Nothing?, context: ToolContext): ToolExecutionResult =
+        ToolExecutionResult.success(objectMapper.writeValueAsString(mapOf("guideline" to guideline)))
+
+    companion object {
+        private val objectMapper = jacksonObjectMapper()
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/WhatsNextTool.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/redirect/WhatsNextTool.kt
@@ -1,0 +1,57 @@
+package io.whozoss.agentos.redirect
+
+import io.whozoss.agentos.sdk.tool.StandardTool
+import io.whozoss.agentos.sdk.tool.ToolContext
+import io.whozoss.agentos.sdk.tool.ToolExecutionResult
+
+/**
+ * Tool that returns the process guideline stored in the REDIRECT [IntegrationConfig].
+ *
+ * The LLM calls this tool when it has finished helping the user and needs to determine
+ * whether a next step exists in the current workflow. The tool returns the guideline
+ * verbatim; the agent then reasons over it — using the available [RedirectTool] if a
+ * handoff is warranted — without any additional LLM call inside this tool.
+ *
+ * ## Design rationale
+ *
+ * Keeping the guideline out of the agent's system prompt preserves context efficiency:
+ * the process guideline is long, rarely needed on every turn, and only relevant at the
+ * moment the agent concludes its task. Delivering it as a tool response means the LLM
+ * receives it exactly when it is about to decide on the next step.
+ *
+ * The tool takes no input — the LLM calls it with an empty argument object. The
+ * [inputSchema] reflects this with an empty `properties` object.
+ *
+ * @param configName The [IntegrationConfig.name] used as tool-name prefix (e.g.
+ *   `"REDIRECT_all__whatsNext"`).
+ * @param guideline The process guideline string from the integration config parameters.
+ */
+class WhatsNextTool(
+    configName: String?,
+    private val guideline: String,
+) : StandardTool<WhatsNextTool.Input> {
+    /** Empty input — the LLM calls this tool with no arguments. */
+    class Input
+
+    override val name: String = configName?.let { "${it}__whatsNext" } ?: "whatsNext"
+
+    override val description: String =
+        "Call this tool when you have finished helping the user with their current request. " +
+            "It returns the process guideline that tells you whether another agent should take over " +
+            "and, if so, which one. Always call this tool before ending your turn."
+
+    override val inputSchema: String =
+        """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+        """.trimIndent()
+
+    override val version: String = "1.0.0"
+    override val paramType: Class<Input> = Input::class.java
+
+    override suspend fun execute(input: Input?, context: ToolContext): ToolExecutionResult =
+        ToolExecutionResult.success(guideline)
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.tool.ToolContext
@@ -195,5 +196,88 @@ class RedirectToolPluginSpec : StringSpec({
         val tools = plugin.provideTools(config = null, context = null)
 
         tools.shouldBeEmpty()
+    }
+
+    // -------------------------------------------------------------------------
+    // WhatsNext tool
+    // -------------------------------------------------------------------------
+
+    "provideTools returns only RedirectTool when config has no guideline" {
+        val plugin = RedirectToolPlugin { _, _, _ -> listOf(agentConfig("AgentA")) }
+        val config = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper()
+            .readTree("""{"agents":["*"]}""")
+
+        val tools = plugin.provideTools(config = config, context = context(userId = userId))
+
+        tools shouldHaveSize 1
+        tools.first() shouldBe tools.filterIsInstance<RedirectTool>().first()
+    }
+
+    "provideTools returns only RedirectTool when config is null" {
+        val plugin = RedirectToolPlugin { _, _, _ -> listOf(agentConfig("AgentA")) }
+
+        val tools = plugin.provideTools(config = null, context = context(userId = userId))
+
+        tools shouldHaveSize 1
+        tools.first() shouldBe tools.filterIsInstance<RedirectTool>().first()
+    }
+
+    "provideTools returns RedirectTool and WhatsNextTool when guideline is present" {
+        val plugin = RedirectToolPlugin { _, _, _ -> listOf(agentConfig("AgentA")) }
+        val config = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper().readTree(
+            """{"agents":["*"],"guideline":"When done, redirect to TRSharing."}"""
+        )
+
+        val tools = plugin.provideTools(config = config, context = context(userId = userId))
+
+        tools shouldHaveSize 2
+        tools.filterIsInstance<RedirectTool>() shouldHaveSize 1
+        tools.filterIsInstance<WhatsNextTool>() shouldHaveSize 1
+    }
+
+    "provideTools WhatsNextTool carries the guideline from config" {
+        val guideline = "When done, redirect to TRSharing."
+        val plugin = RedirectToolPlugin { _, _, _ -> listOf(agentConfig("AgentA")) }
+        val config = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper().readTree(
+            """{"guideline":"$guideline"}"""
+        )
+
+        val tools = plugin.provideTools(config = config, context = context(userId = userId))
+        val whatsNext = tools.filterIsInstance<WhatsNextTool>().first()
+
+        // execute returns the guideline verbatim
+        val result = kotlinx.coroutines.runBlocking {
+            whatsNext.execute(WhatsNextTool.Input(), mockk(relaxed = true))
+        }
+        result.output shouldBe guideline
+        result.success shouldBe true
+    }
+
+    "provideTools does not add WhatsNextTool when guideline is blank" {
+        val plugin = RedirectToolPlugin { _, _, _ -> listOf(agentConfig("AgentA")) }
+        val config = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper().readTree(
+            """{"guideline":"   "}"""
+        )
+
+        val tools = plugin.provideTools(config = config, context = context(userId = userId))
+
+        tools shouldHaveSize 1
+        tools.filterIsInstance<WhatsNextTool>().shouldBeEmpty()
+    }
+
+    "provideTools WhatsNextTool name uses configName prefix" {
+        val plugin = RedirectToolPlugin { _, _, _ -> listOf(agentConfig("AgentA")) }
+        val config = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper().readTree(
+            """{"guideline":"some guideline"}"""
+        )
+
+        val tools = plugin.provideTools(
+            config = config,
+            configName = "REDIRECT_all",
+            context = context(userId = userId),
+        )
+        val whatsNext = tools.filterIsInstance<WhatsNextTool>().first()
+
+        whatsNext.name shouldBe "REDIRECT_all__whatsNext"
     }
 })

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/RedirectToolPluginSpec.kt
@@ -245,12 +245,13 @@ class RedirectToolPluginSpec : StringSpec({
         val tools = plugin.provideTools(config = config, context = context(userId = userId))
         val whatsNext = tools.filterIsInstance<WhatsNextTool>().first()
 
-        // execute returns the guideline verbatim
+        // execute returns a JSON-wrapped guideline: {"guideline": "..."}
         val result = kotlinx.coroutines.runBlocking {
-            whatsNext.execute(WhatsNextTool.Input(), mockk(relaxed = true))
+            whatsNext.execute(null, mockk(relaxed = true))
         }
-        result.output shouldBe guideline
         result.success shouldBe true
+        val parsed = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper().readTree(result.output)
+        parsed.get("guideline").asText() shouldBe guideline
     }
 
     "provideTools does not add WhatsNextTool when guideline is blank" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/WhatsNextToolSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/WhatsNextToolSpec.kt
@@ -1,0 +1,44 @@
+package io.whozoss.agentos.redirect
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.whozoss.agentos.sdk.tool.ToolContext
+
+private val CONTEXT = mockk<ToolContext>(relaxed = true)
+private const val GUIDELINE = "When DemandBuilder finishes, redirect to TRSharing."
+
+class WhatsNextToolSpec : StringSpec({
+
+    // -------------------------------------------------------------------------
+    // name
+    // -------------------------------------------------------------------------
+
+    "name uses configName prefix when provided" {
+        val tool = WhatsNextTool(configName = "REDIRECT_all", guideline = GUIDELINE)
+        tool.name shouldBe "REDIRECT_all__whatsNext"
+    }
+
+    "name is bare whatsNext when configName is null" {
+        val tool = WhatsNextTool(configName = null, guideline = GUIDELINE)
+        tool.name shouldBe "whatsNext"
+    }
+
+    // -------------------------------------------------------------------------
+    // execute
+    // -------------------------------------------------------------------------
+
+    "execute returns the guideline verbatim" {
+        val tool = WhatsNextTool(configName = null, guideline = GUIDELINE)
+        val result = tool.execute(WhatsNextTool.Input(), CONTEXT)
+        result.output shouldBe GUIDELINE
+        result.success shouldBe true
+    }
+
+    "execute returns the guideline verbatim even when input is null" {
+        val tool = WhatsNextTool(configName = null, guideline = GUIDELINE)
+        val result = tool.execute(null, CONTEXT)
+        result.output shouldBe GUIDELINE
+        result.success shouldBe true
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/WhatsNextToolSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/redirect/WhatsNextToolSpec.kt
@@ -1,5 +1,6 @@
 package io.whozoss.agentos.redirect
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
@@ -7,6 +8,7 @@ import io.whozoss.agentos.sdk.tool.ToolContext
 
 private val CONTEXT = mockk<ToolContext>(relaxed = true)
 private const val GUIDELINE = "When DemandBuilder finishes, redirect to TRSharing."
+private val objectMapper = jacksonObjectMapper()
 
 class WhatsNextToolSpec : StringSpec({
 
@@ -28,17 +30,18 @@ class WhatsNextToolSpec : StringSpec({
     // execute
     // -------------------------------------------------------------------------
 
-    "execute returns the guideline verbatim" {
-        val tool = WhatsNextTool(configName = null, guideline = GUIDELINE)
-        val result = tool.execute(WhatsNextTool.Input(), CONTEXT)
-        result.output shouldBe GUIDELINE
-        result.success shouldBe true
-    }
-
-    "execute returns the guideline verbatim even when input is null" {
+    "execute returns the guideline wrapped in a JSON object" {
         val tool = WhatsNextTool(configName = null, guideline = GUIDELINE)
         val result = tool.execute(null, CONTEXT)
-        result.output shouldBe GUIDELINE
         result.success shouldBe true
+        val parsed = objectMapper.readTree(result.output)
+        parsed.get("guideline").asText() shouldBe GUIDELINE
+    }
+
+    "execute output is valid JSON" {
+        val tool = WhatsNextTool(configName = null, guideline = GUIDELINE)
+        val result = tool.execute(null, CONTEXT)
+        // Should not throw
+        objectMapper.readTree(result.output)
     }
 })

--- a/libs/design-system/src/lib/components/json-schema-form/json-schema-field.component.html
+++ b/libs/design-system/src/lib/components/json-schema-form/json-schema-field.component.html
@@ -142,7 +142,7 @@
         rows="4"
         [formControl]="control()"
         [attr.required]="required() || null"
-        placeholder="JSON"
+        [attr.placeholder]="fieldSchema()['x-ui-widget'] === 'textarea' ? null : 'JSON'"
       ></textarea>
     }
   }

--- a/libs/design-system/src/lib/components/json-schema-form/json-schema-field.component.ts
+++ b/libs/design-system/src/lib/components/json-schema-form/json-schema-field.component.ts
@@ -43,6 +43,10 @@ function makeItem(seed: Record<string, unknown> | null): ObjectItem {
  *   - date-time → <input type="datetime-local">
  *   - (others)  → <input type="text">
  *
+ * String fields with `"x-ui-widget": "textarea"` render a resizable <textarea>
+ * regardless of `format`. Use this for fields expected to hold long text
+ * (prompts, templates, multi-line configs, etc.).
+ *
  * Array-of-scalars: each item is a typed <input> with an × remove button.
  * Array-of-objects: each item is rendered as a ds-json-schema-form card with
  *   an × remove button. Items are tracked by a stable uid so Angular destroys
@@ -269,6 +273,8 @@ export class JsonSchemaFieldComponent implements OnInit {
     | 'textarea' {
     const schema = this.fieldSchema()
     if (schema.enum?.length) return 'enum'
+    // x-ui-widget extension: explicit widget override takes priority over type inference.
+    if (schema['x-ui-widget'] === 'textarea') return 'textarea'
     const type = Array.isArray(schema.type) ? schema.type[0] : schema.type
     switch (type) {
       case 'number':

--- a/libs/design-system/src/lib/components/json-schema-form/json-schema.model.ts
+++ b/libs/design-system/src/lib/components/json-schema-form/json-schema.model.ts
@@ -22,6 +22,15 @@ export interface JsonSchemaObject {
   maxLength?: number
   /** Describes the schema of array items — used to render typed item inputs. */
   items?: JsonSchemaObject
+  /**
+   * UI widget override (JSON Schema extension keyword).
+   * `"textarea"` forces a multiline <textarea> instead of the default <input type="text">
+   * for string fields expected to hold long text (prompts, templates, paths, etc.).
+   *
+   * @example
+   * { "type": "string", "title": "System prompt", "x-ui-widget": "textarea" }
+   */
+  'x-ui-widget'?: 'textarea'
   // Allow any additional JSON Schema keywords (format, pattern, etc.)
   [key: string]: unknown
 }


### PR DESCRIPTION
## What's Next Tool — WZ-34228

Adds a `WhatsNextTool` to the REDIRECT integration, enabling agents to consult a process guideline at the end of their turn and decide whether to hand off to another agent.

### How it works

When a `guideline` field is present in an `IntegrationConfig` of type `REDIRECT`, `RedirectToolPlugin.provideTools` now returns two tools instead of one:

- **`RedirectTool`** — unchanged, handles the actual agent handoff
- **`WhatsNextTool`** — takes no arguments; returns the guideline verbatim when called

The agent calls `whatsNext` when it has finished its task, receives the process guideline as the tool response, and then reasons over it using its existing `redirect` tool if a handoff is warranted. No extra LLM call inside the tool — the current agent does the reasoning itself.

The guideline is delivered at tool-call time only, keeping it out of the system prompt and preserving context efficiency.

### Configuration

Add a `guideline` field to an existing REDIRECT `IntegrationConfig`:

```json
{
  "agents": ["*"],
  "guideline": "When DemandBuilder finishes creating a talent request, redirect to TRSharing..."
}
```

No `guideline` field → behaviour identical to before (only `RedirectTool` produced). Fully backward-compatible.

### Changes

- `WhatsNextTool.kt` — new tool, no-arg, returns guideline verbatim
- `RedirectToolPlugin.kt` — produces `WhatsNextTool` when guideline is present; `guideline` field added to `configSchema`
- `WhatsNextToolSpec.kt` — unit tests for name, execute (with/without input)
- `RedirectToolPluginSpec.kt` — tests for guideline present/absent/blank, configName prefix, execute round-trip


### Last additions

- `x-ui-widget` field to indicate preference for a `textarea`