### PR TITLE
Feature/benjamin/#1291 expose execution diagnostics in case conversations

### DIFF
--- a/apps/client/src/app/components/agent-list/agent-list.component.html
+++ b/apps/client/src/app/components/agent-list/agent-list.component.html
@@ -2,6 +2,7 @@
   <ds-entity-list
     title="Agents"
     [items]="agentItems()"
+    [loading]="isLoading()"
     cardMinWidth="260px"
     contentMaxWidth="1400px"
     searchPlaceholder="Filter agents…"

--- a/apps/client/src/app/components/project-list/project-list.component.html
+++ b/apps/client/src/app/components/project-list/project-list.component.html
@@ -2,6 +2,7 @@
   <ds-entity-list
     title="Projects"
     [items]="projectItems()"
+    [loading]="isLoading()"
     [itemTemplate]="projectCard"
     contentMaxWidth="1400px"
     searchPlaceholder="Filter projects…"

--- a/apps/client/src/app/components/project-list/project-list.component.ts
+++ b/apps/client/src/app/components/project-list/project-list.component.ts
@@ -47,6 +47,7 @@ export class ProjectListComponent {
 
   protected readonly projects = toSignal(this.projectStateService.projectList$)
   protected readonly forcedProject = toSignal(this.projectStateService.forcedProject$, { initialValue: null })
+  protected readonly isLoading = toSignal(this.projectStateService.isLoading$, { initialValue: false })
 
   /**
    * Maps the flat project list to EntityListItem[], with three kinds of groups:

--- a/apps/client/src/app/components/prompt-list/prompt-list.component.html
+++ b/apps/client/src/app/components/prompt-list/prompt-list.component.html
@@ -2,6 +2,7 @@
   <ds-entity-list
     title="Prompts"
     [items]="promptItems()"
+    [loading]="isLoading()"
     cardMinWidth="320px"
     contentMaxWidth="1400px"
     searchPlaceholder="Filter prompts…"

--- a/apps/client/src/app/components/scheduler-list/scheduler-list.component.html
+++ b/apps/client/src/app/components/scheduler-list/scheduler-list.component.html
@@ -2,6 +2,7 @@
   <ds-entity-list
     title="Schedulers"
     [items]="schedulerItems()"
+    [loading]="isLoading()"
     cardMinWidth="384px"
     contentMaxWidth="1400px"
     searchPlaceholder="Filter schedulers…"

--- a/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.html
+++ b/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="AI Providers"
   [items]="(listItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No AI providers available."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.ts
+++ b/libs/agentos-ui/src/lib/components/ai-providers-all-scopes/ai-providers-all-scopes.component.ts
@@ -65,6 +65,9 @@ export class AiProvidersAllScopesComponent implements OnInit {
 
   protected readonly listItems$ = this.state.vm$.pipe(map((vm) => this.toListItems(vm)))
 
+  /** True until the first vm$ emission resolves. */
+  protected readonly isLoading = signal(true)
+
   /**
    * Index resolving a composite key (`<scope>:<id>`) → (config, scope) so the item template
    * can render the right component variant. Composite key prevents cross-scope collisions
@@ -88,6 +91,7 @@ export class AiProvidersAllScopesComponent implements OnInit {
       .subscribe((v) => this.isAdmin.set(v))
 
     this.state.vm$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((vm) => {
+      this.isLoading.set(false)
       const next = new Map<string, ResolvedItem>()
       vm.platform.forEach((c) => {
         if (c.id) next.set(this.itemKey('platform', c.id), { config: c, scope: 'platform' })

--- a/libs/agentos-ui/src/lib/components/auth-settings-all-scopes/auth-settings-all-scopes.component.html
+++ b/libs/agentos-ui/src/lib/components/auth-settings-all-scopes/auth-settings-all-scopes.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Auth Settings"
   [items]="(listItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No auth settings available."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/auth-settings-all-scopes/auth-settings-all-scopes.component.ts
+++ b/libs/agentos-ui/src/lib/components/auth-settings-all-scopes/auth-settings-all-scopes.component.ts
@@ -64,6 +64,9 @@ export class AuthSettingsAllScopesComponent implements OnInit {
 
   protected readonly listItems$ = this.state.vm$.pipe(map((vm) => this.toListItems(vm)))
 
+  /** True until the first vm$ emission resolves. */
+  protected readonly isLoading = signal(true)
+
   /**
    * Index resolving a composite key (`<scope>:<id>`) → (config, scope) so the item template
    * can render the right component variant. Composite key prevents cross-scope collisions
@@ -87,6 +90,7 @@ export class AuthSettingsAllScopesComponent implements OnInit {
       .subscribe((v) => this.isAdmin.set(v))
 
     this.state.vm$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((vm) => {
+      this.isLoading.set(false)
       const next = new Map<string, ResolvedItem>()
       vm.platform.forEach((c) => {
         if (c.id) next.set(this.itemKey('platform', c.id), { config: c, scope: 'platform' })

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
@@ -139,11 +139,25 @@
                 <span class="case-chat__role-label">{{ agentDisplayName() }}</span>
                 <div class="case-chat__bubble case-chat__message-text--markdown" [innerHTML]="streamingHtml()"></div>
               </div>
+            } @else if (item.kind === 'notice') {
+              <div
+                class="case-chat__execution-notice"
+                [class.case-chat__execution-notice--warning]="item.notice.severity === 'warning'"
+                [class.case-chat__execution-notice--error]="
+                  item.notice.severity === 'error' || item.notice.severity === 'terminal'
+                "
+                role="status"
+              >
+                <span class="case-chat__execution-notice-title">{{ item.notice.title }}</span>
+                @if (item.notice.detail) {
+                  <span class="case-chat__execution-notice-detail">{{ item.notice.detail }}</span>
+                }
+              </div>
             } @else if (item.kind === 'technical') {
               <details class="case-chat__log">
                 <summary class="case-chat__log-summary">⚙ System log · {{ item.item.label }}</summary>
                 @if (item.item.detail) {
-                  <div class="case-chat__log-body">{{ item.item.detail }}</div>
+                  <pre class="case-chat__log-body">{{ item.item.detail }}</pre>
                 }
               </details>
             } @else if (item.kind === 'question') {
@@ -185,6 +199,15 @@
                     }
                   </span>
                   <span class="case-chat__tool-call-name">{{ item.call.toolName }}</span>
+                  <span class="case-chat__tool-call-status">
+                    @if (!item.call.response) {
+                      Running
+                    } @else if (item.call.response.success) {
+                      Completed
+                    } @else {
+                      Failed
+                    }
+                  </span>
                   <span class="case-chat__tool-call-chevron">{{
                     isToolCallExpanded(item.call.requestId) ? '▼' : '▶'
                   }}</span>
@@ -192,44 +215,58 @@
 
                 @if (isToolCallExpanded(item.call.requestId)) {
                   <div class="case-chat__tool-call-output">
-                    @if (showTechnical() && item.call.enrichmentPhases?.length) {
+                    @if (showTechnical()) {
                       <div class="case-chat__tool-call-section case-chat__enrichment-section">
                         <span class="case-chat__tool-call-label">Enrichment phases</span>
-                        @for (phase of item.call.enrichmentPhases; track phase.phaseIndex) {
-                          <div
-                            class="case-chat__enrichment-phase"
-                            [class.case-chat__enrichment-phase--failed]="!phase.success"
-                          >
-                            <div class="case-chat__enrichment-phase-header">
-                              <span class="case-chat__enrichment-phase-index">Phase {{ phase.phaseIndex }}</span>
-                              <span class="case-chat__enrichment-phase-status">{{ phase.success ? '✅' : '❌' }}</span>
-                            </div>
-                            <div class="case-chat__enrichment-phase-row">
-                              <span class="case-chat__enrichment-phase-label">Prompt</span>
-                              <pre>{{ phase.prompt }}</pre>
-                            </div>
-                            <div class="case-chat__enrichment-phase-row">
-                              <span class="case-chat__enrichment-phase-label">LLM output</span>
-                              <pre>{{ phase.llmOutput }}</pre>
-                            </div>
-                            @if (phase.enrichmentContent) {
-                              <div class="case-chat__enrichment-phase-row">
-                                <span class="case-chat__enrichment-phase-label">Enrichment content</span>
-                                <pre>{{ phase.enrichmentContent }}</pre>
+                        @if (item.call.enrichmentPhases?.length) {
+                          @for (phase of item.call.enrichmentPhases; track phase.phaseIndex) {
+                            <div
+                              class="case-chat__enrichment-phase"
+                              [class.case-chat__enrichment-phase--failed]="!phase.success"
+                            >
+                              <div class="case-chat__enrichment-phase-header">
+                                <span class="case-chat__enrichment-phase-index">Phase {{ phase.phaseIndex }}</span>
+                                <span class="case-chat__enrichment-phase-status">{{
+                                  phase.success ? '✅' : '❌'
+                                }}</span>
                               </div>
-                            }
-                          </div>
+                              <div class="case-chat__enrichment-phase-row">
+                                <span class="case-chat__enrichment-phase-label">Prompt</span>
+                                <pre>{{ phase.prompt }}</pre>
+                              </div>
+                              <div class="case-chat__enrichment-phase-row">
+                                <span class="case-chat__enrichment-phase-label">LLM output</span>
+                                <pre>{{ phase.llmOutput }}</pre>
+                              </div>
+                              @if (phase.enrichmentContent) {
+                                <div class="case-chat__enrichment-phase-row">
+                                  <span class="case-chat__enrichment-phase-label">Enrichment content</span>
+                                  <pre>{{ phase.enrichmentContent }}</pre>
+                                </div>
+                              }
+                            </div>
+                          }
+                        } @else {
+                          <span class="case-chat__tool-call-empty">No enrichment trace was provided.</span>
                         }
                       </div>
                     }
-                    @if (item.call.args) {
+                    @if (formatToolArguments(item.call.args); as args) {
                       <div class="case-chat__tool-call-section">
-                        <span class="case-chat__tool-call-label">Payload</span>
-                        <pre>{{ item.call.args }}</pre>
+                        <span class="case-chat__tool-call-label">Arguments</span>
+                        <pre>{{ args }}</pre>
+                      </div>
+                    }
+                    @if (showTechnical() && formatToolDuration(item.call); as duration) {
+                      <div class="case-chat__tool-call-section">
+                        <span class="case-chat__tool-call-label">Duration</span>
+                        <span>{{ duration }}</span>
                       </div>
                     }
                     <div class="case-chat__tool-call-section">
-                      <span class="case-chat__tool-call-label">Output</span>
+                      <span class="case-chat__tool-call-label">{{
+                        item.call.response?.success === false ? 'Error' : 'Output'
+                      }}</span>
                       @if (extractToolOutput(item.call); as output) {
                         <pre>{{ output }}</pre>
                       } @else if (!item.call.response) {
@@ -238,6 +275,12 @@
                         <span class="case-chat__tool-call-empty">No output</span>
                       }
                     </div>
+                    @if (showTechnical() && formatToolMetadata(item.call); as metadata) {
+                      <div class="case-chat__tool-call-section">
+                        <span class="case-chat__tool-call-label">Metadata</span>
+                        <pre>{{ metadata }}</pre>
+                      </div>
+                    }
                   </div>
                 }
               </div>

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.html
@@ -132,6 +132,14 @@
                     <div class="case-chat__bubble case-chat__message-text--markdown" [innerHTML]="item.html"></div>
                   }
                   <ds-copy-button class="case-chat__bubble-copy" [text]="messageText(item)" title="Copy message" />
+                  @if (item.isLastInGroup) {
+                    <time
+                      class="case-chat__message-time"
+                      [attr.datetime]="item.event.timestamp"
+                      [title]="formatMessageTimestampTitle(item.event.timestamp)"
+                      >{{ formatMessageTime(item.event.timestamp) }}</time
+                    >
+                  }
                 </div>
               </div>
             } @else if (item.kind === 'streaming') {
@@ -208,6 +216,14 @@
                       Failed
                     }
                   </span>
+                  @if (item.call.timestamp) {
+                    <time
+                      class="case-chat__tool-call-time"
+                      [attr.datetime]="item.call.timestamp"
+                      [title]="formatMessageTimestampTitle(item.call.timestamp)"
+                      >{{ formatMessageTime(item.call.timestamp) }}</time
+                    >
+                  }
                   <span class="case-chat__tool-call-chevron">{{
                     isToolCallExpanded(item.call.requestId) ? '▼' : '▶'
                   }}</span>
@@ -253,8 +269,15 @@
                     }
                     @if (formatToolArguments(item.call.args); as args) {
                       <div class="case-chat__tool-call-section">
-                        <span class="case-chat__tool-call-label">Arguments</span>
-                        <pre>{{ args }}</pre>
+                        <span class="case-chat__tool-call-label">
+                          Arguments
+                          @if (!isStructuredPayload(item.call.args)) {
+                            · Text
+                          }
+                        </span>
+                        <pre [class.case-chat__tool-call-code--text]="!isStructuredPayload(item.call.args)">{{
+                          args
+                        }}</pre>
                       </div>
                     }
                     @if (showTechnical() && formatToolDuration(item.call); as duration) {
@@ -264,11 +287,16 @@
                       </div>
                     }
                     <div class="case-chat__tool-call-section">
-                      <span class="case-chat__tool-call-label">{{
-                        item.call.response?.success === false ? 'Error' : 'Output'
-                      }}</span>
+                      <span class="case-chat__tool-call-label">
+                        {{ item.call.response?.success === false ? 'Error' : 'Output' }}
+                        @if (!isToolOutputStructured(item.call)) {
+                          · Text
+                        }
+                      </span>
                       @if (extractToolOutput(item.call); as output) {
-                        <pre>{{ output }}</pre>
+                        <pre [class.case-chat__tool-call-code--text]="!isToolOutputStructured(item.call)">{{
+                          output
+                        }}</pre>
                       } @else if (!item.call.response) {
                         <span class="case-chat__tool-call-pending">Running…</span>
                       } @else {
@@ -277,8 +305,15 @@
                     </div>
                     @if (showTechnical() && formatToolMetadata(item.call); as metadata) {
                       <div class="case-chat__tool-call-section">
-                        <span class="case-chat__tool-call-label">Metadata</span>
-                        <pre>{{ metadata }}</pre>
+                        <span class="case-chat__tool-call-label">
+                          Metadata
+                          @if (!isToolMetadataStructured(item.call)) {
+                            · Text
+                          }
+                        </span>
+                        <pre [class.case-chat__tool-call-code--text]="!isToolMetadataStructured(item.call)">{{
+                          metadata
+                        }}</pre>
                       </div>
                     }
                   </div>

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -398,6 +398,11 @@
     flex: 1;
     min-width: 0;
   }
+  &__tool-call-status {
+    margin-left: auto;
+    color: var(--color-neutral-500);
+    font-size: 0.7rem;
+  }
   &__tool-call-chevron {
     flex-shrink: 0;
     font-size: 0.6rem;
@@ -514,7 +519,35 @@
     font-size: 0.75rem;
   }
 
-  // ── System log ───────────────────────────────────────────────────────────────
+  // ── Execution notices and system log ─────────────────────────────────────────
+
+  &__execution-notice {
+    flex-shrink: 0;
+    align-self: flex-start;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    max-width: 90%;
+    padding: 0.55rem 0.75rem;
+    border-left: 3px solid var(--color-warning);
+    background: color-mix(in srgb, var(--color-warning) 8%, transparent);
+    color: var(--color-text);
+    font-size: 0.8rem;
+
+    &--error {
+      border-left-color: var(--color-error);
+      background: color-mix(in srgb, var(--color-error) 8%, transparent);
+    }
+  }
+
+  &__execution-notice-title {
+    font-weight: 600;
+  }
+
+  &__execution-notice-detail {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
 
   &__log {
     flex-shrink: 0;
@@ -545,6 +578,9 @@
   }
 
   &__log-body {
+    display: block;
+    max-height: 260px;
+    overflow: auto;
     margin-top: 4px;
     padding: 10px 12px;
     font-family: var(--font-heading);

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -304,8 +304,24 @@
     z-index: 1;
   }
 
+  &__message-time {
+    position: absolute;
+    right: 10px;
+    bottom: 7px;
+    font-family: var(--font-heading);
+    font-size: 0.65rem;
+    line-height: 1;
+    color: var(--color-text-tertiary);
+    opacity: 0.8;
+    pointer-events: auto;
+
+    .case-chat__turn--user & {
+      color: var(--color-accent-700);
+    }
+  }
+
   &__bubble {
-    padding: 16px 18px;
+    padding: 16px 18px 28px;
     font-size: 16px;
     line-height: 1.6;
     width: 100%;
@@ -319,7 +335,7 @@
 
     @media (max-width: 600px) {
       font-size: 14px;
-      padding: 12px 14px;
+      padding: 12px 14px 26px;
       width: 100%;
       box-sizing: border-box;
     }
@@ -328,10 +344,10 @@
       background: var(--color-accent-200);
       color: var(--color-accent-800);
       border-left: none;
-      padding: 11px 15px;
+      padding: 11px 15px 24px;
 
       @media (max-width: 600px) {
-        padding: 10px 12px;
+        padding: 10px 12px 24px;
       }
     }
   }
@@ -403,11 +419,19 @@
     color: var(--color-neutral-500);
     font-size: 0.7rem;
   }
+  &__tool-call-time {
+    flex-shrink: 0;
+    font-family: var(--font-heading);
+    font-size: 0.65rem;
+    line-height: 1;
+    color: var(--color-text-tertiary);
+    opacity: 0.8;
+    white-space: nowrap;
+  }
   &__tool-call-chevron {
     flex-shrink: 0;
     font-size: 0.6rem;
     color: var(--color-neutral-500);
-    margin-left: auto;
   }
 
   &__tool-call-output {
@@ -433,6 +457,10 @@
       max-height: 200px;
       overflow-y: auto;
     }
+  }
+
+  &__tool-call-code--text {
+    color: var(--color-neutral-600);
   }
 
   &__tool-call-label {

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.scss
@@ -450,12 +450,14 @@
     pre {
       margin: 0.25rem 0 0;
       white-space: pre-wrap;
-      word-break: break-all;
+      word-break: break-word;
+      overflow-wrap: anywhere;
       font-family: var(--font-heading);
       font-size: 0.75rem;
       color: var(--color-text);
-      max-height: 200px;
+      max-height: 300px;
       overflow-y: auto;
+      overflow-x: hidden;
     }
   }
 

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -970,17 +970,39 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Recursively unescape string values in a parsed JSON structure.
+   * Handles backends that double-encode newlines (\\n → \n) inside JSON string values.
+   */
+  private unescapeStringValues(value: unknown): unknown {
+    if (typeof value === 'string') {
+      // Replace literal \n, \t, \r sequences with real whitespace characters
+      return value.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\r/g, '\r')
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.unescapeStringValues(item))
+    }
+    if (value !== null && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, this.unescapeStringValues(v)])
+      )
+    }
+    return value
+  }
+
   /** Pretty-print valid structured payloads without hiding malformed or plain-text values. */
   protected formatStructuredData(value: unknown): string {
     if (typeof value === 'string') {
       try {
-        return JSON.stringify(JSON.parse(value), null, 2)
+        const parsed = this.unescapeStringValues(JSON.parse(value))
+        return JSON.stringify(parsed, null, 2)
       } catch {
-        return value
+        // Not valid JSON — unescape literal \n sequences so plain-text args render with line breaks
+        return value.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\r/g, '\r')
       }
     }
     try {
-      const formatted = JSON.stringify(value, null, 2)
+      const formatted = JSON.stringify(this.unescapeStringValues(value), null, 2)
       return formatted ?? String(value)
     } catch {
       return String(value)

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -39,6 +39,7 @@ import {
   QuestionEventQuestionTypeEnum,
   ToolRequestEvent,
   ToolResponseEvent,
+  ToolSelectedEvent,
   WarnEvent,
 } from '@whoz-oss/agentos-api-client'
 import { AgentConfig, Prompt } from '@whoz-oss/agentos-api-client'
@@ -73,15 +74,13 @@ export interface ToolCall {
 
 /** A technical event displayed only when showTechnical is enabled. */
 export interface TechnicalItem {
-  type:
-    | 'WarnEvent'
-    | 'ErrorEvent'
-    | 'CaseStatusEvent'
-    | 'AgentRunningEvent'
-    | 'AgentFinishedEvent'
-    | 'AgentSelectedEvent'
-    | 'IntentionGeneratedEvent'
   label: string
+  detail?: string
+}
+
+export interface ExecutionNotice {
+  severity: 'warning' | 'error' | 'terminal'
+  title: string
   detail?: string
 }
 
@@ -89,6 +88,7 @@ export type TimelineItem =
   | { kind: 'message'; event: CaseMessageEvent; html: SafeHtml; isFirstInGroup: boolean }
   | { kind: 'tool'; call: ToolCall }
   | { kind: 'streaming' }
+  | { kind: 'notice'; notice: ExecutionNotice; eventId: string }
   | { kind: 'technical'; item: TechnicalItem; eventId: string }
   | { kind: 'question'; event: QuestionEvent; answered: boolean }
 
@@ -399,12 +399,17 @@ export class CaseChatComponent implements OnInit, OnDestroy {
         // A question is answered when there is a corresponding AnswerEvent in the stream.
         const answered = allEvents.some((ae) => ae.type === 'AnswerEvent' && (ae as AnswerEvent).questionId === qe.id)
         items.push({ kind: 'question', event: qe, answered })
-      } else if (showTechnical) {
-        const technical = this.toTechnicalItem(e)
-        if (technical) {
-          items.push({ kind: 'technical', item: technical, eventId: e.id })
-          lastMessageRole = null
+      } else if (showTechnical && !this.isEventConsumedElsewhere(e)) {
+        // Execution notices and the generic fallback are diagnostics: keep them entirely
+        // behind the technical toggle, while dedicated conversation/tool renderers stay visible.
+        const notice = this.toExecutionNotice(e)
+        if (notice) {
+          items.push({ kind: 'notice', notice, eventId: e.id })
+        } else {
+          // Every event not already represented elsewhere remains inspectable in technical mode.
+          items.push({ kind: 'technical', item: this.toTechnicalItem(e), eventId: e.id })
         }
+        lastMessageRole = null
       }
     }
 
@@ -426,6 +431,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
       case 'tool':
         return item.call.requestId
       case 'technical':
+      case 'notice':
         return item.eventId
       case 'streaming':
         return 'streaming'
@@ -688,6 +694,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
       'TextChunkEvent',
       'ToolRequestEvent',
       'ToolResponseEvent',
+      'ToolSelectedEvent',
       'PendingConfirmationEvent',
       'ConfirmationResolvedEvent',
       'ErrorEvent',
@@ -883,11 +890,53 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     )
   }
 
