### PR TITLE
fix: #1311 add uniqueness constraint on Credential (userId, authSettingId)

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialNode.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialNode.kt
@@ -15,6 +15,8 @@ import java.util.UUID
  *
  * Uniqueness is on the `(userId, authSettingId)` pair — there is no tripleKey
  * discriminator, because credentials have a simpler identity model than [AuthSetting].
+ * This invariant is **enforced** by the composite constraint
+ * `credential_user_auth_setting_unique` created at startup by [CredentialSchemaInitializer].
  *
  * [dataJson] stores the [Credential.data] map serialised as JSON. Encryption and
  * decryption of individual values is handled by the caller ([Neo4jCredentialRepository]),

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialNodeNeo4jRepository.kt
@@ -22,9 +22,15 @@ interface CredentialNodeNeo4jRepository : Neo4jRepository<CredentialNode, String
      * have silently hidden future storage inconsistencies.
      */
     @Query(
-        FIND_BY_USER_AND_AUTH_SETTING,
+        $$"""
+            MATCH (c:Credential) 
+            WHERE c.userId = $userId AND c.authSettingId = $authSettingId 
+            RETURN c""",
     )
-    fun findByUserIdAndAuthSettingId(userId: String, authSettingId: String): CredentialNode?
+    fun findByUserIdAndAuthSettingId(
+        userId: String,
+        authSettingId: String,
+    ): CredentialNode?
 
     /**
      * Find all credentials owned by a given user, ordered by authSettingId
@@ -95,7 +101,10 @@ interface CredentialNodeNeo4jRepository : Neo4jRepository<CredentialNode, String
             DETACH DELETE c
             """,
     )
-    fun deleteByUserIdAndAuthSettingId(userId: String, authSettingId: String)
+    fun deleteByUserIdAndAuthSettingId(
+        userId: String,
+        authSettingId: String,
+    )
 
     /**
      * Hard-delete all credentials associated with a given authSetting.
@@ -109,12 +118,4 @@ interface CredentialNodeNeo4jRepository : Neo4jRepository<CredentialNode, String
             """,
     )
     fun deleteByAuthSettingId(authSettingId: String)
-
-    companion object {
-        // Extracted as a const to avoid Kotlin annotation argument interpolation issues
-        // with the $$ raw-string delimiter. The query uses Spring Data named parameters
-        // ($userId, $authSettingId) which must appear as literal dollar-sign sequences.
-        const val FIND_BY_USER_AND_AUTH_SETTING: String =
-            "MATCH (c:Credential) WHERE c.userId = \$userId AND c.authSettingId = \$authSettingId RETURN c"
-    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialNodeNeo4jRepository.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialNodeNeo4jRepository.kt
@@ -14,13 +14,15 @@ interface CredentialNodeNeo4jRepository : Neo4jRepository<CredentialNode, String
     /**
      * Find the credential for a specific (userId, authSettingId) pair.
      * Returns null if none exists.
+     *
+     * Uniqueness of the pair is enforced by the `credential_user_auth_setting_unique`
+     * constraint created by [CredentialSchemaInitializer], so this query returns at most
+     * one node. The former `LIMIT 1` defensive guard has been removed: it masked
+     * duplicate rows (reads succeeded, only writes surfaced the duplication) and would
+     * have silently hidden future storage inconsistencies.
      */
     @Query(
-        $$"""
-            MATCH (c:Credential)
-            WHERE c.userId = $userId AND c.authSettingId = $authSettingId
-            RETURN c LIMIT 1
-            """,
+        FIND_BY_USER_AND_AUTH_SETTING,
     )
     fun findByUserIdAndAuthSettingId(userId: String, authSettingId: String): CredentialNode?
 
