### PR TITLE
feat(agentos): #WZ-34091 restrict scheduler execution to off-peak time windows

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -1,0 +1,227 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import mu.KLogging
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/**
+ * Evaluates whether the current time falls within a configured execution window.
+ *
+ * ### Configuration format
+ *
+ * The window list is specified as a comma-separated string of `DayOfWeek HH:mm` pairs.
+ * Pairs are ordered as alternating open/close boundaries: open₁, close₁, open₂, close₂, …
+ *
+ * Each boundary is a `java.time.DayOfWeek` name (case-insensitive) followed by a space
+ * and an `HH:mm` time in UTC.
+ *
+ * Example — nightly Mon–Thu + continuous weekend:
+ * ```
+ * MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00
+ * ```
+ * This defines two windows:
+ * - Window 1: Monday 22:00 UTC → Friday 05:00 UTC
+ * - Window 2: Friday 22:00 UTC → Monday 05:00 UTC
+ *
+ * Windows are expressed as weekly offsets (minutes since Monday 00:00 UTC).
+ * A window that crosses the Sunday→Monday boundary is handled via modular arithmetic.
+ *
+ * ### No windows configured
+ *
+ * When [SchedulerProperties.windows] is null or blank, [isWithinWindow] always returns `true`
+ * — the scheduler runs continuously, preserving the existing behaviour.
+ *
+ * ### Validation
+ *
+ * [parseAndValidate] is called at construction time. If the string is malformed, all
+ * errors are collected and logged; [isWithinWindow] then always returns `true` (fail-open)
+ * so that a misconfiguration does not silently halt all scheduled executions.
+ *
+ * Validation rules:
+ * - Even number of entries (open/close pairs).
+ * - Each entry matches `DayOfWeek HH:mm` with a valid day name and time.
+ * - Windows do not overlap (close must be strictly after open in weekly offset).
+ * - Windows are ordered (each open must be strictly after the previous close).
+ */
+class ExecutionWindowService(windows: String?) {
+
+    /**
+     * A parsed window boundary: minutes elapsed since Monday 00:00 UTC within the week.
+     * Range: [0, 7×24×60) = [0, 10080).
+     */
+    private data class WeeklyBoundary(val minuteOfWeek: Int)
+
+    /**
+     * A validated open/close window pair, both expressed as [WeeklyBoundary].
+     * A window where [close] < [open] wraps around the Sunday→Monday boundary.
+     */
+    private data class Window(val open: WeeklyBoundary, val close: WeeklyBoundary)
+
+    /**
+     * Parsed and validated windows.
+     * - `null`  → no windows configured (always-open) OR config was invalid (fail-open).
+     * - non-null list → validated windows to evaluate.
+     */
+    private val parsedWindows: List<Window>?
+
+    init {
+        parsedWindows = parseAndValidate(windows)
+    }
+
+    /**
+     * Returns `true` when [now] falls within any configured execution window.
+     *
+     * Returns `true` unconditionally when no windows are configured (always-open behaviour)
+     * or when configuration parsing failed (fail-open).
+     */
+    fun isWithinWindow(now: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)): Boolean {
+        val windows = parsedWindows ?: return true
+        val current = minuteOfWeek(now)
+        return windows.any { window -> isInWindow(current, window) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns `true` when [minuteOfWeek] falls within [window].
+     *
+     * Handles wrap-around (e.g. Friday 22:00 → Monday 05:00): when close < open,
+     * the window spans the Sunday→Monday boundary and the check is inverted.
+     */
+    private fun isInWindow(minuteOfWeek: Int, window: Window): Boolean {
+        val open = window.open.minuteOfWeek
+        val close = window.close.minuteOfWeek
+        return if (open <= close) {
+            // Normal window: open ≤ current < close
+            minuteOfWeek >= open && minuteOfWeek < close
+        } else {
+            // Wrap-around: current ≥ open OR current < close
+            minuteOfWeek >= open || minuteOfWeek < close
+        }
+    }
+
+    /**
+     * Converts a [ZonedDateTime] (any zone, reinterpreted as UTC) to minutes elapsed
+     * since Monday 00:00 UTC within the week.
+     *
+     * [DayOfWeek.getValue] returns 1 (Monday) … 7 (Sunday).
+     * Subtracting 1 gives 0-based day index (Monday = 0, Sunday = 6).
+     */
+    private fun minuteOfWeek(now: ZonedDateTime): Int {
+        val utc = now.withZoneSameInstant(ZoneOffset.UTC)
+        val dayOffset = (utc.dayOfWeek.value - 1) * MINUTES_PER_DAY
+        val timeOffset = utc.hour * 60 + utc.minute
+        return dayOffset + timeOffset
+    }
+
+    /**
+     * Parses [raw] into a list of [Window]s, collecting all validation errors.
+     *
+     * Returns `null` when [raw] is null or blank (no windows → always-open).
+     * Returns an empty list on parse failure (fail-open — [isWithinWindow] returns true).
+     * Returns the validated windows on success.
+     */
+    private fun parseAndValidate(raw: String?): List<Window>? {
+        if (raw.isNullOrBlank()) return null
+
+        val entries = raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        val errors = mutableListOf<String>()
+
+        if (entries.size % 2 != 0) {
+            errors += "windows must contain an even number of entries (open/close pairs), got ${entries.size}"
+        }
+
+        val boundaries = entries.mapIndexedNotNull { index, entry ->
+            parseBoundary(entry, index, errors)
+        }
+
+        if (errors.isNotEmpty()) {
+            logger.error {
+                "[ExecutionWindowService] Invalid scheduler windows configuration — " +
+                    "scheduler will run continuously (fail-open). Errors: ${errors.joinToString("; ")}"
+            }
+            return null  // fail-open: null triggers always-open in isWithinWindow
+        }
+
+        // Pair into windows: (0,1), (2,3), …
+        val windows = boundaries.chunked(2) { (open, close) -> Window(open, close) }
+
+        // Validate: within each window, close must differ from open
+        windows.forEachIndexed { i, w ->
+            if (w.open == w.close) {
+                errors += "window[$i]: open and close are identical (${entries[i * 2]})"
+            }
+        }
+
+        // Validate ordering: each open must be strictly after the previous close,
+        // and within a window the close must be strictly after the open (no wrap for ordering check).
+        // Wrap-around windows (close < open) are valid but must not overlap each other.
+        for (i in windows.indices) {
+            val w = windows[i]
+            // Check no zero-length window
+            if (w.open.minuteOfWeek == w.close.minuteOfWeek) continue // already reported above
+
+            if (i > 0) {
+                val prev = windows[i - 1]
+                if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
+                    errors += "window[$i] open (${entries[i * 2]}) must be strictly after " +
+                        "window[${i - 1}] close (${entries[(i - 1) * 2 + 1]})"
+                }
+            }
+        }
+
+        if (errors.isNotEmpty()) {
+            logger.error {
+                "[ExecutionWindowService] Invalid scheduler windows configuration — " +
+                    "scheduler will run continuously (fail-open). Errors: ${errors.joinToString("; ")}"
+            }
+            return null  // fail-open: null triggers always-open in isWithinWindow
+        }
+
+        logger.info {
+            "[ExecutionWindowService] Execution windows configured: " +
+                windows.joinToString(", ") { w ->
+                    "[${minuteOfWeekToLabel(w.open.minuteOfWeek)} → ${minuteOfWeekToLabel(w.close.minuteOfWeek)}]"
+                }
+        }
+        return windows
+    }
+
+    /**
+     * Parses a single boundary entry of the form `DAYOFWEEK HH:mm`.
+     * Appends to [errors] on failure and returns `null`.
+     */
+    private fun parseBoundary(entry: String, index: Int, errors: MutableList<String>): WeeklyBoundary? {
+        val parts = entry.split(" ")
+        if (parts.size != 2) {
+            errors += "entry[$index] '$entry': expected 'DAYOFWEEK HH:mm'"
+            return null
+        }
+        val day = runCatching { DayOfWeek.valueOf(parts[0].uppercase()) }.getOrElse {
+            errors += "entry[$index] '$entry': unknown day '${parts[0]}' (expected MONDAY…SUNDAY)"
+            return null
+        }
+        val time = runCatching { LocalTime.parse(parts[1]) }.getOrElse {
+            errors += "entry[$index] '$entry': invalid time '${parts[1]}' (expected HH:mm)"
+            return null
+        }
+        val minuteOfWeek = (day.value - 1) * MINUTES_PER_DAY + time.hour * 60 + time.minute
+        return WeeklyBoundary(minuteOfWeek)
+    }
+
+    /** Human-readable label for a minuteOfWeek value, used in log messages. */
+    private fun minuteOfWeekToLabel(minuteOfWeek: Int): String {
+        val day = DayOfWeek.of(minuteOfWeek / MINUTES_PER_DAY + 1)
+        val hour = (minuteOfWeek % MINUTES_PER_DAY) / 60
+        val minute = minuteOfWeek % 60
+        return "$day %02d:%02d UTC".format(hour, minute)
+    }
+
+    companion object : KLogging() {
+        private const val MINUTES_PER_DAY = 24 * 60
+    }
+}

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -122,7 +122,7 @@ class ExecutionWindowService(windows: String?) {
      * Parses [raw] into a list of [Window]s, collecting all validation errors.
      *
      * Returns `null` when [raw] is null or blank (no windows → always-open).
-     * Returns an empty list on parse failure (fail-open — [isWithinWindow] returns true).
+     * Returns `null` on parse failure (fail-open — [isWithinWindow] returns true).
      * Returns the validated windows on success.
      */
     private fun parseAndValidate(raw: String?): List<Window>? {
@@ -167,7 +167,12 @@ class ExecutionWindowService(windows: String?) {
 
             if (i > 0) {
                 val prev = windows[i - 1]
-                if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
+                val prevIsWrapAround = prev.close.minuteOfWeek < prev.open.minuteOfWeek
+                val currIsWrapAround = w.close.minuteOfWeek < w.open.minuteOfWeek
+                if (prevIsWrapAround && currIsWrapAround) {
+                    errors += "window[$i]: only one wrap-around window (crossing Sunday\u2192Monday) is allowed; " +
+                        "window[${i - 1}] and window[$i] both wrap around"
+                } else if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
                     errors += "window[$i] open (${entries[i * 2]}) must be strictly after " +
                         "window[${i - 1}] close (${entries[(i - 1) * 2 + 1]})"
                 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -227,6 +227,6 @@ class ExecutionWindowService(windows: String?) {
     }
 
     companion object : KLogging() {
-        private const val MINUTES_PER_DAY = 24 * 60
+        private val MINUTES_PER_DAY = Duration.ofDays(1).toMinutes().toInt()
     }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -48,16 +48,22 @@ import java.time.ZonedDateTime
 class ExecutionWindowService(windows: String?) {
 
     /**
-     * A parsed window boundary: minutes elapsed since Monday 00:00 UTC within the week.
+     * A parsed window boundary, retaining the original [day] and [time] for readability.
+     * [minuteOfWeek] is derived: minutes elapsed since Monday 00:00 UTC within the week.
      * Range: [0, 7×24×60) = [0, 10080).
      */
-    private data class WeeklyBoundary(val minuteOfWeek: Int)
+    private data class WeeklyBoundary(val day: DayOfWeek, val time: LocalTime) {
+        val minuteOfWeek: Int get() = (day.value - 1) * 24 * 60 + time.toSecondOfDay() / 60
+        override fun toString(): String = "$day ${time} UTC"
+    }
 
     /**
      * A validated open/close window pair, both expressed as [WeeklyBoundary].
      * A window where [close] < [open] wraps around the Sunday→Monday boundary.
      */
-    private data class Window(val open: WeeklyBoundary, val close: WeeklyBoundary)
+    private data class Window(val open: WeeklyBoundary, val close: WeeklyBoundary) {
+        override fun toString(): String = "[$open → $close]"
+    }
 
     /**
      * Parsed and validated windows.
@@ -105,17 +111,12 @@ class ExecutionWindowService(windows: String?) {
     }
 
     /**
-     * Converts a [ZonedDateTime] (any zone, reinterpreted as UTC) to minutes elapsed
-     * since Monday 00:00 UTC within the week.
-     *
-     * [DayOfWeek.getValue] returns 1 (Monday) … 7 (Sunday).
-     * Subtracting 1 gives 0-based day index (Monday = 0, Sunday = 6).
+     * Converts a [ZonedDateTime] (any zone) to minutes elapsed since Monday 00:00 UTC
+     * within the week.
      */
     private fun minuteOfWeek(now: ZonedDateTime): Int {
         val utc = now.withZoneSameInstant(ZoneOffset.UTC)
-        val dayOffset = (utc.dayOfWeek.value - 1) * MINUTES_PER_DAY
-        val timeOffset = utc.hour * 60 + utc.minute
-        return dayOffset + timeOffset
+        return WeeklyBoundary(utc.dayOfWeek, utc.toLocalTime()).minuteOfWeek
     }
 
     /**
@@ -140,29 +141,24 @@ class ExecutionWindowService(windows: String?) {
         }
 
         if (errors.isNotEmpty()) {
-            logger.error {
-                "[ExecutionWindowService] Invalid scheduler windows configuration — " +
-                    "scheduler will run continuously (fail-open). Errors: ${errors.joinToString("; ")}"
-            }
-            return null  // fail-open: null triggers always-open in isWithinWindow
+            logErrors(errors)
+            return null
         }
 
         // Pair into windows: (0,1), (2,3), …
         val windows = boundaries.chunked(2) { (open, close) -> Window(open, close) }
 
-        // Validate: within each window, close must differ from open
+        // Validate: within each window, open and close must differ
         windows.forEachIndexed { i, w ->
             if (w.open == w.close) {
                 errors += "window[$i]: open and close are identical (${entries[i * 2]})"
             }
         }
 
-        // Validate ordering: each open must be strictly after the previous close,
-        // and within a window the close must be strictly after the open (no wrap for ordering check).
-        // Wrap-around windows (close < open) are valid but must not overlap each other.
+        // Validate ordering: each open must be strictly after the previous close.
+        // Wrap-around windows (close < open) are valid but must not coexist (ambiguous overlap).
         for (i in windows.indices) {
             val w = windows[i]
-            // Check no zero-length window
             if (w.open.minuteOfWeek == w.close.minuteOfWeek) continue // already reported above
 
             if (i > 0) {
@@ -170,28 +166,21 @@ class ExecutionWindowService(windows: String?) {
                 val prevIsWrapAround = prev.close.minuteOfWeek < prev.open.minuteOfWeek
                 val currIsWrapAround = w.close.minuteOfWeek < w.open.minuteOfWeek
                 if (prevIsWrapAround && currIsWrapAround) {
-                    errors += "window[$i]: only one wrap-around window (crossing Sunday\u2192Monday) is allowed; " +
-                        "window[${i - 1}] and window[$i] both wrap around"
+                    errors += "window[$i]: only one wrap-around window (crossing Sunday→Monday) is allowed; " +
+                        "window[${i - 1}] ($prev) and window[$i] ($w) both wrap around"
                 } else if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
-                    errors += "window[$i] open (${entries[i * 2]}) must be strictly after " +
-                        "window[${i - 1}] close (${entries[(i - 1) * 2 + 1]})"
+                    errors += "window[$i] open (${w.open}) must be strictly after window[${i - 1}] close (${prev.close})"
                 }
             }
         }
 
         if (errors.isNotEmpty()) {
-            logger.error {
-                "[ExecutionWindowService] Invalid scheduler windows configuration — " +
-                    "scheduler will run continuously (fail-open). Errors: ${errors.joinToString("; ")}"
-            }
-            return null  // fail-open: null triggers always-open in isWithinWindow
+            logErrors(errors)
+            return null
         }
 
         logger.info {
-            "[ExecutionWindowService] Execution windows configured: " +
-                windows.joinToString(", ") { w ->
-                    "[${minuteOfWeekToLabel(w.open.minuteOfWeek)} → ${minuteOfWeekToLabel(w.close.minuteOfWeek)}]"
-                }
+            "[ExecutionWindowService] Execution windows configured: ${windows.joinToString(", ")}"
         }
         return windows
     }
@@ -214,19 +203,15 @@ class ExecutionWindowService(windows: String?) {
             errors += "entry[$index] '$entry': invalid time '${parts[1]}' (expected HH:mm)"
             return null
         }
-        val minuteOfWeek = (day.value - 1) * MINUTES_PER_DAY + time.hour * 60 + time.minute
-        return WeeklyBoundary(minuteOfWeek)
+        return WeeklyBoundary(day, time)
     }
 
-    /** Human-readable label for a minuteOfWeek value, used in log messages. */
-    private fun minuteOfWeekToLabel(minuteOfWeek: Int): String {
-        val day = DayOfWeek.of(minuteOfWeek / MINUTES_PER_DAY + 1)
-        val hour = (minuteOfWeek % MINUTES_PER_DAY) / 60
-        val minute = minuteOfWeek % 60
-        return "$day %02d:%02d UTC".format(hour, minute)
+    private fun logErrors(errors: List<String>) {
+        logger.error {
+            "[ExecutionWindowService] Invalid scheduler windows configuration — " +
+                "scheduler will run continuously (fail-open). Errors: ${errors.joinToString("; ")}"
+        }
     }
 
-    companion object : KLogging() {
-        private val MINUTES_PER_DAY = Duration.ofDays(1).toMinutes().toInt()
-    }
+    companion object : KLogging()
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -81,8 +81,9 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
 
     /**
      * Parsed and validated windows.
-     * - `null`  → no windows configured (always-open) OR config was invalid (fail-open).
-     * - non-null list → validated windows to evaluate.
+     * - `null`        → config was invalid (fail-open, warning logged).
+     * - `emptyList()` → no windows configured (always-open, intentional).
+     * - non-empty list → validated windows to evaluate.
      */
     private val parsedWindows: List<Window>?
 
@@ -104,9 +105,11 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
      * Exposed for callers that already hold an [Instant] (e.g. [SchedulerScanner]).
      */
     fun isWithinExecutionWindow(now: Instant): Boolean {
-        val windows = parsedWindows ?: return true
+        if (parsedWindows == null) {
+            logger.warn { "[ExecutionWindowService] Invalid windows config — running fail-open (always active)" }
+        }
         val current = minuteOfWeek(now)
-        return windows.any { window -> isInWindow(current, window) }
+        return parsedWindows.isNullOrEmpty() || parsedWindows.any { window -> isInWindow(current, window) }
     }
 
     // -------------------------------------------------------------------------
@@ -142,14 +145,17 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
     /**
      * Parses [raw] into a list of [Window]s, collecting all validation errors.
      *
-     * Returns `null` when [raw] is empty (no windows → always-open).
+     * Blank/empty entries (e.g. from stray commas in the env var) are silently filtered
+     * out before any validation, so `"MONDAY 22:00,,FRIDAY 05:00"` is treated the same
+     * as `"MONDAY 22:00,FRIDAY 05:00"`.
+     *
+     * Returns `emptyList()` when no non-blank entries remain (no windows → always-open).
      * Returns `null` on parse failure (fail-open — [isWithinExecutionWindow] returns true).
      * Returns the validated windows on success.
      */
     private fun parseAndValidate(raw: List<String>): List<Window>? {
-        if (raw.isEmpty()) return null
-
         val entries = raw.map { it.trim() }.filter { it.isNotEmpty() }
+        if (entries.isEmpty()) return emptyList()
         val errors = mutableListOf<String>()
 
         if (entries.size % 2 != 0) {
@@ -214,7 +220,7 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
      * Appends to [errors] on failure and returns `null`.
      */
     private fun parseBoundary(entry: String, index: Int, errors: MutableList<String>): WeeklyBoundary? {
-        val parts = entry.split(" ")
+        val parts = entry.trim().split(Regex("\\s+"))
         if (parts.size != 2) {
             errors += "entry[$index] '$entry': expected 'DAYOFWEEK HH:mm'"
             return null

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos.scheduledPrompt
 
 import mu.KLogging
+import org.springframework.stereotype.Service
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneOffset
@@ -54,7 +55,8 @@ import java.time.ZonedDateTime
  * - At most one wrap-around window (crossing Sunday→Monday), since two such windows
  *   cannot be ordered by weekly offset and may overlap undetected.
  */
-class ExecutionWindowService(windows: List<String>) {
+@Service
+class ExecutionWindowService(properties: SchedulerProperties) {
 
     /**
      * A parsed window boundary, retaining the original [day] and [time] for readability.
@@ -84,16 +86,16 @@ class ExecutionWindowService(windows: List<String>) {
     private val parsedWindows: List<Window>?
 
     init {
-        parsedWindows = parseAndValidate(windows)
+        parsedWindows = parseAndValidate(properties.windows)
     }
 
     /**
-     * Returns `true` when [now] falls within any configured execution window.
+     * Returns `true` when [now] falls within any configured execution window (execution allowed).
      *
      * Returns `true` unconditionally when no windows are configured (always-open behaviour)
      * or when configuration parsing failed (fail-open).
      */
-    fun isWithinWindow(now: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)): Boolean {
+    fun isWithinExecutionWindow(now: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)): Boolean {
         val windows = parsedWindows ?: return true
         val current = minuteOfWeek(now)
         return windows.any { window -> isInWindow(current, window) }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -11,41 +11,50 @@ import java.time.ZonedDateTime
  *
  * ### Configuration format
  *
- * The window list is specified as a comma-separated string of `DayOfWeek HH:mm` pairs.
- * Pairs are ordered as alternating open/close boundaries: open₁, close₁, open₂, close₂, …
+ * The constructor receives a flat list of **boundaries**, each of the form `DayOfWeek HH:mm`.
+ * Spring produces this list by splitting the comma-separated value of
+ * [SchedulerProperties.windows] — this class never splits on `,` itself.
+ *
+ * Boundaries are ordered as alternating open/close pairs: open₁, close₁, open₂, close₂, …
+ * and are grouped into [Window]s by position in [parseAndValidate] (`chunked(2)`).
+ * The open/close role is therefore carried by the **index**, not by the type — a deliberate
+ * trade-off to keep the whole configuration in a single environment variable.
  *
  * Each boundary is a `java.time.DayOfWeek` name (case-insensitive) followed by a space
  * and an `HH:mm` time in UTC.
  *
- * Example — nightly Mon–Thu + continuous weekend:
+ * Example — continuous Mon-night→Fri-morning + continuous weekend:
  * ```
- * MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00
+ * AGENTOS_PROMPT_SCHEDULER_WINDOWS=MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00
  * ```
- * This defines two windows:
+ * Spring binds this to `["MONDAY 22:00", "FRIDAY 05:00", "FRIDAY 22:00", "MONDAY 05:00"]`,
+ * which this class groups into two windows:
  * - Window 1: Monday 22:00 UTC → Friday 05:00 UTC
  * - Window 2: Friday 22:00 UTC → Monday 05:00 UTC
  *
- * Windows are expressed as weekly offsets (minutes since Monday 00:00 UTC).
+ * Windows are evaluated as weekly offsets (minutes since Monday 00:00 UTC).
  * A window that crosses the Sunday→Monday boundary is handled via modular arithmetic.
  *
  * ### No windows configured
  *
- * When [SchedulerProperties.windows] is null or blank, [isWithinWindow] always returns `true`
- * — the scheduler runs continuously, preserving the existing behaviour.
+ * When the list is empty, [isWithinWindow] always returns `true` — the scheduler runs
+ * continuously, preserving the existing behaviour.
  *
  * ### Validation
  *
- * [parseAndValidate] is called at construction time. If the string is malformed, all
+ * [parseAndValidate] is called at construction time. If the configuration is malformed, all
  * errors are collected and logged; [isWithinWindow] then always returns `true` (fail-open)
  * so that a misconfiguration does not silently halt all scheduled executions.
  *
  * Validation rules:
- * - Even number of entries (open/close pairs).
- * - Each entry matches `DayOfWeek HH:mm` with a valid day name and time.
- * - Windows do not overlap (close must be strictly after open in weekly offset).
- * - Windows are ordered (each open must be strictly after the previous close).
+ * - Even number of boundaries (each window needs both an open and a close).
+ * - Each boundary matches `DayOfWeek HH:mm` with a valid day name and time.
+ * - Within a window, open and close differ (no zero-length window).
+ * - Windows are ordered and non-overlapping (each open strictly after the previous close).
+ * - At most one wrap-around window (crossing Sunday→Monday), since two such windows
+ *   cannot be ordered by weekly offset and may overlap undetected.
  */
-class ExecutionWindowService(windows: String?) {
+class ExecutionWindowService(windows: List<String>) {
 
     /**
      * A parsed window boundary, retaining the original [day] and [time] for readability.
@@ -62,6 +71,8 @@ class ExecutionWindowService(windows: String?) {
      * A window where [close] < [open] wraps around the Sunday→Monday boundary.
      */
     private data class Window(val open: WeeklyBoundary, val close: WeeklyBoundary) {
+        /** True when the window crosses the Sunday→Monday boundary (close offset before open offset). */
+        val isWrapAround: Boolean get() = close.minuteOfWeek < open.minuteOfWeek
         override fun toString(): String = "[$open → $close]"
     }
 
@@ -122,14 +133,14 @@ class ExecutionWindowService(windows: String?) {
     /**
      * Parses [raw] into a list of [Window]s, collecting all validation errors.
      *
-     * Returns `null` when [raw] is null or blank (no windows → always-open).
+     * Returns `null` when [raw] is empty (no windows → always-open).
      * Returns `null` on parse failure (fail-open — [isWithinWindow] returns true).
      * Returns the validated windows on success.
      */
-    private fun parseAndValidate(raw: String?): List<Window>? {
-        if (raw.isNullOrBlank()) return null
+    private fun parseAndValidate(raw: List<String>): List<Window>? {
+        if (raw.isEmpty()) return null
 
-        val entries = raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        val entries = raw.map { it.trim() }.filter { it.isNotEmpty() }
         val errors = mutableListOf<String>()
 
         if (entries.size % 2 != 0) {
@@ -151,24 +162,30 @@ class ExecutionWindowService(windows: String?) {
         // Validate: within each window, open and close must differ
         windows.forEachIndexed { i, w ->
             if (w.open == w.close) {
-                errors += "window[$i]: open and close are identical (${entries[i * 2]})"
+                errors += "window[$i]: open and close are identical (${w.open})"
             }
         }
 
-        // Validate ordering: each open must be strictly after the previous close.
-        // Wrap-around windows (close < open) are valid but must not coexist (ambiguous overlap).
-        for (i in windows.indices) {
-            val w = windows[i]
-            if (w.open.minuteOfWeek == w.close.minuteOfWeek) continue // already reported above
+        // Validate: at most one wrap-around window. Two of them cannot be ordered by weekly
+        // offset (both have a high open and a low close), so the ordering check below cannot
+        // detect an overlap between them. Checked globally rather than pairwise so the rule
+        // matches its stated intent regardless of window positions.
+        val wrapAroundWindows = windows.filter { it.isWrapAround }
+        if (wrapAroundWindows.size > 1) {
+            errors += "at most one wrap-around window (crossing Sunday→Monday) is allowed, " +
+                "got ${wrapAroundWindows.size}: ${wrapAroundWindows.joinToString(", ")}"
+        }
 
-            if (i > 0) {
+        // Validate ordering: each open must be strictly after the previous close.
+        // Skipped when a wrap-around pair was already reported — raw offset comparison is
+        // meaningless in that case and would emit a confusing secondary error.
+        if (wrapAroundWindows.size <= 1) {
+            for (i in 1 until windows.size) {
+                val w = windows[i]
                 val prev = windows[i - 1]
-                val prevIsWrapAround = prev.close.minuteOfWeek < prev.open.minuteOfWeek
-                val currIsWrapAround = w.close.minuteOfWeek < w.open.minuteOfWeek
-                if (prevIsWrapAround && currIsWrapAround) {
-                    errors += "window[$i]: only one wrap-around window (crossing Sunday→Monday) is allowed; " +
-                        "window[${i - 1}] ($prev) and window[$i] ($w) both wrap around"
-                } else if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
+                if (w.open == w.close || prev.open == prev.close) continue // already reported above
+
+                if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
                     errors += "window[$i] open (${w.open}) must be strictly after window[${i - 1}] close (${prev.close})"
                 }
             }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.scheduledPrompt
 
 import mu.KLogging
 import org.springframework.stereotype.Service
+import java.time.Clock
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneOffset
@@ -56,7 +57,7 @@ import java.time.ZonedDateTime
  *   cannot be ordered by weekly offset and may overlap undetected.
  */
 @Service
-class ExecutionWindowService(properties: SchedulerProperties) {
+class ExecutionWindowService(properties: SchedulerProperties, private val clock: Clock = Clock.systemUTC()) {
 
     /**
      * A parsed window boundary, retaining the original [day] and [time] for readability.
@@ -90,12 +91,20 @@ class ExecutionWindowService(properties: SchedulerProperties) {
     }
 
     /**
-     * Returns `true` when [now] falls within any configured execution window (execution allowed).
+     * Returns `true` when the current time (from the injected [clock]) falls within any
+     * configured execution window (execution allowed).
      *
      * Returns `true` unconditionally when no windows are configured (always-open behaviour)
      * or when configuration parsing failed (fail-open).
      */
-    fun isWithinExecutionWindow(now: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)): Boolean {
+    fun isWithinExecutionWindow(): Boolean = isWithinExecutionWindow(ZonedDateTime.now(clock))
+
+    /**
+     * Returns `true` when [now] falls within any configured execution window.
+     * Exposed for callers that already hold a [ZonedDateTime] (e.g. [SchedulerScanner]
+     * which derives [now] from its own injected clock).
+     */
+    fun isWithinExecutionWindow(now: ZonedDateTime): Boolean {
         val windows = parsedWindows ?: return true
         val current = minuteOfWeek(now)
         return windows.any { window -> isInWindow(current, window) }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -4,6 +4,7 @@ import mu.KLogging
 import org.springframework.stereotype.Service
 import java.time.Clock
 import java.time.DayOfWeek
+import java.time.Instant
 import java.time.LocalTime
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -97,14 +98,13 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
      * Returns `true` unconditionally when no windows are configured (always-open behaviour)
      * or when configuration parsing failed (fail-open).
      */
-    fun isWithinExecutionWindow(): Boolean = isWithinExecutionWindow(ZonedDateTime.now(clock))
+    fun isWithinExecutionWindow(): Boolean = isWithinExecutionWindow(Instant.now(clock))
 
     /**
      * Returns `true` when [now] falls within any configured execution window.
-     * Exposed for callers that already hold a [ZonedDateTime] (e.g. [SchedulerScanner]
-     * which derives [now] from its own injected clock).
+     * Exposed for callers that already hold an [Instant] (e.g. [SchedulerScanner]).
      */
-    fun isWithinExecutionWindow(now: ZonedDateTime): Boolean {
+    fun isWithinExecutionWindow(now: Instant): Boolean {
         val windows = parsedWindows ?: return true
         val current = minuteOfWeek(now)
         return windows.any { window -> isInWindow(current, window) }
@@ -133,11 +133,10 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
     }
 
     /**
-     * Converts a [ZonedDateTime] (any zone) to minutes elapsed since Monday 00:00 UTC
-     * within the week.
+     * Converts an [Instant] to minutes elapsed since Monday 00:00 UTC within the week.
      */
-    private fun minuteOfWeek(now: ZonedDateTime): Int {
-        val utc = now.withZoneSameInstant(ZoneOffset.UTC)
+    private fun minuteOfWeek(now: Instant): Int {
+        val utc = now.atZone(ZoneOffset.UTC)
         return WeeklyBoundary(utc.dayOfWeek, utc.toLocalTime()).minuteOfWeek
     }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowService.kt
@@ -7,7 +7,6 @@ import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalTime
 import java.time.ZoneOffset
-import java.time.ZonedDateTime
 
 /**
  * Evaluates whether the current time falls within a configured execution window.
@@ -40,13 +39,13 @@ import java.time.ZonedDateTime
  *
  * ### No windows configured
  *
- * When the list is empty, [isWithinWindow] always returns `true` — the scheduler runs
+ * When the list is empty, [isWithinExecutionWindow] always returns `true` — the scheduler runs
  * continuously, preserving the existing behaviour.
  *
  * ### Validation
  *
  * [parseAndValidate] is called at construction time. If the configuration is malformed, all
- * errors are collected and logged; [isWithinWindow] then always returns `true` (fail-open)
+ * errors are collected and logged; [isWithinExecutionWindow] then always returns `true` (fail-open)
  * so that a misconfiguration does not silently halt all scheduled executions.
  *
  * Validation rules:
@@ -144,7 +143,7 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
      * Parses [raw] into a list of [Window]s, collecting all validation errors.
      *
      * Returns `null` when [raw] is empty (no windows → always-open).
-     * Returns `null` on parse failure (fail-open — [isWithinWindow] returns true).
+     * Returns `null` on parse failure (fail-open — [isWithinExecutionWindow] returns true).
      * Returns the validated windows on success.
      */
     private fun parseAndValidate(raw: List<String>): List<Window>? {
@@ -190,15 +189,13 @@ class ExecutionWindowService(properties: SchedulerProperties, private val clock:
         // Skipped when a wrap-around pair was already reported — raw offset comparison is
         // meaningless in that case and would emit a confusing secondary error.
         if (wrapAroundWindows.size <= 1) {
-            for (i in 1 until windows.size) {
-                val w = windows[i]
-                val prev = windows[i - 1]
-                if (w.open == w.close || prev.open == prev.close) continue // already reported above
-
-                if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
-                    errors += "window[$i] open (${w.open}) must be strictly after window[${i - 1}] close (${prev.close})"
+            windows.zipWithNext()
+                .filterNot { (prev, w) -> prev.open == prev.close || w.open == w.close } // skip already-reported zero-length windows
+                .forEachIndexed { i, (prev, w) ->
+                    if (w.open.minuteOfWeek <= prev.close.minuteOfWeek) {
+                        errors += "window[${i + 1}] open (${w.open}) must be strictly after window[$i] close (${prev.close})"
+                    }
                 }
-            }
         }
 
         if (errors.isNotEmpty()) {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutor.kt
@@ -65,8 +65,12 @@ import java.util.UUID
  * claimed [ScheduledPromptUserRun] off for processing. When the batch is empty the poller
  * delays [SchedulerProperties.emptyPollDelayMs] before polling again, avoiding a busy-loop.
  * On database errors it applies exponential backoff (capped at 60 s). The poller respects
- * [consumePaused]: when paused it delays [SchedulerProperties.pausedPollDelayMs] per
- * iteration without touching the database.
+ * two pause conditions combined: [consumePaused] (operator pause via [SchedulerEndpoint])
+ * or outside the execution window ([ExecutionWindowService.isWithinWindow] returns false).
+ * In either case the poller delays [SchedulerProperties.pausedPollDelayMs] per iteration
+ * without touching the database. Workers drain whatever is already in the channel, then block on receive.
+ * At most [SchedulerProperties.channelCapacity] UserRuns may still be processed after the
+ * window closes — bounded and deliberate (no lease expiry risk, no duplicate execution).
  * The handoff channel is closed in the poller's `finally` block, guaranteeing that workers
  * exit their iteration loop cleanly regardless of how the poller stops.
  *
@@ -128,8 +132,13 @@ class ScheduledPromptExecutor(
     private val clock: Clock,
     private val userContextProvider: UserContextProvider? = null,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    /**
+     * Evaluates whether Phase B is allowed to poll the database and dispatch UserRuns.
+     * Injected by Spring as [ExecutionWindowService] — same window config as Phase A.
+     * Defaults to always-open so tests and non-windowed deployments are unaffected.
+     */
+    private val executionWindowService: ExecutionWindowService = ExecutionWindowService(SchedulerProperties()),
 ) {
-
     /** When true, the poller skips claimBatch and delays instead. */
     private val consumePaused = AtomicBoolean(false)
 
@@ -216,7 +225,7 @@ class ScheduledPromptExecutor(
             try {
                 while (isActive) {
                     when {
-                        consumePaused.get() -> delay(properties.pausedPollDelayMs)
+                        consumePaused.get() || !executionWindowService.isWithinExecutionWindow() -> delay(properties.pausedPollDelayMs)
                         else -> {
                             try {
                                 val batch = userRunRepository.claimBatch(leaseDuration, properties.batchSize)

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpoint.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpoint.kt
@@ -38,6 +38,7 @@ import org.springframework.stereotype.Component
 class SchedulerEndpoint(
     private val schedulerScanner: SchedulerScanner,
     private val executor: ScheduledPromptExecutor,
+    private val executionWindowService: ExecutionWindowService
 ) {
     /**
      * Read current scheduler status.
@@ -50,6 +51,7 @@ class SchedulerEndpoint(
         mapOf(
             "claimPaused" to schedulerScanner.isClaimPaused(),
             "consumePaused" to executor.isConsumePaused(),
+            "withinExecutionWindow" to executionWindowService.isWithinExecutionWindow()
         )
 
     /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -15,6 +15,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 5 | Max UserRuns claimed and executed in parallel per consume tick |
  * | `agentos.prompt.scheduler.launch-timeout-seconds` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `agentos.prompt.scheduler.lease-minutes` | `AGENTOS_PROMPT_SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
+ * | `agentos.prompt.scheduler.windows` | `AGENTOS_PROMPT_SCHEDULER_WINDOWS` | null | Comma-separated open/close window pairs: `DAYOFWEEK HH:mm` in UTC. See [ExecutionWindowService]. |
  */
 @ConfigurationProperties(prefix = "agentos.prompt.scheduler")
 data class SchedulerProperties(
@@ -34,4 +35,21 @@ data class SchedulerProperties(
      * Must be strictly greater than [launchTimeoutSeconds] ÷ 60 — enforced at startup by [SchedulerScanner].
      */
     val leaseMinutes: Long = 30L,
+    /**
+     * Optional execution time windows. When set, the scheduler only dispatches new claims
+     * during the specified UTC windows; outside windows tickClaim is a no-op and prompts
+     * accumulate until the next window opens.
+     *
+     * Format: comma-separated `DAYOFWEEK HH:mm` pairs — alternating open, close boundaries.
+     * Day names are case-insensitive [java.time.DayOfWeek] values. Times are UTC `HH:mm`.
+     *
+     * Example (nightly Mon–Thu + continuous Fri–Mon weekend):
+     * `MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00`
+     *
+     * When null or blank, the scheduler runs continuously (existing behaviour).
+     * On parse failure the scheduler also runs continuously (fail-open).
+     *
+     * State is not persisted — on restart the window is re-evaluated from config + current time.
+     */
+    val windows: String? = null,
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerProperties.kt
@@ -15,7 +15,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * | `agentos.prompt.scheduler.batch-size` | `AGENTOS_PROMPT_SCHEDULER_BATCH_SIZE` | 5 | Max UserRuns claimed and executed in parallel per consume tick |
  * | `agentos.prompt.scheduler.launch-timeout-seconds` | `AGENTOS_PROMPT_SCHEDULER_LAUNCH_TIMEOUT_SECONDS` | 30 | Max seconds to wait for a Case to reach IDLE or terminal after launch |
  * | `agentos.prompt.scheduler.lease-minutes` | `AGENTOS_PROMPT_SCHEDULER_LEASE_MINUTES` | 30 | Lease duration for RUNNING UserRuns (minutes) |
- * | `agentos.prompt.scheduler.windows` | `AGENTOS_PROMPT_SCHEDULER_WINDOWS` | null | Comma-separated open/close window pairs: `DAYOFWEEK HH:mm` in UTC. See [ExecutionWindowService]. |
+ * | `agentos.prompt.scheduler.windows` | `AGENTOS_PROMPT_SCHEDULER_WINDOWS` | [] | Comma-separated `DAYOFWEEK HH:mm` boundaries, grouped as open/close pairs. See [ExecutionWindowService]. |
  */
 @ConfigurationProperties(prefix = "agentos.prompt.scheduler")
 data class SchedulerProperties(
@@ -40,16 +40,17 @@ data class SchedulerProperties(
      * during the specified UTC windows; outside windows tickClaim is a no-op and prompts
      * accumulate until the next window opens.
      *
-     * Format: comma-separated `DAYOFWEEK HH:mm` pairs — alternating open, close boundaries.
+     * Format: comma-separated `DAYOFWEEK HH:mm` boundaries — alternating open, close.
+     * Spring binds the comma-separated string into a [List<String>] automatically.
      * Day names are case-insensitive [java.time.DayOfWeek] values. Times are UTC `HH:mm`.
      *
      * Example (nightly Mon–Thu + continuous Fri–Mon weekend):
      * `MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00`
      *
-     * When null or blank, the scheduler runs continuously (existing behaviour).
+     * When empty, the scheduler runs continuously (existing behaviour).
      * On parse failure the scheduler also runs continuously (fail-open).
      *
      * State is not persisted — on restart the window is re-evaluated from config + current time.
      */
-    val windows: String? = null,
+    val windows: List<String> = emptyList(),
 )

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -11,6 +11,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -73,6 +74,15 @@ class SchedulerScanner(
     private val nextRunCalculatorService: NextRunCalculatorService,
     private val executor: ScheduledPromptExecutor,
 ) {
+    private val executionWindowService = ExecutionWindowService(properties.windows)
+    /**
+     * Tracks whether the scheduler was last seen inside or outside the execution window,
+     * so WINDOW_OPEN / WINDOW_CLOSE transitions are logged exactly once per transition
+     * rather than on every tick.
+     * Initialised to `null` — unknown until the first tick evaluation.
+     */
+    private var lastWindowState: Boolean? = null
+
     /** When true, tickClaim() exits immediately without processing. */
     private val claimPaused = AtomicBoolean(false)
 
@@ -119,15 +129,57 @@ class SchedulerScanner(
      * Fully blocking — materialize runs synchronously within the tick.
      * Spring fixedDelay guarantees no overlap between ticks.
      *
-     * When [claimPaused] the tick is a no-op — the scheduling thread still fires
-     * but [processClaim] is not called.
+     * Guards (evaluated in order):
+     * 1. [claimPaused] — operator pause via [pauseClaim] / [SchedulerEndpoint].
+     * 2. [ExecutionWindowService.isWithinWindow] — time-window guard; logs WINDOW_OPEN /
+     *    WINDOW_CLOSE on transitions and REQUEST_HELD when outside the window.
+     *
+     * When outside the execution window, due prompts are not dispatched and nextRunAt is
+     * not advanced — they accumulate and are processed at the next window open, including
+     * after a service restart (state is not persisted; the window is re-evaluated from
+     * config + current time on every tick).
      */
     @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:30000}")
     fun tickClaim() {
         when {
             claimPaused.get() -> logger.debug { "[SchedulerScanner] tickClaim PAUSED — skipping" }
+            !checkExecutionWindow() -> return
             else -> processClaim()
         }
+    }
+
+    /**
+     * Evaluates the execution window and emits transition log events.
+     *
+     * Returns `true` when the scheduler is allowed to dispatch (inside the window or no
+     * window configured). Returns `false` when outside the window — the caller must skip
+     * processing.
+     *
+     * Logs:
+     * - `WINDOW_OPEN`  on the first tick after entering the window.
+     * - `WINDOW_CLOSE` on the first tick after leaving the window.
+     * - `REQUEST_HELD` on every tick while outside the window (indicates pending work is waiting).
+     */
+    private fun checkExecutionWindow(): Boolean {
+        val now = ZonedDateTime.now(clock)
+        val inWindow = executionWindowService.isWithinWindow(now)
+
+        when {
+            inWindow && lastWindowState != true -> {
+                logger.info { "[SchedulerScanner] WINDOW_OPEN — scheduler resuming dispatch (${now.toLocalTime()} UTC)" }
+                lastWindowState = true
+            }
+            !inWindow && lastWindowState != false -> {
+                logger.info { "[SchedulerScanner] WINDOW_CLOSE — scheduler pausing dispatch (${now.toLocalTime()} UTC)" }
+                lastWindowState = false
+            }
+        }
+
+        if (!inWindow) {
+            logger.debug { "[SchedulerScanner] REQUEST_HELD — outside execution window, due prompts will wait" }
+        }
+
+        return inWindow
     }
 
     /**
@@ -236,6 +288,10 @@ class SchedulerScanner(
      *
      * When [consumePaused] the tick is a no-op — the scheduling thread still fires
      * but [ScheduledPromptExecutor.consumeAvailable] is not called.
+     *
+     * The time-window guard applies only to [tickClaim] (Phase A). This tick (Phase B)
+     * always runs so that UserRuns already materialised before the window closed are
+     * consumed to completion — in-flight requests are never interrupted.
      *
      * The IO dispatcher is managed by [ScheduledPromptExecutor.consumeAvailable] itself
      * via [kotlinx.coroutines.withContext].

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -143,8 +143,7 @@ class SchedulerScanner(
     fun tickClaim() {
         when {
             claimPaused.get() -> logger.debug { "[SchedulerScanner] tickClaim PAUSED — skipping" }
-            !checkExecutionWindow() -> return
-            else -> processClaim()
+            else -> if (checkExecutionWindow()) processClaim()
         }
     }
 
@@ -162,15 +161,16 @@ class SchedulerScanner(
      */
     private fun checkExecutionWindow(): Boolean {
         val now = ZonedDateTime.now(clock)
+        val nowUtc = now.withZoneSameInstant(ZoneOffset.UTC)
         val inWindow = executionWindowService.isWithinWindow(now)
 
         when {
             inWindow && lastWindowState != true -> {
-                logger.info { "[SchedulerScanner] WINDOW_OPEN — scheduler resuming dispatch (${now.toLocalTime()} UTC)" }
+                logger.info { "[SchedulerScanner] WINDOW_OPEN — scheduler resuming dispatch (${nowUtc.toLocalTime()} UTC)" }
                 lastWindowState = true
             }
             !inWindow && lastWindowState != false -> {
-                logger.info { "[SchedulerScanner] WINDOW_CLOSE — scheduler pausing dispatch (${now.toLocalTime()} UTC)" }
+                logger.info { "[SchedulerScanner] WINDOW_CLOSE — scheduler pausing dispatch (${nowUtc.toLocalTime()} UTC)" }
                 lastWindowState = false
             }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -11,7 +11,6 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
-import java.time.ZonedDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
 
@@ -156,17 +155,16 @@ class SchedulerScanner(
      * - `REQUEST_HELD` on every tick while outside the window (indicates pending work is waiting).
      */
     private fun checkExecutionWindow(): Boolean {
-        val now = ZonedDateTime.now(clock)
-        val nowUtc = now.withZoneSameInstant(ZoneOffset.UTC)
+        val now = Instant.now(clock)
         val inWindow = executionWindowService.isWithinExecutionWindow(now)
 
         when {
             inWindow && lastWindowState != true -> {
-                logger.info { "[SchedulerScanner] WINDOW_OPEN — scheduler resuming dispatch (${nowUtc.toLocalTime()} UTC)" }
+                logger.info { "[SchedulerScanner] WINDOW_OPEN — scheduler resuming dispatch (${now.atZone(ZoneOffset.UTC).toLocalTime()} UTC)" }
                 lastWindowState = true
             }
             !inWindow && lastWindowState != false -> {
-                logger.info { "[SchedulerScanner] WINDOW_CLOSE — scheduler pausing dispatch (${nowUtc.toLocalTime()} UTC)" }
+                logger.info { "[SchedulerScanner] WINDOW_CLOSE — scheduler pausing dispatch (${now.atZone(ZoneOffset.UTC).toLocalTime()} UTC)" }
                 lastWindowState = false
             }
         }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -76,8 +76,8 @@ class SchedulerScanner(
     private val clock: Clock,
     private val nextRunCalculatorService: NextRunCalculatorService,
     private val executor: ScheduledPromptExecutor,
+    private val executionWindowService: ExecutionWindowService,
 ) {
-    private val executionWindowService = ExecutionWindowService(properties.windows)
     /**
      * Tracks whether the scheduler was last seen inside or outside the execution window,
      * so WINDOW_OPEN / WINDOW_CLOSE transitions are logged exactly once per transition
@@ -158,7 +158,7 @@ class SchedulerScanner(
     private fun checkExecutionWindow(): Boolean {
         val now = ZonedDateTime.now(clock)
         val nowUtc = now.withZoneSameInstant(ZoneOffset.UTC)
-        val inWindow = executionWindowService.isWithinWindow(now)
+        val inWindow = executionWindowService.isWithinExecutionWindow(now)
 
         when {
             inWindow && lastWindowState != true -> {

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScanner.kt
@@ -14,11 +14,11 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
+
 /**
- * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them,
- * and a separate tick that consumes available [ScheduledPromptUserRun]s.
+ * Periodic scanner that discovers [ScheduledPrompt]s due for execution and claims them.
  *
- * ### Two-tick architecture
+ * ### Scheduled entry points
  *
  * **[tickClaim]** (Phase A, every `agentos.prompt.scheduler.tick-interval-ms`):
  * 1. Sweep orphaned CLAIMED runs via [recoverOrphanedClaimedRuns] — handles the crash
@@ -28,13 +28,16 @@ import java.util.concurrent.atomic.AtomicBoolean
  *    calls [ScheduledPromptExecutor.materialize] to create PENDING UserRuns.
  * 4. Always advance `nextRunAt` via [ScheduledPromptRepository.advanceNextRunAt].
  *
- * **[tickConsume]** (Phase B, every `agentos.prompt.scheduler.consume-interval-ms`):
- * Declared `suspend` — Spring Framework 6.1+ natively supports suspend functions on
- * `@Scheduled` methods. Calls [ScheduledPromptExecutor.consumeAvailable] which suspends
- * until ALL UserRuns from ALL batches have finished executing. Spring `fixedDelay`
- * guarantees no overlap between consecutive consume ticks.
+ * **[tickWatchdog]** (every `agentos.prompt.scheduler.tick-interval-ms`):
+ * Checks [ScheduledPromptExecutor.isRunning] and calls [ScheduledPromptExecutor.restart]
+ * if the consumer loop has died unexpectedly. Runs on the same interval as [tickClaim]
+ * so a dead producer is detected within one tick.
  *
- * Both ticks use Spring's `@Scheduled(fixedDelay)` to ensure no tick overlaps with its
+ * Phase B (UserRun consumption) is handled by [ScheduledPromptExecutor], which runs a
+ * continuous DB poller + worker-pool loop started by `@PostConstruct`. There is no consume
+ * tick in this scanner.
+ *
+ * [tickClaim] uses Spring's `@Scheduled(fixedDelay)` to ensure no tick overlaps with its
  * own successor. No fire-and-forget coroutines are used at the Scanner level.
  *
  * ### Claim logic
@@ -86,11 +89,7 @@ class SchedulerScanner(
     /** When true, tickClaim() exits immediately without processing. */
     private val claimPaused = AtomicBoolean(false)
 
-    /** When true, tickConsume() exits immediately without processing. */
-    private val consumePaused = AtomicBoolean(false)
-
     fun isClaimPaused(): Boolean = claimPaused.get()
-    fun isConsumePaused(): Boolean = consumePaused.get()
 
     fun pauseClaim() {
         claimPaused.set(true)
@@ -100,16 +99,6 @@ class SchedulerScanner(
     fun resumeClaim() {
         claimPaused.set(false)
         logger.warn { "[SchedulerScanner] tickClaim RESUMED by operator" }
-    }
-
-    fun pauseConsume() {
-        consumePaused.set(true)
-        logger.warn { "[SchedulerScanner] tickConsume PAUSED by operator" }
-    }
-
-    fun resumeConsume() {
-        consumePaused.set(false)
-        logger.warn { "[SchedulerScanner] tickConsume RESUMED by operator" }
     }
 
     @PostConstruct
@@ -138,6 +127,13 @@ class SchedulerScanner(
      * not advanced — they accumulate and are processed at the next window open, including
      * after a service restart (state is not persisted; the window is re-evaluated from
      * config + current time on every tick).
+     *
+     * Note: the time-window guard applies only to this tick (Phase A). Phase B (UserRun
+     * consumption) runs continuously via [ScheduledPromptExecutor]'s internal loop — already
+     * materialised UserRuns are always consumed to completion even after the window closes.
+     * The volume of in-flight work is bounded by [SchedulerProperties.batchSize] (max UserRuns
+     * claimed per poller iteration) and [SchedulerProperties.channelCapacity] (max UserRuns
+     * buffered in the handoff channel between the poller and the workers).
      */
     @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:30000}")
     fun tickClaim() {
@@ -280,27 +276,16 @@ class SchedulerScanner(
     }
 
     /**
-     * Phase B: Consume available UserRuns.
-     * Declared `suspend` — Spring Framework 6.1+ natively dispatches suspend `@Scheduled`
-     * methods on the application's coroutine scheduler.
-     * Returns only when all claimed UserRuns have finished executing.
-     * Spring fixedDelay guarantees no overlap between ticks.
-     *
-     * When [consumePaused] the tick is a no-op — the scheduling thread still fires
-     * but [ScheduledPromptExecutor.consumeAvailable] is not called.
-     *
-     * The time-window guard applies only to [tickClaim] (Phase A). This tick (Phase B)
-     * always runs so that UserRuns already materialised before the window closed are
-     * consumed to completion — in-flight requests are never interrupted.
-     *
-     * The IO dispatcher is managed by [ScheduledPromptExecutor.consumeAvailable] itself
-     * via [kotlinx.coroutines.withContext].
+     * Watchdog: restarts the consumer loop if it died unexpectedly.
+     * Runs on the same interval as [tickClaim] so a dead producer is detected within one tick.
+     * Safe: Spring guarantees @PostConstruct on all beans completes before @Scheduled ticks fire,
+     * so executor.scope is always initialized when this first runs.
      */
-    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.consume-interval-ms:10000}")
-    suspend fun tickConsume() {
-        when {
-            consumePaused.get() -> logger.debug { "[SchedulerScanner] tickConsume PAUSED — skipping" }
-            else -> executor.consumeAvailable()
+    @Scheduled(fixedDelayString = "\${agentos.prompt.scheduler.tick-interval-ms:30000}")
+    fun tickWatchdog() {
+        if (!executor.isRunning()) {
+            logger.error { "[SchedulerScanner] consumer loop is dead — restarting automatically" }
+            executor.restart()
         }
     }
 

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -243,6 +243,15 @@ agentos:
       # Interval between claim ticks in milliseconds.
       # Override with env var: AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS
       tick-interval-ms: ${AGENTOS_PROMPT_SCHEDULER_TICK_INTERVAL_MS:30000}
+      # Optional execution time windows (UTC). When set, the scheduler only dispatches
+      # new claims during the specified windows; outside windows, due prompts accumulate
+      # and are processed at the next window open (including after a restart).
+      # Format: comma-separated 'DAYOFWEEK HH:mm' pairs — alternating open/close boundaries.
+      # Example (nightly Mon–Thu + continuous Fri–Mon weekend):
+      #   MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00
+      # When unset or blank, the scheduler runs continuously (default behaviour).
+      # Override with env var: AGENTOS_PROMPT_SCHEDULER_WINDOWS
+      # windows: ${AGENTOS_PROMPT_SCHEDULER_WINDOWS:}
 
 springdoc:
   writer-with-order-by-keys: true

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -246,11 +246,12 @@ agentos:
       # Optional execution time windows (UTC). When set, the scheduler only dispatches
       # new claims during the specified windows; outside windows, due prompts accumulate
       # and are processed at the next window open (including after a restart).
-      # Format: comma-separated 'DAYOFWEEK HH:mm' pairs — alternating open/close boundaries.
+      # Comma-separated 'DAYOFWEEK HH:mm' boundaries in UTC — alternating open/close.
+      # Spring binds the comma-separated env var value into a list automatically.
       # Example (nightly Mon–Thu + continuous Fri–Mon weekend):
       #   MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00
-      # When unset or blank, the scheduler runs continuously (default behaviour).
-      # Override with env var: AGENTOS_PROMPT_SCHEDULER_WINDOWS
+      # When unset, the scheduler runs continuously (default behaviour).
+      # Override with env var: AGENTOS_PROMPT_SCHEDULER_WINDOWS=MONDAY 22:00,FRIDAY 05:00,...
       # windows: ${AGENTOS_PROMPT_SCHEDULER_WINDOWS:}
 
 springdoc:

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
@@ -1,0 +1,264 @@
+package io.whozoss.agentos.scheduledPrompt
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/**
+ * Unit tests for [ExecutionWindowService].
+ *
+ * Uses fixed [ZonedDateTime] values — no Spring context, no Clock injection.
+ *
+ * Reference week (ISO 8601, Monday = day 1):
+ *   MONDAY    = minuteOfWeek   0 – 1439
+ *   TUESDAY   = minuteOfWeek 1440 – 2879
+ *   WEDNESDAY = minuteOfWeek 2880 – 4319
+ *   THURSDAY  = minuteOfWeek 4320 – 5759
+ *   FRIDAY    = minuteOfWeek 5760 – 7199
+ *   SATURDAY  = minuteOfWeek 7200 – 8639
+ *   SUNDAY    = minuteOfWeek 8640 – 10079
+ *
+ * Business-hours config used in most tests:
+ *   `MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00`
+ *   Window 1: Mon 22:00 → Fri 05:00  (nightly Mon–Thu + early Fri)
+ *   Window 2: Fri 22:00 → Mon 05:00  (continuous weekend)
+ */
+class ExecutionWindowServiceSpec : StringSpec() {
+
+    /** Canonical business-hours config: nightly Mon–Thu + continuous Fri–Mon. */
+    private val businessHoursConfig = "MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00"
+
+    private fun at(day: String, hour: Int, minute: Int = 0): ZonedDateTime {
+        val dayOfWeek = java.time.DayOfWeek.valueOf(day)
+        // Use any Monday as anchor (2024-01-01 is a Monday)
+        val monday = java.time.LocalDate.of(2024, 1, 1)
+        val date = monday.plusDays((dayOfWeek.value - 1).toLong())
+        return ZonedDateTime.of(date, java.time.LocalTime.of(hour, minute), ZoneOffset.UTC)
+    }
+
+    init {
+
+        // -------------------------------------------------------------------------
+        // No windows configured — always open
+        // -------------------------------------------------------------------------
+
+        "no windows (null): always within window" {
+            val svc = ExecutionWindowService(null)
+            svc.isWithinWindow(at("MONDAY", 10)).shouldBeTrue()
+            svc.isWithinWindow(at("SATURDAY", 14)).shouldBeTrue()
+        }
+
+        "no windows (blank): always within window" {
+            val svc = ExecutionWindowService("   ")
+            svc.isWithinWindow(at("WEDNESDAY", 9)).shouldBeTrue()
+        }
+
+        // -------------------------------------------------------------------------
+        // Business-hours config — inside windows
+        // -------------------------------------------------------------------------
+
+        "inside window 1: Monday night is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
+        }
+
+        "inside window 1: Tuesday 02:00 is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("TUESDAY", 2)).shouldBeTrue()
+        }
+
+        "inside window 1: Thursday 23:59 is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("THURSDAY", 23, 59)).shouldBeTrue()
+        }
+
+        "inside window 1: Friday 04:59 is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("FRIDAY", 4, 59)).shouldBeTrue()
+        }
+
+        "inside window 2: Friday night is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("FRIDAY", 23)).shouldBeTrue()
+        }
+
+        "inside window 2: Saturday is always within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("SATURDAY", 0)).shouldBeTrue()
+            svc.isWithinWindow(at("SATURDAY", 12)).shouldBeTrue()
+            svc.isWithinWindow(at("SATURDAY", 23, 59)).shouldBeTrue()
+        }
+
+        "inside window 2: Sunday is always within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("SUNDAY", 0)).shouldBeTrue()
+            svc.isWithinWindow(at("SUNDAY", 12)).shouldBeTrue()
+            svc.isWithinWindow(at("SUNDAY", 23, 59)).shouldBeTrue()
+        }
+
+        "inside window 2: Monday 04:59 is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("MONDAY", 4, 59)).shouldBeTrue()
+        }
+
+        // -------------------------------------------------------------------------
+        // Business-hours config — outside windows (business hours)
+        // -------------------------------------------------------------------------
+
+        "outside window: Monday 10:00 is outside window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
+        }
+
+        // Note: window 1 is MONDAY 22:00 → FRIDAY 05:00, a *continuous* block.
+        // Tuesday 09:00, Wednesday 14:00, Thursday 08:00 are all inside that continuous
+        // window (Mon night through Fri morning). To restrict to nightly slots only,
+        // the operator would need to configure one window per night.
+        "inside window 1: Tuesday 09:00 is within the continuous Mon–Fri window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("TUESDAY", 9)).shouldBeTrue()
+        }
+
+        "inside window 1: Wednesday 14:00 is within the continuous Mon–Fri window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+        }
+
+        "inside window 1: Thursday 08:00 is within the continuous Mon–Fri window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("THURSDAY", 8)).shouldBeTrue()
+        }
+
+        "outside window: Friday 10:00 is outside window (between window 1 close and window 2 open)" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("FRIDAY", 10)).shouldBeFalse()
+        }
+
+        // -------------------------------------------------------------------------
+        // Exact boundary conditions (inclusive open, exclusive close)
+        // -------------------------------------------------------------------------
+
+        "boundary: exactly at window 1 open (Monday 22:00) is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("MONDAY", 22, 0)).shouldBeTrue()
+        }
+
+        "boundary: exactly at window 1 close (Friday 05:00) is outside window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("FRIDAY", 5, 0)).shouldBeFalse()
+        }
+
+        "boundary: exactly at window 2 open (Friday 22:00) is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("FRIDAY", 22, 0)).shouldBeTrue()
+        }
+
+        "boundary: exactly at window 2 close (Monday 05:00) is outside window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("MONDAY", 5, 0)).shouldBeFalse()
+        }
+
+        "boundary: one minute before window 1 open (Monday 21:59) is outside window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("MONDAY", 21, 59)).shouldBeFalse()
+        }
+
+        "boundary: one minute before window 1 close (Friday 04:59) is within window" {
+            val svc = ExecutionWindowService(businessHoursConfig)
+            svc.isWithinWindow(at("FRIDAY", 4, 59)).shouldBeTrue()
+        }
+
+        // -------------------------------------------------------------------------
+        // Single nightly window (no weekend extension)
+        // -------------------------------------------------------------------------
+
+        "single nightly window: within window" {
+            // Every night 22:00 → 05:00 (wraps midnight)
+            val svc = ExecutionWindowService("MONDAY 22:00,TUESDAY 05:00")
+            svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
+            svc.isWithinWindow(at("TUESDAY", 2)).shouldBeTrue()
+        }
+
+        "single nightly window: outside window" {
+            val svc = ExecutionWindowService("MONDAY 22:00,TUESDAY 05:00")
+            svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
+            svc.isWithinWindow(at("TUESDAY", 6)).shouldBeFalse()
+        }
+
+        // -------------------------------------------------------------------------
+        // Wrap-around: window spanning Sunday → Monday midnight
+        // -------------------------------------------------------------------------
+
+        "wrap-around: Sunday 23:00 is within a Sun 22:00 → Mon 05:00 window" {
+            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            svc.isWithinWindow(at("SUNDAY", 23)).shouldBeTrue()
+        }
+
+        "wrap-around: Monday 02:00 is within a Sun 22:00 → Mon 05:00 window" {
+            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            svc.isWithinWindow(at("MONDAY", 2)).shouldBeTrue()
+        }
+
+        "wrap-around: Monday 06:00 is outside a Sun 22:00 → Mon 05:00 window" {
+            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            svc.isWithinWindow(at("MONDAY", 6)).shouldBeFalse()
+        }
+
+        "wrap-around: Sunday 21:59 is outside a Sun 22:00 → Mon 05:00 window" {
+            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            svc.isWithinWindow(at("SUNDAY", 21, 59)).shouldBeFalse()
+        }
+
+        // -------------------------------------------------------------------------
+        // Invalid configuration — fail-open (always within window)
+        // -------------------------------------------------------------------------
+
+        "invalid config: odd number of entries — fail-open" {
+            val svc = ExecutionWindowService("MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00")
+            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+        }
+
+        "invalid config: unknown day name — fail-open" {
+            val svc = ExecutionWindowService("FUNDAY 22:00,FRIDAY 05:00")
+            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+        }
+
+        "invalid config: malformed time — fail-open" {
+            val svc = ExecutionWindowService("MONDAY 25:00,FRIDAY 05:00")
+            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+        }
+
+        "invalid config: missing time part — fail-open" {
+            val svc = ExecutionWindowService("MONDAY,FRIDAY 05:00")
+            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+        }
+
+        "invalid config: overlapping windows — fail-open" {
+            // Window 2 open (TUESDAY 08:00) is before window 1 close (WEDNESDAY 05:00)
+            val svc = ExecutionWindowService("MONDAY 22:00,WEDNESDAY 05:00,TUESDAY 08:00,THURSDAY 05:00")
+            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+        }
+
+        "invalid config: identical open and close — fail-open" {
+            val svc = ExecutionWindowService("MONDAY 22:00,MONDAY 22:00")
+            svc.isWithinWindow(at("MONDAY", 22)).shouldBeTrue()
+        }
+
+        // -------------------------------------------------------------------------
+        // Case-insensitive day names
+        // -------------------------------------------------------------------------
+
+        "case-insensitive: lowercase day names are accepted" {
+            val svc = ExecutionWindowService("monday 22:00,friday 05:00,friday 22:00,monday 05:00")
+            svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
+            svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
+        }
+
+        "case-insensitive: mixed-case day names are accepted" {
+            val svc = ExecutionWindowService("Monday 22:00,Friday 05:00,Friday 22:00,Monday 05:00")
+            svc.isWithinWindow(at("SATURDAY", 12)).shouldBeTrue()
+        }
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
@@ -11,19 +11,10 @@ import java.time.ZonedDateTime
  *
  * Uses fixed [ZonedDateTime] values — no Spring context, no Clock injection.
  *
- * Reference week (ISO 8601, Monday = day 1):
- *   MONDAY    = minuteOfWeek   0 – 1439
- *   TUESDAY   = minuteOfWeek 1440 – 2879
- *   WEDNESDAY = minuteOfWeek 2880 – 4319
- *   THURSDAY  = minuteOfWeek 4320 – 5759
- *   FRIDAY    = minuteOfWeek 5760 – 7199
- *   SATURDAY  = minuteOfWeek 7200 – 8639
- *   SUNDAY    = minuteOfWeek 8640 – 10079
- *
  * Business-hours config used in most tests:
  *   `MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00`
- *   Window 1: Mon 22:00 → Fri 05:00  (nightly Mon–Thu + early Fri)
- *   Window 2: Fri 22:00 → Mon 05:00  (continuous weekend)
+ *   Window 1: Mon 22:00 UTC → Fri 05:00 UTC  (continuous nightly Mon–Thu + early Fri)
+ *   Window 2: Fri 22:00 UTC → Mon 05:00 UTC  (continuous weekend)
  */
 class ExecutionWindowServiceSpec : StringSpec() {
 
@@ -247,10 +238,9 @@ class ExecutionWindowServiceSpec : StringSpec() {
         }
 
         "invalid config: two overlapping wrap-around windows — fail-open" {
-            // Both windows cross the Sunday→Monday boundary:
-            //   Window 1: SUNDAY 20:00 → MONDAY 02:00  (minuteOfWeek 8880 → 120)
-            //   Window 2: SUNDAY 22:00 → MONDAY 05:00  (minuteOfWeek 9000 → 300)
-            // Raw comparison (9000 > 120) passes the old check — this test guards the fix.
+            // Both windows cross the Sunday→Monday boundary and overlap:
+            //   Window 1: SUNDAY 20:00 → MONDAY 02:00
+            //   Window 2: SUNDAY 22:00 → MONDAY 05:00  (starts inside window 1)
             val svc = ExecutionWindowService("SUNDAY 20:00,MONDAY 02:00,SUNDAY 22:00,MONDAY 05:00")
             svc.isWithinWindow(at("SUNDAY", 23)).shouldBeTrue()  // fail-open
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
@@ -246,6 +246,15 @@ class ExecutionWindowServiceSpec : StringSpec() {
             svc.isWithinWindow(at("MONDAY", 22)).shouldBeTrue()
         }
 
+        "invalid config: two overlapping wrap-around windows — fail-open" {
+            // Both windows cross the Sunday→Monday boundary:
+            //   Window 1: SUNDAY 20:00 → MONDAY 02:00  (minuteOfWeek 8880 → 120)
+            //   Window 2: SUNDAY 22:00 → MONDAY 05:00  (minuteOfWeek 9000 → 300)
+            // Raw comparison (9000 > 120) passes the old check — this test guards the fix.
+            val svc = ExecutionWindowService("SUNDAY 20:00,MONDAY 02:00,SUNDAY 22:00,MONDAY 05:00")
+            svc.isWithinWindow(at("SUNDAY", 23)).shouldBeTrue()  // fail-open
+        }
+
         // -------------------------------------------------------------------------
         // Case-insensitive day names
         // -------------------------------------------------------------------------

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
@@ -3,13 +3,15 @@ package io.whozoss.agentos.scheduledPrompt
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZoneOffset
-import java.time.ZonedDateTime
 
 /**
  * Unit tests for [ExecutionWindowService].
  *
- * Uses fixed [ZonedDateTime] values — no Spring context, no Clock injection.
+ * Uses fixed [Instant] values — no Spring context, no Clock injection.
  *
  * Business-hours config used in most tests:
  *   `MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00`
@@ -22,12 +24,9 @@ class ExecutionWindowServiceSpec : StringSpec() {
 
     private fun svc(windows: List<String>) = ExecutionWindowService(SchedulerProperties(windows = windows))
 
-    private fun at(day: String, hour: Int, minute: Int = 0): ZonedDateTime {
-        val dayOfWeek = java.time.DayOfWeek.valueOf(day)
-        val monday = java.time.LocalDate.of(2024, 1, 1)
-        val date = monday.plusDays((dayOfWeek.value - 1).toLong())
-        return ZonedDateTime.of(date, java.time.LocalTime.of(hour, minute), ZoneOffset.UTC)
-    }
+    private fun at(day: String, hour: Int, minute: Int = 0): Instant =
+        LocalDateTime.of(2024, 1, DayOfWeek.valueOf(day).value, hour, minute)
+            .toInstant(ZoneOffset.UTC)
 
     init {
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
 class ExecutionWindowServiceSpec : StringSpec() {
 
     /** Canonical business-hours config: nightly Mon–Thu + continuous Fri–Mon. */
-    private val businessHoursConfig = "MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00"
+    private val businessHoursConfig = listOf("MONDAY 22:00", "FRIDAY 05:00", "FRIDAY 22:00", "MONDAY 05:00")
 
     private fun at(day: String, hour: Int, minute: Int = 0): ZonedDateTime {
         val dayOfWeek = java.time.DayOfWeek.valueOf(day)
@@ -35,15 +35,10 @@ class ExecutionWindowServiceSpec : StringSpec() {
         // No windows configured — always open
         // -------------------------------------------------------------------------
 
-        "no windows (null): always within window" {
-            val svc = ExecutionWindowService(null)
+        "no windows (empty list): always within window" {
+            val svc = ExecutionWindowService(emptyList())
             svc.isWithinWindow(at("MONDAY", 10)).shouldBeTrue()
             svc.isWithinWindow(at("SATURDAY", 14)).shouldBeTrue()
-        }
-
-        "no windows (blank): always within window" {
-            val svc = ExecutionWindowService("   ")
-            svc.isWithinWindow(at("WEDNESDAY", 9)).shouldBeTrue()
         }
 
         // -------------------------------------------------------------------------
@@ -166,14 +161,13 @@ class ExecutionWindowServiceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "single nightly window: within window" {
-            // Every night 22:00 → 05:00 (wraps midnight)
-            val svc = ExecutionWindowService("MONDAY 22:00,TUESDAY 05:00")
+            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "TUESDAY 05:00"))
             svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
             svc.isWithinWindow(at("TUESDAY", 2)).shouldBeTrue()
         }
 
         "single nightly window: outside window" {
-            val svc = ExecutionWindowService("MONDAY 22:00,TUESDAY 05:00")
+            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "TUESDAY 05:00"))
             svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
             svc.isWithinWindow(at("TUESDAY", 6)).shouldBeFalse()
         }
@@ -183,22 +177,22 @@ class ExecutionWindowServiceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "wrap-around: Sunday 23:00 is within a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
             svc.isWithinWindow(at("SUNDAY", 23)).shouldBeTrue()
         }
 
         "wrap-around: Monday 02:00 is within a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
             svc.isWithinWindow(at("MONDAY", 2)).shouldBeTrue()
         }
 
         "wrap-around: Monday 06:00 is outside a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
             svc.isWithinWindow(at("MONDAY", 6)).shouldBeFalse()
         }
 
         "wrap-around: Sunday 21:59 is outside a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService("SUNDAY 22:00,MONDAY 05:00")
+            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
             svc.isWithinWindow(at("SUNDAY", 21, 59)).shouldBeFalse()
         }
 
@@ -207,33 +201,33 @@ class ExecutionWindowServiceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "invalid config: odd number of entries — fail-open" {
-            val svc = ExecutionWindowService("MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00")
+            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "FRIDAY 05:00", "FRIDAY 22:00"))
             svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: unknown day name — fail-open" {
-            val svc = ExecutionWindowService("FUNDAY 22:00,FRIDAY 05:00")
+            val svc = ExecutionWindowService(listOf("FUNDAY 22:00", "FRIDAY 05:00"))
             svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: malformed time — fail-open" {
-            val svc = ExecutionWindowService("MONDAY 25:00,FRIDAY 05:00")
+            val svc = ExecutionWindowService(listOf("MONDAY 25:00", "FRIDAY 05:00"))
             svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: missing time part — fail-open" {
-            val svc = ExecutionWindowService("MONDAY,FRIDAY 05:00")
+            val svc = ExecutionWindowService(listOf("MONDAY", "FRIDAY 05:00"))
             svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: overlapping windows — fail-open" {
             // Window 2 open (TUESDAY 08:00) is before window 1 close (WEDNESDAY 05:00)
-            val svc = ExecutionWindowService("MONDAY 22:00,WEDNESDAY 05:00,TUESDAY 08:00,THURSDAY 05:00")
+            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "WEDNESDAY 05:00", "TUESDAY 08:00", "THURSDAY 05:00"))
             svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: identical open and close — fail-open" {
-            val svc = ExecutionWindowService("MONDAY 22:00,MONDAY 22:00")
+            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "MONDAY 22:00"))
             svc.isWithinWindow(at("MONDAY", 22)).shouldBeTrue()
         }
 
@@ -241,7 +235,7 @@ class ExecutionWindowServiceSpec : StringSpec() {
             // Both windows cross the Sunday→Monday boundary and overlap:
             //   Window 1: SUNDAY 20:00 → MONDAY 02:00
             //   Window 2: SUNDAY 22:00 → MONDAY 05:00  (starts inside window 1)
-            val svc = ExecutionWindowService("SUNDAY 20:00,MONDAY 02:00,SUNDAY 22:00,MONDAY 05:00")
+            val svc = ExecutionWindowService(listOf("SUNDAY 20:00", "MONDAY 02:00", "SUNDAY 22:00", "MONDAY 05:00"))
             svc.isWithinWindow(at("SUNDAY", 23)).shouldBeTrue()  // fail-open
         }
 
@@ -250,13 +244,13 @@ class ExecutionWindowServiceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "case-insensitive: lowercase day names are accepted" {
-            val svc = ExecutionWindowService("monday 22:00,friday 05:00,friday 22:00,monday 05:00")
+            val svc = ExecutionWindowService(listOf("monday 22:00", "friday 05:00", "friday 22:00", "monday 05:00"))
             svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
             svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
         }
 
         "case-insensitive: mixed-case day names are accepted" {
-            val svc = ExecutionWindowService("Monday 22:00,Friday 05:00,Friday 22:00,Monday 05:00")
+            val svc = ExecutionWindowService(listOf("Monday 22:00", "Friday 05:00", "Friday 22:00", "Monday 05:00"))
             svc.isWithinWindow(at("SATURDAY", 12)).shouldBeTrue()
         }
     }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
@@ -13,17 +13,17 @@ import java.time.ZonedDateTime
  *
  * Business-hours config used in most tests:
  *   `MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00`
- *   Window 1: Mon 22:00 UTC → Fri 05:00 UTC  (continuous nightly Mon–Thu + early Fri)
- *   Window 2: Fri 22:00 UTC → Mon 05:00 UTC  (continuous weekend)
+ *   Execution window 1: Mon 22:00 UTC → Fri 05:00 UTC
+ *   Execution window 2: Fri 22:00 UTC → Mon 05:00 UTC
  */
 class ExecutionWindowServiceSpec : StringSpec() {
 
-    /** Canonical business-hours config: nightly Mon–Thu + continuous Fri–Mon. */
     private val businessHoursConfig = listOf("MONDAY 22:00", "FRIDAY 05:00", "FRIDAY 22:00", "MONDAY 05:00")
+
+    private fun svc(windows: List<String>) = ExecutionWindowService(SchedulerProperties(windows = windows))
 
     private fun at(day: String, hour: Int, minute: Int = 0): ZonedDateTime {
         val dayOfWeek = java.time.DayOfWeek.valueOf(day)
-        // Use any Monday as anchor (2024-01-01 is a Monday)
         val monday = java.time.LocalDate.of(2024, 1, 1)
         val date = monday.plusDays((dayOfWeek.value - 1).toLong())
         return ZonedDateTime.of(date, java.time.LocalTime.of(hour, minute), ZoneOffset.UTC)
@@ -35,208 +35,200 @@ class ExecutionWindowServiceSpec : StringSpec() {
         // No windows configured — always open
         // -------------------------------------------------------------------------
 
-        "no windows (empty list): always within window" {
-            val svc = ExecutionWindowService(emptyList())
-            svc.isWithinWindow(at("MONDAY", 10)).shouldBeTrue()
-            svc.isWithinWindow(at("SATURDAY", 14)).shouldBeTrue()
+        "no windows (empty list): always within execution window" {
+            val svc = svc(emptyList())
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SATURDAY", 14)).shouldBeTrue()
         }
 
         // -------------------------------------------------------------------------
-        // Business-hours config — inside windows
+        // Inside execution windows
         // -------------------------------------------------------------------------
 
-        "inside window 1: Monday night is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
+        "inside window 1: Monday night is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("MONDAY", 23)).shouldBeTrue()
         }
 
-        "inside window 1: Tuesday 02:00 is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("TUESDAY", 2)).shouldBeTrue()
+        "inside window 1: Tuesday 02:00 is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("TUESDAY", 2)).shouldBeTrue()
         }
 
-        "inside window 1: Thursday 23:59 is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("THURSDAY", 23, 59)).shouldBeTrue()
+        "inside window 1: Thursday 23:59 is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("THURSDAY", 23, 59)).shouldBeTrue()
         }
 
-        "inside window 1: Friday 04:59 is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("FRIDAY", 4, 59)).shouldBeTrue()
+        "inside window 1: Friday 04:59 is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("FRIDAY", 4, 59)).shouldBeTrue()
         }
 
-        "inside window 2: Friday night is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("FRIDAY", 23)).shouldBeTrue()
+        "inside window 2: Friday night is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("FRIDAY", 23)).shouldBeTrue()
         }
 
-        "inside window 2: Saturday is always within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("SATURDAY", 0)).shouldBeTrue()
-            svc.isWithinWindow(at("SATURDAY", 12)).shouldBeTrue()
-            svc.isWithinWindow(at("SATURDAY", 23, 59)).shouldBeTrue()
+        "inside window 2: Saturday is always within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("SATURDAY", 0)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SATURDAY", 12)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SATURDAY", 23, 59)).shouldBeTrue()
         }
 
-        "inside window 2: Sunday is always within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("SUNDAY", 0)).shouldBeTrue()
-            svc.isWithinWindow(at("SUNDAY", 12)).shouldBeTrue()
-            svc.isWithinWindow(at("SUNDAY", 23, 59)).shouldBeTrue()
+        "inside window 2: Sunday is always within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("SUNDAY", 0)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SUNDAY", 12)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SUNDAY", 23, 59)).shouldBeTrue()
         }
 
-        "inside window 2: Monday 04:59 is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("MONDAY", 4, 59)).shouldBeTrue()
+        "inside window 2: Monday 04:59 is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("MONDAY", 4, 59)).shouldBeTrue()
         }
 
         // -------------------------------------------------------------------------
-        // Business-hours config — outside windows (business hours)
+        // Outside execution windows (business hours = blocked)
         // -------------------------------------------------------------------------
 
-        "outside window: Monday 10:00 is outside window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
+        "outside window: Monday 10:00 is blocked" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeFalse()
         }
 
-        // Note: window 1 is MONDAY 22:00 → FRIDAY 05:00, a *continuous* block.
-        // Tuesday 09:00, Wednesday 14:00, Thursday 08:00 are all inside that continuous
-        // window (Mon night through Fri morning). To restrict to nightly slots only,
-        // the operator would need to configure one window per night.
         "inside window 1: Tuesday 09:00 is within the continuous Mon–Fri window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("TUESDAY", 9)).shouldBeTrue()
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("TUESDAY", 9)).shouldBeTrue()
         }
 
         "inside window 1: Wednesday 14:00 is within the continuous Mon–Fri window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "inside window 1: Thursday 08:00 is within the continuous Mon–Fri window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("THURSDAY", 8)).shouldBeTrue()
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("THURSDAY", 8)).shouldBeTrue()
         }
 
-        "outside window: Friday 10:00 is outside window (between window 1 close and window 2 open)" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("FRIDAY", 10)).shouldBeFalse()
+        "outside window: Friday 10:00 is blocked (between window 1 close and window 2 open)" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("FRIDAY", 10)).shouldBeFalse()
         }
 
         // -------------------------------------------------------------------------
         // Exact boundary conditions (inclusive open, exclusive close)
         // -------------------------------------------------------------------------
 
-        "boundary: exactly at window 1 open (Monday 22:00) is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("MONDAY", 22, 0)).shouldBeTrue()
+        "boundary: exactly at window 1 open (Monday 22:00) is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("MONDAY", 22, 0)).shouldBeTrue()
         }
 
-        "boundary: exactly at window 1 close (Friday 05:00) is outside window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("FRIDAY", 5, 0)).shouldBeFalse()
+        "boundary: exactly at window 1 close (Friday 05:00) is blocked" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("FRIDAY", 5, 0)).shouldBeFalse()
         }
 
-        "boundary: exactly at window 2 open (Friday 22:00) is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("FRIDAY", 22, 0)).shouldBeTrue()
+        "boundary: exactly at window 2 open (Friday 22:00) is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("FRIDAY", 22, 0)).shouldBeTrue()
         }
 
-        "boundary: exactly at window 2 close (Monday 05:00) is outside window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("MONDAY", 5, 0)).shouldBeFalse()
+        "boundary: exactly at window 2 close (Monday 05:00) is blocked" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("MONDAY", 5, 0)).shouldBeFalse()
         }
 
-        "boundary: one minute before window 1 open (Monday 21:59) is outside window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("MONDAY", 21, 59)).shouldBeFalse()
+        "boundary: one minute before window 1 open (Monday 21:59) is blocked" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("MONDAY", 21, 59)).shouldBeFalse()
         }
 
-        "boundary: one minute before window 1 close (Friday 04:59) is within window" {
-            val svc = ExecutionWindowService(businessHoursConfig)
-            svc.isWithinWindow(at("FRIDAY", 4, 59)).shouldBeTrue()
+        "boundary: one minute before window 1 close (Friday 04:59) is within execution window" {
+            val svc = svc(businessHoursConfig)
+            svc.isWithinExecutionWindow(at("FRIDAY", 4, 59)).shouldBeTrue()
         }
 
         // -------------------------------------------------------------------------
-        // Single nightly window (no weekend extension)
+        // Single nightly window
         // -------------------------------------------------------------------------
 
-        "single nightly window: within window" {
-            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "TUESDAY 05:00"))
-            svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
-            svc.isWithinWindow(at("TUESDAY", 2)).shouldBeTrue()
+        "single nightly window: within execution window" {
+            val svc = svc(listOf("MONDAY 22:00", "TUESDAY 05:00"))
+            svc.isWithinExecutionWindow(at("MONDAY", 23)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("TUESDAY", 2)).shouldBeTrue()
         }
 
-        "single nightly window: outside window" {
-            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "TUESDAY 05:00"))
-            svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
-            svc.isWithinWindow(at("TUESDAY", 6)).shouldBeFalse()
+        "single nightly window: outside execution window (blocked)" {
+            val svc = svc(listOf("MONDAY 22:00", "TUESDAY 05:00"))
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeFalse()
+            svc.isWithinExecutionWindow(at("TUESDAY", 6)).shouldBeFalse()
         }
 
         // -------------------------------------------------------------------------
         // Wrap-around: window spanning Sunday → Monday midnight
         // -------------------------------------------------------------------------
 