+  protected formatToolArguments(args: string | null): string | null {
+    return args === null ? null : this.formatStructuredData(args)
+  }
+
+  protected formatToolDuration(call: ToolCall): string | null {
+    const durationMs = call.response?.durationMs
+    if (typeof durationMs !== 'number' || !Number.isFinite(durationMs)) return null
+    return durationMs < 1000 ? `${durationMs} ms` : `${(durationMs / 1000).toFixed(durationMs < 10_000 ? 1 : 0)} s`
+  }
+
+  protected formatToolMetadata(call: ToolCall): string | null {
+    const metadata = call.response?.toolMetadata
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata) || Object.keys(metadata).length === 0) {
+      return null
+    }
+    return this.formatStructuredData(metadata)
+  }
+
   protected extractToolOutput(call: ToolCall): string | null {
     if (!call.response) return null
-    const output = call.response.output as { content?: string } | null
-    if (!output) return null
-    return output.content ?? null
+    const output = call.response.output as unknown
+    if (output === null || output === undefined) return null
+
+    // Most tools currently use { content }, but retain the complete payload when a tool
+    // returns another shape or a malformed value.
+    if (typeof output === 'object' && 'content' in output) {
+      const content = (output as { content?: unknown }).content
+      if (content !== undefined && content !== null) return this.formatStructuredData(content)
+    }
+    return this.formatStructuredData(output)
+  }
+
+  /** Pretty-print valid structured payloads without hiding malformed or plain-text values. */
+  protected formatStructuredData(value: unknown): string {
+    if (typeof value === 'string') {
+      try {
+        return JSON.stringify(JSON.parse(value), null, 2)
+      } catch {
+        return value
+      }
+    }
+    try {
+      const formatted = JSON.stringify(value, null, 2)
+      return formatted ?? String(value)
+    } catch {
+      return String(value)
+    }
   }
 
   protected toggleToolCall(requestId: string): void {
@@ -985,38 +1034,65 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   // Technical event mapping
   // ---------------------------------------------------------------------------
 
-  private toTechnicalItem(event: CaseEvent): TechnicalItem | null {
+  /**
+   * Events with a dedicated chat rendering or side effect must not also become fallback log
+   * rows. Keep orchestration events out of this list: they remain useful technical history.
+   */
+  private isEventConsumedElsewhere(event: CaseEvent): boolean {
     switch (event.type) {
-      case 'WarnEvent': {
-        const e = event as WarnEvent
-        return { type: 'WarnEvent', label: '⚠️ Warn', detail: e.message }
-      }
-      case 'ErrorEvent': {
-        const e = event as ErrorEvent
-        return { type: 'ErrorEvent', label: '❌ Error', detail: e.message }
-      }
+      case 'MessageEvent':
+      case 'ToolRequestEvent':
+      case 'ToolResponseEvent':
+      case 'QuestionEvent':
+      case 'AnswerEvent':
+      case 'CaseUpdatedEvent':
+      case 'TextChunkEvent':
+        return true
+      default:
+        return false
+    }
+  }
+
+  private toExecutionNotice(event: CaseEvent): ExecutionNotice | null {
+    switch (event.type) {
+      case 'WarnEvent':
+        return { severity: 'warning', title: 'Warning', detail: (event as WarnEvent).message }
+      case 'ErrorEvent':
+        return { severity: 'error', title: 'Execution error', detail: (event as ErrorEvent).message }
       case 'CaseStatusEvent': {
-        const e = event as CaseStatusEvent
-        return { type: 'CaseStatusEvent', label: `🟡 Status: ${e.status}` }
-      }
-      case 'AgentRunningEvent': {
-        const e = event as AgentRunningEvent
-        return { type: 'AgentRunningEvent', label: `▶️ Agent running: ${e.agentName}` }
-      }
-      case 'AgentFinishedEvent': {
-        const e = event as AgentFinishedEvent
-        return { type: 'AgentFinishedEvent', label: `✅ Agent finished: ${e.agentName}` }
-      }
-      case 'AgentSelectedEvent': {
-        const e = event as AgentSelectedEvent
-        return { type: 'AgentSelectedEvent', label: `🎯 Agent selected: ${e.agentName}` }
-      }
-      case 'IntentionGeneratedEvent': {
-        const e = event as IntentionGeneratedEvent
-        return { type: 'IntentionGeneratedEvent', label: `🧠 Intention → ${e.toolName}`, detail: e.intention }
+        const status = (event as CaseStatusEvent).status
+        if (status === 'ERROR') return { severity: 'terminal', title: 'Execution ended with an error' }
+        if (status === 'KILLED') return { severity: 'terminal', title: 'Execution was killed' }
+        return null
       }
       default:
         return null
+    }
+  }
+
+  private toTechnicalItem(event: CaseEvent): TechnicalItem {
+    switch (event.type) {
+      case 'CaseStatusEvent':
+        return { label: `Status: ${(event as CaseStatusEvent).status}` }
+      case 'AgentRunningEvent':
+        return { label: `Agent running: ${(event as AgentRunningEvent).agentName}` }
+      case 'AgentFinishedEvent':
+        return { label: `Agent finished: ${(event as AgentFinishedEvent).agentName}` }
+      case 'AgentSelectedEvent':
+        return { label: `Agent selected: ${(event as AgentSelectedEvent).agentName}` }
+      case 'IntentionGeneratedEvent': {
+        const e = event as IntentionGeneratedEvent
+        return { label: `Intention → ${e.toolName}`, detail: e.intention }
+      }
+      case 'ToolSelectedEvent':
+        return { label: `Tool selected: ${(event as ToolSelectedEvent).toolName}` }
+      default:
+        // Defensive fallback for known but not specifically formatted events, and for
+        // forward-compatible payloads received at runtime.
+        return {
+          label: `Event: ${(event as { type?: string }).type ?? 'unknown'}`,
+          detail: this.formatStructuredData(event),
+        }
     }
   }
 

--- a/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-chat/case-chat.component.ts
@@ -66,6 +66,8 @@ export interface ToolCall {
   requestId: string
   toolName: string
   args: string | null
+  /** ISO timestamp from the ToolRequestEvent. */
+  timestamp?: string
   /** undefined = pending, defined = done */
   response?: ToolResponseEvent
   /** Enrichment phase traces from multi-step parameter generation (null when no enrichment). */
@@ -85,7 +87,13 @@ export interface ExecutionNotice {
 }
 
 export type TimelineItem =
-  | { kind: 'message'; event: CaseMessageEvent; html: SafeHtml; isFirstInGroup: boolean }
+  | {
+      kind: 'message'
+      event: CaseMessageEvent
+      html: SafeHtml
+      isFirstInGroup: boolean
+      isLastInGroup: boolean
+    }
   | { kind: 'tool'; call: ToolCall }
   | { kind: 'streaming' }
   | { kind: 'notice'; notice: ExecutionNotice; eventId: string }
@@ -258,6 +266,9 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   readonly showTechnicalOverride = input(false)
   protected readonly showTechnical = computed(() => this.showTechnicalOverride())
 
+  readonly showToolCallsOverride = input(true)
+  protected readonly showToolCalls = computed(() => this.showToolCallsOverride())
+
   /** Streaming assistant text assembled from TextChunkEvent during a RUNNING turn. */
   protected readonly streamingText = signal('')
 
@@ -341,6 +352,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
   private readonly baseTimeline = computed<TimelineItem[]>(() => {
     const allEvents = this.events()
     const showTechnical = this.showTechnical()
+    const showToolCalls = this.showToolCalls()
 
     // Pass 1: build complete tool call map (request + optional response)
     const toolCallMap = new Map<string, ToolCall>()
@@ -353,6 +365,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
           requestId,
           toolName: req.toolName ?? 'unknown',
           args: req.args ?? null,
+          timestamp: req.timestamp ?? existing?.timestamp,
           response: existing?.response,
           enrichmentPhases: (req as ToolRequestEvent).enrichmentPhases ?? null,
         })
@@ -364,6 +377,7 @@ export class CaseChatComponent implements OnInit, OnDestroy {
           requestId,
           toolName: existing?.toolName ?? res.toolName ?? 'unknown',
           args: existing?.args ?? null,
+          timestamp: existing?.timestamp,
           response: res,
           enrichmentPhases: existing?.enrichmentPhases ?? null,
         })
@@ -386,12 +400,15 @@ export class CaseChatComponent implements OnInit, OnDestroy {
           event: msg,
           html: this.messageHtmlCache.get(e.id) ?? '',
           isFirstInGroup,
+          isLastInGroup: false,
         })
       } else if (e.type === 'ToolRequestEvent' || e.type === 'ToolResponseEvent') {
         const requestId = e.toolRequestId ?? e.id
         if (!seenToolIds.has(requestId)) {
           seenToolIds.add(requestId)
-          items.push({ kind: 'tool', call: toolCallMap.get(requestId)! })
+          if (showToolCalls) {
+            items.push({ kind: 'tool', call: toolCallMap.get(requestId)! })
+          }
         }
         lastMessageRole = null
       } else if (e.type === 'QuestionEvent') {
@@ -411,6 +428,13 @@ export class CaseChatComponent implements OnInit, OnDestroy {
         }
         lastMessageRole = null
       }
