### PR TITLE
fix: #1317 surface provider error body on streaming path

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentAdvanced.kt
@@ -237,14 +237,7 @@ class AgentAdvanced(
                     ),
                 )
             } catch (e: Exception) {
-                logger.error(e) { "Error during agent execution" }
-                emit(
-                    WarnEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        message = "Error during agent execution: ${e.message}",
-                    ),
-                )
+                handleGenericAgentException(this@AgentAdvanced, e, namespaceId, caseId, logger)
             }
         }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentInterruptHandler.kt
@@ -6,9 +6,12 @@ import io.whozoss.agentos.sdk.caseEvent.AgentSelectedEvent
 import io.whozoss.agentos.sdk.caseEvent.CaseEvent
 import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
 import io.whozoss.agentos.sdk.caseEvent.QuestionEvent
+import io.whozoss.agentos.sdk.caseEvent.WarnEvent
+import io.whozoss.agentos.util.unwrapToProviderAiException
 import kotlinx.coroutines.flow.FlowCollector
 import mu.KLogger
 import org.springframework.ai.retry.NonTransientAiException
+import org.springframework.ai.retry.TransientAiException
 import java.util.UUID
 
 /**
@@ -41,6 +44,79 @@ suspend fun FlowCollector<CaseEvent>.emitProviderErrorAndFinishEvents(
             llmModel = agent.llmModel,
         ),
     )
+}
+
+/**
+ * Handles any [Exception] that escapes the agent's main loop by first checking whether
+ * it wraps a provider HTTP error on the streaming path (a [WebClientResponseException]
+ * buried under Reactor envelopes).
+ *
+ * If [e] or any cause in its chain is a [WebClientResponseException], it is translated
+ * to the appropriate Spring AI exception ([NonTransientAiException] for 4xx,
+ * [TransientAiException] for 5xx) so the response body surfaces in logs and in the
+ * [ErrorEvent] — exactly as it does on the blocking path.
+ *
+ * If [e] is not a provider HTTP error, the function falls back to the original generic
+ * behaviour: log at ERROR level and emit a [WarnEvent].
+ *
+ * This function is the single point of streaming-path exception enrichment. Every agent
+ * that follows the `catch (e: NonTransientAiException) { … } catch (e: Exception) { … }`
+ * pattern must delegate the generic catch to this function so future agents automatically
+ * benefit without needing to know about [WebClientResponseException].
+ */
+suspend fun FlowCollector<CaseEvent>.handleGenericAgentException(
+    agent: Agent,
+    e: Exception,
+    namespaceId: UUID,
+    caseId: UUID,
+    logger: KLogger,
+) {
+    when (val providerException = e.unwrapToProviderAiException()) {
+        is NonTransientAiException -> emitProviderErrorAndFinishEvents(agent, providerException, namespaceId, caseId, logger)
+        is TransientAiException -> {
+            // 5xx — provider-side failure, potentially transient.
+            // Emit ErrorEvent (same lifecycle termination) but log at WARN since a retry may succeed.
+            logger.warn(e) { "LLM provider returned a transient error for case $caseId" }
+            emit(
+                ErrorEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    message = "The AI provider returned a transient error and the agent cannot continue: ${providerException.message}",
+                ),
+            )
+            emit(
+                AgentFinishedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agent.id,
+                    agentName = agent.name,
+                    llmProvider = agent.llmProvider,
+                    llmModel = agent.llmModel,
+                ),
+            )
+        }
+        else -> {
+            // Not a provider HTTP error — preserve the original generic behaviour.
+            logger.error(e) { "Error during agent execution" }
+            emit(
+                WarnEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    message = "Error during agent execution: ${e.message}",
+                ),
+            )
+            emit(
+                AgentFinishedEvent(
+                    namespaceId = namespaceId,
+                    caseId = caseId,
+                    agentId = agent.id,
+                    agentName = agent.name,
+                    llmProvider = agent.llmProvider,
+                    llmModel = agent.llmModel,
+                ),
+            )
+        }
+    }
 }
 
 /**

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/agent/AgentSimple.kt
@@ -14,7 +14,6 @@ import io.whozoss.agentos.sdk.caseEvent.TextChunkEvent
 import io.whozoss.agentos.sdk.caseEvent.ThinkingEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolRequestEvent
 import io.whozoss.agentos.sdk.caseEvent.ToolResponseEvent
-import io.whozoss.agentos.sdk.caseEvent.WarnEvent
 import io.whozoss.agentos.sdk.entity.EntityMetadata
 import io.whozoss.agentos.sdk.tool.StandardTool
 import io.whozoss.agentos.sdk.tool.ToolContext
@@ -260,25 +259,7 @@ class AgentSimple(
             } catch (e: NonTransientAiException) {
                 emitProviderErrorAndFinishEvents(this@AgentSimple, e, namespaceId, caseId, logger)
             } catch (e: Exception) {
-                logger.error(e) { "Error during agent execution" }
-                emit(
-                    WarnEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        message = "Error during agent execution: ${e.message}",
-                    ),
-                )
-
-                emit(
-                    AgentFinishedEvent(
-                        namespaceId = namespaceId,
-                        caseId = caseId,
-                        agentId = id,
-                        agentName = name,
-                        llmProvider = llmProvider,
-                        llmModel = llmModel,
-                    ),
-                )
+                handleGenericAgentException(this@AgentSimple, e, namespaceId, caseId, logger)
             }
         }
 

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/util/WebClientExceptionUtils.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/util/WebClientExceptionUtils.kt
@@ -1,0 +1,83 @@
+package io.whozoss.agentos.util
+
+import kotlinx.coroutines.CancellationException
+import org.springframework.ai.retry.NonTransientAiException
+import org.springframework.ai.retry.TransientAiException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.Exceptions
+
+/** Maximum number of characters retained from the HTTP response body in the error message. */
+private const val MAX_BODY_CHARS = 4_000
+
+/** Marker appended when the response body is truncated. */
+private const val TRUNCATION_MARKER = "…[truncated]"
+
+/**
+ * Unwraps the throwable chain (Reactor envelope + cause chain) looking for a
+ * [WebClientResponseException] that signals a provider-side HTTP error on a
+ * streaming call.
+ *
+ * Returns:
+ * - [NonTransientAiException] for 4xx responses (the request is faulty — retrying is useless).
+ * - [TransientAiException] for 5xx responses (provider-side failure — may be retried).
+ * - `null` for anything else, including [CancellationException] (which must never be swallowed).
+ *
+ * Reactor frequently wraps exceptions via [Exceptions.propagate] or composite exceptions.
+ * [Exceptions.unwrap] strips the Reactor envelope (one level). If the root cause is still
+ * not a [WebClientResponseException], the function walks the [Throwable.cause] chain up to
+ * [MAX_CAUSE_DEPTH] levels deep, covering nested wrapping patterns.
+ *
+ * [CancellationException] is never converted: Kotlin coroutine cancellation must propagate
+ * unchanged so the cooperative cancellation protocol is respected.
+ */
+fun Throwable.unwrapToProviderAiException(): Exception? {
+    // Coroutine cancellation must never be swallowed or converted.
+    if (this is CancellationException) return null
+
+    // Walk the cause chain, starting with the Reactor-unwrapped root.
+    val unwrapped = Exceptions.unwrap(this)
+    return findWebClientException(unwrapped)
+        ?: findWebClientException(this)
+}
+
+/** Maximum depth when walking [Throwable.cause] chains. */
+private const val MAX_CAUSE_DEPTH = 10
+
+/**
+ * Recursively walks the cause chain of [root] up to [MAX_CAUSE_DEPTH] levels,
+ * returning the first [WebClientResponseException] found as a Spring AI exception,
+ * or `null` when none is found.
+ */
+private fun findWebClientException(root: Throwable): Exception? {
+    var current: Throwable? = root
+    var depth = 0
+    while (current != null && depth < MAX_CAUSE_DEPTH) {
+        if (current is WebClientResponseException) {
+            return current.toProviderAiException()
+        }
+        current = current.cause
+        depth++
+    }
+    return null
+}
+
+/**
+ * Converts a [WebClientResponseException] to the appropriate Spring AI exception type,
+ * embedding the response body in the message (bounded to [MAX_BODY_CHARS]).
+ *
+ * The body is what the provider sent as its error description — exactly the information
+ * that is otherwise lost on the streaming path.
+ */
+private fun WebClientResponseException.toProviderAiException(): Exception {
+    val body = responseBodyAsString
+        .take(MAX_BODY_CHARS + TRUNCATION_MARKER.length)
+        .let { raw ->
+            if (raw.length > MAX_BODY_CHARS) raw.take(MAX_BODY_CHARS) + TRUNCATION_MARKER else raw
+        }
+        .ifBlank { "<empty body>" }
+    val message = "${statusCode} from ${request?.method} ${request?.uri}: $body"
+    return when {
+        statusCode.is4xxClientError -> NonTransientAiException(message, this)
+        else -> TransientAiException(message, this)
+    }
+}

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleProviderErrorUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/agent/AgentSimpleProviderErrorUnitSpec.kt
@@ -1,0 +1,186 @@
+package io.whozoss.agentos.agent
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.whozoss.agentos.sdk.actor.Actor
+import io.whozoss.agentos.sdk.actor.ActorRole
+import io.whozoss.agentos.sdk.caseEvent.AgentFinishedEvent
+import io.whozoss.agentos.sdk.caseEvent.ErrorEvent
+import io.whozoss.agentos.sdk.caseEvent.MessageContent
+import io.whozoss.agentos.sdk.caseEvent.MessageEvent
+import io.whozoss.agentos.sdk.caseEvent.WarnEvent
+import io.whozoss.agentos.sdk.entity.EntityMetadata
+import kotlinx.coroutines.flow.toList
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.Exceptions
+import reactor.core.publisher.Flux
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+/**
+ * Tests that verify the streaming-path provider error surfacing fix.
+ *
+ * When the LLM provider rejects a streaming request with an HTTP error, the response body
+ * (containing the actionable error description) must appear in the [ErrorEvent] emitted —
+ * exactly as it does on the blocking path via [org.springframework.ai.retry.NonTransientAiException].
+ */
+class AgentSimpleProviderErrorUnitSpec : StringSpec({
+    timeout = 5000
+
+    fun makeAgent(
+        agentId: UUID,
+        chatClient: ChatClient,
+    ): AgentSimple =
+        AgentSimple(
+            metadata = EntityMetadata(id = agentId),
+            name = "TestAgent",
+            chatClient = chatClient,
+            tools = emptyList(),
+            llmProvider = "openai",
+            llmModel = "gpt-4o",
+        )
+
+    fun userMessage(
+        namespaceId: UUID,
+        caseId: UUID,
+    ) = MessageEvent(
+        namespaceId = namespaceId,
+        caseId = caseId,
+        actor = Actor("user1", "User", ActorRole.USER),
+        content = listOf(MessageContent.Text("hello")),
+    )
+
+    fun webClientException(
+        status: HttpStatus,
+        body: String,
+    ): WebClientResponseException =
+        WebClientResponseException(
+            status.value(),
+            status.reasonPhrase,
+            org.springframework.http.HttpHeaders.EMPTY,
+            body.toByteArray(StandardCharsets.UTF_8),
+            StandardCharsets.UTF_8,
+        )
+
+    // -----------------------------------------------------------------------
+    // 4xx bare — emitted as ErrorEvent (not WarnEvent) with body in message
+    // -----------------------------------------------------------------------
+
+    "streaming 400 from provider surfaces as ErrorEvent containing the response body" {
+        val namespaceId = UUID.randomUUID()
+        val caseId = UUID.randomUUID()
+        val agentId = UUID.randomUUID()
+
+        val body = """{"error":{"type":"invalid_request_error","message":"tools.9.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'"}}"""
+        val ex = webClientException(HttpStatus.BAD_REQUEST, body)
+
+        val mockChatClient = mockk<ChatClient>(relaxed = true)
+        val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+        every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+        every { mockStreamSpec.content() } returns Flux.error(ex)
+
+        val events = makeAgent(agentId, mockChatClient)
+            .run(listOf(userMessage(namespaceId, caseId)))
+            .toList()
+
+        // Must emit ErrorEvent (not WarnEvent) so the case lifecycle terminates correctly
+        val errorEvent = events.filterIsInstance<ErrorEvent>().firstOrNull()
+        errorEvent shouldNotBe null
+        errorEvent!!.message shouldContain body
+
+        // Must NOT emit a WarnEvent for a provider error (WarnEvent = generic path)
+        events.filterIsInstance<WarnEvent>().size shouldBe 0
+
+        // Run must still terminate
+        events.filterIsInstance<AgentFinishedEvent>().size shouldBe 1
+    }
+
+    // -----------------------------------------------------------------------
+    // 4xx Reactor-wrapped — the real production path
+    // -----------------------------------------------------------------------
+
+    "streaming 400 wrapped by Reactor surfaces as ErrorEvent containing the response body" {
+        val namespaceId = UUID.randomUUID()
+        val caseId = UUID.randomUUID()
+        val agentId = UUID.randomUUID()
+
+        val body = """{"error":{"type":"invalid_request_error","message":"bad tool name"}}"""
+        val raw = webClientException(HttpStatus.BAD_REQUEST, body)
+        // Simulate Reactor wrapping: this is what actually arrives at the catch block
+        val wrapped = Exceptions.propagate(raw)
+
+        val mockChatClient = mockk<ChatClient>(relaxed = true)
+        val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+        every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+        every { mockStreamSpec.content() } returns Flux.error(wrapped)
+
+        val events = makeAgent(agentId, mockChatClient)
+            .run(listOf(userMessage(namespaceId, caseId)))
+            .toList()
+
+        val errorEvent = events.filterIsInstance<ErrorEvent>().firstOrNull()
+        errorEvent shouldNotBe null
+        errorEvent!!.message shouldContain body
+        events.filterIsInstance<WarnEvent>().size shouldBe 0
+        events.filterIsInstance<AgentFinishedEvent>().size shouldBe 1
+    }
+
+    // -----------------------------------------------------------------------
+    // 5xx — becomes TransientAiException path — still ErrorEvent
+    // -----------------------------------------------------------------------
+
+    "streaming 503 from provider surfaces as ErrorEvent (transient path)" {
+        val namespaceId = UUID.randomUUID()
+        val caseId = UUID.randomUUID()
+        val agentId = UUID.randomUUID()
+
+        val body = """{"error":"service unavailable"}"""
+        val ex = webClientException(HttpStatus.SERVICE_UNAVAILABLE, body)
+
+        val mockChatClient = mockk<ChatClient>(relaxed = true)
+        val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+        every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+        every { mockStreamSpec.content() } returns Flux.error(ex)
+
+        val events = makeAgent(agentId, mockChatClient)
+            .run(listOf(userMessage(namespaceId, caseId)))
+            .toList()
+
+        val errorEvent = events.filterIsInstance<ErrorEvent>().firstOrNull()
+        errorEvent shouldNotBe null
+        errorEvent!!.message shouldContain body
+        events.filterIsInstance<WarnEvent>().size shouldBe 0
+        events.filterIsInstance<AgentFinishedEvent>().size shouldBe 1
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-HTTP exception — must still produce WarnEvent (original behaviour)
+    // -----------------------------------------------------------------------
+
+    "streaming generic RuntimeException still produces WarnEvent (no regression)" {
+        val namespaceId = UUID.randomUUID()
+        val caseId = UUID.randomUUID()
+        val agentId = UUID.randomUUID()
+
+        val mockChatClient = mockk<ChatClient>(relaxed = true)
+        val mockStreamSpec = mockk<ChatClient.StreamResponseSpec>(relaxed = true)
+        every { mockChatClient.prompt(any<Prompt>()).stream() } returns mockStreamSpec
+        every { mockStreamSpec.content() } returns Flux.error(RuntimeException("some generic error"))
+
+        val events = makeAgent(agentId, mockChatClient)
+            .run(listOf(userMessage(namespaceId, caseId)))
+            .toList()
+
+        // Generic exceptions produce WarnEvent (not ErrorEvent)
+        events.filterIsInstance<WarnEvent>().firstOrNull() shouldNotBe null
+        events.filterIsInstance<AgentFinishedEvent>().size shouldBe 1
+    }
+})

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/util/WebClientExceptionUtilsUnitSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/util/WebClientExceptionUtilsUnitSpec.kt
@@ -1,0 +1,200 @@
+package io.whozoss.agentos.util
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CancellationException
+import org.springframework.ai.retry.NonTransientAiException
+import org.springframework.ai.retry.TransientAiException
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.Exceptions
+import java.nio.charset.StandardCharsets
+
+/**
+ * Builds a [WebClientResponseException] with a JSON body.
+ * Uses the base constructor (statusCode: Int, statusText: String, headers, body, charset)
+ * which is stable across Spring 6.x versions and avoids the HttpRequest type mismatch
+ * introduced in later Spring 6 releases for the `create()` factory method.
+ */
+private fun webClientException(
+    status: HttpStatus,
+    body: String = "",
+): WebClientResponseException =
+    WebClientResponseException(
+        status.value(),
+        status.reasonPhrase,
+        org.springframework.http.HttpHeaders.EMPTY,
+        body.toByteArray(StandardCharsets.UTF_8),
+        StandardCharsets.UTF_8,
+    )
+
+/**
+ * Wraps a throwable the same way Reactor does via [Exceptions.propagate].
+ * This simulates what arrives at the agent catch block from a streaming Flux.
+ */
+private fun reactorWrap(cause: Throwable): Throwable = Exceptions.propagate(cause)
+
+class WebClientExceptionUtilsUnitSpec : StringSpec({
+
+    // -----------------------------------------------------------------------
+    // 4xx -- naked WebClientResponseException
+    // -----------------------------------------------------------------------
+
+    "4xx bare exception becomes NonTransientAiException with body in message" {
+        val body = """{"error":{"message":"tools.9.custom.name: String should match pattern"}}"""
+        val ex = webClientException(HttpStatus.BAD_REQUEST, body)
+
+        val result = ex.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+        result.message shouldContain body
+    }
+
+    "4xx bare exception - message also contains status code" {
+        val ex = webClientException(HttpStatus.UNPROCESSABLE_ENTITY, "invalid")
+
+        val result = ex.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+        result.message shouldContain "422"
+    }
+
+    // -----------------------------------------------------------------------
+    // 4xx -- Reactor-wrapped (the real production path)
+    // -----------------------------------------------------------------------
+
+    "4xx wrapped by Reactor becomes NonTransientAiException" {
+        val body = """{"error":{"type":"invalid_request_error","message":"bad tool name"}}"""
+        val raw = webClientException(HttpStatus.BAD_REQUEST, body)
+        val wrapped = reactorWrap(raw)
+
+        val result = wrapped.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+        result.message shouldContain body
+    }
+
+    "4xx doubly-wrapped cause chain depth 2 is still found" {
+        val body = "bad request details"
+        val raw = webClientException(HttpStatus.BAD_REQUEST, body)
+        val wrapped = RuntimeException("outer", RuntimeException("inner", raw))
+
+        val result = wrapped.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+        result.message shouldContain body
+    }
+
+    // -----------------------------------------------------------------------
+    // 5xx -- becomes TransientAiException
+    // -----------------------------------------------------------------------
+
+    "5xx bare exception becomes TransientAiException not NonTransientAiException" {
+        val body = """{"error":"internal server error"}"""
+        val ex = webClientException(HttpStatus.INTERNAL_SERVER_ERROR, body)
+
+        val result = ex.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<TransientAiException>()
+        result.message shouldContain body
+    }
+
+    "429 Too Many Requests is classified as NonTransientAiException by current implementation" {
+        // 429 is a 4xx so HttpStatus.is4xxClientError() returns true.
+        // This test documents the actual behaviour -- reclassifying 429 as transient
+        // is a separate concern that should be addressed explicitly if needed.
+        val ex = webClientException(HttpStatus.TOO_MANY_REQUESTS, "rate limit exceeded")
+
+        val result = ex.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+    }
+
+    "503 Service Unavailable wrapped by Reactor becomes TransientAiException" {
+        val raw = webClientException(HttpStatus.SERVICE_UNAVAILABLE, "provider down")
+        val wrapped = reactorWrap(raw)
+
+        val result = wrapped.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<TransientAiException>()
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-HTTP exceptions -- must return null
+    // -----------------------------------------------------------------------
+
+    "arbitrary RuntimeException returns null" {
+        val ex = RuntimeException("something else")
+
+        ex.unwrapToProviderAiException() shouldBe null
+    }
+
+    "NullPointerException returns null" {
+        val ex = NullPointerException("npe")
+
+        ex.unwrapToProviderAiException() shouldBe null
+    }
+
+    // -----------------------------------------------------------------------
+    // CancellationException -- must never be converted
+    // -----------------------------------------------------------------------
+
+    "CancellationException returns null and is never converted" {
+        val ex = CancellationException("coroutine cancelled")
+
+        ex.unwrapToProviderAiException() shouldBe null
+    }
+
+    "CancellationException in cause chain returns null" {
+        // Ensures the cause-walk loop does not convert a CancellationException
+        // found buried in the chain.
+        val cancel = CancellationException("cancelled")
+        val wrapped = RuntimeException("reactor-like wrapper", cancel)
+
+        wrapped.unwrapToProviderAiException() shouldBe null
+    }
+
+    // -----------------------------------------------------------------------
+    // Body truncation
+    // -----------------------------------------------------------------------
+
+    "body longer than 4000 chars is truncated with marker" {
+        val longBody = "x".repeat(5_000)
+        val ex = webClientException(HttpStatus.BAD_REQUEST, longBody)
+
+        val result = ex.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+        // Truncation marker present
+        result.message shouldContain "[truncated]"
+        // The retained portion must be exactly 4000 chars of the body
+        result.message shouldContain "x".repeat(4_000)
+    }
+
+    "body of exactly 4000 chars is not truncated" {
+        val exactBody = "y".repeat(4_000)
+        val ex = webClientException(HttpStatus.BAD_REQUEST, exactBody)
+
+        val result = ex.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+        (result.message?.contains("[truncated]") ?: false) shouldBe false
+        result.message shouldContain exactBody
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty body
+    // -----------------------------------------------------------------------
+
+    "empty response body is replaced with placeholder" {
+        val ex = webClientException(HttpStatus.BAD_REQUEST, "")
+
+        val result = ex.unwrapToProviderAiException()
+
+        result.shouldBeInstanceOf<NonTransientAiException>()
+        result.message shouldContain "<empty body>"
+    }
+})


### PR DESCRIPTION
Closes #1317 partially — observability only. **The root cause of the 400 is not fixed here** (see [Scope](#scope)).

## Problem

Provider rejections on the streaming path produced no usable diagnostic:

```
Error during agent execution
org.springframework.web.reactive.function.client.WebClientResponseException$BadRequest: 400 Bad Request from POST https://api.openai.com/v1/chat/completions
```

Spring AI 1.1.2 translates provider HTTP errors into `NonTransientAiException` **only on the blocking path**. `RestClient` + `RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER` reads the HTTP body and embeds it in the message. The streaming path goes through `WebClient`, and `OpenAiChatModel.internalStream()` has no `onErrorMap` — so the raw `WebClientResponseException` traverses the `Flux`, reaches `asFlow()`, and lands in the agents' generic `catch (e: Exception)` branch. We logged `e.message`, which carries only status + method + URL. The response body — the only place the provider names the offending field — sat unread on `responseBodyAsString`.

`AgentSimple` uses `.stream()` exclusively for its main LLM call, so **every** provider rejection in a normal agent run hit this blind spot. Diagnosing #1317 took four separate investigations and produced two hypotheses that were later weakened, purely for lack of the error body.

For contrast, here is what a path that surfaces the body gives you — immediately actionable:

```
Status: [400 BAD_REQUEST], Body:[{"type":"error","error":{"type":"invalid_request_error",
"message":"tools.9.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'"},
"request_id":"req_011CesTekr8YWSqVQjNK32uC"}]
```

## Solution

**`util/WebClientExceptionUtils.kt`** (new) — pure extension function `Throwable.unwrapToProviderAiException()`:
- unwraps the Reactor envelope (`Exceptions.unwrap`) then walks the `cause` chain (bounded depth)
- 4xx → `NonTransientAiException`, 5xx → `TransientAiException`, preserving Spring AI's retry semantics
- returns `null` for anything else, leaving propagation untouched
- short-circuits `CancellationException` on the first line, so coroutine cancellation can never be swallowed
- bounds the body to 4000 chars with an explicit truncation marker

**`agent/AgentInterruptHandler.kt`** — new `handleGenericAgentException()` that dispatches on the result. Both agents now delegate their generic catch to it.

### Why this location

`AgentInterruptHandler` is already the file every agent must use for interrupt and provider-error handling. A future agent copying the existing `catch (e: NonTransientAiException) { … } catch (e: Exception) { … }` pattern inherits the enriched behaviour **without needing to know about `WebClientResponseException`, Reactor, or the 4xx/5xx split**. The knowledge lives in one named place rather than scattered across catch blocks.

A `ChatClient` decorator was considered and rejected: intercepting the `Flux` before its conversion to a coroutine `Flow` would complicate cancellation propagation for no benefit here.

The fix is **provider-agnostic** — the defect is in Spring AI's streaming path, not in the OpenAI client. No per-provider branching was introduced, so Anthropic, Gemini, vLLM and Ollama all benefit.

## Behaviour change worth reviewing

`AgentAdvanced`'s generic `catch` previously emitted **no** `AgentFinishedEvent`, unlike `AgentSimple` — a latent defect that could leave a case hanging. `handleGenericAgentException` emits one in all branches, so this is now fixed as a side effect. It is consistent with `AgentSimple` and with the runtime always expecting an `AgentFinishedEvent` to close a run cleanly, but it is **beyond the strict observability scope** and deserves a reviewer's eye.

## Tests

18 new tests (Kotest + mockk), all green. Full `agentos-service` suite passes with no regression.

`WebClientExceptionUtilsUnitSpec` (14) covers: bare 4xx, **Reactor-wrapped 4xx** (the actual production shape), doubly-wrapped, 5xx → transient, non-HTTP exceptions passing through unchanged, **`CancellationException` never converted**, body truncation, empty body.

`AgentSimpleProviderErrorUnitSpec` (4) asserts the emitted `ErrorEvent` now carries the body, on both the bare and Reactor-wrapped paths, plus a non-regression case for generic exceptions.

One test deliberately **documents** that 429 is currently classified non-retryable (via `is4xxClientError`). That is semantically debatable — a rate limit is retryable — but reclassifying it was out of scope. Pinning it in a test makes any future change intentional rather than accidental.

## Scope

Deliberately **not** in this PR, pending an architectural decision:
- inference parameter handling (`temperature`, `maxTokens`, `reasoningEffort`) in `ChatModelFactory`
- MCP tool name and input-schema sanitisation

Both are symptoms of the same underlying gap: requests are built without ever checking the destination's contract. That contract needs to become an explicit, named concept rather than accumulated conditionals — discussion continues on #1317.

## Validation

`compileKotlin` / `compileTestKotlin` succeed (remaining warnings are pre-existing). Full `agentos-service:test` suite: BUILD SUCCESSFUL, 0 failures.