-        "wrap-around: Sunday 23:00 is within a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
-            svc.isWithinWindow(at("SUNDAY", 23)).shouldBeTrue()
+        "wrap-around: Sunday 23:00 is within a Sun 22:00 → Mon 05:00 execution window" {
+            val svc = svc(listOf("SUNDAY 22:00", "MONDAY 05:00"))
+            svc.isWithinExecutionWindow(at("SUNDAY", 23)).shouldBeTrue()
         }
 
-        "wrap-around: Monday 02:00 is within a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
-            svc.isWithinWindow(at("MONDAY", 2)).shouldBeTrue()
+        "wrap-around: Monday 02:00 is within a Sun 22:00 → Mon 05:00 execution window" {
+            val svc = svc(listOf("SUNDAY 22:00", "MONDAY 05:00"))
+            svc.isWithinExecutionWindow(at("MONDAY", 2)).shouldBeTrue()
         }
 
-        "wrap-around: Monday 06:00 is outside a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
-            svc.isWithinWindow(at("MONDAY", 6)).shouldBeFalse()
+        "wrap-around: Monday 06:00 is outside a Sun 22:00 → Mon 05:00 execution window (blocked)" {
+            val svc = svc(listOf("SUNDAY 22:00", "MONDAY 05:00"))
+            svc.isWithinExecutionWindow(at("MONDAY", 6)).shouldBeFalse()
         }
 