+    }
+
+    for (let index = 0; index < items.length; index++) {
+      const item = items[index]
+      if (item?.kind !== 'message') continue
+      const next = items[index + 1]
+      item.isLastInGroup = next?.kind !== 'message' || next.event.actor.role !== item.event.actor.role
     }
 
     return items
@@ -908,7 +932,20 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     return this.formatStructuredData(metadata)
   }
 
+  protected isToolMetadataStructured(call: ToolCall): boolean {
+    return this.isStructuredPayload(call.response?.toolMetadata)
+  }
+
   protected extractToolOutput(call: ToolCall): string | null {
+    const output = this.extractToolOutputValue(call)
+    return output === null || output === undefined ? null : this.formatStructuredData(output)
+  }
+
+  protected isToolOutputStructured(call: ToolCall): boolean {
+    return this.isStructuredPayload(this.extractToolOutputValue(call))
+  }
+
+  private extractToolOutputValue(call: ToolCall): unknown {
     if (!call.response) return null
     const output = call.response.output as unknown
     if (output === null || output === undefined) return null
@@ -917,9 +954,20 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     // returns another shape or a malformed value.
     if (typeof output === 'object' && 'content' in output) {
       const content = (output as { content?: unknown }).content
-      if (content !== undefined && content !== null) return this.formatStructuredData(content)
+      if (content !== undefined && content !== null) return content
     }
-    return this.formatStructuredData(output)
+    return output
+  }
+
+  /** True when a payload can be displayed as formatted JSON rather than plain text. */
+  protected isStructuredPayload(value: unknown): boolean {
+    if (typeof value !== 'string') return value !== null && value !== undefined
+    try {
+      JSON.parse(value)
+      return true
+    } catch {
+      return false
+    }
   }
 
   /** Pretty-print valid structured payloads without hiding malformed or plain-text values. */
