### PR TITLE
fix: #1322 sort tools by name for stable prompt cache prefix

### DIFF
--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -80,8 +80,7 @@ class ToolResolverService(
                     logger.warn { "[ToolResolver] Tool name conflict: '$name' present ${duplicates.size} times, keeping the first one." }
                 }
                 duplicates.first()
-            }
-            .sortedWith(compareBy { it.name })
+            }.sortedBy { it.name }
 
     private fun extractTools(
         allowedNames: List<String>?,

--- a/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
+++ b/agentos/agentos-service/src/main/kotlin/io/whozoss/agentos/tool/ToolResolverService.kt
@@ -58,7 +58,18 @@ class ToolResolverService(
     }
 
     /**
-     * De-duplicate tools by name, keeping the first occurrence and warning on each conflict.
+     * De-duplicate tools by name, keeping the first occurrence and warning on each conflict,
+     * then sort the result by name using binary (locale-independent) ordering.
+     *
+     * Sorting after deduplication is intentional: sorting before would change which duplicate
+     * is kept (the first alphabetically rather than the first encountered), breaking the
+     * existing selection semantics.
+     *
+     * The binary sort (compareBy with String.compareTo using ordinal comparison) is independent
+     * of the JVM default locale, ensuring a stable, reproducible order across deployments.
+     * This matters for prompt-cache stability: OpenAI's prefix cache is invalidated by any
+     * change in tool name order, so a deterministic order maximises cache reuse.
+     *
      * Shared so every tool source (resolver, delegation, exchange) reconciles collisions identically.
      */
     fun dedupToolsByName(tools: List<StandardTool<*>>): List<StandardTool<*>> =
@@ -70,6 +81,7 @@ class ToolResolverService(
                 }
                 duplicates.first()
             }
+            .sortedWith(compareBy { it.name })
 
     private fun extractTools(
         allowedNames: List<String>?,

--- a/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
+++ b/agentos/agentos-service/src/test/kotlin/io/whozoss/agentos/tool/ToolResolverServiceSpec.kt
@@ -317,6 +317,127 @@ class ToolResolverServiceSpec :
         }
 
         // -------------------------------------------------------------------------
+        // dedupToolsByName — ordering guarantee (prompt-cache stability)
+        // -------------------------------------------------------------------------
+
+        "dedupToolsByName returns tools in alphabetical order by name" {
+            // Tools intentionally given in reverse-alphabetical order to detect sort.
+            val tools =
+                listOf(
+                    makeTool("Zebra"),
+                    makeTool("Mango"),
+                    makeTool("Apple"),
+                )
+
+            val result = buildService().dedupToolsByName(tools)
+
+            result.map { it.name } shouldBe listOf("Apple", "Mango", "Zebra")
+        }
+
+        "dedupToolsByName produces the same ordered list regardless of the input order" {
+            // Core regression guard: two calls with the same logical tool set but different
+            // input orderings must produce identical output. This is the property that
+            // prevents OpenAI prompt-cache invalidation when Neo4j changes its return order.
+            val service = buildService()
+            val toolsAbc =
+                listOf(
+                    makeTool("Alpha"),
+                    makeTool("Beta"),
+                    makeTool("Gamma"),
+                )
+            val toolsCba =
+                listOf(
+                    makeTool("Gamma"),
+                    makeTool("Beta"),
+                    makeTool("Alpha"),
+                )
+
+            val resultAbc = service.dedupToolsByName(toolsAbc)
+            val resultCba = service.dedupToolsByName(toolsCba)
+
+            resultAbc.map { it.name } shouldBe resultCba.map { it.name }
+        }
+
+        "dedupToolsByName keeps the first-encountered tool when names collide" {
+            // Non-regression: the first tool in the input list is the one kept, not
+            // the first alphabetically. Sorting happens AFTER selection, so this is
+            // unaffected by the sort.
+            val keeper = makeTool("tool").also { _ -> }   // will be first in input
+            // Build a second tool with the same name but a different description
+            // so we can distinguish them.
+            val duplicate =
+                object : io.whozoss.agentos.sdk.tool.StandardTool<Nothing> {
+                    override val name = "tool"
+                    override val description = "DUPLICATE — must be dropped"
+                    override val inputSchema = """{"type":"object"}"""
+                    override val version = "1.0.0"
+                    override val paramType: Class<Nothing>? = null
+
+                    override suspend fun execute(
+                        input: Nothing?,
+                        context: ToolContext,
+                    ): io.whozoss.agentos.sdk.tool.ToolExecutionResult =
+                        io.whozoss.agentos.sdk.tool.ToolExecutionResult.success(name)
+                }
+
+            val result = buildService().dedupToolsByName(listOf(keeper, duplicate))
+
+            result shouldHaveSize 1
+            // The kept tool must be the first one from the original list, not the duplicate.
+            result.first().description shouldBe keeper.description
+            result.first().description shouldNotBe "DUPLICATE — must be dropped"
+        }
+
+        "dedupToolsByName on an empty list returns an empty list" {
+            buildService().dedupToolsByName(emptyList()).shouldBeEmpty()
+        }
+
+        "dedupToolsByName on a single-element list returns that element" {
+            val tool = makeTool("OnlyTool")
+
+            val result = buildService().dedupToolsByName(listOf(tool))
+
+            result shouldHaveSize 1
+            result.first().name shouldBe "OnlyTool"
+        }
+
+        "dedupToolsByName uses binary (locale-independent) ordering" {
+            // Uppercase ASCII letters sort before lowercase in binary order (A=65, Z=90, a=97).
+            // A locale-sensitive sort (e.g. Locale.FRENCH) would treat 'A' and 'a' as equal
+            // and produce a different, locale-dependent order. We verify the binary contract.
+            val tools =
+                listOf(
+                    makeTool("zebra"),   // lowercase z = 122
+                    makeTool("Apple"),   // uppercase A = 65
+                    makeTool("Banana"),  // uppercase B = 66
+                )
+
+            val result = buildService().dedupToolsByName(tools)
+
+            // Binary order: 'A'(65) < 'B'(66) < 'z'(122)
+            result.map { it.name } shouldBe listOf("Apple", "Banana", "zebra")
+        }
+
+        "resolveToolsForRun returns tools in alphabetical order" {
+            // End-to-end: the order guarantee must hold even when tools come from the
+            // integration-config resolution path, not just from a direct dedupToolsByName call.
+            val nsId = UUID.randomUUID()
+            val jiraPlugin = makePlugin("JIRA", "SearchIssues", "GetIssue")  // reversed alphabetical
+            val service = buildService(plugins = listOf(jiraPlugin))
+            val config = integrationConfig(namespaceId = nsId, name = "JIRA_PROD", integrationType = "JIRA")
+
+            val tools =
+                service.resolveToolsForRun(
+                    agentIntegrations = mapOf("JIRA_PROD" to null),
+                    context = ctx(nsId),
+                    allIntegrationConfigs = listOf(config),
+                )
+
+            // Alphabetical: JIRA_PROD__GetIssue < JIRA_PROD__SearchIssues
+            tools.map { it.name } shouldBe listOf("JIRA_PROD__GetIssue", "JIRA_PROD__SearchIssues")
+        }
+
+        // -------------------------------------------------------------------------
         // ToolContext forwarding
         // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1322

