### PR TITLE
fix(release): restore minor bump for feat commits after nx 23 migration

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -85,7 +85,8 @@
       "git": {
         "commit": false,
         "tag": false
-      }
+      },
+        "adjustSemverBumpsForZeroMajorVersion": false
     },
     "releaseTag": {
       "pattern": "release/{version}"


### PR DESCRIPTION
Nx 23 flipped `adjustSemverBumpsForZeroMajorVersion` to `true` by default,
silently downgrading `feat:` → patch for all `0.x` versions.

Set it explicitly to `false` to restore standard semver behavior.

Closes #1278