@@ -937,6 +985,18 @@ export class CaseChatComponent implements OnInit, OnDestroy {
     } catch {
       return String(value)
     }
+  }
+
+  /** Local time for message cards; the full source timestamp remains available via title. */
+  protected formatMessageTime(timestamp: string): string {
+    const date = new Date(timestamp)
+    if (Number.isNaN(date.getTime())) return ''
+    return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', hour12: false }).format(date)
+  }
+
+  protected formatMessageTimestampTitle(timestamp: string): string {
+    const date = new Date(timestamp)
+    return Number.isNaN(date.getTime()) ? timestamp : date.toLocaleString()
   }
 
   protected toggleToolCall(requestId: string): void {

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.html
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.html
@@ -22,6 +22,7 @@
     [userName]="userName()"
     [isAdmin]="isAdmin()"
     [isDark]="isDark()"
+    [showToolCalls]="showToolCalls()"
     (closed)="mobileDrawerOpen.set(false)"
     (caseSelected)="onMobileCaseSelect($event)"
     (starToggled)="onStarToggled($event)"
@@ -29,6 +30,7 @@
     (navigateTo)="onMenuNavigate($event)"
     (themeToggled)="onMenuToggleTheme()"
     (logsToggled)="onMenuToggleLogs()"
+    (toolCallsToggled)="onMenuToggleToolCalls()"
   />
 
   <!-- ═══ DESKTOP SIDEBAR ═══ -->
@@ -48,6 +50,7 @@
     [isDark]="isDark()"
     [themeVariant]="themeVariant()"
     [showTechnical]="showTechnical()"
+    [showToolCalls]="showToolCalls()"
     (collapseRequested)="collapseSidebar()"
     (homeClicked)="navigateHome()"
     (namespaceSelected)="onNamespaceSelected($event)"
@@ -64,6 +67,7 @@
     (themeToggled)="onMenuToggleTheme()"
     (themeVariantChanged)="onMenuThemeVariantChanged($event)"
     (logsToggled)="onMenuToggleLogs()"
+    (toolCallsToggled)="onMenuToggleToolCalls()"
   />
 
   <!-- Resize handle (hidden when sidebar is collapsed) -->
@@ -89,6 +93,7 @@
     @if (activeCaseId()) {
       <agentos-case-chat
         [showTechnicalOverride]="showTechnical()"
+        [showToolCallsOverride]="showToolCalls()"
         (starToggled)="onStarToggled($event)"
         (deleteRequested)="onDeleteRequested($event)"
         (logsToggled)="onMenuToggleLogs()"

--- a/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/case-shell.component.ts
@@ -116,9 +116,13 @@ export class CaseShellComponent {
   protected readonly mobileDrawerOpen = signal(false)
 
   private static readonly SHOW_TECHNICAL_KEY = 'agentos.case-chat.showTechnical'
+  private static readonly SHOW_TOOL_CALLS_KEY = 'agentos.case-chat.showToolCalls'
 
   /** Global toggle for technical log events — persisted in localStorage. */
   protected readonly showTechnical = signal(localStorage.getItem(CaseShellComponent.SHOW_TECHNICAL_KEY) === 'true')
+
+  /** Global toggle for tool calls — visible by default and persisted in localStorage. */
+  protected readonly showToolCalls = signal(localStorage.getItem(CaseShellComponent.SHOW_TOOL_CALLS_KEY) !== 'false')
 
   /** Whether to show the namespace picker (admin or multiple namespaces) */
   protected readonly showNsPicker = computed(() => this.isAdmin() || this.namespaces().length > 1)
@@ -328,6 +332,15 @@ export class CaseShellComponent {
     this.showTechnical.update((v) => {
       const next = !v
       localStorage.setItem(CaseShellComponent.SHOW_TECHNICAL_KEY, String(next))
+      return next
+    })
+  }
+
+  protected onMenuToggleToolCalls(): void {
+    this.menuOpen.set(false)
+    this.showToolCalls.update((v) => {
+      const next = !v
+      localStorage.setItem(CaseShellComponent.SHOW_TOOL_CALLS_KEY, String(next))
       return next
     })
   }

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-case-switcher-mobile/shell-case-switcher-mobile.component.html
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-case-switcher-mobile/shell-case-switcher-mobile.component.html
@@ -280,6 +280,26 @@
                 </svg>
                 Technical logs
               </button>
+              <button class="mobile-drawer__user-menu-item" type="button" (click)="onMenuToolCallsToggle()">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                  style="color: var(--color-neutral-600)"
+                >
+                  <path d="M9 18l6-6-6-6" />
+                  <path d="M4 6h8M4 12h5M4 18h8" />
+                </svg>
+                Tool calls
+                <span style="flex: 1"></span>
+                <span class="mobile-drawer__user-menu-hint">{{ showToolCalls() ? 'On' : 'Off' }}</span>
+              </button>
             </div>
             <div class="mobile-drawer__user-menu-sep"></div>
             <div class="mobile-drawer__user-menu-section">

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-case-switcher-mobile/shell-case-switcher-mobile.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-case-switcher-mobile/shell-case-switcher-mobile.component.ts
@@ -27,6 +27,7 @@ export class ShellCaseSwitcherMobileComponent {
   readonly userName = input.required<string>()
   readonly isAdmin = input.required<boolean>()
   readonly isDark = input.required<boolean>()
+  readonly showToolCalls = input.required<boolean>()
 
   // ── Internal state ────────────────────────────────────────
   protected readonly filterQuery = signal('')
@@ -65,6 +66,7 @@ export class ShellCaseSwitcherMobileComponent {
   readonly navigateTo = output<string>()
   readonly themeToggled = output<void>()
   readonly logsToggled = output<void>()
+  readonly toolCallsToggled = output<void>()
 
   // ── Handlers ────────────────────────────────────────────
   protected onCaseSelect(id: string): void {
@@ -108,6 +110,11 @@ export class ShellCaseSwitcherMobileComponent {
   protected onMenuLogsToggle(): void {
     this.userMenuOpen.set(false)
     this.logsToggled.emit()
+  }
+
+  protected onMenuToolCallsToggle(): void {
+    this.userMenuOpen.set(false)
+    this.toolCallsToggled.emit()
   }
 
   // ── Date helpers ──────────────────────────────────────────

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.html
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.html
@@ -140,11 +140,13 @@
           [isDark]="isDark()"
           [themeVariant]="themeVariant()"
           [showTechnical]="showTechnical()"
+          [showToolCalls]="showToolCalls()"
           variant="desktop"
           (navigateTo)="navigateTo.emit($event)"
           (themeToggled)="themeToggled.emit()"
           (themeVariantChanged)="themeVariantChanged.emit($event)"
           (logsToggled)="logsToggled.emit()"
+          (toolCallsToggled)="toolCallsToggled.emit()"
           (closed)="menuClosed.emit($event)"
         />
       </div>
@@ -324,6 +326,7 @@
       [isDark]="isDark()"
       [themeVariant]="themeVariant()"
       [showTechnical]="showTechnical()"
+      [showToolCalls]="showToolCalls()"
       variant="compact"
       [fixedTop]="compactMenuTop()"
       [fixedLeft]="compactMenuLeft()"
@@ -331,6 +334,7 @@
       (themeToggled)="themeToggled.emit()"
       (themeVariantChanged)="themeVariantChanged.emit($event)"
       (logsToggled)="logsToggled.emit()"
+      (toolCallsToggled)="toolCallsToggled.emit()"
       (closed)="menuClosed.emit($event)"
     />
 

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-sidebar/shell-sidebar.component.ts
@@ -150,6 +150,7 @@ export class ShellSidebarComponent {
   readonly isDark = input.required<boolean>()
   readonly themeVariant = input.required<string>()
   readonly showTechnical = input.required<boolean>()
+  readonly showToolCalls = input.required<boolean>()
 
   // Outputs
   readonly collapseRequested = output<void>()
@@ -168,4 +169,5 @@ export class ShellSidebarComponent {
   readonly themeToggled = output<void>()
   readonly themeVariantChanged = output<string>()
   readonly logsToggled = output<void>()
+  readonly toolCallsToggled = output<void>()
 }

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-user-menu/shell-user-menu.component.html
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-user-menu/shell-user-menu.component.html
@@ -103,6 +103,32 @@
       }
     </button>
 
+    <button
+      class="shell-user-menu__item"
+      [class.shell-user-menu__item--active]="showToolCalls()"
+      type="button"
+      (click)="onToolCallsToggle()"
+    >
+      <svg
+        width="15"
+        height="15"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M9 18l6-6-6-6" />
+        <path d="M4 6h8M4 12h5M4 18h8" />
+      </svg>
+      Tool calls
+      @if (showToolCalls()) {
+        <span class="shell-user-menu__item-badge">On</span>
+      }
+    </button>
+
     <div class="shell-user-menu__separator"></div>
 
     <!-- Light / Dark toggle -->

--- a/libs/agentos-ui/src/lib/components/case-shell/shell-user-menu/shell-user-menu.component.ts
+++ b/libs/agentos-ui/src/lib/components/case-shell/shell-user-menu/shell-user-menu.component.ts
@@ -29,6 +29,9 @@ export class ShellUserMenuComponent {
   /** Whether technical logs are currently shown — drives the active state of the menu item */
   readonly showTechnical = input.required<boolean>()
 
+  /** Whether tool calls are currently shown — drives the active state of the menu item. */
+  readonly showToolCalls = input.required<boolean>()
+
   /**
    * Visual variant:
    * - 'desktop': absolute positioned relative to the user button in the sidebar
@@ -52,6 +55,9 @@ export class ShellUserMenuComponent {
   /** Emits when the user toggles technical logs */
   readonly logsToggled = output<void>()
 
+  /** Emits when the user toggles tool calls. */
+  readonly toolCallsToggled = output<void>()
+
   /** Emits when the backdrop is clicked or Escape is pressed */
   readonly closed = output<Event>()
 
@@ -69,6 +75,10 @@ export class ShellUserMenuComponent {
 
   protected onLogsToggle(): void {
     this.logsToggled.emit()
+  }
+
+  protected onToolCallsToggle(): void {
+    this.toolCallsToggled.emit()
   }
 
   protected onClose(event: Event): void {

--- a/libs/agentos-ui/src/lib/components/integrations-all-scopes/integrations-all-scopes.component.html
+++ b/libs/agentos-ui/src/lib/components/integrations-all-scopes/integrations-all-scopes.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Integrations"
   [items]="(listItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No integrations available."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/integrations-all-scopes/integrations-all-scopes.component.ts
+++ b/libs/agentos-ui/src/lib/components/integrations-all-scopes/integrations-all-scopes.component.ts
@@ -68,6 +68,9 @@ export class IntegrationsAllScopesComponent implements OnInit {
 
   protected readonly listItems$ = this.state.vm$.pipe(map((vm) => this.toListItems(vm)))
 
+  /** True until the first vm$ emission resolves. */
+  protected readonly isLoading = signal(true)
+
   /**
    * Index resolving a composite key (`<scope>:<id>`) → (config, scope) so the item template
    * can render the right component variant. The composite key prevents cross-scope collisions
@@ -94,6 +97,7 @@ export class IntegrationsAllScopesComponent implements OnInit {
       .subscribe((v) => this.isAdmin.set(v))
 
     this.state.vm$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((vm) => {
+      this.isLoading.set(false)
       const next = new Map<string, ResolvedItem>()
       vm.platform.forEach((c) => {
         if (c.id) next.set(this.itemKey('platform', c.id), { config: c, scope: 'platform' })

--- a/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Agent Configs"
   [items]="(configItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No agent configs defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-agent-configs/namespace-agent-configs.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import { AgentConfig, AgentConfigControllerService } from '@whoz-oss/agentos-api-client'
@@ -40,20 +40,23 @@ export class NamespaceAgentConfigsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /**
    * Fetches both namespace-level and platform-level configs in parallel.
    * Platform configs are appended with a groupKey so ds-entity-list renders them
    * in a separate collapsed-by-default group.
    */
   private readonly allConfigs$ = this.refresh$.pipe(
-    switchMap(() =>
-      forkJoin({
+    switchMap(() => {
+      this.isLoading.set(true)
+      return forkJoin({
         namespace: this.agentConfigController.listByParentAgentConfig(this.namespaceId),
         platform: this.agentConfigController
           .listPlatformAgentsAgentConfig()
           .pipe(catchError(() => of([] as AgentConfig[]))),
       })
-    )
+    })
   )
 
   /** Mapped to EntityListItem[] for ds-entity-list, grouped by level. */
@@ -85,9 +88,13 @@ export class NamespaceAgentConfigsComponent {
   private platformConfigsById = new Map<string, AgentConfig>()
 
   constructor() {
-    this.allConfigs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ namespace, platform }) => {
-      this.namespaceConfigsById = new Map(namespace.map((c: AgentConfig) => [c.id ?? '', c]))
-      this.platformConfigsById = new Map(platform.map((c: AgentConfig) => [c.id ?? '', c]))
+    this.allConfigs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: ({ namespace, platform }) => {
+        this.namespaceConfigsById = new Map(namespace.map((c: AgentConfig) => [c.id ?? '', c]))
+        this.platformConfigsById = new Map(platform.map((c: AgentConfig) => [c.id ?? '', c]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="AI models"
   [items]="(modelItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No AI models configured yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-ai-models/namespace-ai-models.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import {
@@ -48,19 +48,22 @@ export class NamespaceAiModelsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /**
    * Fetches namespace models, platform models, and providers in parallel.
    * Providers are needed to resolve group labels for namespace-level models.
    */
   private readonly data$: Observable<{ namespace: AiModel[]; platform: AiModel[]; providers: AiProvider[] }> =
     this.refresh$.pipe(
-      switchMap(() =>
-        forkJoin({
+      switchMap(() => {
+        this.isLoading.set(true)
+        return forkJoin({
           namespace: this.aiModelController.listByNamespaceIdAiModel(this.namespaceId),
           platform: this.aiModelController.listPlatformLevelAiModel().pipe(catchError(() => of([] as AiModel[]))),
           providers: this.aiProviderController.listAiProvider(this.namespaceId),
         })
-      )
+      })
     )
 
   /** Mapped to EntityListItem[] with groupKey/groupLabel for ds-entity-list grouping.
@@ -96,9 +99,13 @@ export class NamespaceAiModelsComponent {
   private platformModelsById = new Map<string, AiModel>()
 
   constructor() {
-    this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ namespace, platform }) => {
-      this.namespaceModelsById = new Map(namespace.map((m: AiModel) => [m.id ?? '', m]))
-      this.platformModelsById = new Map(platform.map((m: AiModel) => [m.id ?? '', m]))
+    this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: ({ namespace, platform }) => {
+        this.namespaceModelsById = new Map(namespace.map((m: AiModel) => [m.id ?? '', m]))
+        this.platformModelsById = new Map(platform.map((m: AiModel) => [m.id ?? '', m]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/namespace-list/namespace-list.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-list/namespace-list.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Namespaces"
   [items]="(namespaceItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No namespaces yet. Create one to get started."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/namespace-list/namespace-list.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-list/namespace-list.component.ts
@@ -32,8 +32,15 @@ export class NamespaceListComponent {
   /** Trigger to refresh the list (emitting a new value forces re-subscription). */
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /** Raw namespaces, kept for delete lookups. */
-  private readonly namespaces$ = this.refresh$.pipe(switchMap(() => this.namespaceController.listAllNamespace()))
+  private readonly namespaces$ = this.refresh$.pipe(
+    switchMap(() => {
+      this.isLoading.set(true)
+      return this.namespaceController.listAllNamespace()
+    })
+  )
 
   /** Mapped to EntityListItem[] for ds-entity-list. */
   protected readonly namespaceItems$ = this.namespaces$.pipe(
@@ -53,8 +60,12 @@ export class NamespaceListComponent {
   protected readonly namespacesById = signal(new Map<string, Namespace>())
 
   constructor() {
-    this.namespaces$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((namespaces) => {
-      this.namespacesById.set(new Map(namespaces.map((ns) => [ns.id ?? '', ns])))
+    this.namespaces$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (namespaces) => {
+        this.namespacesById.set(new Map(namespaces.map((ns) => [ns.id ?? '', ns])))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.html
+++ b/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Prompts"
   [items]="(promptItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No prompts defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.ts
+++ b/libs/agentos-ui/src/lib/components/namespace-prompts/namespace-prompts.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import { Prompt } from '@whoz-oss/agentos-api-client'
@@ -41,14 +41,17 @@ export class NamespacePromptsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /** Fetches both namespace-level and platform-level prompts in parallel. */
   private readonly allPrompts$ = this.refresh$.pipe(
-    switchMap(() =>
-      forkJoin({
+    switchMap(() => {
+      this.isLoading.set(true)
+      return forkJoin({
         platform: this.promptState.listPlatform().pipe(catchError(() => of([] as Prompt[]))),
         namespace: this.promptState.listByNamespace(this.namespaceId),
       })
-    )
+    })
   )
 
   /** Mapped to EntityListItem[] for ds-entity-list, platform group first. */
@@ -80,9 +83,13 @@ export class NamespacePromptsComponent {
   private platformPromptsById = new Map<string, Prompt>()
 
   constructor() {
-    this.allPrompts$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ platform, namespace }) => {
-      this.platformPromptsById = new Map(platform.map((p: Prompt) => [p.id ?? '', p]))
-      this.namespacePromptsById = new Map(namespace.map((p: Prompt) => [p.id ?? '', p]))
+    this.allPrompts$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: ({ platform, namespace }) => {
+        this.platformPromptsById = new Map(platform.map((p: Prompt) => [p.id ?? '', p]))
+        this.namespacePromptsById = new Map(namespace.map((p: Prompt) => [p.id ?? '', p]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/platform-agent-configs/platform-agent-configs.component.html
+++ b/libs/agentos-ui/src/lib/components/platform-agent-configs/platform-agent-configs.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Platform Agent Configs"
   [items]="(configItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No platform agent configs defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/platform-agent-configs/platform-agent-configs.component.ts
+++ b/libs/agentos-ui/src/lib/components/platform-agent-configs/platform-agent-configs.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { Router } from '@angular/router'
 import { AgentConfig, AgentConfigControllerService } from '@whoz-oss/agentos-api-client'
@@ -30,9 +30,14 @@ export class PlatformAgentConfigsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /** Raw platform configs, kept for delete lookups. */
   private readonly configs$ = this.refresh$.pipe(
-    switchMap(() => this.agentConfigController.listPlatformAgentsAgentConfig(true))
+    switchMap(() => {
+      this.isLoading.set(true)
+      return this.agentConfigController.listPlatformAgentsAgentConfig(true)
+    })
   )
 
   /** Mapped to EntityListItem[] for ds-entity-list. */
@@ -52,8 +57,12 @@ export class PlatformAgentConfigsComponent {
   private configsById = new Map<string, AgentConfig>()
 
   constructor() {
-    this.configs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((configs) => {
-      this.configsById = new Map(configs.map((c: AgentConfig) => [c.id ?? '', c]))
+    this.configs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (configs) => {
+        this.configsById = new Map(configs.map((c: AgentConfig) => [c.id ?? '', c]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/platform-ai-models/platform-ai-models.component.html
+++ b/libs/agentos-ui/src/lib/components/platform-ai-models/platform-ai-models.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Platform AI Models"
   [items]="(modelItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No platform AI models defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/platform-ai-models/platform-ai-models.component.ts
+++ b/libs/agentos-ui/src/lib/components/platform-ai-models/platform-ai-models.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { Router } from '@angular/router'
 import {
@@ -39,18 +39,21 @@ export class PlatformAiModelsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /**
    * Raw models and their parent providers loaded in parallel.
    * Providers are scoped to platform level (namespaceId='none') so group labels
    * resolve correctly without falling back to UUIDs.
    */
   private readonly data$: Observable<[AiModel[], AiProvider[]]> = this.refresh$.pipe(
-    switchMap(() =>
-      combineLatest([
+    switchMap(() => {
+      this.isLoading.set(true)
+      return combineLatest([
         this.aiModelController.listPlatformLevelAiModel(),
         this.aiProviderController.listAiProvider('none'),
       ])
-    )
+    })
   )
 
   /** Mapped to EntityListItem[] with groupKey/groupLabel for ds-entity-list grouping. */
@@ -73,8 +76,12 @@ export class PlatformAiModelsComponent {
   private modelsById = new Map<string, AiModel>()
 
   constructor() {
-    this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(([models]) => {
-      this.modelsById = new Map(models.map((m: AiModel) => [m.id ?? '', m]))
+    this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: ([models]) => {
+        this.modelsById = new Map(models.map((m: AiModel) => [m.id ?? '', m]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/platform-ai-providers/platform-ai-providers.component.html
+++ b/libs/agentos-ui/src/lib/components/platform-ai-providers/platform-ai-providers.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Platform AI Providers"
   [items]="(providerItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No platform AI providers defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/platform-ai-providers/platform-ai-providers.component.ts
+++ b/libs/agentos-ui/src/lib/components/platform-ai-providers/platform-ai-providers.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { Router } from '@angular/router'
 import { AiProvider, AiProviderControllerService } from '@whoz-oss/agentos-api-client'
@@ -31,8 +31,15 @@ export class PlatformAiProvidersComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /** Raw platform providers, kept for delete lookups. */
-  private readonly providers$ = this.refresh$.pipe(switchMap(() => this.aiProviderController.listAiProvider('none')))
+  private readonly providers$ = this.refresh$.pipe(
+    switchMap(() => {
+      this.isLoading.set(true)
+      return this.aiProviderController.listAiProvider('none')
+    })
+  )
 
   /** Mapped to EntityListItem[] for ds-entity-list. */
   protected readonly providerItems$ = this.providers$.pipe(
@@ -51,8 +58,12 @@ export class PlatformAiProvidersComponent {
   private providersById = new Map<string, AiProvider>()
 
   constructor() {
-    this.providers$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((providers) => {
-      this.providersById = new Map(providers.map((p: AiProvider) => [p.id ?? '', p]))
+    this.providers$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (providers) => {
+        this.providersById = new Map(providers.map((p: AiProvider) => [p.id ?? '', p]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/platform-auth-settings/platform-auth-settings.component.html
+++ b/libs/agentos-ui/src/lib/components/platform-auth-settings/platform-auth-settings.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Platform Auth Settings"
   [items]="(settingItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No platform auth settings defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/platform-auth-settings/platform-auth-settings.component.ts
+++ b/libs/agentos-ui/src/lib/components/platform-auth-settings/platform-auth-settings.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { Router } from '@angular/router'
 import { AuthSettingDto } from '@whoz-oss/agentos-api-client'
@@ -30,8 +30,15 @@ export class PlatformAuthSettingsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /** Raw platform auth settings, kept for delete lookups. */
-  private readonly settings$ = this.refresh$.pipe(switchMap(() => this.state.loadPlatformSettings()))
+  private readonly settings$ = this.refresh$.pipe(
+    switchMap(() => {
+      this.isLoading.set(true)
+      return this.state.loadPlatformSettings()
+    })
+  )
 
   /** Mapped to EntityListItem[] for ds-entity-list. */
   protected readonly settingItems$ = this.settings$.pipe(
@@ -50,8 +57,12 @@ export class PlatformAuthSettingsComponent {
   private settingsById = new Map<string, AuthSettingDto>()
 
   constructor() {
-    this.settings$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((settings) => {
-      this.settingsById = new Map(settings.map((s: AuthSettingDto) => [s.id ?? '', s]))
+    this.settings$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (settings) => {
+        this.settingsById = new Map(settings.map((s: AuthSettingDto) => [s.id ?? '', s]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/platform-integration-configs/platform-integration-configs.component.html
+++ b/libs/agentos-ui/src/lib/components/platform-integration-configs/platform-integration-configs.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Platform Integration Configs"
   [items]="(configItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No platform integration configs defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/platform-integration-configs/platform-integration-configs.component.ts
+++ b/libs/agentos-ui/src/lib/components/platform-integration-configs/platform-integration-configs.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { Router } from '@angular/router'
 import { IntegrationConfig, IntegrationConfigControllerService } from '@whoz-oss/agentos-api-client'
@@ -30,9 +30,14 @@ export class PlatformIntegrationConfigsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /** Raw platform configs, kept for delete lookups. */
   private readonly configs$ = this.refresh$.pipe(
-    switchMap(() => this.integrationConfigController.listIntegrationConfig())
+    switchMap(() => {
+      this.isLoading.set(true)
+      return this.integrationConfigController.listIntegrationConfig()
+    })
   )
 
   /** Mapped to EntityListItem[] for ds-entity-list. */
@@ -52,8 +57,12 @@ export class PlatformIntegrationConfigsComponent {
   private configsById = new Map<string, IntegrationConfig>()
 
   constructor() {
-    this.configs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((configs) => {
-      this.configsById = new Map(configs.map((c: IntegrationConfig) => [c.id ?? '', c]))
+    this.configs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (configs) => {
+        this.configsById = new Map(configs.map((c: IntegrationConfig) => [c.id ?? '', c]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/platform-prompts/platform-prompts.component.html
+++ b/libs/agentos-ui/src/lib/components/platform-prompts/platform-prompts.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Platform Prompts"
   [items]="(promptItems$ | async) ?? []"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No platform prompts defined yet. Add one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/platform-prompts/platform-prompts.component.ts
+++ b/libs/agentos-ui/src/lib/components/platform-prompts/platform-prompts.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common'
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { Router } from '@angular/router'
 import { Prompt } from '@whoz-oss/agentos-api-client'
@@ -31,8 +31,15 @@ export class PlatformPromptsComponent {
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined)
 
+  protected readonly isLoading = signal(true)
+
   /** Raw platform prompts, kept for delete lookups. */
-  private readonly prompts$ = this.refresh$.pipe(switchMap(() => this.promptState.listPlatform()))
+  private readonly prompts$ = this.refresh$.pipe(
+    switchMap(() => {
+      this.isLoading.set(true)
+      return this.promptState.listPlatform()
+    })
+  )
 
   /** Mapped to EntityListItem[] for ds-entity-list. */
   protected readonly promptItems$ = this.prompts$.pipe(
@@ -51,8 +58,12 @@ export class PlatformPromptsComponent {
   private promptsById = new Map<string, Prompt>()
 
   constructor() {
-    this.prompts$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((prompts) => {
-      this.promptsById = new Map(prompts.map((p: Prompt) => [p.id ?? '', p]))
+    this.prompts$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (prompts) => {
+        this.promptsById = new Map(prompts.map((p: Prompt) => [p.id ?? '', p]))
+        this.isLoading.set(false)
+      },
+      error: () => this.isLoading.set(false),
     })
   }
 

--- a/libs/agentos-ui/src/lib/components/platform-scheduled-prompts/platform-scheduled-prompts.component.html
+++ b/libs/agentos-ui/src/lib/components/platform-scheduled-prompts/platform-scheduled-prompts.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Platform Scheduled Prompts"
   [items]="promptItems()"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No platform scheduled prompts defined yet. Add one above."
   cardMinWidth="420px"

--- a/libs/agentos-ui/src/lib/components/platform-scheduled-prompts/platform-scheduled-prompts.component.ts
+++ b/libs/agentos-ui/src/lib/components/platform-scheduled-prompts/platform-scheduled-prompts.component.ts
@@ -34,6 +34,8 @@ export class PlatformScheduledPromptsComponent {
   /** Single source of truth for platform scheduled prompts, loaded once in the constructor. */
   private readonly prompts = signal<ScheduledPrompt[]>([])
 
+  protected readonly isLoading = signal(true)
+
   /** Mapped to EntityListItem[] for ds-entity-list. */
   protected readonly promptItems = computed<EntityListItem[]>(() =>
     this.prompts().map(
@@ -55,7 +57,13 @@ export class PlatformScheduledPromptsComponent {
     this.state
       .listPlatform()
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((defs) => this.prompts.set(defs))
+      .subscribe({
+        next: (defs) => {
+          this.prompts.set(defs)
+          this.isLoading.set(false)
+        },
+        error: () => this.isLoading.set(false),
+      })
   }
 
   protected goBack(): void {

--- a/libs/agentos-ui/src/lib/components/scheduled-prompt-list/scheduled-prompt-list.component.html
+++ b/libs/agentos-ui/src/lib/components/scheduled-prompt-list/scheduled-prompt-list.component.html
@@ -1,6 +1,7 @@
 <ds-entity-list
   title="Scheduled Prompts"
   [items]="promptItems()"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No scheduled prompts yet. Create one to get started."
   cardMinWidth="420px"

--- a/libs/agentos-ui/src/lib/components/scheduled-prompt-list/scheduled-prompt-list.component.ts
+++ b/libs/agentos-ui/src/lib/components/scheduled-prompt-list/scheduled-prompt-list.component.ts
@@ -44,6 +44,8 @@ export class ScheduledPromptListComponent {
   private readonly platformPrompts = signal<ScheduledPrompt[]>([])
   private readonly namespacePrompts = signal<ScheduledPrompt[]>([])
 
+  protected readonly isLoading = signal(true)
+
   /** Mapped to EntityListItem[] for ds-entity-list, platform group first. */
   protected readonly promptItems = computed<EntityListItem[]>(() => [
     ...this.platformPrompts().map(
@@ -84,9 +86,13 @@ export class ScheduledPromptListComponent {
       namespace: this.state.listByNamespace(this.namespaceId),
     })
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(({ platform, namespace }) => {
-        this.platformPrompts.set(platform)
-        this.namespacePrompts.set(namespace)
+      .subscribe({
+        next: ({ platform, namespace }) => {
+          this.platformPrompts.set(platform)
+          this.namespacePrompts.set(namespace)
+          this.isLoading.set(false)
+        },
+        error: () => this.isLoading.set(false),
       })
   }
 

--- a/libs/agentos-ui/src/lib/components/shell-topbar/shell-topbar.component.html
+++ b/libs/agentos-ui/src/lib/components/shell-topbar/shell-topbar.component.html
@@ -21,11 +21,13 @@
       [isDark]="isDark()"
       [themeVariant]="themeVariant()"
       [showTechnical]="showTechnical()"
+      [showToolCalls]="showToolCalls()"
       variant="topbar"
       (navigateTo)="onNavigate($event)"
       (themeToggled)="onThemeToggle()"
       (themeVariantChanged)="onThemeVariantChanged($event)"
       (logsToggled)="onLogsToggle()"
+      (toolCallsToggled)="onToolCallsToggle()"
       (closed)="closeMenu($event)"
     />
   </div>

--- a/libs/agentos-ui/src/lib/components/shell-topbar/shell-topbar.component.ts
+++ b/libs/agentos-ui/src/lib/components/shell-topbar/shell-topbar.component.ts
@@ -51,8 +51,9 @@ export class ShellTopbarComponent {
     return (first + last).toUpperCase() || user.email?.[0]?.toUpperCase() || ''
   })
 
-  // showTechnical n'a pas de sens hors du CaseShell — on le passe à false
+  // Technical display toggles have no effect outside the CaseShell.
   protected readonly showTechnical = signal(false)
+  protected readonly showToolCalls = signal(true)
 
   protected navigateHome(): void {
     const nsId = this.namespaceState.activeNamespaceId()
@@ -87,6 +88,11 @@ export class ShellTopbarComponent {
   }
 
   protected onLogsToggle(): void {
+    // no-op hors du CaseShell
+    this.menuOpen.set(false)
+  }
+
+  protected onToolCallsToggle(): void {
     // no-op hors du CaseShell
     this.menuOpen.set(false)
   }

--- a/libs/agentos-ui/src/lib/components/user-group-list/user-group-list.component.html
+++ b/libs/agentos-ui/src/lib/components/user-group-list/user-group-list.component.html
@@ -2,6 +2,7 @@
   title="User Groups"
   [hideTitle]="hideTitle()"
   [items]="groupItems()"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No user groups yet. Create one above."
   cardMinWidth="400px"

--- a/libs/agentos-ui/src/lib/components/user-group-list/user-group-list.component.ts
+++ b/libs/agentos-ui/src/lib/components/user-group-list/user-group-list.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { Router } from '@angular/router'
 import { Namespace, UserGroupSearchResult } from '@whoz-oss/agentos-api-client'
 import { EntityListComponent, EntityListItem } from '@whoz-oss/design-system'
-import { catchError, combineLatest, of, switchMap } from 'rxjs'
+import { catchError, combineLatest, of, switchMap, tap } from 'rxjs'
 import { UserGroupStateService } from '../../services/user-group-state.service'
 import { NamespaceSelectComponent } from '../namespace-select/namespace-select.component'
 import { UserGroupItemComponent } from '../user-group-item/user-group-item.component'
@@ -48,19 +48,24 @@ export class UserGroupListComponent {
   /** Bumped to force a reload after a delete. */
   private readonly refresh = signal(0)
 
+  protected readonly isLoading = signal(true)
+
   private readonly groups = toSignal(
     combineLatest([toObservable(this.namespaceId), toObservable(this.refresh)]).pipe(
       // catchError on the inner observable so a transient failure (e.g. switching namespace)
       // does not terminate the outer stream and freeze the list in an error state; fall back
       // to an empty list and log so the failure stays diagnosable (#1076).
-      switchMap(([namespaceId]) =>
-        this.userGroupState.listByNamespace(namespaceId).pipe(
+      switchMap(([namespaceId]) => {
+        this.isLoading.set(true)
+        return this.userGroupState.listByNamespace(namespaceId).pipe(
+          tap(() => this.isLoading.set(false)),
           catchError((err) => {
             console.error('[UserGroupList] Failed to load user groups', err)
+            this.isLoading.set(false)
             return of([] as UserGroupSearchResult[])
           })
         )
-      )
+      })
     ),
     { initialValue: [] as UserGroupSearchResult[] }
   )

--- a/libs/agentos-ui/src/lib/components/user-list/user-list.component.html
+++ b/libs/agentos-ui/src/lib/components/user-list/user-list.component.html
@@ -2,6 +2,7 @@
   title="Users"
   [hideTitle]="hideTitle()"
   [items]="userItems()"
+  [loading]="isLoading()"
   [showCreate]="true"
   emptyMessage="No users found."
   cardMinWidth="320px"

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.html
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.html
@@ -47,7 +47,7 @@
             </div>
           }
         </div>
-        <span class="cdk-visually-hidden" role="status" aria-live="polite">Loading…</span>
+        <span class="entity-list__sr-only" role="status" aria-live="polite">Loading…</span>
       } @else if (filteredItems().length === 0) {
         <p class="entity-list__empty">{{ emptyMessage() }}</p>
       } @else if (hasGroups()) {

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.html
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.html
@@ -35,7 +35,20 @@
   <!-- Content (max-width constrained) — not rendered in toolbar-only mode -->
   @if (!toolbarOnly()) {
     <div class="entity-list__content" [style.max-width]="contentMaxWidth()">
-      @if (filteredItems().length === 0) {
+      @if (loading()) {
+        <!-- Skeleton placeholder — mirrors the grid layout while data loads -->
+        <div class="entity-list__grid" [style.--card-min-width]="cardMinWidth()" aria-hidden="true">
+          @for (_ of skeletonItems(); track $index) {
+            <div class="entity-list__skeleton-card">
+              <div class="entity-list__skeleton-body">
+                <div class="entity-list__skeleton-line entity-list__skeleton-line--name"></div>
+                <div class="entity-list__skeleton-line entity-list__skeleton-line--desc"></div>
+              </div>
+            </div>
+          }
+        </div>
+        <span class="cdk-visually-hidden" role="status" aria-live="polite">Loading…</span>
+      } @else if (filteredItems().length === 0) {
         <p class="entity-list__empty">{{ emptyMessage() }}</p>
       } @else if (hasGroups()) {
         <!-- Grouped view (no active search) -->

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
@@ -197,6 +197,20 @@
   padding: 0.5rem 0;
 }
 
+// ── Screen-reader-only utility (visually hides text without removing it from the a11y tree) ──
+
+.entity-list__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 // ── Skeleton loading state ─────────────────────────────────────────────────────
 
 @keyframes entity-list-shimmer {

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.scss
@@ -196,3 +196,65 @@
   gap: 0.75rem;
   padding: 0.5rem 0;
 }
+
+// ── Skeleton loading state ─────────────────────────────────────────────────────
+
+@keyframes entity-list-shimmer {
+  from {
+    background-position: -400px 0;
+  }
+  to {
+    background-position: 400px 0;
+  }
+}
+
+.entity-list__skeleton-card {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 1rem 1.25rem;
+  background: var(--color-surface, rgba(255, 255, 255, 0.7));
+  border: 1px solid var(--color-divider, rgba(0, 0, 0, 0.08));
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.entity-list__skeleton-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.entity-list__skeleton-line {
+  border-radius: 4px;
+  height: 0.75rem;
+  background: linear-gradient(
+    90deg,
+    var(--color-neutral-200, rgba(0, 0, 0, 0.06)) 25%,
+    var(--color-neutral-100, rgba(0, 0, 0, 0.03)) 50%,
+    var(--color-neutral-200, rgba(0, 0, 0, 0.06)) 75%
+  );
+  background-size: 800px 100%;
+  animation: entity-list-shimmer 1.4s infinite linear;
+
+  &--name {
+    width: 55%;
+    height: 0.875rem;
+  }
+
+  &--desc {
+    width: 80%;
+  }
+}
+
+// Respect users who prefer reduced motion — freeze the shimmer.
+@media (prefers-reduced-motion: reduce) {
+  .entity-list__skeleton-line {
+    animation: none;
+    background: var(--color-neutral-200, rgba(0, 0, 0, 0.06));
+  }
+}

--- a/libs/design-system/src/lib/components/entity-list/entity-list.component.ts
+++ b/libs/design-system/src/lib/components/entity-list/entity-list.component.ts
@@ -74,6 +74,15 @@ export class EntityListComponent implements AfterViewInit, OnDestroy {
   readonly disableInternalFilter = input<boolean>(false)
   readonly toolbarOnly = input<boolean>(false)
   /**
+   * When true, the content area is replaced by skeleton card placeholders.
+   * The toolbar remains visible. Use while data is being fetched.
+   */
+  readonly loading = input<boolean>(false)
+  /**
+   * Number of skeleton cards to render while loading. Defaults to 6.
+   */
+  readonly loadingSkeletonCount = input<number>(6)
+  /**
    * When true, keep rendering the grouped (accordion) view while a search is active,
    * showing only the groups that still have matching items (a group with no match is
    * dropped, since [groupedItems] never creates an empty group). Default false keeps the
@@ -97,6 +106,9 @@ export class EntityListComponent implements AfterViewInit, OnDestroy {
   private observer?: IntersectionObserver
 
   protected readonly isSearchActive = computed(() => this.searchQuery().trim().length > 0)
+
+  /** Array of the requested length used to drive @for skeleton rendering. */
+  protected readonly skeletonItems = computed(() => Array.from({ length: this.loadingSkeletonCount() }))
 
   protected readonly isPaged = computed(() => this.pageSize() > 0)
 


### PR DESCRIPTION
<img width="1361" height="621" alt="image" src="https://github.com/user-attachments/assets/d9d91319-9d1a-4e17-95a5-4a77ad1741eb" />

<img width="1060" height="345" alt="image" src="https://github.com/user-attachments/assets/8f3eea88-a1d2-4e96-a6f0-9e179878d37b" />

Tool calls display (#1291) — Timestamps now visible on tool call events. Fixed JSON formatting of tool arguments: \n sequences double-encoded by the backend are now interpreted as real line breaks. SCSS improvements on `<pre>` blocks (word-break, max-height, overflow).

Entity list loading state — Added a [loading] input to DsEntityListComponent with animated skeleton cards (shimmer effect), prefers-reduced-motion support, and SR accessibility. Wired across all 19 ds-entity-list usages in apps/client and libs/agentos-ui.