### PR TITLE
fix: update countUnread to use max(MessageEvent.timestamp) instead of c.modified

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseNodeNeo4jRepository.kt
@@ -242,12 +242,12 @@ interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
      *
      * A case is unread when:
      * - The user has a direct `[:ADMIN|MEMBER]` edge on the case (access check), AND
-     * - Either no `[:WATCHES]` edge exists (never opened), OR `Case.modified` is after
-     *   the edge's `readAt` (the case changed since the user last read it).
+     * - At least one `MessageEvent` exists on the case (`lastMessageAt` is not null), AND
+     * - Either no `[:WATCHES]` edge exists (`readAt IS NULL`), OR `max(MessageEvent.timestamp)`
+     *   is after the edge's `readAt`.
      *
-     * Uses `Case.modified` rather than scanning `CaseEvent` nodes — O(1) per case
-     * instead of O(events). Requires the `modified` audit field to be kept current
-     * on every case mutation (see known bug: EntityMetadata.modified never updated).
+     * Matches the frontend semantic: `lastMessageAt exists AND (readAt IS NULL OR lastMessageAt > readAt)`.
+     * Cases with no messages are never counted as unread.
      *
      * Returns a scalar Long (0 = all read).
      */
@@ -256,10 +256,13 @@ interface CaseNodeNeo4jRepository : Neo4jRepository<CaseNode, String> {
         $$"""MATCH (c:Case)-[:BELONGS_TO]->(ns:Namespace {id: $namespaceId})
             WHERE (c.removed IS NULL OR c.removed = false)
               AND EXISTS { MATCH (:User {id: $userId})-[:ADMIN|MEMBER]->(c) }
+            OPTIONAL MATCH (msg:MessageEvent {caseId: c.id})
+            WITH c, max(msg.timestamp) AS lastMessageAt
+            WHERE lastMessageAt IS NOT NULL
             OPTIONAL MATCH (:User {id: $userId})-[state:WATCHES]->(c)
-            WITH c, state.readAt AS readAt
-            WHERE readAt IS NULL OR c.modified > readAt
-            RETURN count(c)
+            WITH lastMessageAt, state.readAt AS readAt
+            WHERE readAt IS NULL OR lastMessageAt > readAt
+            RETURN count(*)
             """,
     )
     fun countUnread(

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseReadService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/caseFlow/CaseReadService.kt
@@ -24,9 +24,10 @@ interface CaseReadService {
     /**
      * Counts the number of unread cases in [namespaceId] for [userId].
      *
-     * A case is unread when no `WATCHES` edge exists for the user,
-     * or when the most recent event's timestamp is after the edge's `readAt`.
+     * A case is unread when it has at least one message (`lastMessageAt` is not null) and
+     * either no `WATCHES` edge exists (`readAt IS NULL`) or `max(MessageEvent.timestamp) > readAt`.
      * Only cases the user has a direct `[:ADMIN|MEMBER]` edge on are counted.
+     * Cases with no messages are never counted as unread.
      */
     fun countUnread(userId: String, namespaceId: UUID): Long
 }

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/EmbeddedNeo4jWatchesPersistenceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/persistence/neo4j/EmbeddedNeo4jWatchesPersistenceSpec.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.whozoss.agentos.caseEvent.CaseEventRepository
 import io.whozoss.agentos.caseFlow.Case
 import io.whozoss.agentos.caseFlow.CaseNodeNeo4jRepository
 import io.whozoss.agentos.caseFlow.CaseRepository
@@ -16,6 +17,10 @@ import io.whozoss.agentos.permissions.PermissionNodeNeo4jRepository
 import io.whozoss.agentos.permissions.PermissionRelation
 import io.whozoss.agentos.permissions.PermissionService
 import io.whozoss.agentos.permissions.FavoriteService
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.user.User
 import io.whozoss.agentos.user.UserRepository
@@ -71,6 +76,20 @@ class EmbeddedNeo4jWatchesPersistenceSpec : StringSpec() {
 
     @Autowired
     lateinit var driver: Driver
+
+    @Autowired
+    lateinit var caseEventRepository: CaseEventRepository
+
+    private fun createMessage(caseId: java.util.UUID) =
+        caseEventRepository.save(
+            MessageEvent(
+                metadata = EntityMetadata(),
+                namespaceId = java.util.UUID.randomUUID(),
+                caseId = caseId,
+                actor = Actor(id = "system", displayName = "System", role = ActorRole.AGENT),
+                content = listOf(MessageContent.Text("hello")),
+            ),
+        )
 
     private fun createUser(externalId: String = "test@example.com"): User =
         userRepository.save(
@@ -358,13 +377,14 @@ class EmbeddedNeo4jWatchesPersistenceSpec : StringSpec() {
                 entityId = caseId,
                 entityLabel = "Case",
             )
+            createMessage(case.id)
 
-            // Before any read: case is unread.
+            // Before any read: case has a message and no WATCHES edge → unread.
             caseNodeRepository.countUnread(userId = userId, namespaceId = namespaceId) shouldBe 1L
 
             caseNodeRepository.markRead(userId = userId, caseId = caseId, readAt = Instant.now())
 
-            // After markRead: case with no events since readAt is considered read.
+            // After markRead: readAt is after the message timestamp → read.
             caseNodeRepository.countUnread(userId = userId, namespaceId = namespaceId) shouldBe 0L
         }
 
@@ -387,6 +407,8 @@ class EmbeddedNeo4jWatchesPersistenceSpec : StringSpec() {
                 entityId = theirCase.id.toString(),
                 entityLabel = "Case",
             )
+            createMessage(myCase.id)
+            createMessage(theirCase.id)
 
             // user has access only to myCase, not theirCase.
             caseNodeRepository.countUnread(userId = userId, namespaceId = namespaceId) shouldBe 1L


### PR DESCRIPTION
`countUnread` compared `c.modified > readAt` but `Case.modified` is never updated on message activity.
Now uses `max(MessageEvent.timestamp)` per case, matching the frontend `lastMessageAt` semantic.
Cases with no messages are excluded. Tests updated accordingly.

Fixes #1295