### PR TITLE
Feature/benjamin/#1290 update delegate view part 3

### DIFF
--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
@@ -162,6 +162,8 @@
                   <span class="case-chat__question-answered-text">{{ item.event.question }}</span>
                 </div>
               }
+            } @else if (item.kind === 'delegation') {
+              <agentos-delegation-card [delegation]="item.delegation" [namespaceId]="namespaceId" />
             } @else {
               <div
                 class="case-chat__tool-call"

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.spec.ts
@@ -2,7 +2,12 @@ import { HttpClient } from '@angular/common/http'
 import { ComponentRef, createComponent, EnvironmentInjector, signal } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import { ActivatedRoute } from '@angular/router'
-import { Configuration, ExchangeFileEntryScopeEnum } from '@whoz-oss/agentos-api-client'
+import {
+  Configuration,
+  ExchangeFileEntryScopeEnum,
+  ToolRequestEvent,
+  ToolResponseEvent,
+} from '@whoz-oss/agentos-api-client'
 import { of, throwError } from 'rxjs'
 import { CaseStateService } from '../../services/case-state.service'
 import { ExchangeStateService } from '../../services/exchange-state.service'
@@ -223,5 +228,71 @@ describe('CaseChatComponent — submit with attachments', () => {
     attachments(ref).isUploading.set(false)
     ref.instance['isTerminal'].set(true)
     expect(ref.instance['canSend']).toBe(false)
+  })
+
+  it('replaces the generic delegate tool card when its real content-wrapped output contains delegation JSON', () => {
+    const ref = makeComponent()
+    const toolRequestId = 'tool-request-1'
+    const output = JSON.stringify([
+      {
+        delegationId: 'delegation-1',
+        toolRequestId,
+        subCaseId: 'sub-case-1',
+        agentName: 'Research',
+        success: true,
+        result: '**Done**',
+      },
+    ])
+    const request: ToolRequestEvent = {
+      id: 'request-event-id',
+      type: 'ToolRequestEvent',
+      caseId: 'c-1',
+      namespaceId: 'ns-1',
+      timestamp: '2026-01-01T00:00:00Z',
+      metadata: { id: 'request-event-id', created: '', modified: '', removed: false },
+      toolName: 'DELEGATE__delegate',
+      toolRequestId,
+      args: '{"delegations":[]}',
+    }
+    const response: ToolResponseEvent = {
+      id: 'response-event-id',
+      type: 'ToolResponseEvent',
+      caseId: 'c-1',
+      namespaceId: 'ns-1',
+      timestamp: '2026-01-01T00:00:01Z',
+      metadata: { id: 'response-event-id', created: '', modified: '', removed: false },
+      toolName: 'DELEGATE__delegate',
+      toolRequestId,
+      output: { content: output },
+      success: true,
+      images: [],
+      toolMetadata: {},
+    }
+
+    // This is the exact source used by the generic tool-card OUTPUT block.
+    expect(
+      ref.instance['extractToolOutput']({
+        requestId: toolRequestId,
+        toolName: request.toolName,
+        args: request.args,
+        response,
+      })
+    ).toBe(output)
+
+    ref.instance['events'].set([request, response])
+
+    const timeline = ref.instance['timeline']()
+    expect(timeline).toHaveLength(1)
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: 'delegation',
+        delegation: expect.objectContaining({
+          delegationId: 'delegation-1',
+          toolRequestId,
+          subCaseId: 'sub-case-1',
+        }),
+      })
+    )
+    expect(timeline.some((item) => item.kind === 'tool')).toBe(false)
   })
 })

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -19,7 +19,7 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
+import { SafeHtml } from '@angular/platform-browser'
 import { ActivatedRoute } from '@angular/router'
 import {
   AgentFinishedEvent,
@@ -47,8 +47,14 @@ import { CaseStatusGlyphComponent } from '../case-status-glyph/case-status-glyph
 import { CaseStateService } from '../../services/case-state.service'
 import { OAuthAgentosService } from '../../services/oauth-agentos.service'
 import { QuestionPanelComponent } from '../question-panel/question-panel.component'
-import DOMPurify from 'dompurify'
-import { marked, Renderer } from 'marked'
+import { MarkdownRendererService } from '../../services/markdown-renderer.service'
+import { DelegationCardComponent } from '../delegation/delegation-card/delegation-card.component'
+import {
+  buildDelegations,
+  DelegationPresentation,
+  extractToolOutputText,
+  isCorrelatedDelegateTool,
+} from '../delegation/models/delegation.models'
 import { PromptAutocompleteComponent } from '../prompt-autocomplete/prompt-autocomplete.component'
 import { AgentAutocompleteComponent } from '../agent-autocomplete/agent-autocomplete.component'
 import { ComposerAutocompleteService } from '../composer-autocomplete/composer-autocomplete.service'
@@ -91,6 +97,7 @@ export type TimelineItem =
   | { kind: 'streaming' }
   | { kind: 'technical'; item: TechnicalItem; eventId: string }
   | { kind: 'question'; event: QuestionEvent; answered: boolean }
+  | { kind: 'delegation'; delegation: DelegationPresentation }
 
 /** Threshold (px) from the bottom of the scroll container below which we consider "at bottom". */
 const SCROLL_BOTTOM_THRESHOLD = 64
@@ -129,6 +136,7 @@ function hasActiveSelection(): boolean {
     CopyButtonComponent,
     ComposerAttachmentsComponent,
     QuestionPanelComponent,
+    DelegationCardComponent,
   ],
   providers: [ComposerAttachmentsService, ComposerAutocompleteService],
   templateUrl: './case-chat.component.html',
@@ -140,7 +148,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   private readonly http = inject(HttpClient)
   private readonly zone = inject(NgZone)
   private readonly destroyRef = inject(DestroyRef)
-  private readonly domSanitizer = inject(DomSanitizer)
+  private readonly markdown = inject(MarkdownRendererService)
   private readonly exchangeState = inject(ExchangeStateService)
 
   private readonly config = inject(Configuration)
@@ -174,10 +182,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   // The case-shell renders this component directly (not via router-outlet),
   // so route params are empty — all context comes through query params.
   protected caseId = this.route.snapshot.queryParams['case'] as string
-  private readonly namespaceId = this.route.snapshot.queryParams['ns'] as string
-
-  /** Markdown renderer shared across all message pre-computations. */
-  private readonly markdownRenderer = this.buildMarkdownRenderer()
+  protected readonly namespaceId = this.route.snapshot.queryParams['ns'] as string
 
   /** Display name used for the streaming assistant bubble (before final MessageEvent arrives). */
   protected readonly agentDisplayName = computed(() => {
@@ -338,9 +343,12 @@ export class CaseChatComponent implements OnInit, OnDestroy {
    * 2. Walk events in order to emit timeline items, deduplicating tool entries
    *    so TOOL_RESPONSE doesn't create a second item — it's already merged.
    */
+  protected readonly delegations = computed(() => buildDelegations(this.events()))
+
   private readonly baseTimeline = computed<TimelineItem[]>(() => {
     const allEvents = this.events()
     const showTechnical = this.showTechnical()
+    const delegations = this.delegations()
 
     // Pass 1: build complete tool call map (request + optional response)
     const toolCallMap = new Map<string, ToolCall>()
@@ -372,6 +380,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
 
     const items: TimelineItem[] = []
     const seenToolIds = new Set<string>()
+    const emittedDelegationIds = new Set<string>()
     // Track the last role to detect group boundaries (consecutive same-role messages).
     // Any non-message item (tool call, technical event) resets the group.
     let lastMessageRole: string | null = null
@@ -391,9 +400,26 @@ export class CaseChatComponent implements OnInit, OnDestroy {
         const requestId = e.toolRequestId ?? e.id
         if (!seenToolIds.has(requestId)) {
           seenToolIds.add(requestId)
-          items.push({ kind: 'tool', call: toolCallMap.get(requestId)! })
+          const call = toolCallMap.get(requestId)!
+          if (isCorrelatedDelegateTool(call.toolName, requestId, call.response, delegations)) {
+            for (const delegation of delegations.filter((candidate) => candidate.toolRequestId === requestId)) {
+              if (!emittedDelegationIds.has(delegation.delegationId)) {
+                emittedDelegationIds.add(delegation.delegationId)
+                items.push({ kind: 'delegation', delegation })
+              }
+            }
+          } else items.push({ kind: 'tool', call })
         }
         lastMessageRole = null
+      } else if (e.type === 'SubCaseStartedEvent') {
+        const delegation = delegations.find((candidate) => candidate.delegationId === e.delegationId)
+        if (delegation && !emittedDelegationIds.has(delegation.delegationId)) {
+          emittedDelegationIds.add(delegation.delegationId)
+          items.push({ kind: 'delegation', delegation })
+        }
+        lastMessageRole = null
+      } else if (e.type === 'SubCaseFinishedEvent') {
+        // The corresponding Started event owns the single visual card.
       } else if (e.type === 'QuestionEvent') {
         const qe = e as QuestionEvent
         // A question is answered when there is a corresponding AnswerEvent in the stream.
@@ -431,6 +457,8 @@ export class CaseChatComponent implements OnInit, OnDestroy {
         return 'streaming'
       case 'question':
         return `question-${item.event.id}`
+      case 'delegation':
+        return `delegation-${item.delegation.delegationId}`
     }
   }
 
@@ -852,10 +880,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   }
 
   protected extractToolOutput(call: ToolCall): string | null {
-    if (!call.response) return null
-    const output = call.response.output as { content?: string } | null
-    if (!output) return null
-    return output.content ?? null
+    return call.response ? extractToolOutputText(call.response.output) : null
   }
 
   protected toggleToolCall(requestId: string): void {
@@ -900,53 +925,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
    * Called once per MessageEvent at SSE ingestion time.
    */
   private renderMarkdown(text: string): SafeHtml {
-    if (!text) return ''
-    const rawHtml = marked.parse(text, {
-      renderer: this.markdownRenderer,
-      breaks: true,
-      gfm: true,
-      async: false,
-    }) as string
-
-    const clean = DOMPurify.sanitize(rawHtml, {
-      ADD_TAGS: ['span'],
-      ADD_ATTR: ['aria-hidden', 'aria-label', 'target', 'rel'],
-      ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
-    })
-
-    return this.domSanitizer.bypassSecurityTrustHtml(clean)
-  }
-
-  private buildMarkdownRenderer(): Renderer {
-    const renderer = new Renderer()
-    const originalLink = renderer.link.bind(renderer)
-    const originalCode = renderer.code.bind(renderer)
-    renderer.code = (token): string => {
-      // [innerHTML] content is not decorated with Angular's emulated-encapsulation
-      // attribute. Mark generated fenced code explicitly so global, agentos-scoped CSS
-      // can create its own horizontal scroll container.
-      return originalCode(token).replace('<pre>', '<pre class="agentos-chat-code-block">')
-    }
-    renderer.link = (token): string => {
-      let html = originalLink(token)
-      if (this.isExternalLink(token.href)) {
-        html = html
-          .replace('<a ', '<a target="_blank" rel="noopener noreferrer" ')
-          .replace('</a>', '<span class="external-link-icon" aria-hidden="true">↗</span></a>')
-      }
-      return html
-    }
-    return renderer
-  }
-
-  private isExternalLink(href: string): boolean {
-    if (!href || href.startsWith('/') || href.startsWith('#') || href.startsWith('?')) return false
-    if (href.startsWith('//')) return true
-    try {
-      return new URL(href, window.location.href).hostname !== window.location.hostname
-    } catch {
-      return false
-    }
+    return this.markdown.render(text)
   }
 
   // ---------------------------------------------------------------------------

--- a/libs/agentos-ui/src/lib/components/delegation/delegation-card/delegation-card.component.html
+++ b/libs/agentos-ui/src/lib/components/delegation/delegation-card/delegation-card.component.html
@@ -1,0 +1,50 @@
+<article
+  class="delegation-card"
+  [class.delegation-card--working]="delegation().status === 'WORKING'"
+  [class.delegation-card--error]="
+    delegation().status === 'ERROR' || delegation().status === 'TIMEOUT' || delegation().status === 'KILLED'
+  "
+>
+  <header class="delegation-card__header">
+    <button
+      type="button"
+      class="delegation-card__toggle"
+      (click)="toggle()"
+      [attr.aria-expanded]="open()"
+      [attr.aria-label]="(open() ? 'Collapse' : 'Expand') + ' delegation for ' + delegation().agentName"
+    >
+      <span>{{ open() ? '▾' : '▸' }}</span
+      ><strong>{{ delegation().agentName }}</strong
+      ><span class="delegation-card__status">{{ statusLabel() }}</span>
+      @if (delegation().resumed) {
+        <span class="delegation-card__resumed">Resumed</span>
+      }</button
+    ><button
+      type="button"
+      class="delegation-card__open"
+      (click)="openSubCase()"
+      [attr.aria-label]="'Open sub-case for ' + delegation().agentName"
+    >
+      Open sub-case
+    </button>
+  </header>
+  @if (open()) {
+    @if (delegation().result) {
+      <agentos-delegation-result [result]="delegation().result!" />
+    } @else {
+      <ol class="delegation-card__activity" aria-label="Live sub-case activity">
+        @if (activity().length) {
+          @for (entry of activity(); track entry) {
+            <li>{{ entry }}</li>
+          }
+        } @else {
+          <li>Working…</li>
+        }
+      </ol>
+      <section class="delegation-card__task">
+        <strong>Task</strong>
+        <p>{{ delegation().task }}</p>
+      </section>
+    }
+  }
+</article>

--- a/libs/agentos-ui/src/lib/components/delegation/delegation-card/delegation-card.component.scss
+++ b/libs/agentos-ui/src/lib/components/delegation/delegation-card/delegation-card.component.scss
@@ -1,0 +1,69 @@
+.delegation-card {
+  align-self: flex-start;
+  width: min(90%, 720px);
+  border: 1px solid var(--color-divider);
+  border-left: 3px solid var(--color-success);
+  background: var(--color-surface);
+}
+.delegation-card--working {
+  border-left-color: var(--color-warning);
+}
+.delegation-card--error {
+  border-left-color: var(--color-error);
+}
+.delegation-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.7rem;
+}
+.delegation-card__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  text-align: left;
+  cursor: pointer;
+}
+.delegation-card__status,
+.delegation-card__resumed {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.delegation-card__status {
+  margin-left: auto;
+}
+.delegation-card__resumed {
+  color: var(--color-text-secondary);
+}
+.delegation-card__open {
+  border: 0;
+  background: transparent;
+  color: var(--color-accent);
+  cursor: pointer;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.delegation-card__activity,
+.delegation-card__task {
+  margin: 0;
+  padding: 0.6rem 1rem;
+  border-top: 1px solid var(--color-divider);
+  font-size: 0.85rem;
+}
+.delegation-card__activity {
+  padding-left: 2rem;
+}
+.delegation-card__task p {
+  margin: 0.25rem 0 0;
+  white-space: pre-wrap;
+}

--- a/libs/agentos-ui/src/lib/components/delegation/delegation-card/delegation-card.component.ts
+++ b/libs/agentos-ui/src/lib/components/delegation/delegation-card/delegation-card.component.ts
@@ -1,0 +1,67 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, NgZone, computed, inject, input, signal } from '@angular/core'
+import { Router } from '@angular/router'
+import { Configuration, CaseEvent } from '@whoz-oss/agentos-api-client'
+import { DelegationPresentation } from '../models/delegation.models'
+import { DelegationResultComponent } from '../delegation-result/delegation-result.component'
+@Component({
+  selector: 'agentos-delegation-card',
+  imports: [DelegationResultComponent],
+  templateUrl: './delegation-card.component.html',
+  styleUrl: './delegation-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DelegationCardComponent {
+  readonly delegation = input.required<DelegationPresentation>()
+  readonly namespaceId = input.required<string>()
+  private readonly router = inject(Router)
+  private readonly config = inject(Configuration)
+  private readonly zone = inject(NgZone)
+  private readonly destroyRef = inject(DestroyRef)
+  protected readonly open = signal(false)
+  protected readonly activity = signal<string[]>([])
+  private source: EventSource | null = null
+  protected readonly statusLabel = computed(() => this.delegation().status.replace('_', ' '))
+  protected toggle(): void {
+    this.open.update((value) => !value)
+    this.open() ? this.connect() : this.disconnect()
+  }
+  protected openSubCase(): void {
+    this.router.navigate(['/agentos/home'], {
+      queryParams: { ns: this.namespaceId(), case: this.delegation().subCaseId },
+    })
+  }
+  private connect(): void {
+    if (this.source) return
+    this.source = this.zone.runOutsideAngular(
+      () => new EventSource(`${this.config.basePath}/api/cases/${this.delegation().subCaseId}/events`)
+    )
+    this.source.addEventListener('case-event', (message: MessageEvent<string>) => {
+      try {
+        const event = JSON.parse(message.data) as CaseEvent
+        this.zone.run(() => this.addActivity(event))
+      } catch {
+        /* child diagnostics remain isolated */
+      }
+    })
+    this.destroyRef.onDestroy(() => this.disconnect())
+  }
+  private disconnect(): void {
+    this.source?.close()
+    this.source = null
+  }
+  private addActivity(event: CaseEvent): void {
+    const label =
+      event.type === 'MessageEvent'
+        ? 'Agent produced a message'
+        : event.type === 'ToolRequestEvent'
+          ? `Tool started: ${event.toolName}`
+          : event.type === 'ToolResponseEvent'
+            ? `Tool completed: ${event.toolName}`
+            : event.type === 'QuestionEvent'
+              ? 'Waiting for input'
+              : event.type === 'AgentFinishedEvent'
+                ? 'Agent finished'
+                : null
+    if (label) this.activity.update((items) => (items.includes(label) ? items : [...items, label].slice(-6)))
+  }
+}

--- a/libs/agentos-ui/src/lib/components/delegation/delegation-result/delegation-result.component.html
+++ b/libs/agentos-ui/src/lib/components/delegation/delegation-result/delegation-result.component.html
@@ -1,0 +1,13 @@
+<section class="delegation-result" aria-label="Delegation result">
+  <div class="delegation-result__markdown" [innerHTML]="html()"></div>
+  @if (result().pendingQuestion) {
+    <p><strong>Waiting for your answer:</strong> {{ result().pendingQuestion }}</p>
+  }
+  @if (result().options?.length) {
+    <ul>
+      @for (option of result().options!; track option) {
+        <li>{{ option }}</li>
+      }
+    </ul>
+  }
+</section>

--- a/libs/agentos-ui/src/lib/components/delegation/delegation-result/delegation-result.component.scss
+++ b/libs/agentos-ui/src/lib/components/delegation/delegation-result/delegation-result.component.scss
@@ -1,0 +1,12 @@
+.delegation-result {
+  padding: 0.75rem 1rem;
+  color: var(--color-text);
+  line-height: 1.55;
+}
+.delegation-result p {
+  margin: 0.5rem 0 0;
+}
+.delegation-result ul {
+  margin: 0.4rem 0 0;
+  padding-left: 1.3rem;
+}

--- a/libs/agentos-ui/src/lib/components/delegation/delegation-result/delegation-result.component.ts
+++ b/libs/agentos-ui/src/lib/components/delegation/delegation-result/delegation-result.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core'
+import { MarkdownRendererService } from '../../../services/markdown-renderer.service'
+import { DelegationResult } from '../models/delegation.models'
+@Component({
+  selector: 'agentos-delegation-result',
+  templateUrl: './delegation-result.component.html',
+  styleUrl: './delegation-result.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DelegationResultComponent {
+  readonly result = input.required<DelegationResult>()
+  private readonly markdown = inject(MarkdownRendererService)
+  protected readonly html = computed(() =>
+    this.markdown.render(this.result().result ?? this.result().error ?? 'No result returned.')
+  )
+}

--- a/libs/agentos-ui/src/lib/components/delegation/models/delegation.models.spec.ts
+++ b/libs/agentos-ui/src/lib/components/delegation/models/delegation.models.spec.ts
@@ -1,0 +1,70 @@
+import {
+  buildDelegations,
+  extractToolOutputText,
+  isCorrelatedDelegateTool,
+  parseDelegationResults,
+} from './delegation.models'
+
+describe('delegation correlation', () => {
+  const backendOutput = JSON.stringify([
+    {
+      agentName: 'Research',
+      delegationId: 'd-1',
+      toolRequestId: 't-1',
+      subCaseId: 'c-1',
+      success: true,
+      result: '**Done**',
+    },
+  ])
+  const response = {
+    type: 'ToolResponseEvent',
+    toolName: 'DELEGATE__delegate',
+    toolRequestId: 't-1',
+    output: backendOutput,
+  } as any
+  const request = { type: 'ToolRequestEvent', toolName: 'DELEGATE__delegate', toolRequestId: 't-1' } as any
+  const started = {
+    type: 'SubCaseStartedEvent',
+    delegationId: 'd-1',
+    toolRequestId: 't-1',
+    subCaseId: 'c-1',
+    agentName: 'Research',
+    task: 'Find facts',
+    resumed: false,
+  } as any
+  const finished = {
+    type: 'SubCaseFinishedEvent',
+    delegationId: 'd-1',
+    toolRequestId: 't-1',
+    subCaseId: 'c-1',
+    agentName: 'Research',
+    outcome: 'SUCCESS',
+  } as any
+
+  it('parses the raw string output format emitted by the backend', () => {
+    expect(extractToolOutputText(backendOutput)).toBe(backendOutput)
+    expect(parseDelegationResults(response)).toEqual([
+      expect.objectContaining({ delegationId: 'd-1', toolRequestId: 't-1' }),
+    ])
+  })
+
+  it('creates a delegation and hides the raw delegate card even when Started was not replayed', () => {
+    const delegations = buildDelegations([request, response])
+    expect(delegations).toEqual([expect.objectContaining({ delegationId: 'd-1', status: 'SUCCESS' })])
+    expect(isCorrelatedDelegateTool('DELEGATE__delegate', 't-1', response, delegations)).toBe(true)
+  })
+
+  it('correlates lifecycle and parent response independently from arrival order', () => {
+    expect(buildDelegations([response, finished, started])).toEqual([
+      expect.objectContaining({
+        delegationId: 'd-1',
+        status: 'SUCCESS',
+        result: expect.objectContaining({ result: '**Done**' }),
+      }),
+    ])
+  })
+
+  it('keeps raw fallback only for genuinely invalid output', () => {
+    expect(parseDelegationResults({ output: '{invalid' } as any)).toBeNull()
+  })
+})

--- a/libs/agentos-ui/src/lib/components/delegation/models/delegation.models.ts
+++ b/libs/agentos-ui/src/lib/components/delegation/models/delegation.models.ts
@@ -1,0 +1,136 @@
+import { CaseEvent, SubCaseFinishedEvent, SubCaseStartedEvent, ToolResponseEvent } from '@whoz-oss/agentos-api-client'
+
+export type DelegationStatus = 'WORKING' | 'SUCCESS' | 'WAITING_USER' | 'ERROR' | 'TIMEOUT' | 'KILLED'
+
+export interface DelegationResult {
+  delegationId: string
+  toolRequestId: string
+  subCaseId?: string
+  agentName?: string
+  success?: boolean
+  result?: string
+  pendingQuestion?: string
+  options?: string[]
+  error?: string
+  errorType?: string
+}
+
+export interface DelegationPresentation {
+  delegationId: string
+  toolRequestId: string
+  subCaseId: string
+  agentName: string
+  task: string
+  resumed: boolean
+  status: DelegationStatus
+  result?: DelegationResult
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+/**
+ * OpenAPI currently describes output as an empty object although the SSE payload can be a raw
+ * string, a MessageContent-like { content } object, or nested content parts. Extract the first
+ * textual representation without assuming one generated client shape.
+ */
+export function extractToolOutputText(output: unknown): string | null {
+  if (typeof output === 'string') return output
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      const text = extractToolOutputText(item)
+      if (text !== null) return text
+    }
+    return null
+  }
+  const value = asRecord(output)
+  if (!value) return null
+  for (const key of ['content', 'text', 'output']) {
+    const text = extractToolOutputText(value[key])
+    if (text !== null) return text
+  }
+  return null
+}
+
+/** Parses only the documented delegation response shape; invalid tool output stays on the raw fallback card. */
+export function parseDelegationResults(response: ToolResponseEvent | undefined): DelegationResult[] | null {
+  const content = extractToolOutputText(response?.output)
+  if (content === null) return null
+  try {
+    const parsed: unknown = JSON.parse(content)
+    const entries = Array.isArray(parsed) ? parsed : [parsed]
+    const results = entries.map((entry): DelegationResult | null => {
+      const value = asRecord(entry)
+      if (!value || typeof value['delegationId'] !== 'string' || typeof value['toolRequestId'] !== 'string') return null
+
+      const result: DelegationResult = {
+        delegationId: value['delegationId'],
+        toolRequestId: value['toolRequestId'],
+      }
+      if (typeof value['subCaseId'] === 'string') result.subCaseId = value['subCaseId']
+      if (typeof value['agentName'] === 'string') result.agentName = value['agentName']
+      if (typeof value['success'] === 'boolean') result.success = value['success']
+      if (typeof value['result'] === 'string') result.result = value['result']
+      if (typeof value['pendingQuestion'] === 'string') result.pendingQuestion = value['pendingQuestion']
+      if (Array.isArray(value['options'])) {
+        result.options = value['options'].filter((option): option is string => typeof option === 'string')
+      }
+      if (typeof value['error'] === 'string') result.error = value['error']
+      if (typeof value['errorType'] === 'string') result.errorType = value['errorType']
+      return result
+    })
+    return results.every((result): result is DelegationResult => result !== null) ? results : null
+  } catch {
+    return null
+  }
+}
+
+export function buildDelegations(events: CaseEvent[]): DelegationPresentation[] {
+  const started = new Map<string, SubCaseStartedEvent>()
+  const finished = new Map<string, SubCaseFinishedEvent>()
+  const results = new Map<string, DelegationResult>()
+  for (const event of events) {
+    if (event.type === 'SubCaseStartedEvent') started.set(event.delegationId, event as SubCaseStartedEvent)
+    if (event.type === 'SubCaseFinishedEvent') finished.set(event.delegationId, event as SubCaseFinishedEvent)
+    if (event.type === 'ToolResponseEvent') {
+      for (const result of parseDelegationResults(event as ToolResponseEvent) ?? [])
+        results.set(result.delegationId, result)
+    }
+  }
+  const ids = new Set([...started.keys(), ...results.keys()])
+  return [...ids].map((delegationId) => {
+    const start = started.get(delegationId)
+    const result = results.get(delegationId)!
+    const finish = finished.get(delegationId)
+    const status =
+      finish?.outcome ??
+      (result?.pendingQuestion ? 'WAITING_USER' : result ? (result.success === false ? 'ERROR' : 'SUCCESS') : 'WORKING')
+    return {
+      delegationId,
+      toolRequestId: start?.toolRequestId ?? result.toolRequestId,
+      subCaseId: start?.subCaseId ?? result.subCaseId ?? '',
+      agentName: start?.agentName ?? result.agentName ?? 'Delegated agent',
+      task: start?.task ?? 'Delegated task',
+      resumed: start?.resumed ?? false,
+      status,
+      result,
+    }
+  })
+}
+
+export function isCorrelatedDelegateTool(
+  toolName: string,
+  requestId: string,
+  response: ToolResponseEvent | undefined,
+  delegations: DelegationPresentation[]
+): boolean {
+  if (toolName !== 'DELEGATE__delegate') return false
+  if (!delegations.some((delegation) => delegation.toolRequestId === requestId)) return false
+  // While running, Started is sufficient. Once a response exists it must contain valid structured
+  // JSON correlated to this exact request; otherwise preserve the raw tool card as a diagnostic fallback.
+  if (!response) return true
+  return parseDelegationResults(response)?.some((result) => result.toolRequestId === requestId) ?? false
+}

--- a/libs/agentos-ui/src/lib/services/markdown-renderer.service.ts
+++ b/libs/agentos-ui/src/lib/services/markdown-renderer.service.ts
@@ -1,0 +1,46 @@
+import { inject, Injectable } from '@angular/core'
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
+import DOMPurify from 'dompurify'
+import { marked, Renderer } from 'marked'
+
+/** Single sanitized Markdown pipeline shared by chat messages and delegation outcomes. */
+@Injectable({ providedIn: 'root' })
+export class MarkdownRendererService {
+  private readonly sanitizer = inject(DomSanitizer)
+  private readonly renderer = this.buildRenderer()
+
+  render(text: string): SafeHtml {
+    if (!text) return ''
+    const html = marked.parse(text, { renderer: this.renderer, breaks: true, gfm: true, async: false }) as string
+    return this.sanitizer.bypassSecurityTrustHtml(
+      DOMPurify.sanitize(html, {
+        ADD_TAGS: ['span'],
+        ADD_ATTR: ['aria-hidden', 'aria-label', 'target', 'rel'],
+        ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
+      })
+    )
+  }
+  private buildRenderer(): Renderer {
+    const renderer = new Renderer()
+    const link = renderer.link.bind(renderer)
+    const code = renderer.code.bind(renderer)
+    renderer.code = (token): string => code(token).replace('<pre>', '<pre class="agentos-chat-code-block">')
+    renderer.link = (token): string => {
+      let html = link(token)
+      if (this.isExternal(token.href))
+        html = html
+          .replace('<a ', '<a target="_blank" rel="noopener noreferrer" ')
+          .replace('</a>', '<span class="external-link-icon" aria-hidden="true">↗</span></a>')
+      return html
+    }
+    return renderer
+  }
+  private isExternal(href: string): boolean {
+    if (!href || href.startsWith('/') || href.startsWith('#') || href.startsWith('?')) return false
+    try {
+      return new URL(href, window.location.href).hostname !== window.location.hostname
+    } catch {
+      return href.startsWith('//')
+    }
+  }
+}


### PR DESCRIPTION
Adds structured delegation cards to the case chat. Delegations are correlated through delegationId and toolRequestId, replacing raw DELEGATE__delegate JSON output with an evolving card showing the delegated agent, status, sub-case navigation, live child activity, and rendered Markdown results.

<img width="1389" height="341" alt="image" src="https://github.com/user-attachments/assets/b0872820-10fb-4590-9050-214426274364" />

<img width="855" height="549" alt="image" src="https://github.com/user-attachments/assets/963d5e8b-6662-4339-85c6-9a5963a105ce" />
