### PR TITLE
feat(agentos): #1053 credentialType-driven MCP_HTTP auth header and URL validation

### DIFF
--- a/agentos/agentos-mcp-plugin/build.gradle.kts
+++ b/agentos/agentos-mcp-plugin/build.gradle.kts
@@ -87,6 +87,9 @@ dependencies {
     testImplementation(libs.bundles.jackson)
     testImplementation(libs.bundles.testing.common)
     testImplementation(libs.pf4j)
+    // SLF4J binding for tests: lets specs attach a Logback ListAppender and assert on WARN emission
+    // and on the absence of secrets in log output.
+    testImplementation(libs.logback.classic)
     testRuntimeOnly(libs.junit.platform.launcher)
     kaptTest(libs.pf4j)
 }

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/AuthorizationHeader.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/AuthorizationHeader.kt
@@ -1,0 +1,68 @@
+package io.whozoss.agentos.plugins.mcp
+
+import io.whozoss.agentos.sdk.credential.Credential
+import io.whozoss.agentos.sdk.credential.CredentialType
+import java.util.Base64
+
+/**
+ * Value of the HTTP `Authorization` header sent to a remote MCP server.
+ *
+ * The scheme is derived from the [CredentialType] alone (see [from]); the credential
+ * material is read from the single key the SDK contract assigns to that type, never
+ * by probing alternative key names.
+ *
+ * [toString] is overridden on every variant so that no credential material can leak
+ * through logs, exception messages or debug output.
+ */
+sealed class AuthorizationHeader {
+
+    /** Builds the exact header value to send on the wire. */
+    abstract fun headerValue(): String
+
+    /** `Authorization: Bearer <token>` (RFC 6750). */
+    class Bearer(private val token: String) : AuthorizationHeader() {
+        override fun headerValue(): String = "Bearer $token"
+
+        override fun toString(): String = "AuthorizationHeader.Bearer"
+    }
+
+    /** `Authorization: Basic base64(username ":" password)` (RFC 7617, UTF-8). */
+    class Basic(private val username: String, private val password: String) : AuthorizationHeader() {
+        override fun headerValue(): String {
+            val userPass = "$username:$password".toByteArray(Charsets.UTF_8)
+            return "Basic ${Base64.getEncoder().encodeToString(userPass)}"
+        }
+
+        override fun toString(): String = "AuthorizationHeader.Basic(username=***)"
+    }
+
+    companion object {
+        /**
+         * Maps a [Credential] to the header its [CredentialType] dictates, or `null` when
+         * the credential carries no usable material (required key missing or blank).
+         *
+         * - [CredentialType.OAUTH_TOKENS] → [Bearer] with `accessToken`
+         * - [CredentialType.BEARER_TOKEN] → [Bearer] with `token`
+         * - [CredentialType.API_KEY] → [Bearer] with `key` (kept as Bearer to preserve the behaviour MCP_HTTP
+         *   had before credential-type-driven mapping; the MCP transport has no API-key header convention)
+         * - [CredentialType.BASIC_AUTH] → [Basic] with `username` and `password`
+         */
+        fun from(credential: Credential): AuthorizationHeader? = when (credential.credentialType) {
+            CredentialType.OAUTH_TOKENS -> bearer(credential, "accessToken")
+            CredentialType.BEARER_TOKEN -> bearer(credential, "token")
+            CredentialType.API_KEY -> bearer(credential, "key")
+            CredentialType.BASIC_AUTH -> basic(credential)
+        }
+
+        private fun bearer(credential: Credential, key: String): Bearer? =
+            credential.material(key)?.let { Bearer(it) }
+
+        private fun basic(credential: Credential): Basic? {
+            val username = credential.material("username") ?: return null
+            val password = credential.material("password") ?: return null
+            return Basic(username = username, password = password)
+        }
+
+        private fun Credential.material(key: String): String? = data[key]?.takeIf { it.isNotBlank() }
+    }
+}

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnection.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnection.kt
@@ -16,7 +16,7 @@ import java.time.Duration
  *
  * Unlike [StdioMcpConnection], HTTP connections are NOT pooled — each instance is
  * created per agent run and closed after tool resolution. The [CredentialProvider]
- * supplies per-user auth tokens, making connection sharing across users unsafe.
+ * supplies per-user credentials, making connection sharing across users unsafe.
  *
  * Uses [HttpClientStreamableHttpTransport] from the MCP Java SDK 2.0.
  *
