### PR TITLE
fix: correct context gauge glass color in dark themes

### DIFF
--- a/apps/client/src/app/components/context-gauge/context-gauge.component.scss
+++ b/apps/client/src/app/components/context-gauge/context-gauge.component.scss
@@ -4,6 +4,12 @@
   z-index: 1500;
   display: block;
   top: calc(1rem + 40px + 0.5rem + 40px + 2rem);
+
+  --gauge-glass: #dddddd;
+}
+
+:host-context([data-theme$='dark']) {
+  --gauge-glass: #333333;
 }
 
 .tube-host {
@@ -23,7 +29,7 @@
   width: 24px;
   border: none;
   border-radius: 0 0 50rem 50rem;
-  background-color: #333333;
+  background-color: var(--gauge-glass, #333333);
   cursor: default;
   overflow: visible;
 
@@ -35,7 +41,7 @@
     width: calc(100% + 6px);
     height: 4px;
     border-radius: 50rem;
-    background: #333333;
+    background: var(--gauge-glass, #333333);
   }
 }
 
@@ -269,16 +275,6 @@
   100% {
     background: rgba(255, 255, 255, 0);
     transform: scale(0.6);
-  }
-}
-
-:host-context(:root:not([data-theme='dark'])) {
-  .tube {
-    background-color: #dddddd;
-
-    &::after {
-      background: #dddddd;
-    }
   }
 }
 


### PR DESCRIPTION
## Problem

In dark themes (`industry-dark`, `terminal-dark`), the context gauge tube displayed a light grey background (`#dddddd`) instead of the expected dark grey (`#333333`). The tube was visually broken in dark mode, appearing as a bright element against a dark UI.

## Root Cause

The component contained a legacy rule written before theme variants were introduced:

```scss
:host-context(:root:not([data-theme='dark'])) {
  .tube { background-color: #dddddd; ... }
}
```

`ThemeService.setDocumentTheme()` composes the `data-theme` attribute as `${variant}-${mode}` (e.g. `industry-dark`, `terminal-dark`) — **never** the bare value `dark`. As a result, the selector `:not([data-theme='dark'])` was **always truthy**, even in dark mode, because no theme ever sets `data-theme="dark"` exactly. Its higher specificity then overrode the base dark-colour rule, keeping the tube light in all dark variants.

## Fix

Replaced the broken specificity-based approach with a single CSS custom property `--gauge-glass`, following the same light-default / dark-override pattern already used in `colors.scss`:

```scss
// Default (light themes)
:host {
  --gauge-glass: #dddddd;
}

// All dark variants: 'dark' (legacy), 'industry-dark', 'terminal-dark', …
:host-context([data-theme$='dark']) {
  --gauge-glass: #333333;
}

// Consumers
.tube {
  background-color: var(--gauge-glass, #333333);

  &::after {
    background: var(--gauge-glass, #333333);
  }
}
```

The suffix matcher `$='dark'` covers any current and future `*-dark` variant without requiring an exhaustive enumeration. The dead block `:host-context(:root:not([data-theme='dark']))` is removed entirely.

Verified: `nx lint client` ✅ and `nx build client` ✅ both pass.

## Known Debt (out of scope)

Two other components carry the same pattern with now-inoperative `[data-theme='dark']` exact-match selectors:

- `apps/client/src/app/sidenav/sidenav.component.scss`
- `apps/client/src/app/main-app/main-app.component.scss`

These are **not** addressed in this PR but should be fixed in a follow-up to ensure consistent dark-theme behaviour across the entire shell.