@@ -107,4 +109,12 @@ interface CredentialNodeNeo4jRepository : Neo4jRepository<CredentialNode, String
             """,
     )
     fun deleteByAuthSettingId(authSettingId: String)
+
+    companion object {
+        // Extracted as a const to avoid Kotlin annotation argument interpolation issues
+        // with the $$ raw-string delimiter. The query uses Spring Data named parameters
+        // ($userId, $authSettingId) which must appear as literal dollar-sign sequences.
+        const val FIND_BY_USER_AND_AUTH_SETTING: String =
+            "MATCH (c:Credential) WHERE c.userId = \$userId AND c.authSettingId = \$authSettingId RETURN c"
+    }
 }

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialSchemaInitializer.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/credential/CredentialSchemaInitializer.kt
@@ -1,0 +1,110 @@
+package io.whozoss.agentos.credential
+
+import mu.KLogging
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.data.neo4j.core.Neo4jClient
+import org.springframework.stereotype.Component
+
+/**
+ * Idempotent Neo4j schema initialiser for [CredentialNode].
+ *
+ * Runs as an [ApplicationRunner] after Spring is up but before HTTP traffic is accepted.
+ * The order of operations is significant:
+ *
+ * 1. **Pre-flight check** for duplicate `(userId, authSettingId)` pairs BEFORE invoking
+ *    `CREATE CONSTRAINT`. Without this guard, pre-existing duplicates cause an opaque
+ *    Neo4j error during constraint creation that gives operators no way to identify the
+ *    offending rows. The query returns the first 3 offending pairs to make remediation
+ *    actionable.
+ * 2. **Composite unique constraint** on `(userId, authSettingId)` — the invariant that
+ *    was documented in [CredentialNode] but never enforced at the storage level. A
+ *    composite constraint is correct here because both fields are non-null; the Neo4j 5.x
+ *    silent exemption for NULL components (documented in `IntegrationConfigSchemaInitializer`)
+ *    does not apply.
+ * 3. **Unique constraint on `id`** — defensive, prevents accidental id collisions.
+ * 4. **Auxiliary index on `userId`** — backs [CredentialNodeNeo4jRepository.findByUserId]
+ *    lookups that are not already covered by the composite constraint index.
+ *
+ * Active for both `neo4j` and `embedded-neo4j` persistence modes — exactly the modes
+ * for which a Neo4j Driver bean is provisioned.
+ */
+@Component
+@ConditionalOnExpression(
+    "'\${agentos.persistence.mode:in-memory}' == 'neo4j' " +
+        "or '\${agentos.persistence.mode:in-memory}' == 'embedded-neo4j'",
+)
+class CredentialSchemaInitializer(
+    private val neo4jClient: Neo4jClient,
+) : ApplicationRunner {
+    override fun run(args: ApplicationArguments) {
+        assertNoDuplicateUserAuthSettingPairs()
+        ensureUserAuthSettingUniqueConstraint()
+        ensureIdUniqueConstraint()
+        ensureUserIdIndex()
+    }
+
+    /**
+     * Pre-flight: detect duplicate `(userId, authSettingId)` pairs BEFORE invoking
+     * `CREATE CONSTRAINT`. A pre-existing duplicate would cause `CREATE CONSTRAINT` to
+     * fail with an opaque Neo4j error that does not identify the offending rows.
+     *
+     * When duplicates are found the application refuses to start and logs an actionable
+     * message: keep the most recent node (highest `modified`) and delete the others,
+     * then restart.
+     */
+    private fun assertNoDuplicateUserAuthSettingPairs() {
+        val offendingPairs =
+            neo4jClient
+                .query(
+                    """
+                    MATCH (c:Credential)
+                    WITH c.userId AS userId, c.authSettingId AS authSettingId, count(*) AS dups
+                    WHERE dups > 1
+                    RETURN userId + '/' + authSettingId AS key ORDER BY dups DESC LIMIT 3
+                    """.trimIndent(),
+                )
+                .fetchAs(String::class.java)
+                .all()
+        if (offendingPairs.isNotEmpty()) {
+            error(
+                "[CredentialSchema] aborting: found duplicate Credential row(s) with the same " +
+                    "(userId, authSettingId) pair (${offendingPairs.size} group(s) shown, possibly more). " +
+                    "For each offending pair, keep the node with the highest `modified` timestamp " +
+                    "and hard-delete the others (MATCH (c:Credential) WHERE c.userId = '...' AND " +
+                    "c.authSettingId = '...' WITH c ORDER BY c.modified DESC SKIP 1 DETACH DELETE c), " +
+                    "then restart. Sample pairs: ${offendingPairs.joinToString(prefix = "[", postfix = "]")}.",
+            )
+        }
+        logger.info { "[CredentialSchema] no duplicate (userId, authSettingId) pairs found" }
+    }
+
+    private fun ensureUserAuthSettingUniqueConstraint() {
+        neo4jClient
+            .query(
+                "CREATE CONSTRAINT credential_user_auth_setting_unique IF NOT EXISTS " +
+                    "FOR (c:Credential) REQUIRE (c.userId, c.authSettingId) IS UNIQUE",
+            ).run()
+        logger.info { "[CredentialSchema] constraint 'credential_user_auth_setting_unique' ensured" }
+    }
+
+    private fun ensureIdUniqueConstraint() {
+        neo4jClient
+            .query(
+                "CREATE CONSTRAINT credential_id_unique IF NOT EXISTS " +
+                    "FOR (c:Credential) REQUIRE c.id IS UNIQUE",
+            ).run()
+        logger.info { "[CredentialSchema] constraint 'credential_id_unique' ensured" }
+    }
+
+    private fun ensureUserIdIndex() {
+        neo4jClient
+            .query(
+                "CREATE INDEX credential_user_lookup IF NOT EXISTS FOR (c:Credential) ON (c.userId)",
+            ).run()
+        logger.info { "[CredentialSchema] index 'credential_user_lookup' ensured" }
+    }
+
+    companion object : KLogging()
+}


### PR DESCRIPTION
Closes #1311

## Contexte

Une intégration MCP OAuth (Atlassian) qui fonctionnait a cessé de fonctionner à l'expiration du token. Le refresh OAuth aboutissait côté réseau, mais l'écriture du credential échouait :

```
org.springframework.dao.IncorrectResultSizeDataAccessException:
  Expected a result with a single record, but this result contains at least one more.
	at Neo4jCredentialRepository.save(Neo4jCredentialRepository.kt:29)
	at CredentialServiceImpl.store(CredentialServiceImpl.kt:22)
	at OAuthFlowService.resolveOAuthCredential(OAuthFlowService.kt:80)
```

## Cause

La requête `upsert` fait `MERGE (c:Credential {userId, authSettingId}) ... RETURN c`. Quand plusieurs nœuds matchent la paire, `RETURN c` renvoie plusieurs lignes et la méthode typée (cardinalité 1) lève l'exception.

**Aucune contrainte d'unicité n'existait sur le label `Credential`** : absent des 10 labels couverts par `Neo4jSchemaInitializer`, et sans `SchemaInitializer` dédié contrairement à `AiProvider`, `AuthSetting`, `IntegrationConfig`, `Prompt`, `ScheduledPrompt`, `ScheduledPromptRun` et `ScheduledPromptUserRun`.

Or un `MERGE` sans contrainte d'unicité sous-jacente **n'est pas atomique sous concurrence** : deux transactions simultanées sur la même clé métier créent chacune un nœud. La contrainte est le mécanisme qui rend le `MERGE` correct, pas une optimisation.

Le KDoc de `CredentialNode` affirmait déjà « Uniqueness is on the `(userId, authSettingId)` pair » — invariante documentée mais jamais appliquée au stockage.

## Pourquoi le problème est resté invisible

```cypher
findByUserIdAndAuthSettingId:  ... RETURN c LIMIT 1   <- masque
upsert:                        ... RETURN c            <- révèle
```

Tant que le token restait valide, seule la lecture était sollicitée : `LIMIT 1` renvoyait l'un des doublons et tout paraissait fonctionner. À l'expiration, le refresh a déclenché une **écriture** et l'incohérence a éclaté. Les doublons préexistaient sans aucun signe.

Déclencheur probable : `ToolResolverService.extractTools()` résout le `credentialProvider` **par IntegrationConfig**. Deux configs référençant le même `authSettingName`, ou deux runs concurrents, produisent deux `store()` en parallèle sur la même clé.

## Changements

**`CredentialSchemaInitializer` (nouveau)** — calqué sur `ScheduledPromptUserRunSchemaInitializer`, le précédent le plus proche (contrainte composite déjà en place sur `(runId, userId)`). Quatre étapes ordonnées :

1. **Pré-vol de détection de doublons** avant toute création de contrainte. Sans ce garde-fou, une base déjà polluée empêche le démarrage avec une erreur Neo4j opaque. Le message d'erreur embarque les 3 premières paires fautives **et la requête Cypher de remédiation complète** (`ORDER BY c.modified DESC SKIP 1 DETACH DELETE c`, qui conserve le credential le plus frais).
2. Contrainte composite `credential_user_auth_setting_unique` sur `(userId, authSettingId)`.
3. Contrainte `credential_id_unique` sur `id`.
4. Index auxiliaire `credential_user_lookup` sur `userId`, qui appuie `findByUserId` — non couvert par l'index de la contrainte composite.

Une contrainte composite convient ici car les deux champs sont non-nuls : la limitation Neo4j 5.x (exemption silencieuse quand un composant est NULL, documentée dans `IntegrationConfigSchemaInitializer`) ne s'applique pas. Pas de détour par une `tripleKey`.

Pas d'index sur `authSettingId` : `findByAuthSettingId` est un chemin de cascade-delete peu fréquent.

**`CredentialNodeNeo4jRepository`** — `LIMIT 1` retiré de `findByUserIdAndAuthSettingId`, KDoc expliquant que l'unicité est désormais garantie par la contrainte et pourquoi ce garde défensif était nocif.

**`CredentialNode`** — KDoc aligné : l'invariante d'unicité est maintenant présentée comme **appliquée** par `CredentialSchemaInitializer`, non plus seulement déclarée.

## Note sur les tests

Aucun test ajouté pour l'initialiseur, en cohérence avec les pratiques du projet : aucun des 7 `SchemaInitializer` existants n'est testé unitairement. Mocker `neo4jClient.query(...).run()` pour vérifier qu'une chaîne Cypher est passée testerait l'implémentation, pas le comportement. Le niveau pertinent serait un test de contrat sur Neo4j embarqué — infrastructure inexistante pour les initialiseurs.

## Validation

- Build ✅ compilation Kotlin sans erreur
- Tests ✅ suite `agentos-service` complète au vert

## Gravité

Supérieure aux défauts de configuration silencieux déjà identifiés (#1310, #1201) : il ne s'agit pas d'une configuration inopérante mais d'une **corruption persistante et différée de données d'authentification**. Le `LIMIT 1` défensif est l'archétype du correctif qui masque le symptôme et laisse la cause s'aggraver.

## Hors périmètre

`CaseServiceImpl.shutdown()` propage des `ResourceNotFoundException` sur des cases déjà supprimées (~16 occurrences dans les logs de test). Préexistant, non lié à ce fix, à investiguer séparément.