@@ -37,16 +37,18 @@ class HttpMcpConnection(
     /**
      * Connects to the remote MCP server, performs the MCP handshake, and discovers tools.
      *
-     * Bearer token injection uses [HttpClientStreamableHttpTransport.Builder.requestBuilder]:
+     * Header injection uses [HttpClientStreamableHttpTransport.Builder.requestBuilder]:
      * a pre-configured [HttpRequest.Builder] with the `Authorization` header is passed to
      * the transport. The builder is copied internally on every request, so the header
      * is applied consistently across all JSON-RPC calls (initialize, listTools, callTool).
      *
-     * @param bearerToken Optional Bearer token for the `Authorization` header.
-     *   When non-null, injected via a pre-configured [HttpRequest.Builder].
+     * @param authorization Optional `Authorization` header (Bearer or Basic). When non-null,
+     *   its [AuthorizationHeader.headerValue] is injected via a pre-configured [HttpRequest.Builder].
+     *   Sending it over plain `http` exposes the credential in cleartext and is logged as a warning
+     *   (this covers bound credentials; [McpConfigParser] already warns for a static `authToken`).
      * @throws McpConnectionException if the HTTP connection or MCP handshake fails.
      */
-    fun connect(bearerToken: String? = null) {
+    fun connect(authorization: AuthorizationHeader? = null) {
         require(config.transport == McpTransport.HTTP) {
             "HttpMcpConnection requires HTTP transport config"
         }
@@ -68,12 +70,13 @@ class HttpMcpConnection(
             .also { if (endpoint != null) it.endpoint(endpoint) }
             .connectTimeout(Duration.ofSeconds(config.timeoutSeconds))
 
-        // Inject Bearer token via a pre-configured request builder.
+        // Inject the Authorization header via a pre-configured request builder.
         // The transport copies this builder for each request, so the header is applied
         // to every JSON-RPC call without needing a per-request customizer.
-        if (bearerToken != null) {
+        if (authorization != null) {
+            warnIfCleartext(url)
             transportBuilder.requestBuilder(
-                HttpRequest.newBuilder().header("Authorization", "Bearer $bearerToken")
+                HttpRequest.newBuilder().header("Authorization", authorization.headerValue())
             )
         }
 
@@ -135,6 +138,13 @@ class HttpMcpConnection(
         logger.debug { "[MCP-HTTP] Closing connection to ${config.url}" }
         runCatching { client.closeGracefully() }
             .onFailure { runCatching { client.close() } }
+    }
+
+    private fun warnIfCleartext(url: String) {
+        val uri = java.net.URI.create(url)
+        if (uri.scheme.equals("http", ignoreCase = true)) {
+            logger.warn { "[MCP-HTTP] Sending credentials over cleartext http to '${uri.host}' — use https" }
+        }
     }
 
     private fun formatResult(result: McpSchema.CallToolResult): String {

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpConfigParser.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpConfigParser.kt
@@ -8,6 +8,12 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape
 import com.fasterxml.jackson.databind.type.LogicalType
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import mu.KotlinLogging
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.URI
+import java.net.URISyntaxException
 
 /**
  * Parses and validates a [JsonNode] config into a [McpServerConfig].
@@ -17,10 +23,16 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
  * - Exactly one of `command` (stdio transport) or `url` (HTTP transport) must be present.
  * - `command` and `url` must be non-blank.
  * - `args` entries must not be blank.
- * - `authToken`, when present, must be non-blank.
+ * - `url` must be an absolute `http`/`https` URL with a host, without embedded userinfo, and
+ *   must not target `localhost` or a literal loopback / link-local / site-local / unique-local /
+ *   shared-address-space (CGNAT) / wildcard IP. Only literal IPs are inspected — no DNS
+ *   resolution happens at parse time.
+ * - `authToken`, when present, must be non-blank. Combined with a plain `http` url it is
+ *   accepted but logged as a warning (credential over cleartext transport).
  * - Timeout values, when provided, must be positive.
  *
- * Throws [IllegalArgumentException] with a descriptive message on any violation.
+ * Throws [IllegalArgumentException] with a descriptive message on any violation. Messages
+ * never echo the `authToken`.
  *
  * ## Security / Trust Boundary
  *
@@ -34,6 +46,19 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
  * authorization is delegated to the integration management layer.
  */
 object McpConfigParser {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val SUPPORTED_URL_SCHEMES = setOf("http", "https")
+
+    /** First byte of an IPv6 unique-local address is `1111110x` (`fc` or `fd`). */
+    private const val UNIQUE_LOCAL_PREFIX_MASK = 0xFE
+    private const val UNIQUE_LOCAL_PREFIX = 0xFC
+
+    /** IPv4 shared address space `100.64.0.0/10`: first byte 100, second byte `01xxxxxx` (64..127). */
+    private const val SHARED_ADDRESS_FIRST_BYTE = 100
+    private const val SHARED_ADDRESS_SECOND_BYTE_MASK = 0xC0
+    private const val SHARED_ADDRESS_SECOND_BYTE_PREFIX = 0x40
 
     private val mapper = ObjectMapper()
         .registerModule(
@@ -88,11 +113,105 @@ object McpConfigParser {
     }
 
     private fun validateHttp(config: McpServerConfig) {
+        val uri = validateUrl(config.url!!)
         if (config.authToken != null) {
             require(config.authToken.isNotBlank()) {
                 "MCP integration config: 'authToken' must not be blank when present"
             }
+            if (uri.scheme.equals("http", ignoreCase = true)) {
+                logger.warn {
+                    "MCP integration config: 'authToken' will be sent over cleartext http to '${uri.host}' " +
+                        "— use https"
+                }
+            }
         }
+    }
+
+    private fun validateUrl(url: String): URI {
+        val uri = try {
+            URI(url)
+        } catch (e: URISyntaxException) {
+            throw IllegalArgumentException("MCP integration config: 'url' is not a valid URI (${e.reason})", e)
+        }
+        require(uri.isAbsolute) { "MCP integration config: 'url' must be an absolute http or https URL" }
+        require(uri.scheme.lowercase() in SUPPORTED_URL_SCHEMES) {
+            "MCP integration config: 'url' scheme must be http or https, got '${uri.scheme}'"
+        }
+        require(!hasUserInfo(uri)) { "MCP integration config: 'url' must not embed userinfo credentials" }
+        val host = uri.host
+        require(!host.isNullOrBlank()) { invalidHostMessage(uri) }
+        require(!isLocalOrPrivateHost(host)) {
+            "MCP integration config: 'url' host '$host' is local or private (localhost, loopback, link-local, " +
+                "site-local, unique-local, shared address space or wildcard address); " +
+                "only remote MCP servers are allowed"
+        }
+        return uri
+    }
+
+    /**
+     * True when the authority carries userinfo. [URI.getRawUserInfo] alone is not enough: when the
+     * host part is not a valid host name, [URI] keeps the whole authority raw and reports no userinfo.
+     * Per RFC 3986 a literal `@` in the authority can only be the userinfo delimiter (the last one),
+     * so any `@` means userinfo — including a password that itself contains an unencoded `@`.
+     */
+    private fun hasUserInfo(uri: URI): Boolean =
+        uri.rawUserInfo != null || uri.rawAuthority?.contains('@') == true
+
+    /**
+     * Message for a url whose authority could not be parsed as a host. Only called once
+     * [hasUserInfo] has ruled out any `@` in the authority, so echoing it cannot leak credentials.
+     */
+    private fun invalidHostMessage(uri: URI): String {
+        val authority = uri.rawAuthority
+        return if (authority.isNullOrBlank()) {
+            "MCP integration config: 'url' must have a host"
+        } else {
+            "MCP integration config: 'url' must have a valid host name or IP literal ('$authority' is not one)"
+        }
+    }
+
+    /**
+     * True for `localhost` and literal IPs that are not routable to a remote server on the public
+     * Internet: loopback, link-local, site-local (IPv4 private ranges), IPv6 unique-local, IPv4
+     * shared address space and wildcard addresses. No DNS lookup. An IPv6 zone id (`fe80::1%eth0`,
+     * percent-encoded as `%25` inside a URI) is dropped before classification so that a scoped
+     * link-local literal cannot bypass the check.
+     */
+    private fun isLocalOrPrivateHost(host: String): Boolean {
+        if (host.equals("localhost", ignoreCase = true)) return true
+        val literal = host.removePrefix("[").removeSuffix("]").substringBefore('%')
+        val address = parseLiteralIp(literal) ?: return false
+        return address.isLoopbackAddress ||
+            address.isLinkLocalAddress ||
+            address.isSiteLocalAddress ||
+            address.isAnyLocalAddress ||
+            isUniqueLocal(address) ||
+            isSharedAddressSpace(address)
+    }
+
+    /**
+     * IPv6 unique-local addresses (`fc00::/7`, RFC 4193) are the IPv6 counterpart of IPv4 private
+     * ranges but are not covered by [InetAddress.isSiteLocalAddress], which only knows the
+     * deprecated `fec0::/10` block.
+     */
+    private fun isUniqueLocal(address: InetAddress): Boolean =
+        address is Inet6Address && (address.address[0].toInt() and UNIQUE_LOCAL_PREFIX_MASK) == UNIQUE_LOCAL_PREFIX
+
+    /**
+     * IPv4 shared address space (`100.64.0.0/10`, RFC 6598) is assigned to carrier-grade NAT and is
+     * not routable on the public Internet, yet [InetAddress] exposes no predicate for it.
+     */
+    private fun isSharedAddressSpace(address: InetAddress): Boolean {
+        if (address !is Inet4Address) return false
+        val bytes = address.address
+        return (bytes[0].toInt() and 0xFF) == SHARED_ADDRESS_FIRST_BYTE &&
+            (bytes[1].toInt() and SHARED_ADDRESS_SECOND_BYTE_MASK) == SHARED_ADDRESS_SECOND_BYTE_PREFIX
+    }
+
+    private fun parseLiteralIp(literal: String): InetAddress? = try {
+        InetAddress.ofLiteral(literal)
+    } catch (_: IllegalArgumentException) {
+        null
     }
 
     private fun validateTimeouts(config: McpServerConfig) {

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpHttpToolProvider.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpHttpToolProvider.kt
@@ -2,6 +2,7 @@ package io.whozoss.agentos.plugins.mcp
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.whozoss.agentos.sdk.credential.Credential
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
 import io.whozoss.agentos.sdk.tool.ToolPlugin
@@ -15,9 +16,11 @@ import org.pf4j.Extension
  * remote MCP server, discovers tools, and returns [McpTool] wrappers. The connection
  * is NOT pooled — it lives for the duration of the agent run.
  *
- * Authentication is resolved via [ToolContext.credentialProvider]:
- * - If a credential is available, its `accessToken`, `token`, or `key` is used as Bearer token.
- * - If [McpServerConfig.authToken] is set in the config, it is used as a static fallback.
+ * Authentication is resolved by [resolveAuthorization]:
+ * - If [ToolContext.credentialProvider] yields a credential, its [Credential.credentialType] selects
+ *   the header scheme via [AuthorizationHeader.from] (Bearer for OAuth/API key/Bearer token,
+ *   Basic for BASIC_AUTH).
+ * - Otherwise, if the deprecated [McpServerConfig.authToken] is set, it is sent as a Bearer token.
  * - If neither is available, the connection is attempted without authentication.
  */
 @Extension
@@ -48,12 +51,14 @@ class McpHttpToolProvider : ToolPlugin {
             return emptyList()
         }
 
-        val bearerToken = resolveBearerToken(context, serverConfig)
-        logger.info { "MCP_HTTP integration '$configName': url=${serverConfig.url}, bearerToken=${if (bearerToken != null) "present (${bearerToken.length} chars)" else "absent"}" }
+        val authorization = resolveAuthorization(context, serverConfig)
+        logger.info {
+            "MCP_HTTP integration '$configName': url=${serverConfig.url}, authorization=${authorization ?: "absent"}"
+        }
 
         val connection = HttpMcpConnection(serverConfig)
         return try {
-            connection.connect(bearerToken)
+            connection.connect(authorization)
             if (connection.tools.isEmpty()) {
                 logger.warn { "MCP_HTTP integration '$configName': server advertises no tools" }
                 connection.close()
@@ -72,40 +77,42 @@ class McpHttpToolProvider : ToolPlugin {
     }
 
     /**
-     * Resolves the Bearer token for the HTTP connection.
+     * Resolves the `Authorization` header for the HTTP connection.
      *
      * Priority:
-     * 1. [ToolContext.credentialProvider] — dynamic, per-user credential (OAuth tokens, API keys)
-     * 2. [McpServerConfig.authToken] — static token from IntegrationConfig parameters
-     * 3. null — no authentication
-     *
-     * **Unsupported credential type:** `BASIC_AUTH` credentials carry `username` and
-     * `password` keys, none of which match the recognised token keys (`accessToken`,
-     * `token`, `key`, `apiKey`). A `BASIC_AUTH` credential therefore falls through to
-     * the static-token fallback (or to unauthenticated if no static token is configured).
-     * Full Basic Auth transport support is tracked in issue #1201.
+     * 1. [ToolContext.credentialProvider] — per-user credential mapped by [AuthorizationHeader.from].
+     *    A credential whose material is missing or blank is reported and skipped.
+     * 2. [McpServerConfig.authToken] — deprecated static Bearer token; an Auth Setting should be bound instead.
+     * 3. `null` — no authentication.
      */
-    internal fun resolveBearerToken(context: ToolContext?, serverConfig: McpServerConfig): String? {
-        val credential = context?.credentialProvider?.invoke()
-        if (credential != null) {
-            // Try common token key names in priority order
-            val token = credential.data["accessToken"]
-                ?: credential.data["token"]
-                ?: credential.data["key"]
-                ?: credential.data["apiKey"]
-            if (token != null) {
-                logger.debug { "[MCP-HTTP] Using credential from CredentialProvider" }
-                return token
+    internal fun resolveAuthorization(context: ToolContext?, serverConfig: McpServerConfig): AuthorizationHeader? =
+        context?.credentialProvider?.invoke()?.let { fromCredential(it, serverConfig) }
+            ?: fromStaticToken(serverConfig)
+
+    private fun fromCredential(credential: Credential, serverConfig: McpServerConfig): AuthorizationHeader? {
+        val authorization = AuthorizationHeader.from(credential)
+        if (authorization == null) {
+            logger.warn {
+                "MCP_HTTP integration '${serverConfig.label}': credential of type ${credential.credentialType} " +
+                    "carries no usable material; ignoring it"
             }
+        } else {
+            logger.debug { "[MCP-HTTP] Using ${credential.credentialType} credential from CredentialProvider" }
         }
+        return authorization
+    }
 
-        if (serverConfig.authToken != null) {
-            logger.debug { "[MCP-HTTP] Using static authToken from config" }
-            return serverConfig.authToken
+    private fun fromStaticToken(serverConfig: McpServerConfig): AuthorizationHeader? {
+        val authToken = serverConfig.authToken
+        if (authToken == null) {
+            logger.debug { "[MCP-HTTP] No authentication configured" }
+            return null
         }
-
-        logger.debug { "[MCP-HTTP] No authentication configured" }
-        return null
+        logger.warn {
+            "MCP_HTTP integration '${serverConfig.label}': static 'authToken' is deprecated, " +
+                "bind an Auth Setting to the integration instead"
+        }
+        return AuthorizationHeader.Bearer(authToken)
     }
 
     companion object : KLogging() {
@@ -118,13 +125,14 @@ class McpHttpToolProvider : ToolPlugin {
                 "properties": {
                     "url": {
                         "type": "string",
+                        "format": "uri",
                         "title": "Server URL",
-                        "description": "Base URL of the remote MCP server (e.g. https://mcp.example.com). The SDK appends /mcp as the default endpoint."
+                        "description": "Absolute http(s) URL of the remote MCP server (e.g. https://mcp.example.com/mcp). Must have a public host: localhost, loopback, link-local, private, shared-address-space (CGNAT) and wildcard IPs are rejected, and embedded user:password is not allowed. Without a path the SDK appends /mcp as the default endpoint. Prefer https: credentials sent over plain http travel in cleartext."
                     },
                     "authToken": {
                         "type": "string",
                         "title": "Auth Token",
-                        "description": "Optional static Bearer token. Overridden by credentials from AuthSetting if configured."
+                        "description": "Deprecated: bind an Auth Setting instead; kept as a fallback. Static Bearer token used only when the bound Auth Setting yields no usable credential."
                     },
                     "timeoutSeconds": {
                         "type": "integer",

--- a/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpServerConfig.kt
+++ b/agentos/agentos-mcp-plugin/src/main/kotlin/io/whozoss/agentos/plugins/mcp/McpServerConfig.kt
@@ -9,7 +9,8 @@ package io.whozoss.agentos.plugins.mcp
  *
  * **HTTP (remote)** — reached over the network:
  * - [url] must be set; [command] must be absent.
- * - [authToken] is the optional Bearer token sent in the `Authorization` header.
+ * - [authToken] is the deprecated static Bearer token, used only when no bound Auth Setting
+ *   yields a usable credential.
  *
  * The transport in use is determined by [McpServerConfig.transport]:
  * - [McpTransport.STDIO] when [command] is set.
@@ -21,7 +22,8 @@ package io.whozoss.agentos.plugins.mcp
  * @property cwd Optional working directory for the child process (stdio transport only).
  *   Defaults to the JVM working directory when null.
  * @property url HTTP endpoint of the remote MCP server (HTTP transport only).
- * @property authToken Optional Bearer token sent in the `Authorization` header (HTTP transport only).
+ * @property authToken Optional static Bearer token sent in the `Authorization` header (HTTP transport only).
+ *   Deprecated: bind an Auth Setting to the integration instead; kept as a fallback.
  * @property timeoutSeconds Connection/initialisation timeout in seconds.
  *   Defaults to [DEFAULT_CONNECT_TIMEOUT_SECONDS].
  * @property toolCallTimeoutSeconds Per-tool-call timeout in seconds.

--- a/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/AuthorizationHeaderUnitSpec.kt
+++ b/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/AuthorizationHeaderUnitSpec.kt
@@ -1,0 +1,97 @@
+package io.whozoss.agentos.plugins.mcp
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.whozoss.agentos.sdk.credential.Credential
+import io.whozoss.agentos.sdk.credential.CredentialType
+import java.util.UUID
+
+class AuthorizationHeaderUnitSpec : StringSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    fun credential(type: CredentialType, data: Map<String, String>): Credential = Credential(
+        userId = UUID.randomUUID(),
+        authSettingId = UUID.randomUUID(),
+        credentialType = type,
+        data = data,
+    )
+
+    // One entry per credential type: the material carried and the exact header expected.
+    // A new CredentialType value has no entry here and makes the parameterised block fail.
+    val expectedByType: Map<CredentialType, Pair<Map<String, String>, String>> = mapOf(
+        CredentialType.API_KEY to (mapOf("key" to "api-key-value") to "Bearer api-key-value"),
+        CredentialType.BEARER_TOKEN to (mapOf("token" to "bearer-value") to "Bearer bearer-value"),
+        CredentialType.OAUTH_TOKENS to (mapOf("accessToken" to "oauth-access") to "Bearer oauth-access"),
+        // base64("support@corp.com/token:s3cr3t") computed with an independent tool
+        CredentialType.BASIC_AUTH to (
+            mapOf("username" to "support@corp.com/token", "password" to "s3cr3t")
+                to "Basic c3VwcG9ydEBjb3JwLmNvbS90b2tlbjpzM2NyM3Q="
+            ),
+    )
+
+    // Alternative key names that the legacy probing accepted; none of them must be honoured now.
+    val foreignKeys = mapOf("apiKey" to "x", "accessToken" to "x", "token" to "x", "key" to "x")
+
+    CredentialType.entries.forEach { type ->
+        "from maps $type to the expected Authorization header" {
+            val (data, expectedHeader) = expectedByType.getValue(type)
+            AuthorizationHeader.from(credential(type, data))?.headerValue() shouldBe expectedHeader
+        }
+
+        "from returns null for $type when the required material is missing" {
+            AuthorizationHeader.from(credential(type, emptyMap())) shouldBe null
+        }
+
+        "from returns null for $type when the required material is blank" {
+            val (data, _) = expectedByType.getValue(type)
+            val blanked = data.mapValues { "  " }
+            AuthorizationHeader.from(credential(type, blanked)) shouldBe null
+        }
+
+        "from does not probe alternative key names for $type" {
+            val (data, _) = expectedByType.getValue(type)
+            // Everything the contract requires except the last piece of material, so that the only
+            // way to build a header is to read that piece from one of the foreign keys.
+            val allButLast = data.toList().dropLast(1).toMap()
+            val withForeignKeys = allButLast + foreignKeys.filterKeys { it !in data.keys }
+            AuthorizationHeader.from(credential(type, withForeignKeys)) shouldBe null
+        }
+    }
+
+    "from returns Bearer for API_KEY" {
+        AuthorizationHeader.from(credential(CredentialType.API_KEY, mapOf("key" to "k")))
+            .shouldBeInstanceOf<AuthorizationHeader.Bearer>()
+    }
+
+    "from returns Basic for BASIC_AUTH" {
+        AuthorizationHeader.from(credential(CredentialType.BASIC_AUTH, mapOf("username" to "u", "password" to "p")))
+            .shouldBeInstanceOf<AuthorizationHeader.Basic>()
+    }
+
+    "BASIC_AUTH with only a username is unusable" {
+        AuthorizationHeader.from(credential(CredentialType.BASIC_AUTH, mapOf("username" to "u"))) shouldBe null
+    }
+
+    "BASIC_AUTH with only a password is unusable" {
+        AuthorizationHeader.from(credential(CredentialType.BASIC_AUTH, mapOf("password" to "p"))) shouldBe null
+    }
+
+    "Bearer toString never reveals the token" {
+        val rendered = AuthorizationHeader.Bearer("top-secret-token").toString()
+        rendered shouldNotContain "top-secret-token"
+        rendered shouldContain "Bearer"
+    }
+
+    "Basic toString never reveals the username or the password" {
+        val rendered = AuthorizationHeader.Basic(username = "alice", password = "wonderland").toString()
+        rendered shouldNotContain "alice"
+        rendered shouldNotContain "wonderland"
+        rendered shouldNotContain "YWxpY2U6d29uZGVybGFuZA=="
+        rendered shouldContain "Basic"
+    }
+})

--- a/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnectionUnitSpec.kt
+++ b/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/HttpMcpConnectionUnitSpec.kt
@@ -1,15 +1,22 @@
 package io.whozoss.agentos.plugins.mcp
 
+import ch.qos.logback.classic.Level
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 
 /**
  * Unit tests for [HttpMcpConnection] covering the parts that are testable
  * without a real HTTP server (config validation and transport preconditions).
  *
  * The network-dependent path (connect, callTool, close) requires a live MCP server
- * and is therefore covered by integration tests, not here.
+ * and is therefore covered by integration tests, not here. The cleartext warning is
+ * emitted before any network I/O, so it is asserted against a closed loopback port
+ * (connection refused, no live server needed).
  */
 class HttpMcpConnectionUnitSpec : StringSpec({
 
@@ -17,7 +24,7 @@ class HttpMcpConnectionUnitSpec : StringSpec({
         val stdioConfig = McpServerConfig(command = "docker")
         val connection = HttpMcpConnection(stdioConfig)
         val ex = shouldThrow<IllegalArgumentException> {
-            connection.connect()
+            connection.connect(authorization = AuthorizationHeader.Bearer("unused"))
         }
         ex.message shouldBe "HttpMcpConnection requires HTTP transport config"
     }
@@ -27,4 +34,35 @@ class HttpMcpConnectionUnitSpec : StringSpec({
         val connection = HttpMcpConnection(config)
         connection.tools shouldBe emptyList()
     }
-})
+
+    "connect warns about cleartext http when an Authorization header is sent, without echoing it" {
+        // HttpMcpConnection does not validate the host (McpConfigParser does), so a closed
+        // loopback port gives a fast, deterministic connection failure after the warning.
+        val config = McpServerConfig(url = "http://127.0.0.1:$UNUSED_PORT/mcp", timeoutSeconds = 1)
+        val connection = HttpMcpConnection(config)
+        val logs = LogCapture.capturing {
+            shouldThrow<McpConnectionException> {
+                connection.connect(authorization = AuthorizationHeader.Bearer("secret-token"))
+            }
+        }
+        val warnings = logs.messagesAt(Level.WARN)
+        warnings shouldHaveSize 1
+        warnings.single() shouldContain "cleartext"
+        warnings.single() shouldContain "127.0.0.1"
+        logs.messages.forEach { it shouldNotContain "secret-token" }
+    }
+
+    "connect does not warn about cleartext when no Authorization header is sent" {
+        val config = McpServerConfig(url = "http://127.0.0.1:$UNUSED_PORT/mcp", timeoutSeconds = 1)
+        val connection = HttpMcpConnection(config)
+        val logs = LogCapture.capturing {
+            shouldThrow<McpConnectionException> { connection.connect(authorization = null) }
+        }
+        logs.messagesAt(Level.WARN).shouldBeEmpty()
+    }
+}) {
+    companion object {
+        /** Port 1 (tcpmux) is never bound on a developer machine or CI runner: connect is refused at once. */
+        private const val UNUSED_PORT = 1
+    }
+}

--- a/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/LogCapture.kt
+++ b/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/LogCapture.kt
@@ -1,0 +1,51 @@
+package io.whozoss.agentos.plugins.mcp
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.slf4j.LoggerFactory
+
+/**
+ * Captures every log event emitted under the `io.whozoss.agentos.plugins.mcp` logger hierarchy
+ * for the duration of [block], so that specs can assert on WARN emission and on the absence of
+ * secrets in log output. Test-only helper.
+ */
+class LogCapture private constructor() {
+    private val appender = ListAppender<ILoggingEvent>()
+    private val logger = LoggerFactory.getLogger(PLUGIN_LOGGER_NAME) as Logger
+
+    /** Formatted messages of every captured event, in emission order. */
+    val messages: List<String>
+        get() = appender.list.map { it.formattedMessage }
+
+    /** Formatted messages of captured events at [level]. */
+    fun messagesAt(level: Level): List<String> =
+        appender.list.filter { it.level == level }.map { it.formattedMessage }
+
+    private fun start() {
+        appender.start()
+        logger.addAppender(appender)
+    }
+
+    private fun stop() {
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+
+    companion object {
+        private const val PLUGIN_LOGGER_NAME = "io.whozoss.agentos.plugins.mcp"
+
+        /** Runs [block] with capture enabled and returns the capture for assertions. */
+        fun capturing(block: () -> Unit): LogCapture {
+            val capture = LogCapture()
+            capture.start()
+            try {
+                block()
+            } finally {
+                capture.stop()
+            }
+            return capture
+        }
+    }
+}

--- a/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/McpConfigParserUnitSpec.kt
+++ b/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/McpConfigParserUnitSpec.kt
@@ -1,10 +1,14 @@
 package io.whozoss.agentos.plugins.mcp
 
+import ch.qos.logback.classic.Level
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 
 class McpConfigParserUnitSpec : StringSpec({
 
@@ -108,6 +112,141 @@ class McpConfigParserUnitSpec : StringSpec({
         val json = mapper.readTree("""{ "url": "https://mcp.example.com", "authToken": "" }""")
         val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
         ex.message shouldContain "authToken"
+    }
+
+    // ----- HTTP url validation -----
+
+    "accepts https url with a public host" {
+        val json = mapper.readTree("""{ "url": "https://mcp.atlassian.com/v1/mcp" }""")
+        McpConfigParser.parse(json).url shouldBe "https://mcp.atlassian.com/v1/mcp"
+    }
+
+    listOf(
+        "https://8.8.8.8/mcp" to "public IPv4",
+        "https://100.128.0.1/mcp" to "IPv4 just above the shared address space (100.64.0.0/10)",
+        "https://100.63.255.255/mcp" to "IPv4 just below the shared address space (100.64.0.0/10)",
+        "https://[2001:db8::1]/mcp" to "global IPv6",
+    ).forEach { (url, reason) ->
+        "accepts $reason host in url '$url'" {
+            val json = mapper.readTree("""{ "url": "$url" }""")
+            McpConfigParser.parse(json).url shouldBe url
+        }
+    }
+
+    "accepts plain http url with authToken but keeps it (cleartext is only warned)" {
+        val json = mapper.readTree("""{ "url": "http://mcp.example.com/mcp", "authToken": "secret-token" }""")
+        val config = McpConfigParser.parse(json)
+        config.url shouldBe "http://mcp.example.com/mcp"
+        config.authToken shouldBe "secret-token"
+    }
+
+    "warns once about cleartext http when authToken is set, without echoing the token" {
+        val json = mapper.readTree("""{ "url": "http://mcp.example.com/mcp", "authToken": "secret-token" }""")
+        val logs = LogCapture.capturing { McpConfigParser.parse(json) }
+        val warnings = logs.messagesAt(Level.WARN)
+        warnings shouldHaveSize 1
+        warnings.single() shouldContain "cleartext"
+        warnings.single() shouldContain "mcp.example.com"
+        logs.messages.forEach { it shouldNotContain "secret-token" }
+    }
+
+    "does not warn about cleartext for https url with authToken" {
+        val json = mapper.readTree("""{ "url": "https://mcp.example.com/mcp", "authToken": "secret-token" }""")
+        val logs = LogCapture.capturing { McpConfigParser.parse(json) }
+        logs.messagesAt(Level.WARN).shouldBeEmpty()
+    }
+
+    "does not warn about cleartext for http url without authToken" {
+        val json = mapper.readTree("""{ "url": "http://mcp.example.com/mcp" }""")
+        val logs = LogCapture.capturing { McpConfigParser.parse(json) }
+        logs.messagesAt(Level.WARN).shouldBeEmpty()
+    }
+
+    listOf(
+        "http://127.0.0.1/mcp" to "loopback",
+        "http://localhost:8080/mcp" to "localhost",
+        "http://10.0.0.1/mcp" to "private",
+        "http://169.254.169.254/latest/meta-data" to "link-local",
+        "http://100.64.0.1/mcp" to "shared address space (CGNAT)",
+        "http://100.127.255.254/mcp" to "shared address space upper bound",
+        "http://0.0.0.0/mcp" to "wildcard",
+        "http://[::1]/mcp" to "loopback",
+        "http://[fe80::1%25eth0]/mcp" to "link-local with zone id",
+        "http://[fd00::1]/mcp" to "IPv6 unique-local",
+    ).forEach { (url, reason) ->
+        "rejects $reason host in url '$url'" {
+            val json = mapper.readTree("""{ "url": "$url", "authToken": "secret-token" }""")
+            val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+            ex.message shouldContain "url"
+            ex.message shouldContain "host"
+            ex.message shouldNotContain "secret-token"
+        }
+    }
+
+    "rejects unsupported url scheme" {
+        val json = mapper.readTree("""{ "url": "ftp://mcp.example.com/mcp", "authToken": "secret-token" }""")
+        val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+        ex.message shouldContain "url"
+        ex.message shouldContain "scheme"
+        ex.message shouldNotContain "secret-token"
+    }
+
+    "rejects relative url" {
+        val json = mapper.readTree("""{ "url": "relative/path", "authToken": "secret-token" }""")
+        val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+        ex.message shouldContain "url"
+        ex.message shouldContain "absolute"
+        ex.message shouldNotContain "secret-token"
+    }
+
+    "rejects url with embedded userinfo" {
+        val json = mapper.readTree("""{ "url": "https://user:pw@mcp.example.com/mcp", "authToken": "secret-token" }""")
+        val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+        ex.message shouldContain "url"
+        ex.message shouldContain "userinfo"
+        ex.message shouldNotContain "secret-token"
+        ex.message shouldNotContain "user:pw"
+    }
+
+    "rejects url whose authority is not a valid host name and says so" {
+        val json = mapper.readTree("""{ "url": "http://my_host/mcp", "authToken": "secret-token" }""")
+        val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+        ex.message shouldContain "url"
+        ex.message shouldContain "valid host"
+        ex.message shouldContain "my_host"
+        ex.message shouldNotContain "secret-token"
+    }
+
+    "rejects url with userinfo and an invalid host without echoing the userinfo" {
+        // An invalid host name makes java.net.URI keep the whole authority raw (userInfo == null),
+        // so the host check must not echo the authority verbatim.
+        val json = mapper.readTree("""{ "url": "http://user:pw@my_host/mcp", "authToken": "secret-token" }""")
+        val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+        ex.message shouldContain "url"
+        ex.message shouldNotContain "pw"
+        ex.message shouldNotContain "secret-token"
+    }
+
+    listOf(
+        "http://user:p@ss@mcp.example.com/mcp" to listOf("p@ss", "ss@"),
+        "http://user@name:pw@my_host/mcp" to listOf("name:pw", "pw@"),
+    ).forEach { (url, secretFragments) ->
+        "rejects url with a multi-'@' userinfo without echoing any fragment of it ('$url')" {
+            // RFC 3986 delimits userinfo at the LAST '@'; an unencoded '@' inside the password makes
+            // java.net.URI keep the whole authority raw, so no part of it may be echoed.
+            val json = mapper.readTree("""{ "url": "$url", "authToken": "secret-token" }""")
+            val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+            ex.message shouldContain "url"
+            ex.message shouldContain "userinfo"
+            secretFragments.forEach { ex.message shouldNotContain it }
+            ex.message shouldNotContain "secret-token"
+        }
+    }
+
+    "rejects syntactically invalid url" {
+        val json = mapper.readTree("""{ "url": "https://mcp.example.com/a b" }""")
+        val ex = shouldThrow<IllegalArgumentException> { McpConfigParser.parse(json) }
+        ex.message shouldContain "url"
     }
 
     // ----- empty string coercion (frontend sends "" for optional fields) -----

--- a/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/McpHttpToolProviderUnitSpec.kt
+++ b/agentos/agentos-mcp-plugin/src/test/kotlin/io/whozoss/agentos/plugins/mcp/McpHttpToolProviderUnitSpec.kt
@@ -1,11 +1,14 @@
 package io.whozoss.agentos.plugins.mcp
 
+import ch.qos.logback.classic.Level
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import io.mockk.every
-import io.mockk.mockk
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.whozoss.agentos.sdk.auth.CredentialProvider
 import io.whozoss.agentos.sdk.credential.Credential
 import io.whozoss.agentos.sdk.credential.CredentialType
@@ -42,123 +45,108 @@ class McpHttpToolProviderUnitSpec : StringSpec({
         provider.provideTools(stdioConfig, "test", ctx) shouldBe emptyList()
     }
 
-    // ── resolveBearerToken priority logic ────────────────────────────────────
+    // ── resolveAuthorization priority chain ──────────────────────────────────
 
-    "resolveBearerToken returns null when context is null and no static token" {
+    fun credential(type: CredentialType, data: Map<String, String>): Credential = Credential(
+        metadata = EntityMetadata(),
+        userId = UUID.randomUUID(),
+        authSettingId = UUID.randomUUID(),
+        credentialType = type,
+        data = data,
+    )
+
+    fun contextWith(credProvider: CredentialProvider): ToolContext = ToolContext(
+        namespaceId = UUID.randomUUID(),
+        userId = null,
+        userExternalId = null,
+        caseEvents = emptyList(),
+        credentialProvider = credProvider,
+    )
+
+    "resolveAuthorization returns null when context is null and no static token" {
         val config = McpServerConfig(url = "https://mcp.example.com")
-        provider.resolveBearerToken(null, config) shouldBe null
+        provider.resolveAuthorization(null, config) shouldBe null
     }
 
-    "resolveBearerToken returns static authToken when no credential provider" {
+    "resolveAuthorization returns Bearer static authToken when no credential provider" {
         val config = McpServerConfig(url = "https://mcp.example.com", authToken = "static-token")
-        provider.resolveBearerToken(null, config) shouldBe "static-token"
+        provider.resolveAuthorization(null, config)?.headerValue() shouldBe "Bearer static-token"
     }
 
-    "resolveBearerToken returns static authToken when credential provider returns null" {
+    "resolveAuthorization returns Bearer static authToken when credential provider returns null" {
         val config = McpServerConfig(url = "https://mcp.example.com", authToken = "static-token")
-        val credProvider: CredentialProvider = { null }
-        val context = ToolContext(
-            namespaceId = UUID.randomUUID(),
-            userId = null,
-            userExternalId = null,
-            caseEvents = emptyList(),
-            credentialProvider = credProvider,
-        )
-        provider.resolveBearerToken(context, config) shouldBe "static-token"
+        val context = contextWith { null }
+        provider.resolveAuthorization(context, config)?.headerValue() shouldBe "Bearer static-token"
     }
 
-    "resolveBearerToken returns null when no credential and no static token" {
+    "resolveAuthorization returns null when no credential and no static token" {
         val config = McpServerConfig(url = "https://mcp.example.com")
-        val credProvider: CredentialProvider = { null }
-        val context = ToolContext(
-            namespaceId = UUID.randomUUID(),
-            userId = null,
-            userExternalId = null,
-            caseEvents = emptyList(),
-            credentialProvider = credProvider,
-        )
-        provider.resolveBearerToken(context, config) shouldBe null
+        val context = contextWith { null }
+        provider.resolveAuthorization(context, config) shouldBe null
     }
 
-    "resolveBearerToken prefers credential accessToken over static token" {
+    "resolveAuthorization prefers the credential over the static token" {
         val config = McpServerConfig(url = "https://mcp.example.com", authToken = "static-token")
-        val credential = Credential(
-            metadata = EntityMetadata(),
-            userId = UUID.randomUUID(),
-            authSettingId = UUID.randomUUID(),
-            credentialType = CredentialType.OAUTH_TOKENS,
-            data = mapOf("accessToken" to "oauth-access-token"),
-        )
-        val credProvider: CredentialProvider = { credential }
-        val context = ToolContext(
-            namespaceId = UUID.randomUUID(),
-            userId = null,
-            userExternalId = null,
-            caseEvents = emptyList(),
-            credentialProvider = credProvider,
-        )
-        val result = provider.resolveBearerToken(context, config)
-        result shouldBe "oauth-access-token"
-        result shouldNotBe "static-token"
+        val context = contextWith { credential(CredentialType.OAUTH_TOKENS, mapOf("accessToken" to "oauth-access")) }
+        val result = provider.resolveAuthorization(context, config)
+        result.shouldBeInstanceOf<AuthorizationHeader.Bearer>()
+        result.headerValue() shouldBe "Bearer oauth-access"
     }
 
-    "resolveBearerToken uses token key from credential" {
-        val config = McpServerConfig(url = "https://mcp.example.com")
-        val credential = Credential(
-            metadata = EntityMetadata(),
-            userId = UUID.randomUUID(),
-            authSettingId = UUID.randomUUID(),
-            credentialType = CredentialType.BEARER_TOKEN,
-            data = mapOf("token" to "bearer-value"),
-        )
-        val credProvider: CredentialProvider = { credential }
-        val context = ToolContext(
-            namespaceId = UUID.randomUUID(),
-            userId = null,
-            userExternalId = null,
-            caseEvents = emptyList(),
-            credentialProvider = credProvider,
-        )
-        provider.resolveBearerToken(context, config) shouldBe "bearer-value"
+    "resolveAuthorization maps a BASIC_AUTH credential to a Basic header" {
+        val config = McpServerConfig(url = "https://mcp.example.com", authToken = "static-token")
+        val context = contextWith { credential(CredentialType.BASIC_AUTH, mapOf("username" to "u", "password" to "p")) }
+        val result = provider.resolveAuthorization(context, config)
+        result.shouldBeInstanceOf<AuthorizationHeader.Basic>()
+        result.headerValue() shouldBe "Basic dTpw"
     }
 
-    "resolveBearerToken uses key from credential when accessToken and token are absent" {
-        val config = McpServerConfig(url = "https://mcp.example.com")
-        val credential = Credential(
-            metadata = EntityMetadata(),
-            userId = UUID.randomUUID(),
-            authSettingId = UUID.randomUUID(),
-            credentialType = CredentialType.API_KEY,
-            data = mapOf("key" to "api-key-value"),
-        )
-        val credProvider: CredentialProvider = { credential }
-        val context = ToolContext(
-            namespaceId = UUID.randomUUID(),
-            userId = null,
-            userExternalId = null,
-            caseEvents = emptyList(),
-            credentialProvider = credProvider,
-        )
-        provider.resolveBearerToken(context, config) shouldBe "api-key-value"
-    }
-
-    "resolveBearerToken falls through to static token when credential has no recognised key" {
+    "resolveAuthorization falls back to the static token when the credential carries no usable material" {
         val config = McpServerConfig(url = "https://mcp.example.com", authToken = "fallback")
-        val credential = Credential(
-            metadata = EntityMetadata(),
-            userId = UUID.randomUUID(),
-            authSettingId = UUID.randomUUID(),
-            credentialType = CredentialType.BASIC_AUTH,
-            data = mapOf("username" to "user", "password" to "pass"),
-        )
-        val credProvider: CredentialProvider = { credential }
-        val context = ToolContext(
-            namespaceId = UUID.randomUUID(),
-            userId = null,
-            userExternalId = null,
-            caseEvents = emptyList(),
-            credentialProvider = credProvider,
-        )
-        provider.resolveBearerToken(context, config) shouldBe "fallback"
+        val context = contextWith { credential(CredentialType.BEARER_TOKEN, mapOf("apiKey" to "wrong-key-name")) }
+        provider.resolveAuthorization(context, config)?.headerValue() shouldBe "Bearer fallback"
+    }
+
+    "resolveAuthorization returns null when the credential is unusable and no static token" {
+        val config = McpServerConfig(url = "https://mcp.example.com")
+        val context = contextWith { credential(CredentialType.API_KEY, emptyMap()) }
+        provider.resolveAuthorization(context, config) shouldBe null
+    }
+
+    // ── logging ───────────────────────────────────────────────────────────────
+
+    "resolveAuthorization warns that the static authToken is deprecated, without echoing it" {
+        val config = McpServerConfig(url = "https://mcp.example.com", authToken = "static-token")
+        val logs = LogCapture.capturing { provider.resolveAuthorization(null, config) }
+        val warnings = logs.messagesAt(Level.WARN)
+        warnings shouldHaveSize 1
+        warnings.single() shouldContain "deprecated"
+        warnings.single() shouldContain "https://mcp.example.com"
+        logs.messages.forEach { it shouldNotContain "static-token" }
+    }
+
+    "resolveAuthorization does not warn when a credential is used, and never logs its material" {
+        val config = McpServerConfig(url = "https://mcp.example.com", authToken = "static-token")
+        val context = contextWith { credential(CredentialType.BASIC_AUTH, mapOf("username" to "u", "password" to "p")) }
+        val logs = LogCapture.capturing { provider.resolveAuthorization(context, config) }
+        logs.messagesAt(Level.WARN).shouldBeEmpty()
+        logs.messages.forEach {
+            it shouldNotContain "static-token"
+            it shouldNotContain "dTpw"
+        }
+    }
+
+    "resolveAuthorization warns when the credential carries no usable material, without echoing config" {
+        val config = McpServerConfig(url = "https://mcp.example.com", authToken = "static-token")
+        val context = contextWith { credential(CredentialType.BEARER_TOKEN, mapOf("apiKey" to "wrong-key-name")) }
+        val logs = LogCapture.capturing { provider.resolveAuthorization(context, config) }
+        val warnings = logs.messagesAt(Level.WARN)
+        warnings shouldHaveSize 2
+        warnings[0] shouldContain "no usable material"
+        warnings[1] shouldContain "deprecated"
+        logs.messages.forEach {
+            it shouldNotContain "static-token"
+            it shouldNotContain "wrong-key-name"
+        }
     }
 })

--- a/agentos/gradle/libs.versions.toml
+++ b/agentos/gradle/libs.versions.toml
@@ -43,6 +43,9 @@ springCloudNetflixEureka = "4.3.1"
 # 8.1 is the last version compatible with Jackson 2.x (Spring Boot 3.x);
 # 9.0+ requires Jackson 3.x.
 logstashLogbackEncoder = "8.1"
+# Logback classic — SLF4J binding used by plugin unit tests to capture log events (ListAppender).
+# Aligned with the version Spring Boot 3.5.x brings into agentos-service.
+logback = "1.5.22"
 # Micrometer Datadog registry — version intentionally omitted; managed by
 # the Spring Boot BOM to stay aligned with the rest of the Micrometer stack.
 # OkHttp — version aligned with Spring Cloud BOM constraint (spring-cloud-dependencies 2025.0.1)
@@ -112,6 +115,7 @@ klogger = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "k
 
 # Logstash Logback Encoder — JSON structured logging
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstashLogbackEncoder" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 # Micrometer Datadog registry — exports Micrometer metrics to the Datadog API.
 # Disabled at runtime unless DATADOG_API_KEY is set and datadog.metrics.export.enabled=true.
 # Version managed by Spring Boot BOM.


### PR DESCRIPTION
## Merge order (four related PRs)

1. **#1314** service prerequisites (static Auth Setting credentials delivered to plugins, user-scope policy). Merge first: the three others rely on it functionally.
2. **#1315 (this PR)** MCP_HTTP hardening. Independent code-wise; merge after #1314 so the credentials it starts receiving are mapped with the right `Authorization` scheme.
3. **#1328** `HTTP_API` plugin. Compiles and is tested on master alone, but static credentials reach it end to end only with #1314.
4. **#1325** tool preview. Stacked on the branch of #1314; once #1314 is merged its base moves to `master`, then merge it.

The four branches were merged together in a local integration branch without any conflict, and that build was used for the live Google Drive test recorded in #1328.

## What this PR brings

The remote MCP connector (`MCP_HTTP`) guessed its token by probing several key names and could only send a `Bearer` header, so a Basic-auth credential was silently treated as "no authentication". It also accepted any URL. Once #1314 starts delivering admin-entered secrets, this plugin must use them correctly: this PR makes the header choice depend on the credential type and validates the server URL.

## What changed

- New sealed `AuthorizationHeader` (`Bearer` | `Basic`) built from `Credential.credentialType`, one SDK data key per type: OAuth and bearer tokens as `Bearer`, API keys as `Bearer` (unchanged behaviour), `BASIC_AUTH` as RFC 7617 Basic. No more key probing; `toString` never reveals material.
- Priority stays: bound credential, then the static `authToken` (now deprecated with a warning), then none. A credential with no usable material is reported and skipped.
- `McpConfigParser` validates `url` with `java.net.URI`: absolute `http`/`https`, host required, no embedded `user:password`, `localhost` and loopback / link-local / private / CGNAT / wildcard literal IPs rejected (IPv6 zone ids handled). `http` + credential is accepted with a warning. The config schema marks `url` as `format: uri` and `authToken` as deprecated.

## How it was verified

- `./gradlew :agentos-mcp-plugin:test :agentos-mcp-plugin:jar`: 115 tests, 0 failures; jar built with no logging binding bundled (`logback-classic` is test-scoped only).
- `AuthorizationHeaderUnitSpec` is parameterised over `CredentialType.entries`, with an independent base64 oracle for the Basic vector; parser rejection cases assert that messages never echo the token.
- Not run: no live MCP server.

## Risks and rollback

- Persisted `MCP_HTTP` configs pointing at `localhost` or a private address now yield zero tools with an error log (no save-time feedback yet, see #735).
- Rollback: revert the commit. No persistence, API or client change.

## Related

- #1314 (service side: static secrets delivered to plugins; also carries the `BasicAuthAuthSetting` KDoc rewrite).
- Issues: #1053, #1201, #1136, #1119.

https://claude.ai/code/session_01XNX3YCYNeZU95Fp4eDeGvH