-        "wrap-around: Sunday 21:59 is outside a Sun 22:00 → Mon 05:00 window" {
-            val svc = ExecutionWindowService(listOf("SUNDAY 22:00", "MONDAY 05:00"))
-            svc.isWithinWindow(at("SUNDAY", 21, 59)).shouldBeFalse()
+        "wrap-around: Sunday 21:59 is outside a Sun 22:00 → Mon 05:00 execution window (blocked)" {
+            val svc = svc(listOf("SUNDAY 22:00", "MONDAY 05:00"))
+            svc.isWithinExecutionWindow(at("SUNDAY", 21, 59)).shouldBeFalse()
         }
 
         // -------------------------------------------------------------------------
-        // Invalid configuration — fail-open (always within window)
+        // Invalid configuration — fail-open
         // -------------------------------------------------------------------------
 
         "invalid config: odd number of entries — fail-open" {
-            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "FRIDAY 05:00", "FRIDAY 22:00"))
-            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+            val svc = svc(listOf("MONDAY 22:00", "FRIDAY 05:00", "FRIDAY 22:00"))
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: unknown day name — fail-open" {
-            val svc = ExecutionWindowService(listOf("FUNDAY 22:00", "FRIDAY 05:00"))
-            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+            val svc = svc(listOf("FUNDAY 22:00", "FRIDAY 05:00"))
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: malformed time — fail-open" {
-            val svc = ExecutionWindowService(listOf("MONDAY 25:00", "FRIDAY 05:00"))
-            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+            val svc = svc(listOf("MONDAY 25:00", "FRIDAY 05:00"))
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: missing time part — fail-open" {
-            val svc = ExecutionWindowService(listOf("MONDAY", "FRIDAY 05:00"))
-            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+            val svc = svc(listOf("MONDAY", "FRIDAY 05:00"))
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: overlapping windows — fail-open" {
-            // Window 2 open (TUESDAY 08:00) is before window 1 close (WEDNESDAY 05:00)
-            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "WEDNESDAY 05:00", "TUESDAY 08:00", "THURSDAY 05:00"))
-            svc.isWithinWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+            val svc = svc(listOf("MONDAY 22:00", "WEDNESDAY 05:00", "TUESDAY 08:00", "THURSDAY 05:00"))
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
         }
 
         "invalid config: identical open and close — fail-open" {
-            val svc = ExecutionWindowService(listOf("MONDAY 22:00", "MONDAY 22:00"))
-            svc.isWithinWindow(at("MONDAY", 22)).shouldBeTrue()
+            val svc = svc(listOf("MONDAY 22:00", "MONDAY 22:00"))
+            svc.isWithinExecutionWindow(at("MONDAY", 22)).shouldBeTrue()
         }
 
         "invalid config: two overlapping wrap-around windows — fail-open" {
-            // Both windows cross the Sunday→Monday boundary and overlap:
-            //   Window 1: SUNDAY 20:00 → MONDAY 02:00
-            //   Window 2: SUNDAY 22:00 → MONDAY 05:00  (starts inside window 1)
-            val svc = ExecutionWindowService(listOf("SUNDAY 20:00", "MONDAY 02:00", "SUNDAY 22:00", "MONDAY 05:00"))
-            svc.isWithinWindow(at("SUNDAY", 23)).shouldBeTrue()  // fail-open
+            val svc = svc(listOf("SUNDAY 20:00", "MONDAY 02:00", "SUNDAY 22:00", "MONDAY 05:00"))
+            svc.isWithinExecutionWindow(at("SUNDAY", 23)).shouldBeTrue()
         }
 
         // -------------------------------------------------------------------------
