### PR TITLE
fix: #1310 MCP HTTP root endpoint unreachable due to forced SDK default

### DIFF
--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnection.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnection.kt
@@ -21,10 +21,16 @@ import java.time.Duration
  * Uses [HttpClientStreamableHttpTransport] from the MCP Java SDK 2.0.
  *
  * The URL from [McpServerConfig.url] is automatically split into base URI and endpoint
- * path to work around the MCP Java SDK's `URI.resolve` behavior. When the URL includes
- * a path (e.g. `https://mcp.example.com/v1/mcp`), the path is extracted as the explicit
- * endpoint. When the URL has no path (e.g. `https://mcp.example.com`), the SDK's default
- * `/mcp` endpoint is used.
+ * path to work around the MCP Java SDK's `URI.resolve` behavior. The endpoint is **always**
+ * set explicitly — the SDK's implicit default `/mcp` is never used:
+ *
+ * - URL with a meaningful path (e.g. `https://mcp.atlassian.com/v1/mcp`): the path is
+ *   extracted as the explicit endpoint (`/v1/mcp`), and the origin becomes the base URI.
+ * - URL with no path or root path (e.g. `https://mcp.hubspot.com` or
+ *   `https://mcp.hubspot.com/`): the endpoint is set to `"/"` so the server root is hit.
+ *
+ * This matters because the default `/mcp` is not universal: HubSpot exposes the MCP
+ * endpoint at the root (`/`), while Atlassian uses `/v1/mcp`.
  */
 class HttpMcpConnection(
     private val config: McpServerConfig,
@@ -165,24 +171,28 @@ class HttpMcpConnection(
          *   endpoint = "/mcp"
          *   resolved = "https://mcp.atlassian.com/mcp"  ← WRONG
          *
-         * To work around this, when the configured URL already contains the full path to
-         * the MCP endpoint, we split it into a base (scheme + authority) and the path as
-         * the explicit endpoint. This way `URI.resolve` produces the correct result.
+         * To prevent this, we always split the URL into origin (scheme + authority) and
+         * an explicit endpoint path, so the SDK's implicit default `"/mcp"` never applies.
          *
-         * When the URL has no meaningful path (e.g. `https://mcp.example.com`), we return
-         * `null` for the endpoint and let the SDK use its default `"/mcp"`.
+         * The SDK's default is not universal: HubSpot exposes MCP at the root (`/`),
+         * while Atlassian uses `/v1/mcp`. Letting the SDK silently fall back to `/mcp`
+         * would make root-endpoint servers unreachable.
+         *
+         * @return a pair of (origin, endpoint) where:
+         *   - `origin` is always `scheme://authority` (port preserved when explicit)
+         *   - `endpoint` is the path from the URL, or `"/"` when the URL has no path
+         *     (the second element is typed as [String?] but is never null in practice)
          */
         internal fun splitMcpUrl(url: String): Pair<String, String?> {
             val uri = java.net.URI.create(url)
+            val origin = "${uri.scheme}://${uri.authority}"
             val path = uri.path
-            // If the URL has a meaningful path (more than just "/"), extract it as the endpoint
-            // and use the origin (scheme + authority) as the base URL.
+            // Always set an explicit endpoint so the SDK's implicit "/mcp" default never applies.
+            // Root-only URLs (empty path or bare "/") get endpoint="/" to target the server root.
             return if (!path.isNullOrBlank() && path != "/") {
-                val origin = "${uri.scheme}://${uri.authority}"
                 Pair(origin, path)
             } else {
-                // No path — let the SDK use its default "/mcp" endpoint
-                Pair(url, null)
+                Pair(origin, "/")
             }
         }
     }

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnection.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnection.kt
@@ -67,7 +67,7 @@ class HttpMcpConnection(
         // the SDK from producing a wrong URL like "https://host/v1/mcp" → "https://host/mcp".
         // URI.resolve("/mcp") replaces the entire path — it does NOT append.
         val (baseUrl, endpoint) = splitMcpUrl(url)
-        logger.debug { "[MCP-HTTP] Resolved baseUrl=$baseUrl, endpoint=$endpoint" }
+        logger.info { "[MCP-HTTP] Resolved baseUrl=$baseUrl, endpoint=$endpoint" }
 
         val transportBuilder = HttpClientStreamableHttpTransport
             .builder(baseUrl)

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpHttpToolProvider.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpHttpToolProvider.kt
@@ -119,7 +119,7 @@ class McpHttpToolProvider : ToolPlugin {
                     "url": {
                         "type": "string",
                         "title": "Server URL",
-                        "description": "Base URL of the remote MCP server (e.g. https://mcp.example.com). The SDK appends /mcp as the default endpoint."
+                        "description": "Full URL of the MCP endpoint, path included. Use the URL exactly as documented by the server provider. Examples: 'https://mcp.hubspot.com/' (root endpoint), 'https://mcp.atlassian.net/v1/mcp' (path endpoint). No path is appended automatically."
                     },
                     "authToken": {
                         "type": "string",

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpServerConfig.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpServerConfig.kt
@@ -20,7 +20,10 @@ package io.whozoss.agentos.plugins.mcp
  * @property env Environment variables injected into the child process (stdio transport only).
  * @property cwd Optional working directory for the child process (stdio transport only).
  *   Defaults to the JVM working directory when null.
- * @property url HTTP endpoint of the remote MCP server (HTTP transport only).
+ * @property url Full URL of the MCP endpoint, path included (HTTP transport only).
+ *   Use the URL exactly as documented by the server provider — no path is appended
+ *   automatically. Examples: `https://mcp.hubspot.com/` (root endpoint),
+ *   `https://mcp.atlassian.net/v1/mcp` (path endpoint).
  * @property authToken Optional Bearer token sent in the `Authorization` header (HTTP transport only).
  * @property timeoutSeconds Connection/initialisation timeout in seconds.
  *   Defaults to [DEFAULT_CONNECT_TIMEOUT_SECONDS].

--- a/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnectionUnitSpec.kt
+++ b/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnectionUnitSpec.kt
@@ -27,4 +27,31 @@ class HttpMcpConnectionUnitSpec : StringSpec({
         val connection = HttpMcpConnection(config)
         connection.tools shouldBe emptyList()
     }
+
+    // splitMcpUrl — the endpoint is always explicit; the SDK default "/mcp" never applies
+
+    "splitMcpUrl: bare root URL (no path) returns origin and slash endpoint" {
+        HttpMcpConnection.splitMcpUrl("https://mcp.hubspot.com") shouldBe
+            Pair("https://mcp.hubspot.com", "/")
+    }
+
+    "splitMcpUrl: root URL with trailing slash returns origin and slash endpoint" {
+        HttpMcpConnection.splitMcpUrl("https://mcp.hubspot.com/") shouldBe
+            Pair("https://mcp.hubspot.com", "/")
+    }
+
+    "splitMcpUrl: URL with explicit path returns origin and that path as endpoint" {
+        HttpMcpConnection.splitMcpUrl("https://mcp.atlassian.com/v1/mcp") shouldBe
+            Pair("https://mcp.atlassian.com", "/v1/mcp")
+    }
+
+    "splitMcpUrl: URL with single-segment path returns origin and that path as endpoint" {
+        HttpMcpConnection.splitMcpUrl("https://mcp.example.com/mcp") shouldBe
+            Pair("https://mcp.example.com", "/mcp")
+    }
+
+    "splitMcpUrl: URL with port preserves the port in origin and returns slash endpoint" {
+        HttpMcpConnection.splitMcpUrl("http://localhost:3000") shouldBe
+            Pair("http://localhost:3000", "/")
+    }
 })

--- a/libs/agentos-ui/src/lib/components/auth-setting-form/auth-setting-form.component.html
+++ b/libs/agentos-ui/src/lib/components/auth-setting-form/auth-setting-form.component.html
@@ -13,7 +13,7 @@
     <form class="auth-setting-form__form" [formGroup]="form" (ngSubmit)="submit()">
       @if (!isPlatformMode) {
         <fieldset class="auth-setting-form__scope" [disabled]="isEditMode()">
-          <legend class="auth-setting-form__label">Portée de la configuration</legend>
+          <legend class="auth-setting-form__label">Configuration scope</legend>
           @for (opt of scopeOptions; track trackByScope($index, opt)) {
             <label class="auth-setting-form__scope-option">
               <input
@@ -86,7 +86,11 @@
                   [placeholder]="field.placeholder"
                   [formControl]="ctrl"
                   [autocomplete]="field.secret ? 'new-password' : 'off'"
+                  [attr.aria-describedby]="field.hint ? 'as-hint-' + field.key : null"
                 />
+                @if (field.hint) {
+                  <p class="auth-setting-form__field-hint" [id]="'as-hint-' + field.key">{{ field.hint }}</p>
+                }
               }
             </div>
           }

--- a/libs/agentos-ui/src/lib/components/auth-setting-form/auth-setting-form.component.scss
+++ b/libs/agentos-ui/src/lib/components/auth-setting-form/auth-setting-form.component.scss
@@ -77,6 +77,13 @@
     gap: 0.35rem;
   }
 
+  &__field-hint {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    margin: 0;
+    line-height: 1.4;
+  }
+
   &__label {
     font-size: 0.85rem;
     font-weight: 500;

--- a/libs/agentos-ui/src/lib/components/auth-setting-form/auth-setting-form.component.ts
+++ b/libs/agentos-ui/src/lib/components/auth-setting-form/auth-setting-form.component.ts
@@ -24,20 +24,22 @@ import { NamespaceRoleStateService } from '../../services/namespace-role-state.s
 const VALID_SCOPES: ReadonlySet<AuthSettingScope> = new Set(['namespace', 'userOnNs', 'userGlobal'])
 
 const SCOPE_LABEL: Readonly<Record<AuthSettingScope, string>> = Object.freeze({
-  platform: 'Plateforme (lecture seule)',
-  namespace: 'Configuration du namespace',
-  userOnNs: 'Pour moi sur ce namespace',
-  userGlobal: 'Pour moi globalement',
+  platform: 'Platform (read-only)',
+  namespace: 'Namespace configuration',
+  userOnNs: 'Personal — this namespace only',
+  userGlobal: 'Personal — all namespaces',
 })
 
 /**
  * Credential fields per auth type.
  * `secret: true` → rendered as `type="password"` with masking-sentinel tracking.
+ * `hint` → optional helper text rendered below the input (aria-describedby linked).
  */
 interface CredentialField {
   key: string
   label: string
   placeholder: string
+  hint?: string
   secret: boolean
   required: boolean
 }
@@ -59,7 +61,14 @@ const CREDENTIAL_FIELDS: Readonly<Record<AuthSettingType, ReadonlyArray<Credenti
     },
     { key: 'clientId', label: 'Client ID', placeholder: '', secret: false, required: false },
     { key: 'clientSecret', label: 'Client secret', placeholder: '', secret: true, required: false },
-    { key: 'scopes', label: 'Scopes', placeholder: 'openid profile email', secret: false, required: false },
+    {
+      key: 'scopes',
+      label: 'Scopes',
+      placeholder: '',
+      hint: "Space-separated OAuth scopes to request (e.g. openid profile email). Check your provider's documentation for the exact values.",
+      secret: false,
+      required: false,
+    },
   ],
   OAuthCustomAuthSetting: [
     {
@@ -72,7 +81,14 @@ const CREDENTIAL_FIELDS: Readonly<Record<AuthSettingType, ReadonlyArray<Credenti
     { key: 'tokenUrl', label: 'Token URL', placeholder: 'https://…/token', secret: false, required: false },
     { key: 'clientId', label: 'Client ID', placeholder: '', secret: false, required: false },
     { key: 'clientSecret', label: 'Client secret', placeholder: '', secret: true, required: false },
-    { key: 'scopes', label: 'Scopes', placeholder: 'openid profile email', secret: false, required: false },
+    {
+      key: 'scopes',
+      label: 'Scopes',
+      placeholder: '',
+      hint: "Space-separated OAuth scopes to request (e.g. openid profile email). Check your provider's documentation for the exact values.",
+      secret: false,
+      required: false,
+    },
   ],
   OAuthRegisteredAuthSetting: [
     {
@@ -85,19 +101,41 @@ const CREDENTIAL_FIELDS: Readonly<Record<AuthSettingType, ReadonlyArray<Credenti
     { key: 'tokenUrl', label: 'Token URL', placeholder: 'https://…/token', secret: false, required: false },
     { key: 'clientId', label: 'Client ID', placeholder: '', secret: false, required: false },
     { key: 'clientSecret', label: 'Client secret', placeholder: '', secret: true, required: false },
-    { key: 'scopes', label: 'Scopes', placeholder: 'openid profile email', secret: false, required: false },
+    {
+      key: 'scopes',
+      label: 'Scopes',
+      placeholder: '',
+      hint: "Space-separated OAuth scopes to request (e.g. openid profile email). Check your provider's documentation for the exact values.",
+      secret: false,
+      required: false,
+    },
   ],
   OAuthMcpDiscoverableAuthSetting: [
     {
       key: 'resourceUrl',
       label: 'Resource URL',
-      placeholder: 'https://…/mcp',
+      placeholder: 'https://mcp.example.com',
+      hint: 'Use the base URL exactly as documented by your provider — do not append a path suffix. Examples: https://mcp.hubspot.com (HubSpot), https://mcp.atlassian.com/v1/mcp (Atlassian).',
       secret: false,
       required: false,
     },
-    { key: 'clientId', label: 'Client ID', placeholder: '', secret: false, required: false },
+    {
+      key: 'clientId',
+      label: 'Client ID',
+      placeholder: '',
+      hint: 'Leave empty to let the server register an OAuth client automatically (RFC 7591 dynamic registration). Fill in only if you have a pre-registered client ID from your provider.',
+      secret: false,
+      required: false,
+    },
     { key: 'clientSecret', label: 'Client secret', placeholder: '', secret: true, required: false },
-    { key: 'scopes', label: 'Scopes', placeholder: 'openid profile email', secret: false, required: false },
+    {
+      key: 'scopes',
+      label: 'Scopes',
+      placeholder: '',
+      hint: 'Leave empty in most cases — the MCP server declares the required scopes itself. Fill in only if your provider explicitly requires client-declared scopes.',
+      secret: false,
+      required: false,
+    },
   ],
 }
 


### PR DESCRIPTION
Closes #1310

## Contexte

Une intégration `MCP_HTTP` configurée avec une URL sans chemin (ex. `https://mcp.hubspot.com`) échouait systématiquement au handshake MCP avec un HTTP 404, alors que l'URL fournie était correcte. Le serveur MCP de HubSpot expose son endpoint à la **racine**, ce que le code rendait inatteignable.

Preuve empirique :
- `GET https://mcp.hubspot.com/` → **401** (existe, exige une auth)
- `GET https://mcp.hubspot.com/mcp` → **404** (n'existe pas)

## Cause

`HttpMcpConnection.splitMcpUrl()` retournait `endpoint = null` quand le path de l'URL était vide ou égal à `/`. Le MCP Java SDK appliquait alors son endpoint par défaut `/mcp`, produisant une requête sur `https://mcp.hubspot.com/mcp`.

Aucun contournement par configuration n'existait : `https://mcp.hubspot.com` (path vide) et `https://mcp.hubspot.com/` (path `/`, exclu par la condition) tombaient tous deux dans la même branche.

## Changements

**1. `a4ee35169` — correctif `splitMcpUrl`**

L'endpoint est désormais **toujours explicite**, dérivé de l'URL saisie ; le défaut implicite `/mcp` du SDK ne s'applique plus jamais. La branche racine retourne `Pair(origin, "/")` au lieu de `Pair(url, null)`.

Effet de bord corrigé au passage : l'ancienne branche retournait l'URL brute comme base, laissant un slash final éventuel. `origin` (`scheme://authority`) est maintenant calculé en amont et partagé par les deux branches.

5 cas de test ajoutés : racine nue, racine avec slash, chemin multi-segment, chemin à un segment, URL avec port (vérifie la préservation du port par `uri.authority`).

**2. `96e979ba1` — documentation du champ `url` corrigée**

Le `CONFIG_SCHEMA` de `McpHttpToolProvider`, **rendu directement dans le formulaire de création d'IntegrationConfig**, affirmait : *« The SDK appends /mcp as the default endpoint. »* La documentation validait donc activement le comportement défaillant, au moment même où l'utilisateur saisit l'URL.

Corrigé aux deux endroits (schéma UI + KDoc de `McpServerConfig.url`), avec les exemples HubSpot (racine) et Atlassian (`/v1/mcp`) côte à côte pour rendre la variabilité des chemins immédiatement visible.

**3. `f93abeb67` — log de l'endpoint résolu en `info`**

La ligne `[MCP-HTTP] Resolved baseUrl=..., endpoint=...` était en `debug` — c'était précisément l'information manquante pour diagnostiquer le bug. Asymétrie corrigée : l'URL brute configurée était déjà logguée en `info`, mais pas l'URL effectivement construite. Une ligne par connexion, information de configuration stable, bruit négligeable.

## Impact / régression

Ce changement modifie le comportement des intégrations existantes configurées avec une URL sans chemin qui reposaient implicitement sur `/mcp`. Atlassian, l'autre cas réel connu, utilise `https://mcp.atlassian.com/v1/mcp` et passe par la première branche — non concerné.

## Validation

- `./gradlew :agentos-mcp-plugin:build` ✅
- `./gradlew :agentos-mcp-plugin:test` ✅ 7 tests, 0 failure
- Validé fonctionnellement sur une intégration HubSpot réelle

## Hors périmètre

Identifiés pendant l'investigation, volontairement laissés de côté :
- Validation syntaxique de l'URL dans `McpConfigParser` (à traiter séparément)
- Indications trompeuses dans le formulaire AuthSettings de l'UI (audit réalisé, issue à ouvrir)
- Contrainte d'unicité manquante sur `Credential` → traitée dans #1311