### PR TITLE
refactor: WZ-34007 scheduler processes UserRuns continuously instead of chunk-by-chunk

### DIFF
--- a/agentos/agentos-service/build.gradle.kts
+++ b/agentos/agentos-service/build.gradle.kts
@@ -202,6 +202,10 @@ dependencies {
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.testcontainers.neo4j)
     testImplementation(libs.testcontainers.junit)
+    // kotlinx-coroutines-test — UnconfinedTestDispatcher / runTest for coroutine loop tests.
+    // The resolutionStrategy below pins it to kotlinCoroutines version (same as production coroutines).
+    testImplementation(libs.kotlinx.coroutines.test)
+
     // Neo4j test harness: starts an embedded Neo4j in-process for testing.
     // neo4j-harness 2026.x requires Netty 4.2.x (BoltServer uses 4.2 APIs).
     // Spring Boot BOM pins Netty 4.1.x, which Gradle's conflict resolution selects

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Backoff.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/Backoff.kt
@@ -1,0 +1,26 @@
+package io.whozoss.agentos.scheduledPrompt
+
+/**
+ * Returns the delay in milliseconds for a given attempt number using
+ * truncated exponential backoff.
+ *
+ * Delay = min([baseMs] * 2^(attempt-1), [maxMs])
+ *
+ * Examples with defaults:
+ * - attempt 1 ->  2 000 ms
+ * - attempt 2 ->  4 000 ms
+ * - attempt 3 ->  8 000 ms
+ * - attempt 7 -> 60 000 ms (capped)
+ *
+ * @param attempt 1-based attempt counter (values <= 0 are treated as 1)
+ * @param baseMs  base delay in milliseconds (default 2 000)
+ * @param maxMs   maximum delay in milliseconds (default 60 000)
+ */
+fun exponentialBackoffMs(
+    attempt: Int,
+    baseMs: Long = 2_000L,
+    maxMs: Long = 60_000L,
+): Long {
+    val exp = (attempt - 1).coerceIn(0, 29)
+    return minOf(baseMs * (1L shl exp), maxMs)
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
@@ -35,7 +36,6 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Executes [ScheduledPromptRun]s in two phases.
@@ -125,13 +125,6 @@ class ScheduledPromptExecutor(
     /** When true, the producer skips claimBatch and delays instead. */
     private val consumePaused = AtomicBoolean(false)
 
-    // No synchronisation needed: start() writes scope then immediately launches the coroutine
-    // that reads it — the launch itself establishes a happens-before edge so runConsumerLoop()
-    // always sees the written value. stop() is called by Spring @PreDestroy, sequentially after
-    // start() has returned, never concurrently with it. If this invariant ever changes (e.g. an
-    // admin endpoint calling start/stop concurrently), replace with AtomicReference + compareAndSet.
-    private var scope: CoroutineScope? = null
-
     fun isConsumePaused(): Boolean = consumePaused.get()
 
     fun pauseConsume() {
@@ -143,6 +136,13 @@ class ScheduledPromptExecutor(
         consumePaused.set(false)
         logger.warn { "[Executor] consume RESUMED by operator" }
     }
+
+    // No synchronisation needed: start() writes scope then immediately launches the coroutine
+    // that reads it — the launch itself establishes a happens-before edge so runConsumerLoop()
+    // always sees the written value. stop() is called by Spring @PreDestroy, sequentially after
+    // start() has returned, never concurrently with it. If this invariant ever changes (e.g. an
+    // admin endpoint calling start/stop concurrently), replace with AtomicReference + compareAndSet.
+    private var scope: CoroutineScope? = null
 
     // -------------------------------------------------------------------------
     // Lifecycle
@@ -190,7 +190,7 @@ class ScheduledPromptExecutor(
             try {
                 while (isActive) {
                     when {
-                        consumePaused.get() -> delay(2_000L)
+                        consumePaused.get() -> delay(properties.pausedPollDelayMs)
                         else -> {
                             try {
                                 val batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -125,6 +125,17 @@ class ScheduledPromptExecutor(
     /** When true, the producer skips claimBatch and delays instead. */
     private val consumePaused = AtomicBoolean(false)
 
+
+
+    /** True if the consumer loop is active. Returns false if start() was never called or if
+     * stop() was called. The watchdog uses this to detect unexpected coroutine death. */
+    fun isRunning(): Boolean = scope?.isActive == true
+
+    fun restart() {
+        stop()
+        start()
+    }
+
     fun isConsumePaused(): Boolean = consumePaused.get()
 
     fun pauseConsume() {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -54,22 +54,27 @@ import java.util.UUID
  *
  * ### Phase B — Continuous consumption (producer + channel + worker pool)
  *
- * This bean implements [SmartLifecycle]. On [start], a [CoroutineScope] is created and two
- * structured children are launched inside it:
+ * The lifecycle is driven by `@PostConstruct` / `@PreDestroy` (Jakarta annotations).
+ * On [start], a [CoroutineScope] is created with a [SupervisorJob] and [runConsumerLoop]
+ * is launched inside it on the [dispatcher]. [stop] cancels the scope. [restart] (stop
+ * then start) is called by the watchdog [SchedulerScanner.tickWatchdog] whenever
+ * [isRunning] returns false, recovering from unexpected coroutine death.
  *
- * **Producer** (`Dispatchers.IO`): loops continuously, calling
- * [ScheduledPromptUserRunRepository.claimBatch] and sending each claimed [ScheduledPromptUserRun]
- * into the channel. When the batch is empty the producer delays [SchedulerProperties.emptyPollDelayMs]
- * before polling again, avoiding a busy-loop. On database errors it applies exponential
- * backoff (capped at 60 s). The producer respects [consumePaused]: when paused it delays
- * 2 s per iteration without touching the database.
+ * **Producer** (on the [dispatcher] injected, `Dispatchers.IO` by default): loops
+ * continuously, calling [ScheduledPromptUserRunRepository.claimBatch] and sending each
+ * claimed [ScheduledPromptUserRun] into the channel. When the batch is empty the producer
+ * delays [SchedulerProperties.emptyPollDelayMs] before polling again, avoiding a busy-loop.
+ * On database errors it applies exponential backoff (capped at 60 s). The producer respects
+ * [consumePaused]: when paused it delays [SchedulerProperties.pausedPollDelayMs] per
+ * iteration without touching the database.
  * The channel is closed in the producer's `finally` block, guaranteeing that workers
  * exit their `for (userRun in channel)` loop cleanly regardless of how the producer stops.
  *
- * **Worker pool** ([SchedulerProperties.workerCount] coroutines, `Dispatchers.IO`): each worker
- * receives [ScheduledPromptUserRun]s from the channel and calls [processUserRun] followed by
- * [checkCompletion]. A failure in one worker does not affect its siblings — exceptions are
- * caught per-item; [CancellationException] is always re-thrown to honour cooperative cancellation.
+ * **Worker pool** ([SchedulerProperties.workerCount] coroutines, on the [dispatcher]
+ * injected, `Dispatchers.IO` by default): each worker receives [ScheduledPromptUserRun]s
+ * from the channel and calls [processUserRun]. A failure in one worker does not affect its
+ * siblings — exceptions are caught per-item; [CancellationException] is always re-thrown
+ * to honour cooperative cancellation.
  *
  * **Channel capacity**: [SchedulerProperties.channelCapacity] (default 50 = 2 x batchSize).
  * Double-buffering: the producer can fill a second batch into the channel while workers drain
@@ -126,8 +131,6 @@ class ScheduledPromptExecutor(
 
     /** When true, the producer skips claimBatch and delays instead. */
     private val consumePaused = AtomicBoolean(false)
-
-
 
     /** True if the consumer loop is active. Returns false if start() was never called or if
      * stop() was called. The watchdog uses this to detect unexpected coroutine death. */
@@ -312,15 +315,17 @@ class ScheduledPromptExecutor(
      * Execute a single [ScheduledPromptUserRun]: resolve context, create a Case,
      * inject the prompt message, and await the launch outcome.
      *
-     * Throws on any unrecoverable error (missing entity, Case creation failure, etc.).
-     * The worker catches all non-[CancellationException] exceptions and logs them;
-     * the UserRun stays RUNNING until its lease expires and is reclaimed.
+     * Captures any non-[CancellationException] exception internally and calls [markFailed]
+     * to transition the UserRun to FAILED. If [markFailed] itself fails (e.g. database
+     * unavailable), the error is swallowed by `runCatching` and the UserRun remains RUNNING
+     * until its lease expires and is reclaimed by [ScheduledPromptUserRunRepository.claimBatch]
+     * (at-least-once delivery). This edge case is covered by a dedicated test.
      *
      * On a [CancellationException] (scope cancelled) the exception is re-thrown so the
      * worker exits its channel loop and the coroutine terminates cooperatively.
      *
      * Exposed as `internal` so unit tests can invoke it directly without starting the
-     * full [SmartLifecycle] loop.
+     * full consumption loop.
      */
     internal suspend fun processUserRun(userRun: ScheduledPromptUserRun) {
         // At-least-once delivery: if markTerminal() fails (DB unavailable), the UserRun stays

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -192,10 +192,7 @@ class ScheduledPromptExecutor(
                             throw e
                         } catch (e: Exception) {
                             consecutiveErrors++
-                            val backoffMs = minOf(
-                                2_000L * (1L shl (consecutiveErrors - 1).coerceAtMost(29)),
-                                60_000L,
-                            )
+                            val backoffMs = exponentialBackoffMs(consecutiveErrors)
                             logger.error(e) {
                                 "[Executor] producer error (attempt=$consecutiveErrors), backing off ${backoffMs}ms"
                             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -70,10 +70,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * [checkCompletion]. A failure in one worker does not affect its siblings — exceptions are
  * caught per-item; [CancellationException] is always re-thrown to honour cooperative cancellation.
  *
- * **Channel capacity**: [SchedulerProperties.channelCapacity] (default 50 = 2 x batchSize,
- * double-buffering): the producer can fill a second batch into the channel while workers drain
+ * **Channel capacity**: [SchedulerProperties.channelCapacity] (default 50 = 2 x batchSize).
+ * Double-buffering: the producer can fill a second batch into the channel while workers drain
  * the first, keeping all workers continuously fed without pre-claiming an excessive number of
- * leased UserRuns.
+ * leased UserRuns. The channel capacity should be at least [SchedulerProperties.batchSize]
+ * so the producer never suspends mid-batch.
  *
  * **Shutdown**: [stop] cancels the scope. The [CancellationException] propagates
  * immediately to all coroutines at their next suspension point — no graceful drain.

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -62,19 +62,22 @@ import java.util.concurrent.atomic.AtomicBoolean
  * before polling again, avoiding a busy-loop. On database errors it applies exponential
  * backoff (capped at 60 s). The producer respects [consumePaused]: when paused it delays
  * 2 s per iteration without touching the database.
+ * The channel is closed in the producer's `finally` block, guaranteeing that workers
+ * exit their `for (userRun in channel)` loop cleanly regardless of how the producer stops.
  *
  * **Worker pool** ([SchedulerProperties.workerCount] coroutines, `Dispatchers.IO`): each worker
  * receives [ScheduledPromptUserRun]s from the channel and calls [processUserRun] followed by
  * [checkCompletion]. A failure in one worker does not affect its siblings — exceptions are
  * caught per-item; [CancellationException] is always re-thrown to honour cooperative cancellation.
  *
- * **Channel capacity**: `workerCount`. At most one item waiting per worker beyond what
- * is currently being processed. The producer suspends on `channel.send` once the buffer
- * is full — natural backpressure that prevents pre-claiming more leased UserRuns than
- * workers can absorb.
+ * **Channel capacity**: [SchedulerProperties.channelCapacity] (default 50 = 2 x batchSize,
+ * double-buffering): the producer can fill a second batch into the channel while workers drain
+ * the first, keeping all workers continuously fed without pre-claiming an excessive number of
+ * leased UserRuns.
  *
  * **Shutdown**: [stop] cancels the scope. The [CancellationException] propagates
  * immediately to all coroutines at their next suspension point — no graceful drain.
+ * The producer's `finally` block closes the channel, unblocking workers suspended on receive.
  * UserRuns that were in-flight remain RUNNING; their leases expire and another instance
  * (or the restarted instance) reclaims them via [claimBatch] (at-least-once delivery).
  *
@@ -161,13 +164,14 @@ class ScheduledPromptExecutor(
     /**
      * Runs the producer and worker pool inside the bean’s [CoroutineScope].
      *
-     * The channel capacity is `workerCount * 2`: small enough to prevent the producer
-     * from pre-claiming leased UserRuns that workers won’t reach before expiry, yet
-     * large enough to keep workers busy while the producer fetches the next batch.
+     * The channel is closed in the producer's `finally` block, guaranteeing that workers
+     * iterating `for (userRun in channel)` exit their loop cleanly whether the producer
+     * stops normally, is cancelled, or throws an unexpected exception.
      *
      * The producer and all workers share the same scope. Cancelling the scope (on [stop])
      * propagates [CancellationException] to all of them at their next suspension point.
-     * Workers exit their `for (userRun in channel)` loop; the producer exits its `while (isActive)`.
+     * The producer's `finally` block then closes the channel, which unblocks any worker
+     * suspended on `channel.receive()`.
      */
     private suspend fun runConsumerLoop() {
         val channel = Channel<ScheduledPromptUserRun>(capacity = properties.channelCapacity)
@@ -177,29 +181,33 @@ class ScheduledPromptExecutor(
         currentScope.launch(Dispatchers.IO) {
             val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
             var consecutiveErrors = 0
-            while (isActive) {
-                when {
-                    consumePaused.get() -> delay(2_000L)
-                    else -> {
-                        try {
-                            val batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)
-                            when {
-                                batch.isEmpty() -> delay(properties.emptyPollDelayMs)
-                                else -> batch.forEach { channel.send(it) }
+            try {
+                while (isActive) {
+                    when {
+                        consumePaused.get() -> delay(2_000L)
+                        else -> {
+                            try {
+                                val batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)
+                                when {
+                                    batch.isEmpty() -> delay(properties.emptyPollDelayMs)
+                                    else -> batch.forEach { channel.send(it) }
+                                }
+                                consecutiveErrors = 0
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                consecutiveErrors++
+                                val backoffMs = exponentialBackoffMs(consecutiveErrors)
+                                logger.error(e) {
+                                    "[Executor] producer error (attempt=$consecutiveErrors), backing off ${backoffMs}ms"
+                                }
+                                delay(backoffMs)
                             }
-                            consecutiveErrors = 0
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            consecutiveErrors++
-                            val backoffMs = exponentialBackoffMs(consecutiveErrors)
-                            logger.error(e) {
-                                "[Executor] producer error (attempt=$consecutiveErrors), backing off ${backoffMs}ms"
-                            }
-                            delay(backoffMs)
                         }
                     }
                 }
+            } finally {
+                channel.close()
             }
         }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -17,17 +17,18 @@ import io.whozoss.agentos.user.UserService
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicBoolean
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
@@ -120,6 +121,7 @@ class ScheduledPromptExecutor(
     private val properties: SchedulerProperties,
     private val clock: Clock,
     private val userContextProvider: UserContextProvider? = null,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     /** When true, the producer skips claimBatch and delays instead. */
@@ -163,7 +165,7 @@ class ScheduledPromptExecutor(
     fun start() {
         val newScope = CoroutineScope(SupervisorJob())
         scope = newScope
-        newScope.launch(Dispatchers.IO) { runConsumerLoop() }
+        newScope.launch(dispatcher) { runConsumerLoop() }
         logger.info { "[Executor] consumer loop started (workers=${properties.workerCount}, batchSize=${properties.batchSize}, channelCapacity=${properties.channelCapacity})" }
     }
 
@@ -195,7 +197,7 @@ class ScheduledPromptExecutor(
         val currentScope = checkNotNull(scope)
 
         // Producer
-        currentScope.launch(Dispatchers.IO) {
+        currentScope.launch(dispatcher) {
             val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
             var consecutiveErrors = 0
             try {
@@ -231,7 +233,7 @@ class ScheduledPromptExecutor(
         // Worker pool — Run (parent) completion is NOT checked here.
         // SchedulerScanner.recoverOrphanedRunningRuns handles RUNNING → DONE/FAILED on each tickClaim.
         repeat(properties.workerCount) { workerId ->
-            currentScope.launch(Dispatchers.IO) {
+            currentScope.launch(dispatcher) {
                 for (userRun in channel) {
                     try {
                         logger.info {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -14,12 +14,18 @@ import io.whozoss.agentos.sdk.caseEvent.MessageContent
 import io.whozoss.agentos.sdk.caseFlow.CaseStatus
 import io.whozoss.agentos.sdk.scheduledPrompt.UserContextProvider
 import io.whozoss.agentos.user.UserService
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.supervisorScope
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import mu.KLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -29,11 +35,12 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Executes [ScheduledPromptRun]s in two phases.
  *
- * ### Phase A — Materialisation (fast, no throttle)
+ * ### Phase A — Materialisation (fast, called by [SchedulerScanner])
  *
  * [materialize] is called by [SchedulerScanner.claim] after the Run has been inserted.
  * It resolves all target users and creates PENDING [ScheduledPromptUserRun]s via a single
@@ -44,41 +51,56 @@ import java.util.UUID
  * [materialize] call, the Run remains CLAIMED forever. [SchedulerScanner.recoverOrphanedClaimedRuns]
  * detects such orphans on the next tick and marks them FAILED, unblocking the overlap guard.
  *
- * ### Phase B — Consumption (throttled)
+ * ### Phase B — Continuous consumption (producer + channel + worker pool)
  *
- * Called by [SchedulerScanner.tickConsume] on every consume tick.
- * Loops over [ScheduledPromptUserRunRepository.claimBatch] until the queue is empty.
- * Each claimed [ScheduledPromptUserRun] is executed in a background coroutine:
- * 1. Create a [Case] in the prompt's namespace.
+ * This bean implements [SmartLifecycle]. On [start], a [CoroutineScope] is created and two
+ * structured children are launched inside it:
+ *
+ * **Producer** (`Dispatchers.IO`): loops continuously, calling
+ * [ScheduledPromptUserRunRepository.claimBatch] and sending each claimed [ScheduledPromptUserRun]
+ * into the channel. When the batch is empty the producer delays [SchedulerProperties.emptyPollDelayMs]
+ * before polling again, avoiding a busy-loop. On database errors it applies exponential
+ * backoff (capped at 60 s). The producer respects [consumePaused]: when paused it delays
+ * 2 s per iteration without touching the database.
+ *
+ * **Worker pool** ([SchedulerProperties.workerCount] coroutines, `Dispatchers.IO`): each worker
+ * receives [ScheduledPromptUserRun]s from the channel and calls [processUserRun] followed by
+ * [checkCompletion]. A failure in one worker does not affect its siblings — exceptions are
+ * caught per-item; [CancellationException] is always re-thrown to honour cooperative cancellation.
+ *
+ * **Channel capacity**: `workerCount`. At most one item waiting per worker beyond what
+ * is currently being processed. The producer suspends on `channel.send` once the buffer
+ * is full — natural backpressure that prevents pre-claiming more leased UserRuns than
+ * workers can absorb.
+ *
+ * **Shutdown**: [stop] cancels the scope. The [CancellationException] propagates
+ * immediately to all coroutines at their next suspension point — no graceful drain.
+ * UserRuns that were in-flight remain RUNNING; their leases expire and another instance
+ * (or the restarted instance) reclaims them via [claimBatch] (at-least-once delivery).
+ *
+ * ### Per-UserRun processing
+ *
+ * 1. Create a [Case] in the prompt’s namespace.
  * 2. Grant ADMIN on the Case to the target user via [PermissionService.grantPermission].
  * 3. Build an [Actor] with `role = USER`.
  * 4. Resolve the prompt content directly and inject `"@agentName <content>"` via
  *    [CaseService.addMessage]. The Executor resolves content itself rather than using
  *    a `/slash-command` because PromptCommandParser requires the text to start with `/`,
  *    which is incompatible with the leading `@mention`.
- * 5. Await the Case launch: inspect the runtime's [CaseRuntime.statusFlow] current value,
+ * 5. Await the Case launch: inspect the runtime’s [CaseRuntime.statusFlow] current value,
  *    then observe future transitions for up to [SchedulerProperties.launchTimeoutSeconds]
  *    seconds to detect immediate failures. If the Case is IDLE (turn finished) it is closed
  *    as DONE. If still RUNNING after the timeout, monitoring is released (Case continues
  *    independently) and the UserRun is closed as TIMEOUT. An immediate terminal status
  *    (ERROR/KILLED) marks the UserRun as FAILED.
  *
- * Concurrency is bounded by [SchedulerProperties.batchSize]: at most that many UserRuns
- * are claimed per batch. Within a batch, UserRuns are grouped by their parent Run and each
- * group is processed concurrently under a [supervisorScope] so a failure in one group does
- * not cancel the others. Further burst control is delegated to Spring AI's `RetryTemplate`
- * on each `ChatModel` (exponential backoff on 429 rate-limit responses).
+ * ### Run (parent) completion
  *
- * ### Completion check
- *
- * After each batch of UserRuns finishes, the distinct Runs touched in that batch are
- * checked via [checkCompletion] — one call per Run, not per UserRun. Each check uses
- * two LIMIT 1 queries:
- * 1. [ScheduledPromptUserRunRepository.hasAnyActive] — fast-path exit when work is still in flight.
- * 2. [ScheduledPromptUserRunRepository.hasAnyFailed] — only reached when all UserRuns are terminal.
- * Result: FAILED if any UserRun failed, DONE otherwise.
- * Only RUNNING Runs are inspected — the CLAIMED→RUNNING transition in Phase A acts as
- * the guard ensuring all UserRuns have been materialised before completion is evaluated.
+ * Workers do **not** update the parent [ScheduledPromptRun] status. That responsibility
+ * belongs entirely to [SchedulerScanner.recoverOrphanedRunningRuns], which runs on every
+ * [SchedulerScanner.tickClaim] (approximately every 60 s). It finds all RUNNING Runs whose
+ * UserRuns are all terminal and closes them as DONE or FAILED. This avoids N concurrent
+ * completion checks from parallel workers racing on the same `runId`.
  */
 @Component
 @ConditionalOnProperty(name = ["agentos.prompt.scheduler.enabled"], havingValue = "true")
@@ -95,6 +117,116 @@ class ScheduledPromptExecutor(
     private val clock: Clock,
     private val userContextProvider: UserContextProvider? = null,
 ) {
+
+    /** When true, the producer skips claimBatch and delays instead. */
+    private val consumePaused = AtomicBoolean(false)
+
+    private var scope: CoroutineScope? = null
+
+    fun isConsumePaused(): Boolean = consumePaused.get()
+
+    fun pauseConsume() {
+        consumePaused.set(true)
+        logger.warn { "[Executor] consume PAUSED by operator" }
+    }
+
+    fun resumeConsume() {
+        consumePaused.set(false)
+        logger.warn { "[Executor] consume RESUMED by operator" }
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    @PostConstruct
+    fun start() {
+        val newScope = CoroutineScope(SupervisorJob())
+        scope = newScope
+        newScope.launch(Dispatchers.IO) { runConsumerLoop() }
+        logger.info { "[Executor] consumer loop started (workers=${properties.workerCount}, batchSize=${properties.batchSize}, channelCapacity=${properties.channelCapacity})" }
+    }
+
+    @PreDestroy
+    fun stop() {
+        scope?.cancel()
+        scope = null
+        logger.info { "[Executor] consumer loop stopped" }
+    }
+
+    // -------------------------------------------------------------------------
+    // Consumer loop (producer + channel + worker pool)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Runs the producer and worker pool inside the bean’s [CoroutineScope].
+     *
+     * The channel capacity is `workerCount * 2`: small enough to prevent the producer
+     * from pre-claiming leased UserRuns that workers won’t reach before expiry, yet
+     * large enough to keep workers busy while the producer fetches the next batch.
+     *
+     * The producer and all workers share the same scope. Cancelling the scope (on [stop])
+     * propagates [CancellationException] to all of them at their next suspension point.
+     * Workers exit their `for (userRun in channel)` loop; the producer exits its `while (isActive)`.
+     */
+    private suspend fun runConsumerLoop() {
+        val channel = Channel<ScheduledPromptUserRun>(capacity = properties.channelCapacity)
+        val currentScope = checkNotNull(scope)
+
+        // Producer
+        currentScope.launch(Dispatchers.IO) {
+            val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
+            var consecutiveErrors = 0
+            while (isActive) {
+                when {
+                    consumePaused.get() -> delay(2_000L)
+                    else -> {
+                        try {
+                            val batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)
+                            when {
+                                batch.isEmpty() -> delay(properties.emptyPollDelayMs)
+                                else -> batch.forEach { channel.send(it) }
+                            }
+                            consecutiveErrors = 0
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            consecutiveErrors++
+                            val backoffMs = minOf(
+                                2_000L * (1L shl (consecutiveErrors - 1).coerceAtMost(29)),
+                                60_000L,
+                            )
+                            logger.error(e) {
+                                "[Executor] producer error (attempt=$consecutiveErrors), backing off ${backoffMs}ms"
+                            }
+                            delay(backoffMs)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Worker pool — Run (parent) completion is NOT checked here.
+        // SchedulerScanner.recoverOrphanedRunningRuns handles RUNNING → DONE/FAILED on each tickClaim.
+        repeat(properties.workerCount) { workerId ->
+            currentScope.launch(Dispatchers.IO) {
+                for (userRun in channel) {
+                    try {
+                        logger.info {
+                            "[Executor] worker=$workerId processing UserRun=${userRun.id} runId=${userRun.runId} userId=${userRun.userId}"
+                        }
+                        processUserRun(userRun)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.error(e) {
+                            "[Executor] worker=$workerId failed on UserRun=${userRun.id} — lease expires, will be reclaimed"
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     // -------------------------------------------------------------------------
     // Phase A — Materialisation
@@ -130,18 +262,6 @@ class ScheduledPromptExecutor(
         }
 
         val namespaceId = scheduledPrompt.namespaceId
-        // Transition based on whether any UserRuns were created:
-        // - RUNNING when count > 0 — Phase B will consume the UserRuns and checkCompletion
-        //   will close the Run once all are terminal.
-        // - DONE when count == 0 — no UserRuns to consume (platform-scope ScheduledPrompt
-        //   with no target users, or namespace with no deployed users). Transitioning to
-        //   RUNNING would leave the Run stuck forever since checkCompletion requires at
-        //   least one UserRun closure to trigger.
-        // - On exception from userRunRepository.materialize: the exception propagates,
-        //   Spring rolls back the transaction, and the Run stays CLAIMED. The sweep
-        //   recoverOrphanedClaimedRuns marks it FAILED on the next tick. The caller
-        //   (SchedulerScanner.claim) is protected by runCatching so one failure does
-        //   not block the other prompts in the same tick.
         val count = when {
             namespaceId == null -> {
                 logger.debug {
@@ -161,121 +281,40 @@ class ScheduledPromptExecutor(
     }
 
     // -------------------------------------------------------------------------
-    // Phase B — Consumption
-    // -------------------------------------------------------------------------
-
-    /**
-     * Claim and execute all currently available [ScheduledPromptUserRun]s.
-     *
-     * Suspends until ALL UserRuns from ALL batches have finished executing, so the
-     * caller ([SchedulerScanner.tickConsume]) suspends for the full duration.
-     * Spring `fixedDelay` on [SchedulerScanner.tickConsume] prevents a new consume
-     * tick from starting before this one completes.
-     *
-     * Each batch is claimed via [ScheduledPromptUserRunRepository.claimBatch], which
-     * uses SDN `@Version` optimistic locking so concurrent instances cannot double-claim
-     * the same UserRun. Within a batch, each UserRun is launched as a structured
-     * coroutine inside [supervisorScope]; the scope suspends until all launched children
-     * finish before the next batch is claimed. Using [supervisorScope] instead of
-     * [coroutineScope] ensures that a failure in one UserRun coroutine does not cancel
-     * the sibling coroutines processing other UserRuns in the same batch.
-     *
-     * Runs on [Dispatchers.IO] so the coroutines launched inside [supervisorScope] execute on
-     * the IO thread pool (default 64 threads) rather than being serialised on the caller's
-     * single thread. This is required because [processUserRun] calls blocking Spring services
-     * (Neo4j, CaseService, PermissionService) that would otherwise starve the coroutine dispatcher.
-     *
-     * Concurrency is bounded by [SchedulerProperties.batchSize]: at most that many UserRuns
-     * are claimed per batch. Within a batch, UserRuns are grouped by their parent Run and
-     * each group is processed concurrently under a [supervisorScope] so a failure in one
-     * group does not cancel the others. Further burst control is delegated to Spring AI's
-     * `RetryTemplate` (exponential backoff on 429 responses).
-     *
-     * ### Delivery guarantee: at-least-once
-     *
-     * If an instance crashes after creating a Case but before [markTerminal], the
-     * UserRun's [ScheduledPromptUserRun.leaseUntil] will expire and a subsequent
-     * [claimBatch] will reclaim it, creating a **second** Case for the same user.
-     * This is acceptable for the scheduled-prompt use case (duplicate conversation,
-     * no data corruption). Exactly-once would require an idempotence key on Case
-     * creation (e.g. a UNIQUE constraint on `runId|userId` carried by the Case).
-     *
-     * ### Completion sweep
-     *
-     * UserRuns are grouped by their parent Run so the completion check fires once per Run
-     * at the end of each group. [SchedulerScanner.recoverOrphanedRunningRuns] covers the
-     * crash window between the last [markTerminal] and the completion check, as well as
-     * any failure thrown by [checkCompletion] itself.
-     */
-    suspend fun consumeAvailable() = withContext(Dispatchers.IO) {
-        val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
-
-        // Group by parent Run so the completion check fires once per Run rather than
-        // once per UserRun. Each group runs concurrently under supervisorScope.
-        var batch: List<ScheduledPromptUserRun>
-        do {
-            batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)
-            supervisorScope {
-                // Group by parent Run so the completion check fires once per Run rather than
-                // once per UserRun. Each group runs concurrently; a failure in one group does
-                // not cancel the others (supervisorScope semantics).
-                batch.groupBy { it.runId }.forEach { (runId, userRuns) ->
-                    launch { processUserRunGroup(runId, userRuns) }
-                }
-            }
-        } while (batch.isNotEmpty())
-    }
-
-    // -------------------------------------------------------------------------
-    // Per-Run processing
-    // -------------------------------------------------------------------------
-
-    /**
-     * Process all [userRuns] belonging to the same [runId] concurrently, then check
-     * completion of the parent Run.
-     *
-     * Each UserRun is launched under a [supervisorScope] so an individual failure does
-     * not cancel its siblings. Exceptions are caught at the launch site: [CancellationException]
-     * is re-thrown to preserve cooperative cancellation, all other exceptions mark the
-     * UserRun as FAILED. Once all UserRuns have settled, [checkCompletion] transitions
-     * the parent Run to DONE or FAILED. A failure in [checkCompletion] is caught and logged;
-     * the Run is recovered by [SchedulerScanner.recoverOrphanedRunningRuns] on the next tick.
-     */
-    private suspend fun processUserRunGroup(runId: UUID, userRuns: List<ScheduledPromptUserRun>) {
-        supervisorScope {
-            userRuns.forEach { userRun ->
-                logger.info {
-                    "[Executor] Phase B: claimed UserRun=${userRun.id} runId=${userRun.runId} userId=${userRun.userId}"
-                }
-                launch {
-                    try {
-                        val context = resolveContext(userRun)
-                        val caseId = createAndInjectCase(userRun, context)
-                        awaitLaunch(userRun.id, caseId)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        logger.error(e) { "[Executor] UserRun=${userRun.id} failed for user=${userRun.userId}" }
-                        markFailed(userRun.id, Instant.now(clock), e.message ?: "Unknown error")
-                    }
-                }
-            }
-        }
-        // All UserRuns for this Run have finished — check completion immediately.
-        // The sweep recoverOrphanedRunningRuns covers crashes between markTerminal and this point.
-        runCatching { checkCompletion(runId) }.onFailure { e ->
-            logger.error(e) { "[Executor] checkCompletion failed for run=$runId" }
-        }
-    }
-
-    // -------------------------------------------------------------------------
     // Single UserRun processing
     // -------------------------------------------------------------------------
 
     /**
+     * Execute a single [ScheduledPromptUserRun]: resolve context, create a Case,
+     * inject the prompt message, and await the launch outcome.
+     *
+     * Throws on any unrecoverable error (missing entity, Case creation failure, etc.).
+     * The worker catches all non-[CancellationException] exceptions and logs them;
+     * the UserRun stays RUNNING until its lease expires and is reclaimed.
+     *
+     * On a [CancellationException] (scope cancelled) the exception is re-thrown so the
+     * worker exits its channel loop and the coroutine terminates cooperatively.
+     *
+     * Exposed as `internal` so unit tests can invoke it directly without starting the
+     * full [SmartLifecycle] loop.
+     */
+    internal suspend fun processUserRun(userRun: ScheduledPromptUserRun) {
+        try {
+            val context = resolveContext(userRun)
+            val caseId = createAndInjectCase(userRun, context)
+            awaitLaunch(userRun.id, caseId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error(e) { "[Executor] UserRun=${userRun.id} failed for user=${userRun.userId} — marking FAILED" }
+            markFailed(userRun.id, Instant.now(clock), e.message ?: "Unknown error")
+        }
+    }
+
+    /**
      * Resolve all data required to execute a [ScheduledPromptUserRun].
      * Throws [IllegalStateException] on any missing entity — propagates to the
-     * try/catch in [processUserRunGroup] which marks the UserRun FAILED.
+     * try/catch in [processUserRun] which marks the UserRun FAILED.
      */
     private fun resolveContext(userRun: ScheduledPromptUserRun): UserRunContext {
         val run = checkNotNull(runRepository.findById(userRun.runId)) {
@@ -293,12 +332,8 @@ class ScheduledPromptExecutor(
         val prompt = checkNotNull(promptService.findById(scheduledPrompt.promptTemplateId)) {
             "PromptTemplate ${scheduledPrompt.promptTemplateId} not found"
         }
-        // Mono-line content (enforced by ScheduledPromptService validation).
-        // Future: resolve {{placeholders}} here with execution context (user name, date, etc.)
         val promptContent = prompt.content.firstOrNull()?.takeIf { it.isNotBlank() }
             ?: error("PromptTemplate ${scheduledPrompt.promptTemplateId} has empty content")
-        // Resolve the agent name — prepended as @mention so selectAgent picks it up
-        // via the normal @mention resolution path (no special-casing in the runtime).
         val agentName = checkNotNull(agentConfigService.findById(scheduledPrompt.agentConfigId)?.name) {
             "AgentConfig ${scheduledPrompt.agentConfigId} not found"
         }
@@ -316,8 +351,6 @@ class ScheduledPromptExecutor(
             namespaceId = namespaceId,
             caseTitle = "${scheduledPrompt.name} ${run.scheduledFor}",
             actor = Actor(id = userRun.userId.toString(), displayName = user.displayName(), role = ActorRole.USER),
-            // Inject resolved content with @mention — selectAgent resolves the agent,
-            // PromptCommandParser sees no /command and passes text through unchanged.
             message = "@$agentName $promptContent",
             scheduledPromptId = scheduledPrompt.id,
             sessionContext = sessionContext,
@@ -327,11 +360,6 @@ class ScheduledPromptExecutor(
     /**
      * Create a [Case], grant ADMIN to the target user, and inject the prompt message.
      * Returns the created [Case] id.
-     *
-     * No idempotence key links the Case to the UserRun — if the instance crashes after
-     * this point but before markTerminal(), the lease expires and another instance will
-     * create a second Case for the same user (at-least-once). Exactly-once would require
-     * a UNIQUE constraint on Case keyed by (runId, userId).
      */
     private fun createAndInjectCase(userRun: ScheduledPromptUserRun, context: UserRunContext): UUID {
         val case = caseService.create(
@@ -359,19 +387,6 @@ class ScheduledPromptExecutor(
         return case.id
     }
 
-    /**
-     * Await the Case launch and close the UserRun based on the observed [CaseStatus].
-     * If no active runtime is found, the Case already reached a terminal status.
-     */
-    private suspend fun awaitLaunch(userRunId: UUID, caseId: UUID) {
-        val runtime = caseService.findActiveRuntime(caseId)
-        if (runtime == null) {
-            closeUserRun(userRunId, caseService.findById(caseId)?.status, caseId)
-        } else {
-            monitorLaunch(userRunId, caseId, runtime)
-        }
-    }
-
     /** Resolved execution context for a single [ScheduledPromptUserRun]. */
     private data class UserRunContext(
         val namespaceId: UUID,
@@ -387,6 +402,18 @@ class ScheduledPromptExecutor(
     // -------------------------------------------------------------------------
 
     /**
+     * Await the Case launch and close the UserRun based on the observed [CaseStatus].
+     * If no active runtime is found, the Case already reached a terminal status.
+     */
+    private suspend fun awaitLaunch(userRunId: UUID, caseId: UUID) {
+        val runtime = caseService.findActiveRuntime(caseId)
+        when {
+            runtime == null -> closeUserRun(userRunId, caseService.findById(caseId)?.status, caseId)
+            else -> monitorLaunch(userRunId, caseId, runtime)
+        }
+    }
+
+    /**
      * Await the Case launch and detect immediate failures.
      *
      * Collects [CaseRuntime.statusFlow] for up to [SchedulerProperties.launchTimeoutSeconds]
@@ -394,14 +421,6 @@ class ScheduledPromptExecutor(
      * - IDLE → agent finished its turn quickly → DONE
      * - Timeout (still RUNNING) → Case is healthy but slow; monitoring released → TIMEOUT
      * - ERROR/KILLED → immediate crash → FAILED
-     *
-     * On timeout the UserRun is closed as [UserRunStatus.TIMEOUT] via a direct
-     * [ScheduledPromptUserRunRepository.markTerminal] call, bypassing [closeUserRun] and
-     * [toUserRunOutcome] (which only map [CaseStatus] values).
-     *
-     * The Case continues running independently after this method returns.
-     * The lease on the UserRun is only relevant for crash recovery (instance down
-     * between Case creation and this point).
      *
      * ### StateFlow current-value guard
      *
@@ -414,17 +433,6 @@ class ScheduledPromptExecutor(
      * a false early return is **IDLE**: if a very fast turn completes before `monitorLaunch` is
      * called, `statusFlow.value` is already `IDLE`, and `.first { it == IDLE || it.isTerminal() }`
      * returns it immediately — which is actually the correct behaviour (the turn did finish).
-     *
-     * The guard below makes the intent explicit and handles the `IDLE` case without relying on
-     * the implicit StateFlow current-value semantics:
-     * - Already IDLE or terminal → the turn finished before we arrived; act on it directly.
-     * - PENDING or RUNNING → neither satisfies the predicate, so `.first { … }` suspends and
-     *   waits for the next emission, bounded by the timeout.
-     *
-     * Contract: [CaseRuntime.statusFlow] is initialised to [CaseStatus.PENDING] at construction
-     * and transitions PENDING → RUNNING at the top of [CaseRuntime.run]. It never starts at IDLE.
-     * This invariant is asserted by `CaseRuntimeSpec: "statusFlow reflects RUNNING during run()
-     * and IDLE after normal completion"`. If that test is changed, revisit this guard.
      */
     private suspend fun monitorLaunch(
         userRunId: UUID,
@@ -435,27 +443,15 @@ class ScheduledPromptExecutor(
         val currentStatus = runtime.statusFlow.value
 
         val observedStatus = when {
-            currentStatus == CaseStatus.IDLE || currentStatus.isTerminal() -> {
-                // The turn already completed before we started monitoring — act on it directly.
-                currentStatus
-            }
-            else -> {
-                // Status is PENDING or RUNNING — neither satisfies the predicate.
-                // .first {} evaluates the current value first (StateFlow semantics), finds it
-                // unsatisfying, then suspends until the next emission that does satisfy it.
-                // withTimeoutOrNull returns null if no satisfying emission arrives in time.
-                withTimeoutOrNull(timeoutMs) {
-                    runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
-                }
+            currentStatus == CaseStatus.IDLE || currentStatus.isTerminal() -> currentStatus
+            else -> withTimeoutOrNull(timeoutMs) {
+                runtime.statusFlow.first { it == CaseStatus.IDLE || it.isTerminal() }
             }
         }
 
         when {
-            observedStatus != null ->
-                // Either finished quickly (IDLE) or crashed immediately (ERROR/KILLED).
-                closeUserRun(userRunId, observedStatus, caseId)
+            observedStatus != null -> closeUserRun(userRunId, observedStatus, caseId)
             else -> {
-                // Timeout — Case is still RUNNING; monitoring released, Case continues independently.
                 userRunRepository.markTerminal(userRunId, UserRunStatus.TIMEOUT, Instant.now(clock))
                 logger.info {
                     "[Executor] UserRun=$userRunId timed out (caseId=$caseId still running) — monitoring released"
@@ -466,11 +462,6 @@ class ScheduledPromptExecutor(
 
     /**
      * Close a UserRun based on the final [CaseStatus].
-     *
-     * Maps [CaseStatus] to [UserRunStatus] via [toUserRunOutcome]:
-     * - IDLE or any non-error terminal → DONE
-     * - KILLED, ERROR → FAILED with diagnostic message
-     * - null (Case not found) → DONE (defensive, Case was likely cleaned up)
      */
     private fun closeUserRun(userRunId: UUID, caseStatus: CaseStatus?, caseId: UUID) {
         val now = Instant.now(clock)
@@ -482,52 +473,10 @@ class ScheduledPromptExecutor(
     }
 
     // -------------------------------------------------------------------------
-    // Completion check
-    // -------------------------------------------------------------------------
-
-    /**
-     * Transition the parent [ScheduledPromptRun] to DONE (or FAILED) once all
-     * UserRuns are settled.
-     *
-     * Fast-path: [ScheduledPromptUserRunRepository.hasAnyActive] exits immediately
-     * (EXISTS query, stops at first match) when work is still in flight.
-     * Only when no active UserRuns remain does it check for failures.
-     *
-     * Only inspects RUNNING Runs — a Run only reaches RUNNING after [materialize]
-     * completes, so the CLAIMED→RUNNING transition acts as the completion guard
-     * (a CLAIMED Run whose [materialize] has not yet finished is never prematurely
-     * evaluated). Orphaned CLAIMED Runs (crash before [materialize]) are swept to
-     * FAILED by [SchedulerScanner.recoverOrphanedClaimedRuns] and never reach this path.
-     * The Run is FAILED when at least one UserRun failed; DONE otherwise.
-     *
-     * ### Crash window
-     *
-     * If the instance crashes after the last [ScheduledPromptUserRunRepository.markTerminal]
-     * but before this method runs, or if this method throws, the Run stays RUNNING forever —
-     * no subsequent UserRun closure will re-trigger this check.
-     * [SchedulerScanner.recoverOrphanedRunningRuns] handles both cases by re-evaluating
-     * the completion condition on every tick.
-     */
-    private fun checkCompletion(runId: UUID) {
-        val run = runRepository.findById(runId) ?: return
-        if (run.status != RunStatus.RUNNING) return
-
-        if (userRunRepository.hasAnyActive(runId)) return
-
-        val finalStatus = if (userRunRepository.hasAnyFailed(runId)) RunStatus.FAILED else RunStatus.DONE
-        runRepository.updateStatus(runId, finalStatus, Instant.now(clock))
-        logger.info { "[Executor] Run=$runId → $finalStatus" }
-    }
-
-    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
-    private fun markFailed(
-        userRunId: UUID,
-        now: Instant,
-        error: String,
-    ) {
+    private fun markFailed(userRunId: UUID, now: Instant, error: String) {
         runCatching {
             userRunRepository.markTerminal(userRunId, UserRunStatus.FAILED, now, error)
         }.onFailure { e ->
@@ -536,10 +485,6 @@ class ScheduledPromptExecutor(
     }
 
     companion object : KLogging() {
-        /**
-         * Maps a [CaseStatus] (possibly null when the Case was already cleaned up)
-         * to the corresponding [UserRunStatus] and optional error message.
-         */
         private fun CaseStatus?.toUserRunOutcome(): Pair<UserRunStatus, String?> = when (this) {
             CaseStatus.KILLED, CaseStatus.ERROR ->
                 UserRunStatus.FAILED to "Case reached terminal status $this"

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -125,6 +125,11 @@ class ScheduledPromptExecutor(
     /** When true, the producer skips claimBatch and delays instead. */
     private val consumePaused = AtomicBoolean(false)
 
+    // No synchronisation needed: start() writes scope then immediately launches the coroutine
+    // that reads it — the launch itself establishes a happens-before edge so runConsumerLoop()
+    // always sees the written value. stop() is called by Spring @PreDestroy, sequentially after
+    // start() has returned, never concurrently with it. If this invariant ever changes (e.g. an
+    // admin endpoint calling start/stop concurrently), replace with AtomicReference + compareAndSet.
     private var scope: CoroutineScope? = null
 
     fun isConsumePaused(): Boolean = consumePaused.get()

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -321,6 +321,10 @@ class ScheduledPromptExecutor(
      * full [SmartLifecycle] loop.
      */
     internal suspend fun processUserRun(userRun: ScheduledPromptUserRun) {
+        // At-least-once delivery: if markTerminal() fails (DB unavailable), the UserRun stays
+        // RUNNING until its lease expires and is reclaimed — potentially creating a second Case
+        // for the same user. A future improvement would store the userRunId on the Case and
+        // check for an existing Case before creating one, making execution effectively-once.
         try {
             val context = resolveContext(userRun)
             val caseId = createAndInjectCase(userRun, context)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -197,9 +197,12 @@ class ScheduledPromptExecutor(
      */
     private suspend fun runConsumerLoop() {
         val channel = Channel<ScheduledPromptUserRun>(capacity = properties.channelCapacity)
-        val currentScope = checkNotNull(scope)
+        initUserRunProcessingProducer(channel)
+        initUserRunProcessingWorkers(channel)
+    }
 
-        // Producer
+    private fun initUserRunProcessingProducer(channel: Channel<ScheduledPromptUserRun>) {
+        val currentScope = checkNotNull(scope)
         currentScope.launch(dispatcher) {
             val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
             var consecutiveErrors = 0
@@ -232,9 +235,12 @@ class ScheduledPromptExecutor(
                 channel.close()
             }
         }
+    }
 
-        // Worker pool — Run (parent) completion is NOT checked here.
-        // SchedulerScanner.recoverOrphanedRunningRuns handles RUNNING → DONE/FAILED on each tickClaim.
+    // Run (parent) completion is NOT checked here.
+    // SchedulerScanner.recoverOrphanedRunningRuns handles RUNNING → DONE/FAILED on each tickClaim.
+    private fun initUserRunProcessingWorkers(channel: Channel<ScheduledPromptUserRun>) {
+        val currentScope = checkNotNull(scope)
         repeat(properties.workerCount) { workerId ->
             currentScope.launch(dispatcher) {
                 for (userRun in channel) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -52,52 +52,53 @@ import java.util.UUID
  * [materialize] call, the Run remains CLAIMED forever. [SchedulerScanner.recoverOrphanedClaimedRuns]
  * detects such orphans on the next tick and marks them FAILED, unblocking the overlap guard.
  *
- * ### Phase B — Continuous consumption (producer + channel + worker pool)
+ * ### Phase B — Continuous processing (DB poller + worker pool)
  *
  * The lifecycle is driven by `@PostConstruct` / `@PreDestroy` (Jakarta annotations).
- * On [start], a [CoroutineScope] is created with a [SupervisorJob] and [runConsumerLoop]
+ * On [start], a [CoroutineScope] is created with a [SupervisorJob] and [startProcessingLoop]
  * is launched inside it on the [dispatcher]. [stop] cancels the scope. [restart] (stop
  * then start) is called by the watchdog [SchedulerScanner.tickWatchdog] whenever
  * [isRunning] returns false, recovering from unexpected coroutine death.
  *
- * **Producer** (on the [dispatcher] injected, `Dispatchers.IO` by default): loops
- * continuously, calling [ScheduledPromptUserRunRepository.claimBatch] and sending each
- * claimed [ScheduledPromptUserRun] into the channel. When the batch is empty the producer
+ * **DB poller** (on the [dispatcher] injected, `Dispatchers.IO` by default): loops
+ * continuously, calling [ScheduledPromptUserRunRepository.claimBatch] and handing each
+ * claimed [ScheduledPromptUserRun] off for processing. When the batch is empty the poller
  * delays [SchedulerProperties.emptyPollDelayMs] before polling again, avoiding a busy-loop.
- * On database errors it applies exponential backoff (capped at 60 s). The producer respects
+ * On database errors it applies exponential backoff (capped at 60 s). The poller respects
  * [consumePaused]: when paused it delays [SchedulerProperties.pausedPollDelayMs] per
  * iteration without touching the database.
- * The channel is closed in the producer's `finally` block, guaranteeing that workers
- * exit their `for (userRun in channel)` loop cleanly regardless of how the producer stops.
+ * The handoff channel is closed in the poller's `finally` block, guaranteeing that workers
+ * exit their iteration loop cleanly regardless of how the poller stops.
  *
  * **Worker pool** ([SchedulerProperties.workerCount] coroutines, on the [dispatcher]
  * injected, `Dispatchers.IO` by default): each worker receives [ScheduledPromptUserRun]s
- * from the channel and calls [processUserRun]. A failure in one worker does not affect its
+ * and calls [processUserRun]. A failure in one worker does not affect its
  * siblings — exceptions are caught per-item; [CancellationException] is always re-thrown
  * to honour cooperative cancellation.
  *
  * **Channel capacity**: [SchedulerProperties.channelCapacity] (default 50 = 2 x batchSize).
- * Double-buffering: the producer can fill a second batch into the channel while workers drain
+ * Double-buffering: the poller can fill a second batch into the channel while workers drain
  * the first, keeping all workers continuously fed without pre-claiming an excessive number of
  * leased UserRuns. The channel capacity should be at least [SchedulerProperties.batchSize]
- * so the producer never suspends mid-batch.
+ * so the poller never suspends mid-batch.
  *
  * **Shutdown**: [stop] cancels the scope. The [CancellationException] propagates
- * immediately to all coroutines at their next suspension point — no graceful drain.
- * The producer's `finally` block closes the channel, unblocking workers suspended on receive.
- * UserRuns that were in-flight remain RUNNING; their leases expire and another instance
- * (or the restarted instance) reclaims them via [claimBatch] (at-least-once delivery).
+ * immediately to all coroutines at their next suspension point — minimising shutdown time
+ * without killing coroutines abruptly. The poller's `finally` block closes the channel,
+ * unblocking workers suspended on receive. UserRuns that were in-flight remain RUNNING;
+ * their leases expire and another instance (or the restarted instance) reclaims them
+ * via [claimBatch] (at-least-once delivery).
  *
  * ### Per-UserRun processing
  *
- * 1. Create a [Case] in the prompt’s namespace.
+ * 1. Create a [Case] in the prompt's namespace.
  * 2. Grant ADMIN on the Case to the target user via [PermissionService.grantPermission].
  * 3. Build an [Actor] with `role = USER`.
  * 4. Resolve the prompt content directly and inject `"@agentName <content>"` via
  *    [CaseService.addMessage]. The Executor resolves content itself rather than using
  *    a `/slash-command` because PromptCommandParser requires the text to start with `/`,
  *    which is incompatible with the leading `@mention`.
- * 5. Await the Case launch: inspect the runtime’s [CaseRuntime.statusFlow] current value,
+ * 5. Await the Case launch: inspect the runtime's [CaseRuntime.statusFlow] current value,
  *    then observe future transitions for up to [SchedulerProperties.launchTimeoutSeconds]
  *    seconds to detect immediate failures. If the Case is IDLE (turn finished) it is closed
  *    as DONE. If still RUNNING after the timeout, monitoring is released (Case continues
@@ -129,10 +130,10 @@ class ScheduledPromptExecutor(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
-    /** When true, the producer skips claimBatch and delays instead. */
+    /** When true, the poller skips claimBatch and delays instead. */
     private val consumePaused = AtomicBoolean(false)
 
-    /** True if the consumer loop is active. Returns false if start() was never called or if
+    /** True if the processing loop is active. Returns false if start() was never called or if
      * stop() was called. The watchdog uses this to detect unexpected coroutine death. */
     fun isRunning(): Boolean = scope?.isActive == true
 
@@ -154,10 +155,16 @@ class ScheduledPromptExecutor(
     }
 
     // No synchronisation needed: start() writes scope then immediately launches the coroutine
-    // that reads it — the launch itself establishes a happens-before edge so runConsumerLoop()
+    // that reads it — the launch itself establishes a happens-before edge so startProcessingLoop()
     // always sees the written value. stop() is called by Spring @PreDestroy, sequentially after
     // start() has returned, never concurrently with it. If this invariant ever changes (e.g. an
     // admin endpoint calling start/stop concurrently), replace with AtomicReference + compareAndSet.
+    //
+    // We store a CoroutineScope rather than just the SupervisorJob for convenience: it lets us
+    // call launch() directly (currentScope.launch(...)) and use scope.isActive as a natural
+    // liveness check in isRunning(). Both scope.cancel() and scope.isActive are shortcuts to
+    // the underlying Job: scope.coroutineContext[Job]?.cancel() and
+    // scope.coroutineContext[Job]?.isActive respectively — everything goes through the Job.
     private var scope: CoroutineScope? = null
 
     // -------------------------------------------------------------------------
@@ -168,40 +175,40 @@ class ScheduledPromptExecutor(
     fun start() {
         val newScope = CoroutineScope(SupervisorJob())
         scope = newScope
-        newScope.launch(dispatcher) { runConsumerLoop() }
-        logger.info { "[Executor] consumer loop started (workers=${properties.workerCount}, batchSize=${properties.batchSize}, channelCapacity=${properties.channelCapacity})" }
+        newScope.launch(dispatcher) { startProcessingLoop() }
+        logger.info { "[Executor] started (workers=${properties.workerCount}, batchSize=${properties.batchSize}, channelCapacity=${properties.channelCapacity})" }
     }
 
     @PreDestroy
     fun stop() {
         scope?.cancel()
         scope = null
-        logger.info { "[Executor] consumer loop stopped" }
+        logger.info { "[Executor] stopped" }
     }
 
     // -------------------------------------------------------------------------
-    // Consumer loop (producer + channel + worker pool)
+    // Processing loop (DB poller + worker pool)
     // -------------------------------------------------------------------------
 
     /**
-     * Runs the producer and worker pool inside the bean’s [CoroutineScope].
+     * Orchestrates UserRun processing: starts the DB poller and the worker pool.
      *
-     * The channel is closed in the producer's `finally` block, guaranteeing that workers
-     * iterating `for (userRun in channel)` exit their loop cleanly whether the producer
-     * stops normally, is cancelled, or throws an unexpected exception.
+     * The poller closes the handoff channel in its `finally` block, guaranteeing that workers
+     * exit their iteration loop cleanly whether the poller stops normally, is cancelled, or
+     * throws an unexpected exception.
      *
-     * The producer and all workers share the same scope. Cancelling the scope (on [stop])
-     * propagates [CancellationException] to all of them at their next suspension point.
-     * The producer's `finally` block then closes the channel, which unblocks any worker
-     * suspended on `channel.receive()`.
+     * The poller and all workers share the same scope. Cancelling the scope (on [stop])
+     * propagates [CancellationException] to all of them at their next suspension point —
+     * minimising shutdown time without killing coroutines abruptly.
      */
-    private suspend fun runConsumerLoop() {
+    private suspend fun startProcessingLoop() {
         val channel = Channel<ScheduledPromptUserRun>(capacity = properties.channelCapacity)
-        initUserRunProcessingProducer(channel)
-        initUserRunProcessingWorkers(channel)
+        startUserRunPoller(channel)
+        startUserRunWorkers(channel)
     }
 
-    private fun initUserRunProcessingProducer(channel: Channel<ScheduledPromptUserRun>) {
+    /** Continuously claims UserRuns from the database and hands them off for processing. */
+    private fun startUserRunPoller(channel: Channel<ScheduledPromptUserRun>) {
         val currentScope = checkNotNull(scope)
         currentScope.launch(dispatcher) {
             val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
@@ -224,7 +231,7 @@ class ScheduledPromptExecutor(
                                 consecutiveErrors++
                                 val backoffMs = exponentialBackoffMs(consecutiveErrors)
                                 logger.error(e) {
-                                    "[Executor] producer error (attempt=$consecutiveErrors), backing off ${backoffMs}ms"
+                                    "[Executor] poller error (attempt=$consecutiveErrors), backing off ${backoffMs}ms"
                                 }
                                 delay(backoffMs)
                             }
@@ -237,9 +244,12 @@ class ScheduledPromptExecutor(
         }
     }
 
-    // Run (parent) completion is NOT checked here.
-    // SchedulerScanner.recoverOrphanedRunningRuns handles RUNNING → DONE/FAILED on each tickClaim.
-    private fun initUserRunProcessingWorkers(channel: Channel<ScheduledPromptUserRun>) {
+    /**
+     * Processes claimed UserRuns — one worker per configured [SchedulerProperties.workerCount].
+     * Run (parent) completion is NOT checked here:
+     * [SchedulerScanner.recoverOrphanedRunningRuns] handles RUNNING -> DONE/FAILED on each tickClaim.
+     */
+    private fun startUserRunWorkers(channel: Channel<ScheduledPromptUserRun>) {
         val currentScope = checkNotNull(scope)
         repeat(properties.workerCount) { workerId ->
             currentScope.launch(dispatcher) {
@@ -276,7 +286,7 @@ class ScheduledPromptExecutor(
      * Transitions the Run to [RunStatus.RUNNING] when UserRuns are created, or directly
      * to [RunStatus.DONE] when no target users exist (e.g. platform-scope ScheduledPrompt).
      *
-     * The MERGE and the CLAIMED→RUNNING transition run in a single `@Transactional`:
+     * The MERGE and the CLAIMED->RUNNING transition run in a single `@Transactional`:
      * if the service crashes between the two, neither orphaned PENDING UserRuns (never
      * consumed) nor a RUNNING Run with no UserRuns can result.
      *
@@ -331,7 +341,7 @@ class ScheduledPromptExecutor(
      * worker exits its channel loop and the coroutine terminates cooperatively.
      *
      * Exposed as `internal` so unit tests can invoke it directly without starting the
-     * full consumption loop.
+     * full processing loop.
      */
     internal suspend fun processUserRun(userRun: ScheduledPromptUserRun) {
         // At-least-once delivery: if markTerminal() fails (DB unavailable), the UserRun stays
@@ -457,9 +467,9 @@ class ScheduledPromptExecutor(
      *
      * Collects [CaseRuntime.statusFlow] for up to [SchedulerProperties.launchTimeoutSeconds]
      * seconds. This is a **health check**, not a completion wait:
-     * - IDLE → agent finished its turn quickly → DONE
-     * - Timeout (still RUNNING) → Case is healthy but slow; monitoring released → TIMEOUT
-     * - ERROR/KILLED → immediate crash → FAILED
+     * - IDLE -> agent finished its turn quickly -> DONE
+     * - Timeout (still RUNNING) -> Case is healthy but slow; monitoring released -> TIMEOUT
+     * - ERROR/KILLED -> immediate crash -> FAILED
      *
      * ### StateFlow current-value guard
      *
@@ -467,7 +477,7 @@ class ScheduledPromptExecutor(
      * on a StateFlow always evaluates the **current value** first: if it satisfies the predicate,
      * it is returned immediately without suspending.
      *
-     * The status lifecycle in [CaseRuntime.run] is: `PENDING → RUNNING → IDLE/ERROR/KILLED`.
+     * The status lifecycle in [CaseRuntime.run] is: `PENDING -> RUNNING -> IDLE/ERROR/KILLED`.
      * `statusFlow` is initialised to `PENDING` at construction. The only status that can cause
      * a false early return is **IDLE**: if a very fast turn completes before `monitorLaunch` is
      * called, `statusFlow.value` is already `IDLE`, and `.first { it == IDLE || it.isTerminal() }`

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunNodeNeo4jRepository.kt
@@ -27,7 +27,8 @@ interface ScheduledPromptRunNodeNeo4jRepository : Neo4jRepository<ScheduledPromp
     /**
      * Update status (and optionally finishedAt + error) of a Run by id.
      * Only updates if the Run is not already in a terminal status (DONE or FAILED) —
-     * prevents the orphan sweep from overwriting finishedAt already set by checkCompletion.
+     * prevents concurrent calls to recoverOrphanedRunningRuns from overwriting a finishedAt
+     * already set by a previous invocation.
      * Returns the count of updated nodes (0 if not found or already terminal).
      */
     @Query(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptRunRepository.kt
@@ -79,7 +79,7 @@ interface ScheduledPromptRunRepository {
      *
      * These Runs are presumed orphaned — the instance that processed the last UserRun
      * crashed after [ScheduledPromptUserRunRepository.markTerminal] but before
-     * [ScheduledPromptExecutor]'s `checkCompletion()` could transition the parent Run.
+     * [SchedulerScanner.recoverOrphanedRunningRuns] could close the parent Run.
      */
     fun findSettledRunning(): List<ScheduledPromptRun>
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpoint.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpoint.kt
@@ -8,7 +8,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 /**
- * Actuator endpoint for operational control of the [SchedulerScanner].
+ * Actuator endpoint for operational control of the scheduler.
  *
  * Exposed both as an HTTP endpoint and as a JMX MBean by Spring Boot Actuator:
  * - **HTTP**: `GET /management/scheduler` (read), `POST /management/scheduler/{phase}` (write)
@@ -25,17 +25,19 @@ import org.springframework.stereotype.Component
  * - `phase`: `"claim"`, `"consume"`, or `"all"`
  * - `action`: `"pause"` or `"resume"`
  *
- * Pausing a phase causes the corresponding `@Scheduled` tick to return immediately
- * without processing. The Spring scheduling thread continues to fire ticks at the
- * configured interval; they simply become no-ops. Resuming restores normal processing
- * on the next tick. This is safe for crash recovery: sweeps resume naturally once
- * the phase is unpaused.
+ * The `claim` phase is managed by [SchedulerScanner]: pausing it causes the
+ * `@Scheduled` tick to return immediately without claiming new runs.
+ *
+ * The `consume` phase is managed by [ScheduledPromptExecutor]: pausing it causes the
+ * producer loop to skip `claimBatch` calls and delay instead. Workers continue
+ * to drain items already in the channel, then block on receive until resumed.
  */
 @Component
 @ConditionalOnProperty(name = ["agentos.prompt.scheduler.enabled"], havingValue = "true")
 @Endpoint(id = "scheduler")
 class SchedulerEndpoint(
     private val schedulerScanner: SchedulerScanner,
+    private val executor: ScheduledPromptExecutor,
 ) {
     /**
      * Read current scheduler status.
@@ -47,7 +49,7 @@ class SchedulerEndpoint(
     fun status(): Map<String, Any> =
         mapOf(
             "claimPaused" to schedulerScanner.isClaimPaused(),
-            "consumePaused" to schedulerScanner.isConsumePaused(),
+            "consumePaused" to executor.isConsumePaused(),
         )
 
     /**
@@ -68,21 +70,26 @@ class SchedulerEndpoint(
         val phases =
             when (claimOrConsumeOrAllPhase) {
                 "all" -> listOf("claim", "consume")
-
                 "claim" -> listOf("claim")
-
                 "consume" -> listOf("consume")
-
                 else -> throw IllegalArgumentException(
                     "Invalid phase '$claimOrConsumeOrAllPhase' (expected: claim, consume, all)",
                 )
             }
         val apply: (String) -> Unit =
             when (pauseOrResumeAction) {
-                "pause" -> { p -> if (p == "claim") schedulerScanner.pauseClaim() else schedulerScanner.pauseConsume() }
-
-                "resume" -> { p -> if (p == "claim") schedulerScanner.resumeClaim() else schedulerScanner.resumeConsume() }
-
+                "pause" -> { p ->
+                    when (p) {
+                        "claim" -> schedulerScanner.pauseClaim()
+                        else -> executor.pauseConsume()
+                    }
+                }
+                "resume" -> { p ->
+                    when (p) {
+                        "claim" -> schedulerScanner.resumeClaim()
+                        else -> executor.resumeConsume()
+                    }
+                }
                 else -> throw IllegalArgumentException(
                     "Invalid action '$pauseOrResumeAction' (expected: pause, resume)",
                 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | Property | Env var | Default | Description |
  * |---|---|---|---|
  * | `agentos.prompt.scheduler.enabled` | `AGENTOS_PROMPT_SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
- * | `agentos.prompt.scheduler.tick-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class. Also drives the Run parent completion scan (`recoverOrphanedRunningRuns`) |
+ * | `agentos.prompt.scheduler.tick-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class. Also drives the Run parent completion scan (`recoverOrphanedRunningRuns`) and the consumer-loop watchdog (`tickWatchdog`) |
  * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 25 | Max UserRuns claimed per producer iteration |
  * | `agentos.prompt.scheduler.worker-count` | `AGENTOS_PROMPT_SCHEDULER_WORKER_COUNT` | 5 | Number of parallel consumer workers |
  * | `agentos.prompt.scheduler.channel-capacity` | `AGENTOS_PROMPT_SCHEDULER_CHANNEL_CAPACITY` | 50 | Channel buffer size (2 × batchSize — double-buffering) |
@@ -30,8 +30,9 @@ data class SchedulerProperties(
      */
     val batchSize: Int = 25,
     /**
-     * Number of parallel consumer workers processing UserRuns from the channel.
-     * Matches the former page size (5) so throughput is unchanged vs. the old tick model.
+     * Number of coroutines consuming [ScheduledPromptUserRun]s from the channel in parallel.
+     * A higher value increases the throughput of Case creation at the cost of more
+     * concurrent database and downstream API calls.
      */
     val workerCount: Int = 5,
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -10,9 +10,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | Property | Env var | Default | Description |
  * |---|---|---|---|
  * | `agentos.prompt.scheduler.enabled` | `AGENTOS_PROMPT_SCHEDULER_ENABLED` | false | Enable/disable the scheduler |
- * | `agentos.prompt.scheduler.tick-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS` | 30000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class |
- * | `agentos.prompt.scheduler.consume-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_CONSUME_INTERVAL_MS` | 10000 | Interval between consume ticks (ms) — read directly by `@Scheduled`, not via this class |
- * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 5 | Max UserRuns claimed and executed in parallel per consume tick |
+ * | `agentos.prompt.scheduler.tick-interval-ms` | `AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS` | 60000 | Interval between claim ticks (ms) — read directly by `@Scheduled`, not via this class. Also drives the Run parent completion scan (`recoverOrphanedRunningRuns`) |
+ * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 25 | Max UserRuns claimed per producer iteration |
+ * | `agentos.prompt.scheduler.worker-count` | `AGENTOS_PROMPT_SCHEDULER_WORKER_COUNT` | 5 | Number of parallel consumer workers |
+ * | `agentos.prompt.scheduler.channel-capacity` | `AGENTOS_PROMPT_SCHEDULER_CHANNEL_CAPACITY` | 50 | Channel buffer size (2 × batchSize — double-buffering) |
+ * | `agentos.prompt.scheduler.empty-poll-delay-ms` | `AGENTOS_PROMPT_SCHEDULER_EMPTY_POLL_DELAY_MS` | 5000 | Delay (ms) when claimBatch returns empty — avoids busy-looping |
  * | `agentos.prompt.scheduler.launch-timeout-seconds` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `agentos.prompt.scheduler.lease-minutes` | `AGENTOS_PROMPT_SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
@@ -20,8 +22,30 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class SchedulerProperties(
     /** Disabled by default; enable in production via env var AGENTOS_PROMPT_SCHEDULER_ENABLED=true. */
     val enabled: Boolean = false,
-    /** Maximum number of UserRuns claimed and executed in parallel per consume tick. */
-    val batchSize: Int = 5,
+    /**
+     * Maximum number of UserRuns claimed per producer iteration.
+     * A larger batch reduces DB round-trips; the channel capacity should be at least
+     * `batchSize` so the producer never suspends mid-batch.
+     */
+    val batchSize: Int = 25,
+    /**
+     * Number of parallel consumer workers processing UserRuns from the channel.
+     * Matches the former page size (5) so throughput is unchanged vs. the old tick model.
+     */
+    val workerCount: Int = 5,
+    /**
+     * Capacity of the channel between producer and workers.
+     * `2 × batchSize` (double-buffering): the producer can fill a second batch into the
+     * channel while workers drain the first, keeping all workers continuously fed without
+     * pre-claiming an excessive number of leased UserRuns.
+     */
+    val channelCapacity: Int = 50,
+    /**
+     * Delay in milliseconds when [claimBatch][io.whozoss.agentos.scheduledPrompt.ScheduledPromptUserRunRepository.claimBatch]
+     * returns an empty list. Prevents the producer from busy-looping against the database
+     * when no UserRuns are pending.
+     */
+    val emptyPollDelayMs: Long = 5_000L,
     /**
      * Max seconds to wait for a Case to reach IDLE or terminal after launch.
      * Beyond this the UserRun is closed as TIMEOUT (Case continues running independently).
@@ -29,8 +53,8 @@ data class SchedulerProperties(
      */
     val launchTimeoutSeconds: Long = 30L,
     /**
-     * Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the next
-     * consume tick, creating a second Case for the same user (at-least-once delivery).
+     * Lease duration for RUNNING UserRuns in minutes. Expired leases are reclaimed by the
+     * producer loop, creating a second Case for the same user (at-least-once delivery).
      * Must be strictly greater than [launchTimeoutSeconds] ÷ 60 — enforced at startup by [SchedulerScanner].
      */
     val leaseMinutes: Long = 30L,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -15,6 +15,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | `agentos.prompt.scheduler.worker-count` | `AGENTOS_PROMPT_SCHEDULER_WORKER_COUNT` | 5 | Number of parallel consumer workers |
  * | `agentos.prompt.scheduler.channel-capacity` | `AGENTOS_PROMPT_SCHEDULER_CHANNEL_CAPACITY` | 50 | Channel buffer size (2 × batchSize — double-buffering) |
  * | `agentos.prompt.scheduler.empty-poll-delay-ms` | `AGENTOS_PROMPT_SCHEDULER_EMPTY_POLL_DELAY_MS` | 5000 | Delay (ms) when claimBatch returns empty — avoids busy-looping |
+ * | `agentos.prompt.scheduler.paused-poll-delay-ms` | `AGENTOS_PROMPT_SCHEDULER_PAUSED_POLL_DELAY_MS` | 10000 | Delay (ms) between producer iterations when consume is paused |
  * | `agentos.prompt.scheduler.launch-timeout-seconds` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `agentos.prompt.scheduler.lease-minutes` | `AGENTOS_PROMPT_SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
  */
@@ -46,6 +47,11 @@ data class SchedulerProperties(
      * when no UserRuns are pending.
      */
     val emptyPollDelayMs: Long = 5_000L,
+    /**
+     * Delay in milliseconds between producer iterations when consume is paused.
+     * Keeps the producer responsive to resume without busy-looping.
+     */
+    val pausedPollDelayMs: Long = 10_000L,
     /**
      * Max seconds to wait for a Case to reach IDLE or terminal after launch.
      * Beyond this the UserRun is closed as TIMEOUT (Case continues running independently).

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -203,9 +203,9 @@ class SchedulerScanner(
                 else -> RunStatus.DONE
             }
             runRepository.updateStatus(run.id, finalStatus, now)
-            logger.warn {
-                "[SchedulerScanner] Orphaned RUNNING run=${run.id} sp=${run.scheduledPromptId} " +
-                    "— all UserRuns settled, closing as $finalStatus (crash recovery)"
+            logger.info {
+                "[SchedulerScanner] RUNNING run=${run.id} sp=${run.scheduledPromptId} " +
+                    "— all UserRuns settled, closing as $finalStatus"
             }
         }
     }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them.
  *
- * ### Single-tick architecture
+ * ### Scheduled entry points
  *
  * **[tickClaim]** (Phase A, every `agentos.prompt.scheduler.tick-interval-ms`):
  * 1. Sweep orphaned CLAIMED runs via [recoverOrphanedClaimedRuns] — handles the crash
@@ -26,9 +26,14 @@ import java.util.concurrent.atomic.AtomicBoolean
  *    calls [ScheduledPromptExecutor.materialize] to create PENDING UserRuns.
  * 4. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
  *
+ * **[tickWatchdog]** (every `agentos.prompt.scheduler.tick-interval-ms`):
+ * Checks [ScheduledPromptExecutor.isRunning] and calls [ScheduledPromptExecutor.restart]
+ * if the consumer loop has died unexpectedly. Runs on the same interval as [tickClaim]
+ * so a dead producer is detected within one tick.
+ *
  * Phase B (UserRun consumption) is handled by [ScheduledPromptExecutor], which runs a
- * continuous producer + channel + worker-pool loop as a [org.springframework.context.SmartLifecycle]
- * bean. There is no consume tick in this scanner.
+ * continuous producer + channel + worker-pool loop started by `@PostConstruct` and stopped
+ * by `@PreDestroy`. There is no consume tick in this scanner.
  *
  * [tickClaim] uses Spring's `@Scheduled(fixedDelay)` to ensure no tick overlaps with its
  * own successor. No fire-and-forget coroutines are used at the Scanner level.
@@ -48,10 +53,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * and materialize). [recoverOrphanedClaimedRuns] marks such runs FAILED at the start of
  * each tick, unblocking the [ScheduledPromptRunRepository.hasActive] overlap guard.
  *
- * A RUNNING Run whose UserRuns are all terminal but whose completion check was never
- * called is handled by [recoverOrphanedRunningRuns], also called at the start of each
- * tick. This covers the crash window between [ScheduledPromptUserRunRepository.markTerminal]
- * and [ScheduledPromptExecutor.checkCompletion].
+ * A RUNNING Run whose UserRuns are all terminal but whose parent was never closed is
+ * handled by [recoverOrphanedRunningRuns], also called at the start of each tick.
+ * This covers the crash window between the [ScheduledPromptUserRunRepository.markTerminal]
+ * call of the last UserRun and the closure of the parent Run, which is now performed
+ * exclusively by [recoverOrphanedRunningRuns] on each tick.
  *
  * The [clock] is injected so tests can freeze time.
  *
@@ -143,9 +149,9 @@ class SchedulerScanner(
             logger.error(e) { "[SchedulerScanner] recoverOrphanedClaimedRuns failed — continuing tick" }
         }
 
-        // Sweep: close RUNNING runs whose UserRuns are all settled but whose completion
-        // check was missed. This handles the crash window between markTerminal() and
-        // checkCompletion() in ScheduledPromptExecutor.
+        // Sweep: close RUNNING runs whose UserRuns are all settled but whose parent was
+        // never closed. This handles the crash window between the last markTerminal() call
+        // and the closure of the parent Run by recoverOrphanedRunningRuns.
         runCatching { recoverOrphanedRunningRuns(now) }.onFailure { e ->
             logger.error(e) { "[SchedulerScanner] recoverOrphanedRunningRuns failed — continuing tick" }
         }
@@ -194,12 +200,12 @@ class SchedulerScanner(
     }
 
     /**
-     * Close RUNNING Runs whose UserRuns are all settled but whose completion check was missed.
+     * Close RUNNING Runs whose UserRuns are all settled but whose parent was never closed.
      *
      * This handles the crash window where the last [ScheduledPromptUserRunRepository.markTerminal]
-     * completed but the instance crashed before [ScheduledPromptExecutor]'s `checkCompletion()`
-     * could transition the parent Run. Without this sweep, the Run would stay RUNNING forever
-     * — no subsequent UserRun closure will re-trigger the check.
+     * completed but the instance crashed before the parent Run could be transitioned.
+     * Without this sweep, the Run would stay RUNNING forever — no subsequent event will
+     * re-trigger the closure.
      *
      * Uses a single [ScheduledPromptRunRepository.findSettledRunning] query that filters
      * directly in the database: only RUNNING Runs with no UserRun in PENDING or RUNNING

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -14,10 +14,9 @@ import java.time.ZoneOffset
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them,
- * and a separate tick that consumes available [ScheduledPromptUserRun]s.
+ * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them.
  *
- * ### Two-tick architecture
+ * ### Single-tick architecture
  *
  * **[tickClaim]** (Phase A, every `agentos.prompt.scheduler.tick-interval-ms`):
  * 1. Sweep orphaned CLAIMED runs via [recoverOrphanedClaimedRuns] — handles the crash
@@ -27,13 +26,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  *    calls [ScheduledPromptExecutor.materialize] to create PENDING UserRuns.
  * 4. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
  *
- * **[tickConsume]** (Phase B, every `agentos.prompt.scheduler.consume-interval-ms`):
- * Declared `suspend` — Spring Framework 6.1+ natively supports suspend functions on
- * `@Scheduled` methods. Calls [ScheduledPromptExecutor.consumeAvailable] which suspends
- * until ALL UserRuns from ALL batches have finished executing. Spring `fixedDelay`
- * guarantees no overlap between consecutive consume ticks.
+ * Phase B (UserRun consumption) is handled by [ScheduledPromptExecutor], which runs a
+ * continuous producer + channel + worker-pool loop as a [org.springframework.context.SmartLifecycle]
+ * bean. There is no consume tick in this scanner.
  *
- * Both ticks use Spring's `@Scheduled(fixedDelay)` to ensure no tick overlaps with its
+ * [tickClaim] uses Spring's `@Scheduled(fixedDelay)` to ensure no tick overlaps with its
  * own successor. No fire-and-forget coroutines are used at the Scanner level.
  *
  * ### Claim logic
@@ -76,11 +73,7 @@ class SchedulerScanner(
     /** When true, tickClaim() exits immediately without processing. */
     private val claimPaused = AtomicBoolean(false)
 
-    /** When true, tickConsume() exits immediately without processing. */
-    private val consumePaused = AtomicBoolean(false)
-
     fun isClaimPaused(): Boolean = claimPaused.get()
-    fun isConsumePaused(): Boolean = consumePaused.get()
 
     fun pauseClaim() {
         claimPaused.set(true)
@@ -90,16 +83,6 @@ class SchedulerScanner(
     fun resumeClaim() {
         claimPaused.set(false)
         logger.warn { "[SchedulerScanner] tickClaim RESUMED by operator" }
-    }
-
-    fun pauseConsume() {
-        consumePaused.set(true)
-        logger.warn { "[SchedulerScanner] tickConsume PAUSED by operator" }
-    }
-
-    fun resumeConsume() {
-        consumePaused.set(false)
-        logger.warn { "[SchedulerScanner] tickConsume RESUMED by operator" }
     }
 
     @PostConstruct
@@ -122,7 +105,7 @@ class SchedulerScanner(
      * When [claimPaused] the tick is a no-op — the scheduling thread still fires
      * but [processClaim] is not called.
      */
-    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:30000}")
+    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:60000}")
     fun tickClaim() {
         when {
             claimPaused.get() -> logger.debug { "[SchedulerScanner] tickClaim PAUSED — skipping" }
@@ -224,27 +207,6 @@ class SchedulerScanner(
                 "[SchedulerScanner] Orphaned RUNNING run=${run.id} sp=${run.scheduledPromptId} " +
                     "— all UserRuns settled, closing as $finalStatus (crash recovery)"
             }
-        }
-    }
-
-    /**
-     * Phase B: Consume available UserRuns.
-     * Declared `suspend` — Spring Framework 6.1+ natively dispatches suspend `@Scheduled`
-     * methods on the application's coroutine scheduler.
-     * Returns only when all claimed UserRuns have finished executing.
-     * Spring fixedDelay guarantees no overlap between ticks.
-     *
-     * When [consumePaused] the tick is a no-op — the scheduling thread still fires
-     * but [ScheduledPromptExecutor.consumeAvailable] is not called.
-     *
-     * The IO dispatcher is managed by [ScheduledPromptExecutor.consumeAvailable] itself
-     * via [kotlinx.coroutines.withContext].
-     */
-    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.consume-interval-ms:10000}")
-    suspend fun tickConsume() {
-        when {
-            consumePaused.get() -> logger.debug { "[SchedulerScanner] tickConsume PAUSED — skipping" }
-            else -> executor.consumeAvailable()
         }
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -114,6 +114,20 @@ class SchedulerScanner(
     }
 
     /**
+     * Watchdog: restarts the consumer loop if it died unexpectedly.
+     * Runs on the same interval as [tickClaim] so a dead producer is detected within one tick.
+     * Safe: Spring guarantees @PostConstruct on all beans completes before @Scheduled ticks fire,
+     * so executor.scope is always initialized when this first runs.
+     */
+    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:60000}")
+    fun tickWatchdog() {
+        if (!executor.isRunning()) {
+            logger.error { "[SchedulerScanner] consumer loop is dead — restarting automatically" }
+            executor.restart()
+        }
+    }
+
+    /**
      * Core claim logic, extracted from [tickClaim] so the scheduled entry point
      * remains a pure activation guard.
      */

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -111,7 +111,7 @@ class SchedulerScanner(
      * When [claimPaused] the tick is a no-op — the scheduling thread still fires
      * but [processClaim] is not called.
      */
-    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:60000}")
+    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:30000}")
     fun tickClaim() {
         when {
             claimPaused.get() -> logger.debug { "[SchedulerScanner] tickClaim PAUSED — skipping" }
@@ -125,7 +125,7 @@ class SchedulerScanner(
      * Safe: Spring guarantees @PostConstruct on all beans completes before @Scheduled ticks fire,
      * so executor.scope is always initialized when this first runs.
      */
-    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:60000}")
+    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:30000}")
     fun tickWatchdog() {
         if (!executor.isRunning()) {
             logger.error { "[SchedulerScanner] consumer loop is dead — restarting automatically" }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/AbstractScheduledPromptUserRunPersistenceSpec.kt
@@ -5,6 +5,9 @@ import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigRepository
 import io.whozoss.agentos.config.TestAuditConfiguration
@@ -542,6 +545,75 @@ abstract class AbstractScheduledPromptUserRunPersistenceSpec : StringSpec() {
             userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
 
             userRunRepo.hasAnyFailed(runId) shouldBe false
+        }
+
+        // -------------------------------------------------------------------------
+        // Load — 100 UserRuns claimed across multiple batches without loss
+        // -------------------------------------------------------------------------
+
+        "claimBatch: 100 PENDING UserRuns are all claimed across multiple batches of 25 without loss" {
+            // Create 4 independent runs with 25 distinct users each → 100 PENDING UserRuns total.
+            // Each run uses its own dedicated agent so that materialize traverses an isolated
+            // deployment sub-graph (avoids cross-run interference when counting RUNNING entries).
+            val ns = namespaceRepo.save(namespace())
+            val allRunIds = mutableListOf<UUID>()
+
+            repeat(4) { batchIndex ->
+                val runId = UUID.randomUUID()
+                allRunIds.add(runId)
+                val agent = agentConfigRepo.save(agentConfig(ns.id, "load-agent-$batchIndex"))
+                val group = userGroupRepo.save(userGroup(ns.id, "load-group-$batchIndex"))
+                val emails = (1..25).map { i -> "load-user-$batchIndex-$i@example.com" }
+                emails.forEach { userRepo.save(user(it)) }
+                userGroupRepo.addAgents(group.id, listOf(agent.id))
+                userGroupRepo.addUsers(group.id, emails)
+                userRunRepo.materialize(runId, agent.id, ns.id)
+            }
+
+            // Drain all UserRuns in batches of 25 until no more PENDING remain.
+            // claimBatch may return fewer than requested when the optimistic lock is contended
+            // (even single-threaded, SDN reloads nodes between saves). We loop until empty.
+            var iterations = 0
+            var batch = userRunRepo.claimBatch(Duration.ofMinutes(30), 25)
+            while (batch.isNotEmpty() && iterations < 20) {
+                iterations++
+                batch = userRunRepo.claimBatch(Duration.ofMinutes(30), 25)
+            }
+
+            // Verify no UserRun was lost: all 100 are RUNNING in the DB
+            val totalRunning = allRunIds.sumOf { runId ->
+                userRunRepo.countByRunIdAndStatus(runId, UserRunStatus.RUNNING)
+            }
+            totalRunning shouldBe 100
+        }
+
+        // -------------------------------------------------------------------------
+        // Concurrency — concurrent claimBatch does not double-claim
+        // -------------------------------------------------------------------------
+
+        "claimBatch: concurrent claims do not double-claim the same UserRun" {
+            // Create 10 PENDING UserRuns
+            val runId = UUID.randomUUID()
+            val fixture = setupDeployment(
+                (1..10).map { i -> "concurrent-user-$i@example.com" },
+                agentName = "concurrent-agent",
+            )
+            userRunRepo.materialize(runId, fixture.agent.id, fixture.ns.id)
+
+            // Launch two concurrent claimBatch calls, each asking for all 10
+            val (result1, result2) = runBlocking {
+                val deferred1 = async { userRunRepo.claimBatch(Duration.ofMinutes(30), 10) }
+                val deferred2 = async { userRunRepo.claimBatch(Duration.ofMinutes(30), 10) }
+                awaitAll(deferred1, deferred2)
+            }
+
+            // The Neo4j optimistic lock ensures each UserRun is claimed by exactly one caller
+            val totalClaimed = result1.size + result2.size
+            totalClaimed shouldBe 10
+            // No UserRun appears in both results
+            val ids1 = result1.map { it.id }.toSet()
+            val ids2 = result2.map { it.id }.toSet()
+            ids1.intersect(ids2).size shouldBe 0
         }
     }
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/BackoffUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/BackoffUnitSpec.kt
@@ -1,0 +1,35 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.booleans.shouldBeTrue
+
+class BackoffUnitSpec : StringSpec({
+
+    "attempt 1 returns baseMs" {
+        exponentialBackoffMs(attempt = 1, baseMs = 2_000L, maxMs = 60_000L) shouldBe 2_000L
+    }
+
+    "attempt 2 doubles the delay" {
+        exponentialBackoffMs(attempt = 2, baseMs = 2_000L, maxMs = 60_000L) shouldBe 4_000L
+    }
+
+    "attempt 3 doubles again" {
+        exponentialBackoffMs(attempt = 3, baseMs = 2_000L, maxMs = 60_000L) shouldBe 8_000L
+    }
+
+    "delay is capped at maxMs" {
+        exponentialBackoffMs(attempt = 100, baseMs = 2_000L, maxMs = 60_000L) shouldBe 60_000L
+    }
+
+    "attempt <= 0 is treated as attempt 1" {
+        exponentialBackoffMs(attempt = 0, baseMs = 2_000L, maxMs = 60_000L) shouldBe 2_000L
+        exponentialBackoffMs(attempt = -5, baseMs = 2_000L, maxMs = 60_000L) shouldBe 2_000L
+    }
+
+    "result never exceeds maxMs for any attempt" {
+        (1..1000).forEach { attempt ->
+            (exponentialBackoffMs(attempt, baseMs = 2_000L, maxMs = 60_000L) <= 60_000L).shouldBeTrue()
+        }
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
@@ -21,6 +21,7 @@ import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -30,8 +31,15 @@ import java.util.UUID
 /**
  * End-to-end scenario tests for the scheduled prompt batch pipeline.
  *
- * Each test drives the full sequence tickClaim() → tickConsume() and verifies the
- * cumulative state transitions across both phases, including crash-recovery sweeps.
+ * Each test drives the full sequence: tickClaim() (Phase A) → drivePhaseB() → tickClaim() again
+ * (Run parent completion via [SchedulerScanner.recoverOrphanedRunningRuns]).
+ *
+ * The two-tickClaim pattern mirrors production: workers close UserRuns, then the next
+ * claim tick detects settled RUNNING Runs and transitions them to DONE/FAILED.
+ *
+ * Phase B is driven directly via [ScheduledPromptExecutor.processUserRun] (`internal`)
+ * rather than starting the full [org.springframework.context.SmartLifecycle] loop.
+ * This keeps the tests deterministic without coroutine infrastructure.
  *
  * Uses in-memory repositories and MockK stubs — no Spring context, no Neo4j.
  * Fixed clock: 2026-01-01 09:00:00 UTC (Thursday).
@@ -97,7 +105,10 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
         ),
     )
 
-    private fun makeScanner(
+    /**
+     * Build scanner + executor together. Returns both so tests can drive Phase B directly.
+     */
+    private fun makeComponents(
         spRepo: InMemoryScheduledPromptRepository,
         runRepo: InMemoryScheduledPromptRunRepository,
         userRunRepo: InMemoryScheduledPromptUserRunRepository,
@@ -109,7 +120,7 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             every { it.findById(userId1) } returns user1
             every { it.findById(userId2) } returns user2
         },
-    ): SchedulerScanner {
+    ): Pair<SchedulerScanner, ScheduledPromptExecutor> {
         runRepo.userRunRepository = userRunRepo
         val promptService = mockk<PromptService>().also {
             every { it.findById(promptTemplateId) } returns promptTemplate
@@ -126,7 +137,7 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             properties = properties,
             clock = clock,
         )
-        return SchedulerScanner(
+        val scanner = SchedulerScanner(
             scheduledPromptRepository = spRepo,
             runRepository = runRepo,
             userRunRepository = userRunRepo,
@@ -136,26 +147,21 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             nextRunCalculatorService = NextRunCalculatorService(clock = clock),
             executor = executor,
         )
+        return scanner to executor
     }
 
     /**
-     * CaseService where each Case's runtime transitions to IDLE after addMessage is called,
-     * simulating a fast agent turn completing synchronously from the test's perspective.
+     * CaseService where each Case's runtime is immediately IDLE.
      *
-     * The runtime map is keyed by caseId and populated in `create` so that `findActiveRuntime`
-     * and `addMessage` can look up the correct flow. All state is local to the returned mock.
+     * statusFlow starts at IDLE so monitorLaunch sees the terminal state immediately.
+     * This avoids mocking addMessage (whose sessionContext parameter is nullable, causing
+     * MockK 1.13.x matcher issues) and keeps the scenarios deterministic.
      */
     private fun eventuallyIdleCaseService(): CaseService {
         val runtimeMap = mutableMapOf<UUID, CaseRuntime>()
         return mockk<CaseService>(relaxed = true).also { svc ->
             every { svc.create(any()) } answers {
                 val id = UUID.randomUUID()
-                // statusFlow starts at IDLE rather than transitioning via addMessage callback.
-                // Reason: addMessage's sessionContext parameter is Map<String, Any?>? (nullable).
-                // MockK 1.13.x any<T>() requires T : Any, so there is no matcher for nullable
-                // types usable in every {}. Starting at IDLE avoids needing to mock addMessage
-                // at all — monitorLaunch sees the terminal state immediately, which is
-                // equivalent for what these scenario tests verify (end-to-end UserRunStatus).
                 val flow = MutableStateFlow(CaseStatus.IDLE)
                 val rt = mockk<CaseRuntime>(relaxed = true).also { every { it.statusFlow } returns flow }
                 runtimeMap[id] = rt
@@ -165,19 +171,38 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
         }
     }
 
+    /**
+     * Drive Phase B for all PENDING UserRuns: claim each one and call processUserRun.
+     *
+     * Run (parent) completion is NOT handled here. A second [SchedulerScanner.tickClaim]
+     * call in each test drives [SchedulerScanner.recoverOrphanedRunningRuns], which closes
+     * settled RUNNING Runs — mirroring the production flow.
+     */
+    private suspend fun drivePhaseB(
+        executor: ScheduledPromptExecutor,
+        userRunRepo: InMemoryScheduledPromptUserRunRepository,
+    ) {
+        val leaseDuration = Duration.ofMinutes(properties.leaseMinutes)
+        var batch: List<ScheduledPromptUserRun>
+        do {
+            batch = userRunRepo.claimBatch(leaseDuration, properties.batchSize)
+            batch.forEach { userRun -> executor.processUserRun(userRun) }
+        } while (batch.isNotEmpty())
+    }
+
     // ---------------------------------------------------------------------------
     // Scenarios
     // ---------------------------------------------------------------------------
 
     init {
 
-        "happy path: tickClaim then tickConsume closes Run as DONE" {
+        "happy path: tickClaim then Phase B then tickClaim closes Run as DONE" {
             val spRepo = InMemoryScheduledPromptRepository()
             val runRepo = InMemoryScheduledPromptRunRepository()
             val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> setOf(userId1, userId2) }
             makeScheduledPrompt(spRepo)
 
-            val scanner = makeScanner(
+            val (scanner, executor) = makeComponents(
                 spRepo, runRepo, userRunRepo,
                 caseService = eventuallyIdleCaseService(),
             )
@@ -185,17 +210,21 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             // Phase A: claim the due slot, materialise UserRuns
             scanner.tickClaim()
 
-            val runAfterClaim = runRepo.all().single()
-            runAfterClaim.status shouldBe RunStatus.RUNNING
+            val run = runRepo.all().single()
+            run.status shouldBe RunStatus.RUNNING
             userRunRepo.all() shouldHaveSize 2
             userRunRepo.all().all { it.status == UserRunStatus.PENDING } shouldBe true
 
-            // Phase B: claim and execute UserRuns; Cases reach IDLE → UserRuns DONE → Run DONE
-            scanner.tickConsume()
-
-            val runAfterConsume = runRepo.findById(runAfterClaim.id)!!
-            runAfterConsume.status shouldBe RunStatus.DONE
+            // Phase B: process UserRuns; Cases reach IDLE → UserRuns DONE
+            drivePhaseB(executor, userRunRepo)
             userRunRepo.all().all { it.status == UserRunStatus.DONE } shouldBe true
+
+            // Run still RUNNING — recoverOrphanedRunningRuns has not fired yet
+            runRepo.findById(run.id)!!.status shouldBe RunStatus.RUNNING
+
+            // Second tickClaim: recoverOrphanedRunningRuns detects all UserRuns settled → DONE
+            scanner.tickClaim()
+            runRepo.findById(run.id)!!.status shouldBe RunStatus.DONE
         }
 
         "crash Phase A: orphaned CLAIMED Run is swept to FAILED, next tick creates new Run" {
@@ -205,7 +234,6 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             val sp = makeScheduledPrompt(spRepo, slot = Instant.parse("2026-01-01T08:00:00Z"))
 
             // Simulate crash: insert a CLAIMED Run older than the orphan threshold (5 min)
-            // as if materialize never completed.
             val orphanedRun = ScheduledPromptRun(
                 metadata = EntityMetadata(
                     id = UUID.randomUUID(),
@@ -218,13 +246,13 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             )
             runRepo.insert(orphanedRun)
 
-            val scanner = makeScanner(
+            val (scanner, _) = makeComponents(
                 spRepo, runRepo, userRunRepo,
                 caseService = eventuallyIdleCaseService(),
             )
 
             // tickClaim: sweep marks orphan FAILED (unblocking hasActive guard),
-            // then claims the due slot → materialises → RUNNING.
+            // then claims the due slot -> materialises -> RUNNING.
             scanner.tickClaim()
 
             runRepo.findById(orphanedRun.id)!!.status shouldBe RunStatus.FAILED
@@ -239,7 +267,7 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> setOf(userId1) }
             val sp = makeScheduledPrompt(spRepo, slot = Instant.parse("2026-01-01T10:00:00Z")) // not due
 
-            // Simulate crash: Run is RUNNING but checkCompletion was never called.
+            // Simulate crash: Run is RUNNING, UserRun settled, but the Run was never closed.
             val orphanedRun = runRepo.insert(
                 ScheduledPromptRun(
                     metadata = EntityMetadata(id = UUID.randomUUID()),
@@ -249,7 +277,6 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
                     correlationId = "orphaned-running",
                 ),
             )
-            // Seed a terminal UserRun — all settled, but the Run was never closed.
             userRunRepo.materialize(orphanedRun.id, agentId, namespaceId)
             userRunRepo.markTerminal(
                 userRunRepo.findByRunId(orphanedRun.id).first().id,
@@ -257,25 +284,25 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
                 nowInstant,
             )
 
-            val scanner = makeScanner(
+            val (scanner, _) = makeComponents(
                 spRepo, runRepo, userRunRepo,
-                caseService = mockk(relaxed = true), // no due prompt — consume not invoked
+                caseService = mockk(relaxed = true),
             )
 
-            // tickClaim sweeps the orphaned RUNNING run → DONE (no due prompts to claim)
+            // tickClaim sweeps the orphaned RUNNING run -> DONE
             scanner.tickClaim()
 
             runRepo.findById(orphanedRun.id)!!.status shouldBe RunStatus.DONE
         }
 
-        "multi-batch: all UserRuns processed when count exceeds batchSize" {
+        "multi-batch: all UserRuns processed when count exceeds batchSize, Run closed on next tick" {
             val userIds = (1..5).map { UUID.randomUUID() }.toSet()
             val spRepo = InMemoryScheduledPromptRepository()
             val runRepo = InMemoryScheduledPromptRunRepository()
             val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> userIds }
             makeScheduledPrompt(spRepo)
 
-            // batchSize = 2 → 3 batches needed for 5 UserRuns
+            // batchSize = 2 -> 3 batches needed for 5 UserRuns
             val smallBatchProperties = SchedulerProperties(batchSize = 2, leaseMinutes = 30L)
             val userService = mockk<UserService>().also { svc ->
                 userIds.forEach { id ->
@@ -287,15 +314,13 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
                     )
                 }
             }
-
-            val caseService = eventuallyIdleCaseService()
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns activeAgent
+            }
 
             runRepo.userRunRepository = userRunRepo
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns promptTemplate
-            }
-            val agentConfigService = mockk<AgentConfigService>().also {
-                every { it.findById(agentId) } returns activeAgent
             }
             val executor = ScheduledPromptExecutor(
                 scheduledPromptRepository = spRepo,
@@ -303,7 +328,7 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
                 userRunRepository = userRunRepo,
                 promptService = promptService,
                 agentConfigService = agentConfigService,
-                caseService = caseService,
+                caseService = eventuallyIdleCaseService(),
                 permissionService = mockk(relaxed = true),
                 userService = userService,
                 properties = smallBatchProperties,
@@ -324,11 +349,21 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             scanner.tickClaim()
             userRunRepo.all() shouldHaveSize 5
 
-            // Phase B: 3 batches of 2, 2, 1 — all 5 UserRuns must be processed
-            scanner.tickConsume()
+            // Phase B: 3 batches of 2, 2, 1 — all 5 UserRuns processed
+            val leaseDuration = Duration.ofMinutes(smallBatchProperties.leaseMinutes)
+            var batch: List<ScheduledPromptUserRun>
+            do {
+                batch = userRunRepo.claimBatch(leaseDuration, smallBatchProperties.batchSize)
+                batch.forEach { userRun -> executor.processUserRun(userRun) }
+            } while (batch.isNotEmpty())
 
             userRunRepo.all().all { it.status == UserRunStatus.DONE } shouldBe true
-            runRepo.findById(runRepo.all().single().id)!!.status shouldBe RunStatus.DONE
+            // Run still RUNNING — not yet closed by the scan
+            runRepo.all().single().status shouldBe RunStatus.RUNNING
+
+            // Second tickClaim closes the settled Run
+            scanner.tickClaim()
+            runRepo.all().single().status shouldBe RunStatus.DONE
         }
 
         "crash Phase B: orphaned RUNNING Run with failed UserRun is swept to FAILED" {
@@ -354,7 +389,7 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
                 "Case creation failed",
             )
 
-            val scanner = makeScanner(
+            val (scanner, _) = makeComponents(
                 spRepo, runRepo, userRunRepo,
                 caseService = mockk(relaxed = true),
             )

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
@@ -38,7 +38,7 @@ import java.util.UUID
  * claim tick detects settled RUNNING Runs and transitions them to DONE/FAILED.
  *
  * Phase B is driven directly via [ScheduledPromptExecutor.processUserRun] (`internal`)
- * rather than starting the full [org.springframework.context.SmartLifecycle] loop.
+ * rather than starting the full producer + channel + worker-pool consumption loop.
  * This keeps the tests deterministic without coroutine infrastructure.
  *
  * Uses in-memory repositories and MockK stubs — no Spring context, no Neo4j.

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -734,6 +734,132 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             }
         }
 
+        // -------------------------------------------------------------------------
+        // Phase B — error handling in processUserRun
+        // -------------------------------------------------------------------------
+
+        "processUserRun: resolveContext throws (findById returns null for run) → markFailed called" {
+            // runRepository.findById returns null → resolveContext throws IllegalStateException
+            // → catch block in processUserRun calls markFailed → userRunRepository.markTerminal FAILED
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
+
+            // runRepository that throws on findById
+            val throwingRunRepo = mockk<ScheduledPromptRunRepository>().also {
+                every { it.findById(run.id) } throws RuntimeException("DB unavailable")
+            }
+
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = throwingRunRepo,
+                userRunRepo = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            ).processUserRun(userRun)
+
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.FAILED
+        }
+
+        "processUserRun: markFailed fails (DB down) → exception swallowed, no rethrow" {
+            // Both resolveContext (findById) and markTerminal throw → processUserRun must not propagate
+            val sp = makeScheduledPrompt()
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(UUID.randomUUID(), agentId, namespaceId)
+            }
+            // Claim a userRun from the in-memory repo so we have a valid id
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
+
+            // runRepository throws → resolveContext throws → catch block → markFailed called
+            val throwingRunRepo = mockk<ScheduledPromptRunRepository>().also {
+                every { it.findById(any()) } throws RuntimeException("DB unavailable")
+            }
+            // userRunRepository also throws on markTerminal → markFailed swallows the error
+            val throwingUserRunRepo = mockk<ScheduledPromptUserRunRepository>().also {
+                every { it.markTerminal(any(), any(), any(), any()) } throws RuntimeException("DB also down")
+            }
+
+            // Must not throw — the exception in markFailed is swallowed by runCatching in markFailed
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = throwingRunRepo,
+                userRunRepo = throwingUserRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+            ).processUserRun(userRun)
+            // No assertion needed — the test passes if no exception is thrown
+        }
+
+        "processUserRun: markTerminal fails after successful case creation → UserRun stays RUNNING (at-least-once)" {
+            // resolveContext and createAndInjectCase succeed, but markTerminal (called from closeUserRun)
+            // throws — the UserRun stays RUNNING (lease expires and is reclaimed: at-least-once delivery)
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val realRunRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
+                it.materialize(run.id, agentId, namespaceId)
+            }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also {
+                every { it.findById(userId1) } returns user1
+            }
+            val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
+            val caseService = mockk<CaseService>(relaxed = true).also {
+                every { it.create(any()) } returns createdCase
+                // No active runtime → closeUserRun is called with findById result
+                every { it.findActiveRuntime(caseId) } returns null
+                every { it.findById(caseId) } returns createdCase.copy(status = CaseStatus.IDLE)
+            }
+
+            // Wrap userRunRepo to make markTerminal throw on the first call (from closeUserRun)
+            // but still track the actual state so we can verify the UserRun stays RUNNING
+            val throwingOnMarkTerminalRepo = object : ScheduledPromptUserRunRepository by userRunRepo {
+                override fun markTerminal(
+                    id: UUID,
+                    status: UserRunStatus,
+                    now: Instant,
+                    error: String?,
+                ): ScheduledPromptUserRun {
+                    throw RuntimeException("DB write failed")
+                }
+            }
+
+            // processUserRun catches the exception from closeUserRun → calls markFailed
+            // but markFailed also uses the same repo (throwingOnMarkTerminalRepo) → also throws
+            // → runCatching in markFailed swallows it → no rethrow from processUserRun
+            executor(
+                spRepo = makeSpRepo(sp),
+                runRepo = realRunRepo,
+                userRunRepo = throwingOnMarkTerminalRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+            ).processUserRun(userRun)
+
+            // The original in-memory repo still shows the UserRun as RUNNING (markTerminal was never persisted)
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.RUNNING
+        }
+
         "Phase B: agent config not found marks UserRun FAILED" {
             val sp = makeScheduledPrompt()
             val run = makeRun(sp).copy(status = RunStatus.RUNNING)

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -26,7 +26,11 @@ import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.scheduledPrompt.UserContextProvider
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -48,6 +52,7 @@ import java.util.UUID
  * The [InMemoryScheduledPromptUserRunRepository] is constructed with a [targetUserIdsProvider]
  * lambda to simulate the Neo4j deployment-graph traversal without touching a database.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class ScheduledPromptExecutorUnitSpec : StringSpec() {
 
     private val nowInstant = Instant.parse("2026-01-01T09:00:00Z")
@@ -340,38 +345,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             actorSlot.captured.id shouldBe userId1.toString()
             val text = contentSlot.captured.filterIsInstance<MessageContent.Text>().first().content
             text shouldBe "@weekly-agent Run your weekly digest report."
-        }
-
-        // -------------------------------------------------------------------------
-        // Phase B: user not found — UserRun marked FAILED
-        // -------------------------------------------------------------------------
-
-        "Phase B: user not found in UserService marks UserRun FAILED" {
-            val sp = makeScheduledPrompt()
-            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
-            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
-            val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
-                it.materialize(run.id, agentId, namespaceId)
-            }
-            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
-
-            val userService = mockk<UserService>().also {
-                every { it.findById(userId1) } returns null
-            }
-
-            executor(
-                spRepo = makeSpRepo(sp),
-                runRepo = runRepo,
-                userRunRepo = userRunRepo,
-                promptService = mockk(relaxed = true),
-                agentConfigService = mockk(relaxed = true),
-                caseService = mockk(relaxed = true),
-                permissionService = mockk(relaxed = true),
-                userService = userService,
-            ).processUserRun(userRun)
-
-            val updated = userRunRepo.all().first { it.id == userRun.id }
-            updated.status shouldBe UserRunStatus.FAILED
         }
 
         // -------------------------------------------------------------------------
@@ -858,6 +831,210 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             // The original in-memory repo still shows the UserRun as RUNNING (markTerminal was never persisted)
             val updated = userRunRepo.all().first { it.id == userRun.id }
             updated.status shouldBe UserRunStatus.RUNNING
+        }
+
+        // -------------------------------------------------------------------------
+        // Consumer loop — real coroutine loop tests
+        // -------------------------------------------------------------------------
+
+        "consumer loop: N UserRuns are all processed by the real coroutine loop" {
+            // Verify that the real producer/channel/worker loop processes all PENDING UserRuns.
+            // Uses UnconfinedTestDispatcher so coroutines run eagerly without real threads.
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userIds = (1..10).map { UUID.randomUUID() }.toSet()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> userIds }
+            userRunRepo.materialize(run.id, agentId, namespaceId)
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also { svc ->
+                userIds.forEach { uid ->
+                    every { svc.findById(uid) } returns User(
+                        metadata = EntityMetadata(id = uid),
+                        externalId = "$uid@example.com",
+                        firstname = "User",
+                        lastname = uid.toString().take(6),
+                    )
+                }
+            }
+            // Each Case immediately reaches IDLE so processUserRun marks UserRun DONE quickly.
+            val runtimeMap = mutableMapOf<UUID, CaseRuntime>()
+            val caseService = mockk<CaseService>(relaxed = true).also { svc ->
+                every { svc.create(any()) } answers {
+                    val id = UUID.randomUUID()
+                    val flow = MutableStateFlow(CaseStatus.IDLE)
+                    val rt = mockk<CaseRuntime>(relaxed = true).also { every { it.statusFlow } returns flow }
+                    runtimeMap[id] = rt
+                    Case(metadata = EntityMetadata(id = id), namespaceId = namespaceId)
+                }
+                every { svc.findActiveRuntime(any()) } answers { runtimeMap[firstArg<UUID>()] }
+            }
+
+            val testDispatcher = UnconfinedTestDispatcher()
+            val exec = ScheduledPromptExecutor(
+                scheduledPromptRepository = makeSpRepo(sp),
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+                properties = SchedulerProperties(batchSize = 5, leaseMinutes = 30L, emptyPollDelayMs = 10L),
+                clock = clock,
+                dispatcher = testDispatcher,
+            )
+
+            runTest(testDispatcher) {
+                exec.start()
+                // Poll until all 10 UserRuns are DONE (or timeout after 5 s real time).
+                withTimeout(5_000L) {
+                    while (userRunRepo.all().count { it.status == UserRunStatus.DONE } < 10) {
+                        kotlinx.coroutines.delay(10L)
+                    }
+                }
+                exec.stop()
+            }
+
+            userRunRepo.all().all { it.status == UserRunStatus.DONE } shouldBe true
+        }
+
+        "consumer loop: stop() closes channel and workers exit cleanly" {
+            // After stop(), isRunning() must return false and no coroutine must keep running.
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userIds = setOf(userId1, userId2)
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> userIds }
+            userRunRepo.materialize(run.id, agentId, namespaceId)
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also { svc ->
+                every { svc.findById(userId1) } returns user1
+                every { svc.findById(userId2) } returns user2
+            }
+            val runtimeMap = mutableMapOf<UUID, CaseRuntime>()
+            val caseService = mockk<CaseService>(relaxed = true).also { svc ->
+                every { svc.create(any()) } answers {
+                    val id = UUID.randomUUID()
+                    val flow = MutableStateFlow(CaseStatus.IDLE)
+                    val rt = mockk<CaseRuntime>(relaxed = true).also { every { it.statusFlow } returns flow }
+                    runtimeMap[id] = rt
+                    Case(metadata = EntityMetadata(id = id), namespaceId = namespaceId)
+                }
+                every { svc.findActiveRuntime(any()) } answers { runtimeMap[firstArg<UUID>()] }
+            }
+
+            val testDispatcher = UnconfinedTestDispatcher()
+            val exec = ScheduledPromptExecutor(
+                scheduledPromptRepository = makeSpRepo(sp),
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+                properties = SchedulerProperties(batchSize = 5, leaseMinutes = 30L, emptyPollDelayMs = 10L),
+                clock = clock,
+                dispatcher = testDispatcher,
+            )
+
+            runTest(testDispatcher) {
+                exec.start()
+                exec.isRunning() shouldBe true
+                exec.stop()
+            }
+
+            exec.isRunning() shouldBe false
+        }
+
+        "consumer loop: worker exception does not stop other workers" {
+            // A resolveContext failure on one UserRun must not prevent other UserRuns from completing.
+            // We simulate this by making runRepository.findById throw for one specific runId,
+            // which causes resolveContext to throw for that UserRun only.
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val normalUserIds = (1..5).map { UUID.randomUUID() }.toSet()
+            val failingUserId = UUID.randomUUID()
+            val allUserIds = normalUserIds + failingUserId
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> allUserIds }
+            userRunRepo.materialize(run.id, agentId, namespaceId)
+
+            val promptService = mockk<PromptService>().also {
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
+            }
+            val agentConfigService = mockk<AgentConfigService>().also {
+                every { it.findById(agentId) } returns makeAgentConfig()
+            }
+            val userService = mockk<UserService>().also { svc ->
+                normalUserIds.forEach { uid ->
+                    every { svc.findById(uid) } returns User(
+                        metadata = EntityMetadata(id = uid),
+                        externalId = "$uid@example.com",
+                        firstname = "User",
+                        lastname = uid.toString().take(6),
+                    )
+                }
+                // Simulate missing user for the failing UserRun — resolveContext will throw.
+                every { svc.findById(failingUserId) } returns null
+            }
+            val runtimeMap = mutableMapOf<UUID, CaseRuntime>()
+            val caseService = mockk<CaseService>(relaxed = true).also { svc ->
+                every { svc.create(any()) } answers {
+                    val id = UUID.randomUUID()
+                    val flow = MutableStateFlow(CaseStatus.IDLE)
+                    val rt = mockk<CaseRuntime>(relaxed = true).also { every { it.statusFlow } returns flow }
+                    runtimeMap[id] = rt
+                    Case(metadata = EntityMetadata(id = id), namespaceId = namespaceId)
+                }
+                every { svc.findActiveRuntime(any()) } answers { runtimeMap[firstArg<UUID>()] }
+            }
+
+            val testDispatcher = UnconfinedTestDispatcher()
+            val exec = ScheduledPromptExecutor(
+                scheduledPromptRepository = makeSpRepo(sp),
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = promptService,
+                agentConfigService = agentConfigService,
+                caseService = caseService,
+                permissionService = mockk(relaxed = true),
+                userService = userService,
+                properties = SchedulerProperties(batchSize = 10, leaseMinutes = 30L, emptyPollDelayMs = 10L),
+                clock = clock,
+                dispatcher = testDispatcher,
+            )
+
+            runTest(testDispatcher) {
+                exec.start()
+                // Wait until all 6 UserRuns reach a terminal state (DONE or FAILED).
+                withTimeout(5_000L) {
+                    while (userRunRepo.all().count { it.status == UserRunStatus.DONE || it.status == UserRunStatus.FAILED } < allUserIds.size) {
+                        kotlinx.coroutines.delay(10L)
+                    }
+                }
+                exec.stop()
+            }
+
+            // The 5 normal UserRuns must be DONE.
+            val doneRuns = userRunRepo.all().filter { it.status == UserRunStatus.DONE }
+            doneRuns.size shouldBe normalUserIds.size
+            // The failing UserRun must be FAILED.
+            val failedRun = userRunRepo.all().first { it.userId == failingUserId }
+            failedRun.status shouldBe UserRunStatus.FAILED
         }
 
         "Phase B: agent config not found marks UserRun FAILED" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -41,6 +41,10 @@ import java.util.UUID
  *
  * Fixed clock: 2026-01-01 09:00:00 UTC.
  *
+ * Phase B tests call [ScheduledPromptExecutor.processUserRun] directly (`internal`)
+ * rather than starting the full lifecycle loop. This keeps the tests fast and
+ * deterministic without coroutine infrastructure.
+ *
  * The [InMemoryScheduledPromptUserRunRepository] is constructed with a [targetUserIdsProvider]
  * lambda to simulate the Neo4j deployment-graph traversal without touching a database.
  */
@@ -223,7 +227,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val run = makeRun(sp)
             val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
 
-            // Mock a userRunRepository whose materialize throws
             val throwingUserRunRepo = mockk<ScheduledPromptUserRunRepository>().also {
                 every { it.materialize(run.id, agentId, namespaceId) } throws RuntimeException("Simulated Neo4j failure")
             }
@@ -242,9 +245,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 exec.materialize(run, sp)
             }
 
-            // Run remains CLAIMED because updateStatus is never reached (exception thrown before it).
-            // In production the @Transactional boundary also rolls back any partial writes,
-            // but that cannot be verified in a unit test without a Spring context.
             val updatedRun = runRepo.all().first { it.id == run.id }
             updatedRun.status shouldBe RunStatus.CLAIMED
         }
@@ -253,7 +253,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val sp = makeScheduledPrompt(nsId = null)
             val run = makeRun(sp)
             val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
-            // Provider is never called for platform-scope (namespaceId == null)
             val userRunRepo = makeUserRunRepo(emptySet())
 
             executor(
@@ -267,57 +266,31 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             ).materialize(run, sp)
 
             userRunRepo.all().size shouldBe 0
-            // No target users → Run transitions directly to DONE (nothing to consume)
             val updatedRun = runRepo.all().first { it.id == run.id }
             updatedRun.status shouldBe RunStatus.DONE
         }
 
         // -------------------------------------------------------------------------
-        // Phase B — consumeAvailable with no pending UserRuns
+        // Phase B — processUserRun (called directly, internal)
         // -------------------------------------------------------------------------
 
-        "Phase B: consumeAvailable does nothing when no PENDING UserRuns exist" {
-            val sp = makeScheduledPrompt()
-            val run = makeRun(sp)
-            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
-            val userRunRepo = makeUserRunRepo(emptySet())
-            val caseService = mockk<CaseService>(relaxed = true)
-
-            executor(
-                spRepo = makeSpRepo(sp),
-                runRepo = runRepo,
-                userRunRepo = userRunRepo,
-                promptService = mockk(relaxed = true),
-                caseService = caseService,
-                permissionService = mockk(relaxed = true),
-                userService = mockk(relaxed = true),
-            ).consumeAvailable()
-
-            verify(exactly = 0) { caseService.create(any()) }
-        }
-
-        // -------------------------------------------------------------------------
-        // Phase B — full execution path
-        // -------------------------------------------------------------------------
-
-        "Phase B: consumeAvailable creates Case, grants ADMIN, and injects @agentName /promptName message" {
+        "Phase B: processUserRun creates Case, grants ADMIN, and injects @agentName message" {
             val sp = makeScheduledPrompt()
             val run = makeRun(sp).copy(status = RunStatus.RUNNING)
             val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.all().first()
+            // Transition to RUNNING so processUserRun can mark it terminal
+            userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10)
 
-            val promptTemplate = makePromptTemplate() // name = "digest-template"
             val promptService = mockk<PromptService>().also {
-                every { it.findById(promptTemplateId) } returns promptTemplate
+                every { it.findById(promptTemplateId) } returns makePromptTemplate()
             }
-
-            val agentConfig = makeAgentConfig(name = "weekly-agent")
             val agentConfigService = mockk<AgentConfigService>().also {
-                every { it.findById(agentId) } returns agentConfig
+                every { it.findById(agentId) } returns makeAgentConfig(name = "weekly-agent")
             }
-
             val createdCase = Case(
                 metadata = EntityMetadata(id = caseId),
                 namespaceId = namespaceId,
@@ -325,9 +298,8 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val caseService = mockk<CaseService>(relaxed = true).also {
                 every { it.create(any()) } returns createdCase
                 every { it.findById(caseId) } returns createdCase.copy(status = CaseStatus.IDLE)
-                every { it.findActiveRuntime(caseId) } returns null // runtime evicted — IDLE
+                every { it.findActiveRuntime(caseId) } returns null
             }
-
             val permissionService = mockk<PermissionService>(relaxed = true)
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns user1
@@ -342,10 +314,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = caseService,
                 permissionService = permissionService,
                 userService = userService,
-            ).consumeAvailable()
-
-            // Wait for the background coroutine to settle
-            kotlinx.coroutines.delay(500)
+            ).processUserRun(userRun)
 
             val caseSlot = slot<Case>()
             verify(exactly = 1) { caseService.create(capture(caseSlot)) }
@@ -369,53 +338,8 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             }
             actorSlot.captured.role shouldBe ActorRole.USER
             actorSlot.captured.id shouldBe userId1.toString()
-            // The message must be "@agentName <resolved prompt content>" — the Executor
-            // resolves the content directly rather than injecting a /slash-command, because
-            // PromptCommandParser requires text to start with '/' which is incompatible
-            // with the leading @mention.
             val text = contentSlot.captured.filterIsInstance<MessageContent.Text>().first().content
             text shouldBe "@weekly-agent Run your weekly digest report."
-        }
-
-        // -------------------------------------------------------------------------
-        // Completion check
-        // -------------------------------------------------------------------------
-
-        "Completion: Run transitions to DONE when all UserRuns are settled" {
-            val sp = makeScheduledPrompt()
-            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
-            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
-            val userRunRepo = makeUserRunRepo(setOf(userId1))
-            userRunRepo.materialize(run.id, agentId, namespaceId)
-            val ur = userRunRepo.all().first()
-            userRunRepo.markTerminal(ur.id, UserRunStatus.DONE, nowInstant)
-
-            executor(
-                spRepo = makeSpRepo(sp),
-                runRepo = runRepo,
-                userRunRepo = userRunRepo,
-                promptService = mockk(relaxed = true),
-                caseService = mockk(relaxed = true),
-                permissionService = mockk(relaxed = true),
-                userService = mockk(relaxed = true),
-            ).consumeAvailable()
-
-            val updatedRun = runRepo.all().first { it.id == run.id }
-            updatedRun.status shouldBe RunStatus.RUNNING
-        }
-
-        "Completion: Run transitions to FAILED when a UserRun has failed" {
-            val sp = makeScheduledPrompt()
-            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
-            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
-            val userRunRepo = makeUserRunRepo(setOf(userId1))
-            userRunRepo.materialize(run.id, agentId, namespaceId)
-            val ur = userRunRepo.all().first()
-            userRunRepo.markTerminal(ur.id, UserRunStatus.FAILED, nowInstant, "boom")
-
-            userRunRepo.hasAnyFailed(run.id) shouldBe true
-            userRunRepo.countByRunIdAndStatus(run.id, UserRunStatus.PENDING) shouldBe 0
-            userRunRepo.countByRunIdAndStatus(run.id, UserRunStatus.RUNNING) shouldBe 0
         }
 
         // -------------------------------------------------------------------------
@@ -429,6 +353,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns null
@@ -443,13 +368,10 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = mockk(relaxed = true),
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            // Wait for the background coroutine
-            kotlinx.coroutines.delay(500)
-
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.FAILED
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.FAILED
         }
 
         // -------------------------------------------------------------------------
@@ -463,6 +385,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns null
@@ -480,13 +403,11 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = mockk(relaxed = true),
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            kotlinx.coroutines.delay(500)
-
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.FAILED
-            userRun.error shouldBe "PromptTemplate $promptTemplateId not found"
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.FAILED
+            updated.error shouldBe "PromptTemplate $promptTemplateId not found"
         }
 
         "Phase B: prompt template with empty content marks UserRun FAILED" {
@@ -496,6 +417,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate(content = "")
@@ -513,13 +435,11 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = mockk(relaxed = true),
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            kotlinx.coroutines.delay(500)
-
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.FAILED
-            userRun.error shouldBe "PromptTemplate $promptTemplateId has empty content"
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.FAILED
+            updated.error shouldBe "PromptTemplate $promptTemplateId has empty content"
         }
 
         // -------------------------------------------------------------------------
@@ -533,6 +453,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate()
@@ -543,22 +464,10 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns user1
             }
-
-            val createdCase = Case(
-                metadata = EntityMetadata(id = caseId),
-                namespaceId = namespaceId,
-            )
-
-            // statusFlow starts at IDLE rather than transitioning via addMessage callback.
-            // Reason: addMessage's sessionContext parameter is Map<String, Any?>? (nullable).
-            // MockK 1.13.x any<T>() requires T : Any, so there is no matcher for nullable
-            // types that can be used in every {}. Starting at IDLE avoids needing to mock
-            // addMessage at all — monitorLaunch sees the terminal state immediately,
-            // which is equivalent for what this test verifies (UserRunStatus outcome).
+            val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
             val runtime = mockk<CaseRuntime>(relaxed = true).also {
                 every { it.statusFlow } returns MutableStateFlow(CaseStatus.IDLE)
             }
-
             val caseService = mockk<CaseService>(relaxed = true).also {
                 every { it.create(any()) } returns createdCase
                 every { it.findActiveRuntime(caseId) } returns runtime
@@ -573,10 +482,9 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = caseService,
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.DONE
+            userRunRepo.all().first { it.id == userRun.id }.status shouldBe UserRunStatus.DONE
         }
 
         "Phase B: monitorLaunch closes UserRun as FAILED when runtime reaches ERROR" {
@@ -586,6 +494,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate()
@@ -596,19 +505,10 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns user1
             }
-
-            val createdCase = Case(
-                metadata = EntityMetadata(id = caseId),
-                namespaceId = namespaceId,
-            )
-
-            // Same rationale as the IDLE test above: statusFlow starts at ERROR directly
-            // instead of transitioning via addMessage, to avoid the MockK nullable matcher
-            // limitation on sessionContext.
+            val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
             val runtime = mockk<CaseRuntime>(relaxed = true).also {
                 every { it.statusFlow } returns MutableStateFlow(CaseStatus.ERROR)
             }
-
             val caseService = mockk<CaseService>(relaxed = true).also {
                 every { it.create(any()) } returns createdCase
                 every { it.findActiveRuntime(caseId) } returns runtime
@@ -623,18 +523,17 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = caseService,
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.FAILED
-            userRun.error shouldBe "Case reached terminal status ERROR"
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.FAILED
+            updated.error shouldBe "Case reached terminal status ERROR"
         }
 
         "Phase B: monitorLaunch closes UserRun as TIMEOUT on timeout (Case still RUNNING)" {
-            // Use a zero launch timeout so it times out immediately.
             val shortTimeoutProperties = SchedulerProperties(
                 batchSize = 5,
-                launchTimeoutSeconds = 0L, // 0 seconds → withTimeoutOrNull(0) times out immediately
+                launchTimeoutSeconds = 0L,
                 leaseMinutes = 30L,
             )
 
@@ -644,6 +543,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate()
@@ -654,18 +554,11 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns user1
             }
-
-            val createdCase = Case(
-                metadata = EntityMetadata(id = caseId),
-                namespaceId = namespaceId,
-            )
-
-            // StatusFlow stays RUNNING forever — simulates a slow but healthy agent.
+            val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
             val statusFlow = MutableStateFlow(CaseStatus.RUNNING)
             val runtime = mockk<CaseRuntime>(relaxed = true).also {
                 every { it.statusFlow } returns statusFlow
             }
-
             val caseService = mockk<CaseService>(relaxed = true).also {
                 every { it.create(any()) } returns createdCase
                 every { it.findActiveRuntime(caseId) } returns runtime
@@ -682,26 +575,24 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 userService = userService,
                 properties = shortTimeoutProperties,
                 clock = clock,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            // Timeout on a still-RUNNING Case is not a failure — the Case is healthy,
-            // just slow. Monitoring is released and the UserRun is closed as TIMEOUT
-            // for audit visibility; the Case continues running independently.
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.TIMEOUT
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.TIMEOUT
         }
 
         // -------------------------------------------------------------------------
         // Phase B — scheduledPromptId propagation
         // -------------------------------------------------------------------------
 
-        "Phase B: Case created by ScheduledPrompt carries scheduledPromptId set to the ScheduledPrompt id" {
+        "Phase B: Case created by ScheduledPrompt carries scheduledPromptId" {
             val sp = makeScheduledPrompt()
             val run = makeRun(sp).copy(status = RunStatus.RUNNING)
             val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate()
@@ -712,7 +603,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns user1
             }
-
             val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
             val caseSlot = slot<Case>()
             val caseService = mockk<CaseService>(relaxed = true).also {
@@ -730,14 +620,10 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = caseService,
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
             caseSlot.captured.scheduledPromptId shouldBe sp.id
         }
-
-        // -------------------------------------------------------------------------
-        // Phase B: prompt or agent not found — UserRun marked FAILED
-        // -------------------------------------------------------------------------
 
         // -------------------------------------------------------------------------
         // Phase B — UserContextProvider enrichment
@@ -750,6 +636,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate()
@@ -760,14 +647,12 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns user1
             }
-
             val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
             val caseService = mockk<CaseService>(relaxed = true).also {
                 every { it.create(any()) } returns createdCase
                 every { it.findActiveRuntime(caseId) } returns null
                 every { it.findById(caseId) } returns createdCase.copy(status = CaseStatus.IDLE)
             }
-
             val expectedContext = mapOf("userContext" to mapOf("talentId" to "t1"))
             val provider = mockk<UserContextProvider>().also {
                 every { it.provideUserContext(user1.externalId, namespaceId) } returns expectedContext
@@ -783,7 +668,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 permissionService = mockk(relaxed = true),
                 userService = userService,
                 userContextProvider = provider,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
             val sessionContextSlot = slot<Map<String, Any?>>()
             verify(exactly = 1) {
@@ -804,6 +689,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate()
@@ -814,14 +700,12 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userService = mockk<UserService>().also {
                 every { it.findById(userId1) } returns user1
             }
-
             val createdCase = Case(metadata = EntityMetadata(id = caseId), namespaceId = namespaceId)
             val caseService = mockk<CaseService>(relaxed = true).also {
                 every { it.create(any()) } returns createdCase
                 every { it.findActiveRuntime(caseId) } returns null
                 every { it.findById(caseId) } returns createdCase.copy(status = CaseStatus.IDLE)
             }
-
             val provider = mockk<UserContextProvider>().also {
                 every { it.provideUserContext(any(), any()) } throws RuntimeException("Copilot unreachable")
             }
@@ -836,12 +720,10 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 permissionService = mockk(relaxed = true),
                 userService = userService,
                 userContextProvider = provider,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            // UserRun must not be FAILED — the exception is non-fatal
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.DONE
-            // addMessage must still be called, but with null sessionContext
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.DONE
             verify(exactly = 1) {
                 caseService.addMessage(
                     caseId = caseId,
@@ -852,10 +734,6 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             }
         }
 
-        // -------------------------------------------------------------------------
-        // Phase B: prompt or agent not found — UserRun marked FAILED
-        // -------------------------------------------------------------------------
-
         "Phase B: agent config not found marks UserRun FAILED" {
             val sp = makeScheduledPrompt()
             val run = makeRun(sp).copy(status = RunStatus.RUNNING)
@@ -863,6 +741,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             val userRunRepo = makeUserRunRepo(setOf(userId1)).also {
                 it.materialize(run.id, agentId, namespaceId)
             }
+            val userRun = userRunRepo.claimBatch(java.time.Duration.ofMinutes(30), 10).first()
 
             val promptService = mockk<PromptService>().also {
                 every { it.findById(promptTemplateId) } returns makePromptTemplate()
@@ -883,13 +762,11 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 caseService = mockk(relaxed = true),
                 permissionService = mockk(relaxed = true),
                 userService = userService,
-            ).consumeAvailable()
+            ).processUserRun(userRun)
 
-            kotlinx.coroutines.delay(500)
-
-            val userRun = userRunRepo.all().first()
-            userRun.status shouldBe UserRunStatus.FAILED
-            userRun.error shouldBe "AgentConfig $agentId not found"
+            val updated = userRunRepo.all().first { it.id == userRun.id }
+            updated.status shouldBe UserRunStatus.FAILED
+            updated.error shouldBe "AgentConfig $agentId not found"
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpointUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpointUnitSpec.kt
@@ -10,11 +10,18 @@ import io.mockk.verify
 /**
  * Unit tests for [SchedulerEndpoint].
  *
- * Uses MockK to mock [SchedulerScanner] — no Spring context required.
+ * Uses MockK to mock [SchedulerScanner] and [ScheduledPromptExecutor] — no Spring context required.
  * Data-driven via Kotest [StringSpec] context/test loops for control routing and status assertions.
+ *
+ * The `claim` phase is delegated to [SchedulerScanner]; the `consume` phase is delegated
+ * to [ScheduledPromptExecutor] (which owns the producer loop since the refactoring to
+ * producer+channel+worker-pool).
  */
 class SchedulerEndpointUnitSpec : StringSpec() {
-    private fun endpoint(scanner: SchedulerScanner = mockk(relaxed = true)): SchedulerEndpoint = SchedulerEndpoint(scanner)
+    private fun endpoint(
+        scanner: SchedulerScanner = mockk(relaxed = true),
+        executor: ScheduledPromptExecutor = mockk(relaxed = true),
+    ): SchedulerEndpoint = SchedulerEndpoint(scanner, executor)
 
     data class StatusCase(
         val claimPaused: Boolean,
@@ -26,8 +33,8 @@ class SchedulerEndpointUnitSpec : StringSpec() {
         val action: String,
         val expectClaimPaused: Boolean,
         val expectConsumePaused: Boolean,
-        val verifyCall: (SchedulerScanner) -> Unit,
-        val verifyNotCalled: (SchedulerScanner) -> Unit,
+        val verifyCall: (SchedulerScanner, ScheduledPromptExecutor) -> Unit,
+        val verifyNotCalled: (SchedulerScanner, ScheduledPromptExecutor) -> Unit,
     )
 
     data class InvalidCase(
@@ -47,12 +54,13 @@ class SchedulerEndpointUnitSpec : StringSpec() {
             StatusCase(claimPaused = true, consumePaused = true),
         ).forEach { (claimPaused, consumePaused) ->
             "status claimPaused=$claimPaused consumePaused=$consumePaused" {
-                val scanner =
-                    mockk<SchedulerScanner> {
-                        every { isClaimPaused() } returns claimPaused
-                        every { isConsumePaused() } returns consumePaused
-                    }
-                val result = endpoint(scanner).status()
+                val scanner = mockk<SchedulerScanner> {
+                    every { isClaimPaused() } returns claimPaused
+                }
+                val executor = mockk<ScheduledPromptExecutor> {
+                    every { isConsumePaused() } returns consumePaused
+                }
+                val result = endpoint(scanner, executor).status()
                 result["claimPaused"] shouldBe claimPaused
                 result["consumePaused"] shouldBe consumePaused
             }
@@ -68,65 +76,69 @@ class SchedulerEndpointUnitSpec : StringSpec() {
                 action = "pause",
                 expectClaimPaused = true,
                 expectConsumePaused = false,
-                verifyCall = { verify(exactly = 1) { it.pauseClaim() } },
-                verifyNotCalled = { verify(exactly = 0) { it.pauseConsume() } },
+                verifyCall = { sc, _ -> verify(exactly = 1) { sc.pauseClaim() } },
+                verifyNotCalled = { _, ex -> verify(exactly = 0) { ex.pauseConsume() } },
             ),
             ControlCase(
                 phase = "claim",
                 action = "resume",
                 expectClaimPaused = false,
                 expectConsumePaused = false,
-                verifyCall = { verify(exactly = 1) { it.resumeClaim() } },
-                verifyNotCalled = { verify(exactly = 0) { it.resumeConsume() } },
+                verifyCall = { sc, _ -> verify(exactly = 1) { sc.resumeClaim() } },
+                verifyNotCalled = { _, ex -> verify(exactly = 0) { ex.resumeConsume() } },
             ),
             ControlCase(
                 phase = "consume",
                 action = "pause",
                 expectClaimPaused = false,
                 expectConsumePaused = true,
-                verifyCall = { verify(exactly = 1) { it.pauseConsume() } },
-                verifyNotCalled = { verify(exactly = 0) { it.pauseClaim() } },
+                verifyCall = { _, ex -> verify(exactly = 1) { ex.pauseConsume() } },
+                verifyNotCalled = { sc, _ -> verify(exactly = 0) { sc.pauseClaim() } },
             ),
             ControlCase(
                 phase = "consume",
                 action = "resume",
                 expectClaimPaused = false,
                 expectConsumePaused = false,
-                verifyCall = { verify(exactly = 1) { it.resumeConsume() } },
-                verifyNotCalled = { verify(exactly = 0) { it.resumeClaim() } },
+                verifyCall = { _, ex -> verify(exactly = 1) { ex.resumeConsume() } },
+                verifyNotCalled = { sc, _ -> verify(exactly = 0) { sc.resumeClaim() } },
             ),
             ControlCase(
                 phase = "all",
                 action = "pause",
                 expectClaimPaused = true,
                 expectConsumePaused = true,
-                verifyCall = {
-                    verify(exactly = 1) { it.pauseClaim() }
-                    verify(exactly = 1) { it.pauseConsume() }
+                verifyCall = { sc, ex ->
+                    verify(exactly = 1) { sc.pauseClaim() }
+                    verify(exactly = 1) { ex.pauseConsume() }
                 },
-                verifyNotCalled = { /* both called — nothing to negate */ },
+                verifyNotCalled = { _, _ -> /* both called — nothing to negate */ },
             ),
             ControlCase(
                 phase = "all",
                 action = "resume",
                 expectClaimPaused = false,
                 expectConsumePaused = false,
-                verifyCall = {
-                    verify(exactly = 1) { it.resumeClaim() }
-                    verify(exactly = 1) { it.resumeConsume() }
+                verifyCall = { sc, ex ->
+                    verify(exactly = 1) { sc.resumeClaim() }
+                    verify(exactly = 1) { ex.resumeConsume() }
                 },
-                verifyNotCalled = { /* both called — nothing to negate */ },
+                verifyNotCalled = { _, _ -> /* both called — nothing to negate */ },
             ),
         ).forEach { case ->
             "control phase=${case.phase} action=${case.action}" {
-                val scanner =
-                    mockk<SchedulerScanner>(relaxed = true) {
-                        every { isClaimPaused() } returns case.expectClaimPaused
-                        every { isConsumePaused() } returns case.expectConsumePaused
-                    }
-                val result = endpoint(scanner).control(claimOrConsumeOrAllPhase = case.phase, pauseOrResumeAction = case.action)
-                case.verifyCall(scanner)
-                case.verifyNotCalled(scanner)
+                val scanner = mockk<SchedulerScanner>(relaxed = true) {
+                    every { isClaimPaused() } returns case.expectClaimPaused
+                }
+                val executor = mockk<ScheduledPromptExecutor>(relaxed = true) {
+                    every { isConsumePaused() } returns case.expectConsumePaused
+                }
+                val result = endpoint(scanner, executor).control(
+                    claimOrConsumeOrAllPhase = case.phase,
+                    pauseOrResumeAction = case.action,
+                )
+                case.verifyCall(scanner, executor)
+                case.verifyNotCalled(scanner, executor)
                 result["claimPaused"] shouldBe case.expectClaimPaused
                 result["consumePaused"] shouldBe case.expectConsumePaused
             }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -719,7 +719,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             )
 
             // Insert a RUNNING run directly (simulates a run that was materialised but whose
-            // checkCompletion call was lost in a crash)
+            // parent closure was lost in a crash)
             val run = ScheduledPromptRun(
                 metadata = EntityMetadata(id = UUID.randomUUID(), created = Instant.parse("2026-01-01T08:00:00Z")),
                 scheduledPromptId = sp.id,
@@ -962,7 +962,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
-        // Pause guards — tickConsume
+        // Startup invariant: leaseMinutes > launchTimeoutSeconds (valid case)
         // -------------------------------------------------------------------------
 
         "SchedulerScanner startup: does not throw when leaseMinutes * 60 > launchTimeoutSeconds" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
 import io.whozoss.agentos.caseFlow.CaseService
@@ -1017,6 +1018,58 @@ class SchedulerScannerUnitSpec : StringSpec() {
             }
             scanner(scheduledPromptRepo, runRepo).tickClaim()
             scheduledPromptRepo.findById(sp.id)!!.enabled shouldBe true
+        }
+
+        // -------------------------------------------------------------------------
+        // Watchdog
+        // -------------------------------------------------------------------------
+
+        "tickWatchdog: executor running → no restart" {
+            // Build a scanner with a mocked executor that reports isRunning() = true
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            val mockExecutor = mockk<ScheduledPromptExecutor>(relaxed = true).also {
+                every { it.isRunning() } returns true
+            }
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = properties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = mockExecutor,
+            )
+
+            sc.tickWatchdog()
+
+            verify(exactly = 0) { mockExecutor.restart() }
+        }
+
+        "tickWatchdog: executor dead → restart called" {
+            // Build a scanner with a mocked executor that reports isRunning() = false
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            val mockExecutor = mockk<ScheduledPromptExecutor>(relaxed = true).also {
+                every { it.isRunning() } returns false
+            }
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = properties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = mockExecutor,
+            )
+
+            sc.tickWatchdog()
+
+            verify(exactly = 1) { mockExecutor.restart() }
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -964,60 +964,6 @@ class SchedulerScannerUnitSpec : StringSpec() {
         // Pause guards — tickConsume
         // -------------------------------------------------------------------------
 
-        "tickConsume when paused: consumeAvailable not called" {
-            val scheduledPromptRepo = makeScheduledPromptRepo()
-            val runRepo = makeRunRepo()
-            val sc = scanner(scheduledPromptRepo, runRepo)
-            sc.pauseConsume()
-            // tickConsume is a no-op when paused — verify by checking isConsumePaused
-            sc.isConsumePaused().shouldBeTrue()
-            // Actual consume path is not exercised; this test asserts the guard is active
-            sc.tickConsume()
-            // No exception, no side-effects — the guard returned early
-        }
-
-        "tickConsume when resumed after pause: isConsumePaused returns false" {
-            val scheduledPromptRepo = makeScheduledPromptRepo()
-            val runRepo = makeRunRepo()
-            val sc = scanner(scheduledPromptRepo, runRepo)
-            sc.pauseConsume()
-            sc.isConsumePaused().shouldBeTrue()
-            sc.resumeConsume()
-            sc.isConsumePaused().shouldBeFalse()
-        }
-
-        "isConsumePaused returns false by default" {
-            val sc = scanner(makeScheduledPromptRepo(), makeRunRepo())
-            sc.isConsumePaused().shouldBeFalse()
-        }
-
-        "pauseConsume then resumeConsume: idempotent on multiple calls" {
-            val sc = scanner(makeScheduledPromptRepo(), makeRunRepo())
-            sc.pauseConsume()
-            sc.pauseConsume()
-            sc.isConsumePaused().shouldBeTrue()
-            sc.resumeConsume()
-            sc.resumeConsume()
-            sc.isConsumePaused().shouldBeFalse()
-        }
-
-        "pauseConsume does not affect tickClaim: runs still created" {
-            val scheduledPromptRepo = makeScheduledPromptRepo()
-            val runRepo = makeRunRepo()
-            val slot = Instant.parse("2026-01-01T08:00:00Z")
-            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-            val sc = scanner(scheduledPromptRepo, runRepo)
-            sc.pauseConsume()
-            sc.tickClaim()
-            runRepo.all() shouldHaveSize 1
-        }
-
-        "pauseClaim does not affect isConsumePaused: consume guard independent" {
-            val sc = scanner(makeScheduledPromptRepo(), makeRunRepo())
-            sc.pauseClaim()
-            sc.isConsumePaused().shouldBeFalse()
-        }
-
         "SchedulerScanner startup: does not throw when leaseMinutes * 60 > launchTimeoutSeconds" {
             val goodProperties = SchedulerProperties(
                 leaseMinutes = 2L,          // 120 seconds

--- a/agentos/docs/scheduled-prompt.md
+++ b/agentos/docs/scheduled-prompt.md
@@ -9,8 +9,10 @@ Execution is split into two phases handled by `SchedulerScanner` and `ScheduledP
 
 - **Phase A — Claim** (`tickClaim`): discovers due prompts, inserts a Run, and materialises
   UserRuns via a single Cypher INSERT-SELECT.
-- **Phase B — Consume** (`tickConsume`): claims PENDING UserRuns, creates a Case per user,
-  injects the prompt, and monitors the launch.
+- **Phase B — Consume** (continuous loop in `ScheduledPromptExecutor`): a producer +
+  channel + worker-pool loop started by `@PostConstruct` claims PENDING UserRuns, creates
+  a Case per user, injects the prompt, and monitors the launch. This loop runs
+  independently of the claim tick and is kept alive by a watchdog (see below).
 
 ## UserRun lifecycle
 
@@ -42,7 +44,7 @@ Each mechanism fires automatically on the next tick.
 | Between `runRepository.insert()` and `runCatching { executor.materialize() }` | Run CLAIMED, no UserRuns created | `recoverOrphanedClaimedRuns` marks FAILED after `ORPHAN_THRESHOLD` (5 min) | ~5 min |
 | Inside `materialize()` (transactional) | Run CLAIMED (transaction rolled back), no UserRuns | Inline `runCatching` marks FAILED immediately if instance alive; otherwise same as above | Immediate or ~5 min |
 | Between `materialize()` and `markTerminal()` | UserRun RUNNING with expired lease | `claimBatch` reclaims on lease expiry — new Case created (at-least-once) | `leaseMinutes` |
-| Between last `markTerminal()` and `checkCompletion()` | Run RUNNING, all UserRuns terminal | `recoverOrphanedRunningRuns` closes Run as DONE or FAILED on next tick | Next claim tick |
+| Between last `markTerminal()` and Run closure | Run RUNNING, all UserRuns terminal | `recoverOrphanedRunningRuns` closes Run as DONE or FAILED on next tick | Next claim tick |
 
 ### Delivery guarantee
 
@@ -58,8 +60,17 @@ The lease must outlive the launch timeout. A shorter lease allows UserRuns to be
 before `monitorLaunch` completes, causing double execution within the same slot.
 Enforced at startup via `require()` in `SchedulerScanner.logStartup()`.
 
+## Consumer-loop watchdog
+
+`SchedulerScanner.tickWatchdog` fires on the same interval as `tickClaim`. It calls
+`ScheduledPromptExecutor.isRunning()` and, if the consumer loop has died unexpectedly
+(e.g. due to an uncaught exception escaping the scope), calls `ScheduledPromptExecutor.restart()`
+to recreate the `CoroutineScope` and relaunch the producer + worker pool. This ensures
+Phase B resumes automatically without operator intervention.
+
 ## `updateStatus` guard
 
 `ScheduledPromptRunNodeNeo4jRepository.updateStatus` only writes when the Run is not already
-in a terminal status (`DONE` or `FAILED`). This prevents `recoverOrphanedRunningRuns` from
-overwriting `finishedAt` already set by `checkCompletion` when both race on the same Run.
+in a terminal status (`DONE` or `FAILED`). This prevents concurrent calls to
+`recoverOrphanedRunningRuns` across instances from overwriting a `finishedAt` already set
+by a previous invocation.

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "kotlinCoroutines" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinCoroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 
 # PF4J Plugin Framework
 pf4j = { module = "org.pf4j:pf4j", version.ref = "pf4j" }


### PR DESCRIPTION
Replace chunk-based tick with a producer/channel/worker pool.
Producer claims batches (size=25) into a buffered channel (cap=50).
Five workers process UserRuns concurrently as soon as they are available, instead of waiting for the entire chunk to complete.
Run parent status (DONE/FAILED) updated by tickClaim scan (60s) instead of inline after each UserRun, avoiding N concurrent writes on the same runId.
Backoff on producer DB errors: min(2s * 2^(attempt-1), 60s).

```
CoroutineScope (SupervisorJob)
│
├── Producer (coroutine)        Channel              Workers (×5 coroutines)
│   ────────────────────        ───────              ───────────────────────
│
│   while(isActive)             ┌────────────┐◄──    Worker 1: for(userRun in channel) ──► createCase ──► awaitLaunch (30s)
│   claimBatch(25)              │            │◄──    Worker 2: for(userRun in channel) ──► createCase ──► awaitLaunch (30s)
│        │                      │  cap = 50  │◄──    Worker 3: for(userRun in channel) ──► createCase ──► awaitLaunch (30s)
│        └─────────────────────►│            │◄──    Worker 4: for(userRun in channel) ──► createCase ──► awaitLaunch (30s)
│                               └────────────┘◄──    Worker 5: for(userRun in channel) ──► createCase ──► awaitLaunch (30s)
│
└── cancel() ──► CancellationException propagated to all ──► channel.close() (finally)
```

Tunable via AGENTOS_PROMPT_SCHEDULER_*:
- WORKER_COUNT (default 5)
- BATCH_SIZE (default 25): items claimed per producer iteration
- CHANNEL_CAPACITY (default 50): channel buffer, ~2x batch size
- TICK_INTERVAL_MS (default 60000): claim + Run completion scan interval
- EMPTY_POLL_DELAY_MS (default 5000): producer idle delay
- PAUSED_POLL_DELAY_MS (default 10000): producer delay when consume is paused
- LEASE_MINUTES (default 30): UserRun lease duration
- LAUNCH_TIMEOUT_SECONDS (default 30): health-check window per UserRun

---

**At-least-once delivery & future effectively-once improvement**

If `markTerminal()` fails (DB unavailable) after a Case has been created, the UserRun stays `RUNNING` until its lease expires and is reclaimed by the producer, potentially creating a second Case for the same user on the next execution.

This is a known and accepted trade-off of the current at-least-once model, predating this PR.
A future improvement would store the `userRunId` on the `Case` node and check for an existing Case before creating a new one, making execution effectively-once even under partial failures.

---

**Why Channel rather than Flow?**

Only the producer would map cleanly onto a Flow; the fan-out would not, flatMapMerge is still @FlowPreview, and the recommended alternative (produceIn + N consumers) is exactly what this code already does explicitly. Three implicit behaviours would also creep in: retryWhen's attempt counter never resets (backoff would measure lifetime failures, not a consecutive-error burst), produceIn closes the channel with the terminating exception so workers die in error instead of draining cleanly, and flowOn inserts a hidden 64-element buffer that would silently override [SchedulerProperties.channelCapacity].
Worth revisiting if the polling policy ever becomes composable (prioritisation, per-namespace quotas, adaptive batching).