@@ -244,14 +236,14 @@ class ExecutionWindowServiceSpec : StringSpec() {
         // -------------------------------------------------------------------------
 
         "case-insensitive: lowercase day names are accepted" {
-            val svc = ExecutionWindowService(listOf("monday 22:00", "friday 05:00", "friday 22:00", "monday 05:00"))
-            svc.isWithinWindow(at("MONDAY", 23)).shouldBeTrue()
-            svc.isWithinWindow(at("MONDAY", 10)).shouldBeFalse()
+            val svc = svc(listOf("monday 22:00", "friday 05:00", "friday 22:00", "monday 05:00"))
+            svc.isWithinExecutionWindow(at("MONDAY", 23)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeFalse()
         }
 
         "case-insensitive: mixed-case day names are accepted" {
-            val svc = ExecutionWindowService(listOf("Monday 22:00", "Friday 05:00", "Friday 22:00", "Monday 05:00"))
-            svc.isWithinWindow(at("SATURDAY", 12)).shouldBeTrue()
+            val svc = svc(listOf("Monday 22:00", "Friday 05:00", "Friday 22:00", "Monday 05:00"))
+            svc.isWithinExecutionWindow(at("SATURDAY", 12)).shouldBeTrue()
         }
     }
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ExecutionWindowServiceSpec.kt
@@ -192,6 +192,52 @@ class ExecutionWindowServiceSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
+        // Blank / empty entries from stray commas in the env var
+        //
+        // When Spring binds AGENTOS_PROMPT_SCHEDULER_WINDOWS from an env var, it splits
+        // on commas, so a stray double-comma (e.g. "MONDAY 22:00,,FRIDAY 05:00") produces
+        // an empty-string entry ("") in the list.  The filter step silently drops these.
+        // -------------------------------------------------------------------------
+
+        "blank entries: single empty string — treated as no windows (always active)" {
+            // Simulates WINDOWS=  (blank env var) → Spring may produce [""] or []
+            val svc = svc(listOf(""))
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SATURDAY", 14)).shouldBeTrue()
+        }
+
+        "blank entries: whitespace-only entry — treated as no windows (always active)" {
+            val svc = svc(listOf("   "))
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SATURDAY", 14)).shouldBeTrue()
+        }
+
+        "invalid config: single comma — fail-open" {
+            // listOf(",") → trim() → "," → isNotEmpty() → not filtered
+            // → parseBoundary fails (not a valid DAYOFWEEK HH:mm) → null → fail-open
+            val svc = svc(listOf(","))
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+            svc.isWithinExecutionWindow(at("SATURDAY", 3)).shouldBeTrue()
+        }
+
+        "blank entries: empty entry inside odd number of real entries — fail-open" {
+            // Double-comma in env var with 3 real entries: ["MONDAY 22:00", "", "FRIDAY 05:00", "FRIDAY 22:00", ""]
+            // After filtering: ["MONDAY 22:00", "FRIDAY 05:00", "FRIDAY 22:00"] — odd count → fail-open
+            val svc = svc(listOf("MONDAY 22:00", "", "FRIDAY 05:00", "FRIDAY 22:00", ""))
+            svc.isWithinExecutionWindow(at("WEDNESDAY", 14)).shouldBeTrue()
+        }
+
+        "blank entries: empty entries around a valid pair — parses correctly, window respected" {
+            // Simulates leading/trailing commas in env var: ",MONDAY 22:00,FRIDAY 05:00,"
+            // Spring produces: ["", "MONDAY 22:00", "FRIDAY 05:00", ""]
+            // After filtering: ["MONDAY 22:00", "FRIDAY 05:00"] — one valid window
+            val svc = svc(listOf("", "MONDAY 22:00", "FRIDAY 05:00", ""))
+            svc.isWithinExecutionWindow(at("MONDAY", 23)).shouldBeTrue()   // inside window
+            svc.isWithinExecutionWindow(at("MONDAY", 10)).shouldBeFalse()  // outside window
+        }
+
+        // -------------------------------------------------------------------------
         // Invalid configuration — fail-open
         // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptBatchScenarioSpec.kt
@@ -146,6 +146,7 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
             clock = clock,
             nextRunCalculatorService = NextRunCalculatorService(clock = clock),
             executor = executor,
+            executionWindowService = ExecutionWindowService(properties),
         )
         return scanner to executor
     }
