### PR TITLE
feat: enable Anthropic prompt caching (CONVERSATION_HISTORY strategy)

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/AgentOSApplication.kt
@@ -1,6 +1,7 @@
 package io.whozoss.agentos
 
 import io.whozoss.agentos.agent.AgentConfigProperties
+import io.whozoss.agentos.chat.AnthropicProperties
 import io.whozoss.agentos.caseFlow.CaseConfigProperties
 import io.whozoss.agentos.config.PersistenceConfigProperties
 import io.whozoss.agentos.exchange.ExchangeStorageConfigProperties
@@ -25,6 +26,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 @EnableConfigurationProperties(
     AgentConfigProperties::class,
+    AnthropicProperties::class,
     CaseConfigProperties::class,
     AgentOsPluginsConfigProperties::class,
     PersistenceConfigProperties::class,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/chat/ChatModelFactory.kt
@@ -6,6 +6,8 @@ import io.whozoss.agentos.sdk.aiProvider.AiApiType
 import org.springframework.ai.anthropic.AnthropicChatModel
 import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.anthropic.api.AnthropicApi
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions
+import org.springframework.ai.anthropic.api.AnthropicCacheStrategy
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.google.genai.GoogleGenAiChatModel
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions
@@ -20,12 +22,34 @@ import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.ai.openai.OpenAiChatOptions
 import org.springframework.ai.openai.api.OpenAiApi
 import org.springframework.ai.retry.RetryUtils
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
 import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
+
+/**
+ * Configuration for Anthropic-specific features.
+ *
+ * [promptCachingEnabled] activates the `CONVERSATION_HISTORY` caching strategy on every
+ * Anthropic chat model instance created by [ChatModelFactory]. When enabled, Anthropic
+ * caches the system prompt, tool definitions, and the growing conversation history across
+ * API calls. This is the optimal strategy for agent runs: each turn reuses the cached
+ * prefix built by previous turns, yielding significant cost and latency savings on
+ * multi-turn interactions.
+ *
+ * Default: `true`. Disable via `agentos.anthropic.prompt-caching-enabled=false` or
+ * `AGENTOS_ANTHROPIC_PROMPT_CACHING_ENABLED=false`.
+ */
+@ConfigurationProperties(prefix = "agentos.anthropic")
+data class AnthropicProperties(
+    @DefaultValue("true")
+    val promptCachingEnabled: Boolean,
+)
 
 @Component
 class ChatModelFactory(
     private val observationRegistry: ObservationRegistry,
+    private val anthropicProperties: AnthropicProperties,
 ) {
     fun createChatModel(
         apiType: AiApiType,
@@ -179,6 +203,15 @@ class ChatModelFactory(
 
         if (maxTokens != null) {
             options.maxTokens(maxTokens)
+        }
+
+        if (anthropicProperties.promptCachingEnabled) {
+            options.cacheOptions(
+                AnthropicCacheOptions
+                    .builder()
+                    .strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+                    .build(),
+            )
         }
 
         return AnthropicChatModel(

--- a/agentos/agentos-service/src/main/resources/application.yml
+++ b/agentos/agentos-service/src/main/resources/application.yml
@@ -193,6 +193,13 @@ agentos:
   # Maximum tool-response images attached as Media across a whole prompt (newest first).
   # Override with env var: AGENTOS_DEFAULTS_MAX_ATTACHED_IMAGES
   # max-attached-images: 20
+  anthropic:
+    # Activate Anthropic prompt caching (CONVERSATION_HISTORY strategy) on every Anthropic chat model
+    # instance. Caches the system prompt, tool definitions, and the conversation history across API
+    # calls — the full prefix grows incrementally each turn, yielding significant cost and latency
+    # savings on multi-turn agent runs. Disable if prompt caching is not available on your plan.
+    # Override with env var: AGENTOS_ANTHROPIC_PROMPT_CACHING_ENABLED
+    # prompt-caching-enabled: true
   plugins:
     dir: ${PLUGINS_DIR:plugins/}
   security:

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiProvider/ChatModelFactoryUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/aiProvider/ChatModelFactoryUnitSpec.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.micrometer.observation.ObservationRegistry
+import io.whozoss.agentos.chat.AnthropicProperties
 import io.whozoss.agentos.chat.ChatModelFactory
 import io.whozoss.agentos.sdk.aiProvider.AiApiType
 import org.springframework.ai.anthropic.AnthropicChatModel
@@ -12,7 +13,7 @@ import org.springframework.ai.openai.OpenAiChatModel
 
 class ChatModelFactoryUnitSpec : StringSpec({
 
-    val factory = ChatModelFactory(ObservationRegistry.NOOP)
+    val factory = ChatModelFactory(ObservationRegistry.NOOP, AnthropicProperties(promptCachingEnabled = true))
 
     "createChatModel should create OpenAI chat model" {
         val model = factory.createChatModel(


### PR DESCRIPTION
## What

Activates Anthropic prompt caching on every `AnthropicChatModel` instance created by `ChatModelFactory`, using the `CONVERSATION_HISTORY` strategy.

## Why

Each agent run sends the full conversation history to Anthropic on every turn. Without caching, all those tokens are reprocessed from scratch each time. With `CONVERSATION_HISTORY`, Anthropic caches the growing prefix (system prompt + tool definitions + prior turns) so each new turn only pays for the net-new tokens — yielding significant cost and latency savings on multi-turn runs.

## How

- `AnthropicProperties` (`@ConfigurationProperties(prefix = "agentos.anthropic")`) — a single `promptCachingEnabled: Boolean` (default `true`), registered in `@EnableConfigurationProperties`.
- `ChatModelFactory` injects `AnthropicProperties` and, when enabled, sets `AnthropicCacheOptions` with `AnthropicCacheStrategy.CONVERSATION_HISTORY` on the options builder.
- The feature is off-able via `agentos.anthropic.prompt-caching-enabled=false` / `AGENTOS_ANTHROPIC_PROMPT_CACHING_ENABLED=false` for plans that don't support prompt caching.
- `ChatModelFactoryUnitSpec` updated to pass the new constructor parameter.