## Problem

OpenAI prompt caching is **enabled by default** — there is no opt-in, unlike Anthropic which requires explicit `cache_control` markers. The only lever available is therefore **prefix stability**, and tool definitions sit at the very front of that prefix. Per the OpenAI caching guide, any change to tool names, descriptions, schemas **or ordering** prevents cache reuse.

Tool ordering was not guaranteed by contract:

- `integrationConfigService.findEffective()` returns `List<IntegrationConfig>` from Neo4j **with no `ORDER BY`**
- `dedupToolsByName()` relied on `.groupBy { it.name }` returning a `LinkedHashMap`, so insertion order was preserved — stability was **accidental and never asserted**

If Neo4j's return order changed (adding or removing an integration, a reindex), the tool block at the head of the prefix would change and the entire cached prefix would be invalidated on every request. MCP tool definitions are verbose, and cache reads cost 0.1× the uncached input rate against 1.25× for a write — one write plus nine reads costs 2.15× versus 10× uncached. Losing the prefix means paying full price every turn.

## Change

One line in `ToolResolverService.dedupToolsByName()`:

```kotlin
.sortedWith(compareBy { it.name })
```

### Why this location

`dedupToolsByName()` is the mandatory convergence point for every tool source: `resolveToolsForRun()` calls it internally, and `AgentServiceImpl.resolveAgentDefinition()` calls it again over `baseTools + delegationTools + exchangeTools + queryUserTools`. Sorting in either caller alone would have missed the other tier; sorting in both would have been redundant and fragile. The existing KDoc already frames this method as the shared reconciliation point.

### Two details worth a reviewer's attention

**The sort is applied after deduplication, never before.** This is the trap in this change: sorting first would alter *which* duplicate is kept — the first alphabetically instead of the first encountered — silently changing selection semantics. Dedup behaviour is strictly unchanged, and the KDoc now documents the trap explicitly.

**The sort is binary, not locale-sensitive.** `compareBy` over `String.compareTo` compares Unicode code points. A JVM running under a Turkish or French locale with a `Collator` would produce a different order — an order varying by deployment environment would cause exactly the instability this PR removes. A dedicated test pins this.

## Verified: no caller depends on existing order

- `AgentAdvanced` resolves tools strictly by name (`firstOrNull { it.name == intention.toolName }`), never by position
- `AgentSimple` maps tools to `toolCallbacks` in list order, but position confers no priority — the model distinguishes tools by name in the schema
- The `baseTools + delegationTools + exchangeTools + queryUserTools` precedence operates at the *duplicate selection* level, which the sort does not touch since it runs afterwards

## Tests

7 new tests in `ToolResolverServiceSpec` (23 total). Full suite green: ~2,400 tests, 0 failures, no regression.

The test that justifies the exercise is **"produces the same ordered list regardless of the input order"**. The others verify behaviour; that one locks the *property*. Current stability rested entirely on `groupBy` preserving insertion order — without this test a future refactor would break it silently, and nobody would notice before reading an invoice.

Also covered: alphabetical ordering, first-encountered-wins on collision (non-regression), empty and single-element lists, and locale-independent binary ordering.

## Scope

Deliberately **not** here:
- No `OpenAiProperties` mirroring `AnthropicProperties` — it would activate nothing, OpenAI caching is already on
- No `prompt_cache_key` or GPT-5.6 explicit breakpoints — both need measurement before they can be judged
- MCP tool name sanitisation and inference parameter handling remain open on #1317

## Known remaining gap

`cached_tokens` (`usage.prompt_tokens_details.cached_tokens` for OpenAI, `cache_read_input_tokens` / `cache_creation_input_tokens` for Anthropic) is **not read, logged or persisted anywhere**. This PR maximises cache reuse but its effect cannot currently be measured — the same blind spot as the provider errors in #1318, except this one is paid in invoices rather than investigation time. It applies equally to Anthropic, whose caching we enabled without ever measuring it. Worth a separate issue.