@@ -343,6 +344,7 @@ class ScheduledPromptBatchScenarioSpec : StringSpec() {
                 clock = clock,
                 nextRunCalculatorService = NextRunCalculatorService(clock = clock),
                 executor = executor,
+                executionWindowService = ExecutionWindowService(smallBatchProperties),
             )
 
             // Phase A

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/ScheduledPromptExecutorUnitSpec.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
 import io.whozoss.agentos.agentConfig.AgentConfig
 import io.whozoss.agentos.agentConfig.AgentConfigService
@@ -27,6 +28,7 @@ import io.whozoss.agentos.sdk.scheduledPrompt.UserContextProvider
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -896,7 +898,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 // Poll until all 10 UserRuns are DONE (or timeout after 5 s real time).
                 withTimeout(5_000L) {
                     while (userRunRepo.all().count { it.status == UserRunStatus.DONE } < 10) {
-                        kotlinx.coroutines.delay(10L)
+                        delay(10L)
                     }
                 }
                 exec.stop()
@@ -1023,7 +1025,7 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
                 // Wait until all 6 UserRuns reach a terminal state (DONE or FAILED).
                 withTimeout(5_000L) {
                     while (userRunRepo.all().count { it.status == UserRunStatus.DONE || it.status == UserRunStatus.FAILED } < allUserIds.size) {
-                        kotlinx.coroutines.delay(10L)
+                        delay(10L)
                     }
                 }
                 exec.stop()
@@ -1035,6 +1037,67 @@ class ScheduledPromptExecutorUnitSpec : StringSpec() {
             // The failing UserRun must be FAILED.
             val failedRun = userRunRepo.all().first { it.userId == failingUserId }
             failedRun.status shouldBe UserRunStatus.FAILED
+        }
+
+        // -------------------------------------------------------------------------
+        // Consumer loop — execution window guard (Phase B)
+        // -------------------------------------------------------------------------
+
+        "consumer loop: poller does not claim any UserRun when outside the execution window" {
+            // Arrange: 3 PENDING UserRuns exist, but the clock is fixed to a time outside the
+            // configured window. The poller must delay on every iteration without ever calling
+            // claimBatch, so all UserRuns remain PENDING throughout.
+            //
+            // clock is fixed to 2026-01-01T09:00:00Z (Thursday 09:00 UTC).
+            // Window: FRIDAY 22:00 → MONDAY 05:00 (weekend only) — Thursday is outside.
+            val sp = makeScheduledPrompt()
+            val run = makeRun(sp).copy(status = RunStatus.RUNNING)
+            val runRepo = InMemoryScheduledPromptRunRepository().also { it.insert(run) }
+            val userIds = (1..3).map { UUID.randomUUID() }.toSet()
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository { _, _ -> userIds }
+            userRunRepo.materialize(run.id, agentId, namespaceId)
+
+            // Spy on userRunRepo so we can assert claimBatch is never called.
+            val spyUserRunRepo = spyk(userRunRepo)
+
+            // Real ExecutionWindowService with the fixed clock — Thursday 09:00 is outside
+            // the weekend-only window, so isWithinExecutionWindow() returns false.
+            val closedWindowService = ExecutionWindowService(
+                properties = SchedulerProperties(windows = listOf("FRIDAY 22:00", "MONDAY 05:00")),
+                clock = clock,
+            )
+
+            val testDispatcher = UnconfinedTestDispatcher()
+            val exec = ScheduledPromptExecutor(
+                scheduledPromptRepository = makeSpRepo(sp),
+                runRepository = runRepo,
+                userRunRepository = spyUserRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = SchedulerProperties(batchSize = 5, leaseMinutes = 30L, pausedPollDelayMs = 10L),
+                clock = clock,
+                dispatcher = testDispatcher,
+                executionWindowService = closedWindowService,
+            )
+
+            runTest(testDispatcher) {
+                exec.start()
+                // All coroutines (poller, workers, and this test body) share the same
+                // TestCoroutineScheduler because testDispatcher was created with
+                // UnconfinedTestDispatcher() and passed to runTest — runTest reuses its
+                // scheduler. delay() therefore advances virtual time, not real time:
+                // 200ms virtual = 200/10 = 20 poller iterations, instant in wall-clock time.
+                delay(200L)
+                exec.stop()
+            }
+
+            // claimBatch must never have been called — the poller only delayed.
+            verify(exactly = 0) { spyUserRunRepo.claimBatch(any(), any()) }
+            // All UserRuns must still be PENDING.
+            userRunRepo.all().all { it.status == UserRunStatus.PENDING } shouldBe true
         }
 
         "Phase B: agent config not found marks UserRun FAILED" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpointUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerEndpointUnitSpec.kt
@@ -21,7 +21,8 @@ class SchedulerEndpointUnitSpec : StringSpec() {
     private fun endpoint(
         scanner: SchedulerScanner = mockk(relaxed = true),
         executor: ScheduledPromptExecutor = mockk(relaxed = true),
-    ): SchedulerEndpoint = SchedulerEndpoint(scanner, executor)
+        executionWindowService: ExecutionWindowService = mockk(relaxed = true),
+    ): SchedulerEndpoint = SchedulerEndpoint(scanner, executor,executionWindowService)
 
     data class StatusCase(
         val claimPaused: Boolean,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -71,6 +71,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
         scheduledPromptRepo: InMemoryScheduledPromptRepository,
         runRepo: InMemoryScheduledPromptRunRepository,
         agentConfigService: AgentConfigService = defaultAgentConfigService(),
+        properties: SchedulerProperties = this.properties,
     ): SchedulerScanner {
         val userRunRepo = InMemoryScheduledPromptUserRunRepository()
         runRepo.userRunRepository = userRunRepo
@@ -1016,6 +1017,43 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val sc = scanner(makeScheduledPromptRepo(), makeRunRepo())
             sc.pauseClaim()
             sc.isConsumePaused().shouldBeFalse()
+        }
+
+        // -------------------------------------------------------------------------
+        // Execution window guard — tickClaim
+        // Fixed clock: 2026-01-01T09:00:00Z = Thursday 09:00 UTC
+        // -------------------------------------------------------------------------
+
+        "tickClaim outside execution window: no runs created" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T08:00:00Z"))
+            // Thursday 09:00 is outside THURSDAY 22:00 → FRIDAY 05:00
+            val sc = scanner(scheduledPromptRepo, runRepo,
+                properties = SchedulerProperties(windows = "THURSDAY 22:00,FRIDAY 05:00"))
+            sc.tickClaim()
+            runRepo.all().shouldBeEmpty()
+        }
+
+        "tickClaim inside execution window: runs created normally" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T08:00:00Z"))
+            // Thursday 09:00 is inside THURSDAY 08:00 → FRIDAY 05:00
+            val sc = scanner(scheduledPromptRepo, runRepo,
+                properties = SchedulerProperties(windows = "THURSDAY 08:00,FRIDAY 05:00"))
+            sc.tickClaim()
+            runRepo.all() shouldHaveSize 1
+        }
+
+        "tickClaim with invalid window config: runs created (fail-open)" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T08:00:00Z"))
+            val sc = scanner(scheduledPromptRepo, runRepo,
+                properties = SchedulerProperties(windows = "BADDAY 22:00,FRIDAY 05:00"))
+            sc.tickClaim()
+            runRepo.all() shouldHaveSize 1
         }
 
         "SchedulerScanner startup: does not throw when leaseMinutes * 60 > launchTimeoutSeconds" {

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -1021,6 +1021,185 @@ class SchedulerScannerUnitSpec : StringSpec() {
         }
 
         // -------------------------------------------------------------------------
+        // Execution window guard (offpeak exclusion)
+        // -------------------------------------------------------------------------
+
+        "tickClaim outside execution window: no runs created" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z") // due
+            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+
+            // nowInstant = 2026-01-01T09:00:00Z (Thursday)
+            // Window: FRIDAY 22:00 → MONDAY 05:00 (weekend only) — Thursday 09:00 is outside
+            val outsideWindowProperties = SchedulerProperties(
+                windows = listOf("FRIDAY 22:00", "MONDAY 05:00"),
+            )
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            runRepo.userRunRepository = userRunRepo
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = outsideWindowProperties,
+                clock = clock,
+            )
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = outsideWindowProperties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+
+            sc.tickClaim()
+
+            runRepo.all().shouldBeEmpty()
+        }
+
+        "tickClaim inside execution window: runs created normally" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z") // due
+            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+
+            // nowInstant = 2026-01-01T09:00:00Z (Thursday)
+            // Window: MONDAY 00:00 → FRIDAY 22:00 — Thursday 09:00 is inside
+            val insideWindowProperties = SchedulerProperties(
+                windows = listOf("MONDAY 00:00", "FRIDAY 22:00"),
+            )
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            runRepo.userRunRepository = userRunRepo
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = insideWindowProperties,
+                clock = clock,
+            )
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = insideWindowProperties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+
+            sc.tickClaim()
+
+            runRepo.all() shouldHaveSize 1
+        }
+
+        "tickClaim outside window: nextRunAt is NOT advanced (prompts accumulate)" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+
+            // Thursday 09:00 is outside the weekend-only window
+            val outsideWindowProperties = SchedulerProperties(
+                windows = listOf("FRIDAY 22:00", "MONDAY 05:00"),
+            )
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            runRepo.userRunRepository = userRunRepo
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = outsideWindowProperties,
+                clock = clock,
+            )
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = outsideWindowProperties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+
+            sc.tickClaim()
+
+            // nextRunAt must be unchanged — the slot must accumulate until the window opens
+            scheduledPromptRepo.findById(sp.id)!!.nextRunAt shouldBe slot
+        }
+
+        "tickClaim pause takes precedence over window check" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+
+            // Thursday 09:00 is inside this window
+            val insideWindowProperties = SchedulerProperties(
+                windows = listOf("MONDAY 00:00", "FRIDAY 22:00"),
+            )
+            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
+            runRepo.userRunRepository = userRunRepo
+            val executor = ScheduledPromptExecutor(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                promptService = mockk(relaxed = true),
+                agentConfigService = mockk(relaxed = true),
+                caseService = mockk(relaxed = true),
+                permissionService = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                properties = insideWindowProperties,
+                clock = clock,
+            )
+            val sc = SchedulerScanner(
+                scheduledPromptRepository = scheduledPromptRepo,
+                runRepository = runRepo,
+                userRunRepository = userRunRepo,
+                agentConfigService = defaultAgentConfigService(),
+                properties = insideWindowProperties,
+                clock = clock,
+                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
+                executor = executor,
+            )
+
+            // Pause takes precedence — even inside the window, no runs should be created
+            sc.pauseClaim()
+            sc.tickClaim()
+
+            runRepo.all().shouldBeEmpty()
+        }
+
+        "tickClaim no windows configured: runs created regardless of time" {
+            val scheduledPromptRepo = makeScheduledPromptRepo()
+            val runRepo = makeRunRepo()
+            val slot = Instant.parse("2026-01-01T08:00:00Z")
+            scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
+            // Default SchedulerProperties has windows = emptyList() → always-open
+            scanner(scheduledPromptRepo, runRepo).tickClaim()
+            runRepo.all() shouldHaveSize 1
+        }
+
+        // -------------------------------------------------------------------------
         // Watchdog
         // -------------------------------------------------------------------------
 

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -1030,7 +1030,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T08:00:00Z"))
             // Thursday 09:00 is outside THURSDAY 22:00 → FRIDAY 05:00
             val sc = scanner(scheduledPromptRepo, runRepo,
-                properties = SchedulerProperties(windows = "THURSDAY 22:00,FRIDAY 05:00"))
+                properties = SchedulerProperties(windows = listOf("THURSDAY 22:00", "FRIDAY 05:00")))
             sc.tickClaim()
             runRepo.all().shouldBeEmpty()
         }
@@ -1041,7 +1041,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T08:00:00Z"))
             // Thursday 09:00 is inside THURSDAY 08:00 → FRIDAY 05:00
             val sc = scanner(scheduledPromptRepo, runRepo,
-                properties = SchedulerProperties(windows = "THURSDAY 08:00,FRIDAY 05:00"))
+                properties = SchedulerProperties(windows = listOf("THURSDAY 08:00", "FRIDAY 05:00")))
             sc.tickClaim()
             runRepo.all() shouldHaveSize 1
         }
@@ -1051,7 +1051,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val runRepo = makeRunRepo()
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = Instant.parse("2026-01-01T08:00:00Z"))
             val sc = scanner(scheduledPromptRepo, runRepo,
-                properties = SchedulerProperties(windows = "BADDAY 22:00,FRIDAY 05:00"))
+                properties = SchedulerProperties(windows = listOf("BADDAY 22:00", "FRIDAY 05:00")))
             sc.tickClaim()
             runRepo.all() shouldHaveSize 1
         }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/scheduledPrompt/SchedulerScannerUnitSpec.kt
@@ -72,6 +72,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
         scheduledPromptRepo: InMemoryScheduledPromptRepository,
         runRepo: InMemoryScheduledPromptRunRepository,
         agentConfigService: AgentConfigService = defaultAgentConfigService(),
+        scannerProperties: SchedulerProperties = properties,
     ): SchedulerScanner {
         val userRunRepo = InMemoryScheduledPromptUserRunRepository()
         runRepo.userRunRepository = userRunRepo
@@ -84,7 +85,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             caseService = mockk(relaxed = true),
             permissionService = mockk(relaxed = true),
             userService = mockk(relaxed = true),
-            properties = properties,
+            properties = scannerProperties,
             clock = clock,
         )
         return SchedulerScanner(
@@ -92,10 +93,11 @@ class SchedulerScannerUnitSpec : StringSpec() {
             runRepository = runRepo,
             userRunRepository = userRunRepo,
             agentConfigService = agentConfigService,
-            properties = properties,
+            properties = scannerProperties,
             clock = clock,
             nextRunCalculatorService = NextRunCalculatorService(clock = clock),
             executor = executor,
+            executionWindowService = ExecutionWindowService(scannerProperties),
         )
     }
 
@@ -133,6 +135,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
             clock = clock,
             nextRunCalculatorService = NextRunCalculatorService(clock = clock),
             executor = executor,
+            executionWindowService = ExecutionWindowService(properties),
         )
         return scanner to userRunRepo
     }
@@ -844,6 +847,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 clock = clock,
                 nextRunCalculatorService = NextRunCalculatorService(clock = clock),
                 executor = executor,
+                executionWindowService = ExecutionWindowService(properties),
             )
 
             // Must not throw — sp1 fails, sp2 must still be processed
@@ -926,6 +930,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 clock = clock,
                 nextRunCalculatorService = NextRunCalculatorService(clock = clock),
                 executor = executor,
+                executionWindowService = ExecutionWindowService(badProperties),
             )
             io.kotest.assertions.throwables.shouldThrow<IllegalArgumentException> {
                 sc.logStartup()
@@ -994,6 +999,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 clock = clock,
                 nextRunCalculatorService = NextRunCalculatorService(clock = clock),
                 executor = executor,
+                executionWindowService = ExecutionWindowService(goodProperties),
             )
             // Must not throw
             sc.logStartup()
@@ -1029,39 +1035,9 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z") // due
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-
             // nowInstant = 2026-01-01T09:00:00Z (Thursday)
             // Window: FRIDAY 22:00 → MONDAY 05:00 (weekend only) — Thursday 09:00 is outside
-            val outsideWindowProperties = SchedulerProperties(
-                windows = listOf("FRIDAY 22:00", "MONDAY 05:00"),
-            )
-            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
-            runRepo.userRunRepository = userRunRepo
-            val executor = ScheduledPromptExecutor(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                promptService = mockk(relaxed = true),
-                agentConfigService = mockk(relaxed = true),
-                caseService = mockk(relaxed = true),
-                permissionService = mockk(relaxed = true),
-                userService = mockk(relaxed = true),
-                properties = outsideWindowProperties,
-                clock = clock,
-            )
-            val sc = SchedulerScanner(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                agentConfigService = defaultAgentConfigService(),
-                properties = outsideWindowProperties,
-                clock = clock,
-                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
-                executor = executor,
-            )
-
-            sc.tickClaim()
-
+            scanner(scheduledPromptRepo, runRepo, scannerProperties = SchedulerProperties(windows = listOf("FRIDAY 22:00", "MONDAY 05:00"))).tickClaim()
             runRepo.all().shouldBeEmpty()
         }
 
@@ -1070,39 +1046,9 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z") // due
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-
             // nowInstant = 2026-01-01T09:00:00Z (Thursday)
             // Window: MONDAY 00:00 → FRIDAY 22:00 — Thursday 09:00 is inside
-            val insideWindowProperties = SchedulerProperties(
-                windows = listOf("MONDAY 00:00", "FRIDAY 22:00"),
-            )
-            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
-            runRepo.userRunRepository = userRunRepo
-            val executor = ScheduledPromptExecutor(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                promptService = mockk(relaxed = true),
-                agentConfigService = mockk(relaxed = true),
-                caseService = mockk(relaxed = true),
-                permissionService = mockk(relaxed = true),
-                userService = mockk(relaxed = true),
-                properties = insideWindowProperties,
-                clock = clock,
-            )
-            val sc = SchedulerScanner(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                agentConfigService = defaultAgentConfigService(),
-                properties = insideWindowProperties,
-                clock = clock,
-                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
-                executor = executor,
-            )
-
-            sc.tickClaim()
-
+            scanner(scheduledPromptRepo, runRepo, scannerProperties = SchedulerProperties(windows = listOf("MONDAY 00:00", "FRIDAY 22:00"))).tickClaim()
             runRepo.all() shouldHaveSize 1
         }
 
@@ -1111,38 +1057,8 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             val sp = scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-
             // Thursday 09:00 is outside the weekend-only window
-            val outsideWindowProperties = SchedulerProperties(
-                windows = listOf("FRIDAY 22:00", "MONDAY 05:00"),
-            )
-            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
-            runRepo.userRunRepository = userRunRepo
-            val executor = ScheduledPromptExecutor(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                promptService = mockk(relaxed = true),
-                agentConfigService = mockk(relaxed = true),
-                caseService = mockk(relaxed = true),
-                permissionService = mockk(relaxed = true),
-                userService = mockk(relaxed = true),
-                properties = outsideWindowProperties,
-                clock = clock,
-            )
-            val sc = SchedulerScanner(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                agentConfigService = defaultAgentConfigService(),
-                properties = outsideWindowProperties,
-                clock = clock,
-                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
-                executor = executor,
-            )
-
-            sc.tickClaim()
-
+            scanner(scheduledPromptRepo, runRepo, scannerProperties = SchedulerProperties(windows = listOf("FRIDAY 22:00", "MONDAY 05:00"))).tickClaim()
             // nextRunAt must be unchanged — the slot must accumulate until the window opens
             scheduledPromptRepo.findById(sp.id)!!.nextRunAt shouldBe slot
         }
@@ -1152,40 +1068,10 @@ class SchedulerScannerUnitSpec : StringSpec() {
             val runRepo = makeRunRepo()
             val slot = Instant.parse("2026-01-01T08:00:00Z")
             scheduledPromptRepo.insertScheduledPrompt(nextRunAt = slot)
-
-            // Thursday 09:00 is inside this window
-            val insideWindowProperties = SchedulerProperties(
-                windows = listOf("MONDAY 00:00", "FRIDAY 22:00"),
-            )
-            val userRunRepo = InMemoryScheduledPromptUserRunRepository()
-            runRepo.userRunRepository = userRunRepo
-            val executor = ScheduledPromptExecutor(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                promptService = mockk(relaxed = true),
-                agentConfigService = mockk(relaxed = true),
-                caseService = mockk(relaxed = true),
-                permissionService = mockk(relaxed = true),
-                userService = mockk(relaxed = true),
-                properties = insideWindowProperties,
-                clock = clock,
-            )
-            val sc = SchedulerScanner(
-                scheduledPromptRepository = scheduledPromptRepo,
-                runRepository = runRepo,
-                userRunRepository = userRunRepo,
-                agentConfigService = defaultAgentConfigService(),
-                properties = insideWindowProperties,
-                clock = clock,
-                nextRunCalculatorService = NextRunCalculatorService(clock = clock),
-                executor = executor,
-            )
-
-            // Pause takes precedence — even inside the window, no runs should be created
+            // Thursday 09:00 is inside this window — but pause takes precedence
+            val sc = scanner(scheduledPromptRepo, runRepo, scannerProperties = SchedulerProperties(windows = listOf("MONDAY 00:00", "FRIDAY 22:00")))
             sc.pauseClaim()
             sc.tickClaim()
-
             runRepo.all().shouldBeEmpty()
         }
 
@@ -1220,6 +1106,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 clock = clock,
                 nextRunCalculatorService = NextRunCalculatorService(clock = clock),
                 executor = mockExecutor,
+                executionWindowService = ExecutionWindowService(properties),
             )
 
             sc.tickWatchdog()
@@ -1244,6 +1131,7 @@ class SchedulerScannerUnitSpec : StringSpec() {
                 clock = clock,
                 nextRunCalculatorService = NextRunCalculatorService(clock = clock),
                 executor = mockExecutor,
+                executionWindowService = ExecutionWindowService(properties),
             )
 
             sc.tickWatchdog()


### PR DESCRIPTION
**Context**

The scheduler was running continuously 24/7, competing with live user traffic for LLM capacity. The goal is to restrict execution to configurable time windows so LLM resources are preserved for live users during business hours.

**What was implemented**

Time-window guard on both phases of the scheduler, implemented via environment variable — without relying on the existing start/pause mechanism (`SchedulerEndpoint`). The window is evaluated dynamically from config + current time on every tick, including after a restart (no persisted state). When no windows are configured, the scheduler runs continuously (existing behaviour preserved).

 **New `ExecutionWindowService`** (`@Service`): receives `SchedulerProperties` and a `Clock` (default `Clock.systemUTC()`) injected by Spring, parses each `DAYOFWEEK HH:mm UTC` boundary into a weekly minute offset at startup (`init` block), groups them pairwise into open/close execution windows, and evaluates whether the current `Instant` falls within any of them via `isWithinExecutionWindow()`. The `Clock` injection makes the service fully testable without mocking. Handles wrap-around windows (e.g. `FRIDAY 22:00 → MONDAY 05:00`). Validates parity, boundary syntax, zero-length windows, ordering/overlap, and allows at most one wrap-around window. Fails open on any invalid config so a misconfiguration never silently halts all scheduled executions.

**New config property** `agentos.prompt.scheduler.windows` (`AGENTOS_PROMPT_SCHEDULER_WINDOWS`), bound as a `List<String>` — Spring splits the comma-separated value, so the whole schedule stays in a single environment variable:

```
MONDAY 22:00,FRIDAY 05:00,FRIDAY 22:00,MONDAY 05:00
```

Boundaries alternate open/close: the example above defines two execution windows — `Mon 22:00 → Fri 05:00` and `Fri 22:00 → Mon 05:00`. When unset (empty list), the scheduler runs continuously.

The open/close role is carried by position in the list rather than by a structured type — a deliberate trade-off to keep the configuration in a single environment variable (structured YAML binding would require one env var per boundary in production).

**Behaviour:**

- **Phase A** (`tickClaim`): outside the window, the tick is a no-op — due prompts accumulate in DB and are processed at the next window open, including after a restart
- **Phase B** (DB poller in `ScheduledPromptExecutor`): the poller skips `claimBatch()` and delays when `consumePaused || !isWithinExecutionWindow()`. Workers drain whatever is already buffered in the channel (at most `channelCapacity` UserRuns, default 50), then block on `receive()` — bounded and deliberate (no lease expiry risk, no duplicate execution)